### PR TITLE
Avoid argparse problem, fix image_dir extractor

### DIFF
--- a/datumaro/cli/contexts/project/__init__.py
+++ b/datumaro/cli/contexts/project/__init__.py
@@ -447,7 +447,8 @@ def filter_command(args):
     if not args.filter:
         raise CliException("Expected a filter expression ('-e' argument)")
 
-    dataset.filter_project(save_dir=dst_dir, expr=args.filter, **filter_args)
+    dataset.filter_project(save_dir=dst_dir,
+        filter_expr=args.filter, **filter_args)
 
     log.info("Subproject has been extracted to '%s'" % dst_dir)
 
@@ -565,6 +566,8 @@ def diff_command(args):
 
     return 0
 
+_ediff_default_if = ['id', 'group'] # avoid https://bugs.python.org/issue16399
+
 def build_ediff_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(help="Compare projects for equality",
         description="""
@@ -583,9 +586,9 @@ def build_ediff_parser(parser_ctor=argparse.ArgumentParser):
         help="Ignore item attribute (repeatable)")
     parser.add_argument('-ia', '--ignore-attr', action='append',
         help="Ignore annotation attribute (repeatable)")
-    parser.add_argument('-if', '--ignore-field',
-        action='append', default=['id', 'group'],
-        help="Ignore annotation field (repeatable, default: %(default)s)")
+    parser.add_argument('-if', '--ignore-field', action='append',
+        help="Ignore annotation field (repeatable, default: %s)" % \
+            _ediff_default_if)
     parser.add_argument('--match-images', action='store_true',
         help='Match dataset items by images instead of ids')
     parser.add_argument('--all', action='store_true',
@@ -600,6 +603,8 @@ def ediff_command(args):
     first_project = load_project(args.project_dir)
     second_project = load_project(args.other_project_dir)
 
+    if args.ignore_field:
+        args.ignore_field = _ediff_default_if
     comparator = ExactComparator(
         match_images=args.match_images,
         ignored_fields=args.ignore_field,

--- a/datumaro/plugins/image_dir.py
+++ b/datumaro/plugins/image_dir.py
@@ -42,8 +42,8 @@ class ImageDirExtractor(SourceExtractor):
         for dirpath, _, filenames in os.walk(url):
             for name in filenames:
                 path = osp.join(dirpath, name)
+                image = Image(path=path)
                 try:
-                    image = Image(path)
                     # force loading
                     image.data # pylint: disable=pointless-statement
                 except Exception:

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -41,6 +41,8 @@ def load_image(path):
     else:
         raise NotImplementedError()
 
+    if image is None:
+        raise ValueError("Can't open image '%s'" % path)
     assert len(image.shape) in {2, 3}
     if len(image.shape) == 3:
         assert image.shape[2] in {3, 4}
@@ -206,6 +208,8 @@ class Image:
         self._path = path
 
         assert data is not None or path or loader, "Image can not be empty"
+        if data is not None:
+            assert callable(data) or isinstance(data, np.ndarray), type(data)
         if data is None and (path or loader):
             if osp.isfile(path) or loader:
                 data = lazy_image(path, loader=loader, cache=cache)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Resolves https://github.com/opencv/cvat/issues/2132
Resolves https://github.com/opencv/cvat/issues/2137

- Changed default parameter handling for `action='append'` cases in CLI
- Fixed `filter_expr` parameter in the `project filter` command
- Fixed an error in the `image_dir` extractor, which led to image skipping

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
