### PR TITLE
Add reindexing option in COCO and CVAT export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
 
+## [Unreleased]
+### Added
+- `reindex` option in COCO and CVAT converters (<https://github.com/openvinotoolkit/datumaro/pull/18>)
+
+### Changed
+-
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+-
+
+### Security
+-
+
+
+## 09/10/2020 - Release v0.1.0
 ### Added
 - Initial release
 

--- a/datumaro/components/operations.py
+++ b/datumaro/components/operations.py
@@ -49,10 +49,9 @@ def merge_annotations_equal(a, b):
 def merge_categories(sources):
     categories = {}
     for source in sources:
-        categories.update(source)
-    for source in sources:
         for cat_type, source_cat in source.items():
-            if not categories[cat_type] == source_cat:
+            existing_cat = categories.setdefault(cat_type, source_cat)
+            if existing_cat != source_cat:
                 raise NotImplementedError(
                     "Merging of datasets with different categories is "
                     "only allowed in 'merge' command.")

--- a/datumaro/plugins/cvat_format/converter.py
+++ b/datumaro/plugins/cvat_format/converter.py
@@ -158,9 +158,9 @@ class _SubsetWriter:
         self._writer.close_root()
 
     def _write_item(self, item, index):
-        image_info = OrderedDict([
-            ("id", str(cast(item.attributes.get('frame'), int, index))),
-        ])
+        if not self._context._reindex:
+            index = cast(item.attributes.get('frame'), int, index)
+        image_info = OrderedDict([ ("id", str(index)), ])
         filename = item.id + CvatPath.IMAGE_EXT
         image_info["name"] = filename
         if item.has_image:
@@ -309,6 +309,18 @@ class _SubsetWriter:
 
 class CvatConverter(Converter):
     DEFAULT_IMAGE_EXT = CvatPath.IMAGE_EXT
+
+    @classmethod
+    def build_cmdline_parser(cls, **kwargs):
+        parser = super().build_cmdline_parser(**kwargs)
+        parser.add_argument('--reindex', action='store_true',
+            help="Assign new indices to frames (default: %(default)s)")
+        return parser
+
+    def __init__(self, extractor, save_dir, reindex=False, **kwargs):
+        super().__init__(extractor, save_dir, **kwargs)
+
+        self._reindex = reindex
 
     def apply(self):
         images_dir = osp.join(self._save_dir, CvatPath.IMAGES_DIR)

--- a/tests/test_coco_format.py
+++ b/tests/test_coco_format.py
@@ -495,3 +495,22 @@ class CocoConverterTest(TestCase):
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
                 CocoConverter.convert, test_dir, target_dataset=target_dataset)
+
+    def test_reindex(self):
+        source_dataset = Dataset.from_iterable([
+            DatasetItem(id=2, image=np.ones((4, 2, 3)), annotations=[
+                Polygon([0, 0, 4, 0, 4, 4], label=0, id=5),
+            ], attributes={'id': 22})
+        ], categories=[str(i) for i in range(10)])
+
+        target_dataset = Dataset.from_iterable([
+            DatasetItem(id=2, image=np.ones((4, 2, 3)), annotations=[
+                Polygon([0, 0, 4, 0, 4, 4], label=0, id=1, group=1,
+                    attributes={'is_crowd': False}),
+            ], attributes={'id': 1})
+        ], categories=[str(i) for i in range(10)])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(source_dataset,
+                partial(CocoConverter.convert, reindex=True),
+                test_dir, target_dataset=target_dataset)

--- a/tests/test_cvat_format.py
+++ b/tests/test_cvat_format.py
@@ -276,3 +276,19 @@ class CvatConverterTest(TestCase):
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
                 CvatConverter.convert, test_dir)
+
+    def test_reindex(self):
+        source_dataset = Dataset.from_iterable([
+            DatasetItem(id='some/name1', image=np.ones((4, 2, 3)),
+                attributes={'frame': 40}),
+        ], categories={ AnnotationType.label: LabelCategories() })
+
+        expected_dataset = Dataset.from_iterable([
+            DatasetItem(id='some/name1', image=np.ones((4, 2, 3)),
+                attributes={'frame': 0}),
+        ], categories={ AnnotationType.label: LabelCategories() })
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(source_dataset,
+                partial(CvatConverter.convert, reindex=True), test_dir,
+                target_dataset=expected_dataset)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -239,6 +239,35 @@ class ProjectTest(TestCase):
 
         self.assertEqual(n1 + n2, len(dataset))
 
+    def test_cant_merge_different_categories(self):
+        class TestExtractor1(Extractor):
+            def __iter__(self):
+                return iter([])
+
+            def categories(self):
+                return { AnnotationType.label:
+                    LabelCategories.from_iterable(['a', 'b']) }
+
+        class TestExtractor2(Extractor):
+            def __iter__(self):
+                return iter([])
+
+            def categories(self):
+                return { AnnotationType.label:
+                    LabelCategories.from_iterable(['b', 'a']) }
+
+        e_name1 = 'e1'
+        e_name2 = 'e2'
+
+        project = Project()
+        project.env.extractors.register(e_name1, lambda p: TestExtractor1(p))
+        project.env.extractors.register(e_name2, lambda p: TestExtractor2(p))
+        project.add_source('source1', { 'format': e_name1 })
+        project.add_source('source2', { 'format': e_name2 })
+
+        with self.assertRaisesRegex(Exception, "different categories"):
+            dataset = project.make_dataset()
+
     def test_project_filter_can_be_applied(self):
         class TestExtractor(Extractor):
             def __iter__(self):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -260,13 +260,13 @@ class ProjectTest(TestCase):
         e_name2 = 'e2'
 
         project = Project()
-        project.env.extractors.register(e_name1, lambda p: TestExtractor1(p))
-        project.env.extractors.register(e_name2, lambda p: TestExtractor2(p))
+        project.env.extractors.register(e_name1, TestExtractor1)
+        project.env.extractors.register(e_name2, TestExtractor2)
         project.add_source('source1', { 'format': e_name1 })
         project.add_source('source2', { 'format': e_name2 })
 
         with self.assertRaisesRegex(Exception, "different categories"):
-            dataset = project.make_dataset()
+            project.make_dataset()
 
     def test_project_filter_can_be_applied(self):
         class TestExtractor(Extractor):


### PR DESCRIPTION
Related #16 

- Added the `reindex` option in COCO and CVAT converters to force reindexing (helpful for merging annotations from COCO/CVAT sources)
- Added tests for errors on trying to join datasets with different categories

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
