### PR TITLE
Support relative paths in LabelMe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
 
+## [Unreleased]
+### Added
+- Support for relative paths in LabelMe format (<https://github.com/openvinotoolkit/datumaro/pull/19>)
+
+### Changed
+-
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+-
+
+### Security
+-
+
+
+## 09/10/2020 - Release v0.1.0
 ### Added
 - Initial release
 

--- a/tests/test_labelme_format.py
+++ b/tests/test_labelme_format.py
@@ -30,7 +30,7 @@ class LabelMeConverterTest(TestCase):
 
     def test_can_save_and_load(self):
         source_dataset = Dataset.from_iterable([
-            DatasetItem(id=1, subset='train',
+            DatasetItem(id='dir1/1', subset='train',
                 image=np.ones((16, 16, 3)),
                 annotations=[
                     Bbox(0, 4, 4, 8, label=2, group=2),
@@ -54,7 +54,7 @@ class LabelMeConverterTest(TestCase):
         })
 
         target_dataset = Dataset.from_iterable([
-            DatasetItem(id=1, subset='train',
+            DatasetItem(id='dir1/1', subset='train',
                 image=np.ones((16, 16, 3)),
                 annotations=[
                     Bbox(0, 4, 4, 8, label=0, group=2, id=0,
@@ -96,18 +96,6 @@ class LabelMeConverterTest(TestCase):
                 partial(LabelMeConverter.convert, save_images=True),
                 test_dir, target_dataset=target_dataset)
 
-    def test_cant_save_dataset_with_relative_paths(self):
-        expected_dataset = Dataset.from_iterable([
-            DatasetItem(id='dir/1', image=np.ones((2, 6, 3))),
-        ], categories={
-            AnnotationType.label: LabelCategories(),
-        })
-
-        with self.assertRaisesRegex(Exception, r'only supports flat'):
-            with TestDir() as test_dir:
-                self._test_save_and_load(expected_dataset,
-                    LabelMeConverter.convert, test_dir)
-
 
 DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'labelme_dataset')
 
@@ -139,7 +127,7 @@ class LabelMeImporterTest(TestCase):
         ]
 
         target_dataset = Dataset.from_iterable([
-            DatasetItem(id='img1', image=img1,
+            DatasetItem(id='example_folder/img1', image=img1,
                 annotations=[
                     Polygon([43, 34, 45, 34, 45, 37, 43, 37],
                         label=0, id=0,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Resolves #17 

- Added experimental support for relative image paths in LabelMe format
  - Used `filename` and `folder` annotation properties, file names are just numbers

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
