### PR TITLE
Add byte images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Removed
--
+- `image/depth` value from VOC export (<https://github.com/openvinotoolkit/datumaro/pull/27>)
 
 ### Fixed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
--
+- `ByteImage` class to represent encoded images in memory and avoid recoding on save (<https://github.com/openvinotoolkit/datumaro/pull/27>)
 
 ### Changed
 -

--- a/datumaro/components/converter.py
+++ b/datumaro/components/converter.py
@@ -9,7 +9,7 @@ import os.path as osp
 import shutil
 
 from datumaro.components.cli_plugin import CliPlugin
-from datumaro.util.image import save_image
+from datumaro.util.image import save_image, BytesImage
 
 
 class IConverter:
@@ -54,7 +54,7 @@ class Converter(IConverter, CliPlugin):
     def _find_image_ext(self, item):
         src_ext = None
         if item.has_image:
-            src_ext = osp.splitext(osp.basename(item.image.path))[1]
+            src_ext = item.image.ext
 
         return self._image_ext or src_ext or self._default_image_ext
 
@@ -62,18 +62,20 @@ class Converter(IConverter, CliPlugin):
         return item.id + self._find_image_ext(item)
 
     def _save_image(self, item, path=None):
-        image = item.image.data
-        if image is None:
+        if not item.image.has_data:
             log.warning("Item '%s' has no image", item.id)
-            return item.image.path
+            return
 
         path = path or self._make_image_filename(item)
 
-        src_ext = osp.splitext(osp.basename(item.image.path))[1]
+        src_ext = item.image.ext
         dst_ext = osp.splitext(osp.basename(path))[1]
 
         os.makedirs(osp.dirname(path), exist_ok=True)
         if src_ext == dst_ext and osp.isfile(item.image.path):
             shutil.copyfile(item.image.path, path)
+        elif src_ext == dst_ext and isinstance(item.image, BytesImage):
+            with open(path, 'wb') as f:
+                f.write(item.image.get_bytes())
         else:
-            save_image(path, image)
+            save_image(path, item.image.data)

--- a/datumaro/components/converter.py
+++ b/datumaro/components/converter.py
@@ -9,7 +9,7 @@ import os.path as osp
 import shutil
 
 from datumaro.components.cli_plugin import CliPlugin
-from datumaro.util.image import save_image, BytesImage
+from datumaro.util.image import save_image, ByteImage
 
 
 class IConverter:
@@ -74,7 +74,7 @@ class Converter(IConverter, CliPlugin):
         os.makedirs(osp.dirname(path), exist_ok=True)
         if src_ext == dst_ext and osp.isfile(item.image.path):
             shutil.copyfile(item.image.path, path)
-        elif src_ext == dst_ext and isinstance(item.image, BytesImage):
+        elif src_ext == dst_ext and isinstance(item.image, ByteImage):
             with open(path, 'wb') as f:
                 f.write(item.image.get_bytes())
         else:

--- a/datumaro/components/converter.py
+++ b/datumaro/components/converter.py
@@ -68,8 +68,8 @@ class Converter(IConverter, CliPlugin):
 
         path = path or self._make_image_filename(item)
 
-        src_ext = item.image.ext
-        dst_ext = osp.splitext(osp.basename(path))[1]
+        src_ext = item.image.ext.lower()
+        dst_ext = osp.splitext(osp.basename(path))[1].lower()
 
         os.makedirs(osp.dirname(path), exist_ok=True)
         if src_ext == dst_ext and osp.isfile(item.image.path):

--- a/datumaro/plugins/tf_detection_api_format/converter.py
+++ b/datumaro/plugins/tf_detection_api_format/converter.py
@@ -15,7 +15,7 @@ from datumaro.components.extractor import (AnnotationType, DEFAULT_SUBSET_NAME,
     LabelCategories
 )
 from datumaro.components.converter import Converter
-from datumaro.util.image import encode_image
+from datumaro.util.image import encode_image, BytesImage
 from datumaro.util.annotation_util import (max_bbox,
     find_group_leader, find_instances)
 from datumaro.util.mask_tools import merge_masks
@@ -207,11 +207,16 @@ class TfDetectionApiConverter(Converter):
         return tf_example
 
     def _save_image(self, item, path=None):
+        src_ext = item.image.ext
         dst_ext = osp.splitext(osp.basename(path))[1]
         fmt = DetectionApiPath.IMAGE_EXT_FORMAT.get(dst_ext)
         if not fmt:
             log.warning("Item '%s': can't find format string for the '%s' "
                 "image extension, the corresponding field will be empty." % \
                 (item.id, dst_ext))
-        buffer = encode_image(item.image.data, dst_ext)
+
+        if src_ext == dst_ext and isinstance(item.image, BytesImage):
+            buffer = item.image.get_bytes()
+        else:
+            buffer = encode_image(item.image.data, dst_ext)
         return buffer, fmt

--- a/datumaro/plugins/tf_detection_api_format/converter.py
+++ b/datumaro/plugins/tf_detection_api_format/converter.py
@@ -207,8 +207,8 @@ class TfDetectionApiConverter(Converter):
         return tf_example
 
     def _save_image(self, item, path=None):
-        src_ext = item.image.ext
-        dst_ext = osp.splitext(osp.basename(path))[1]
+        src_ext = item.image.ext.lower()
+        dst_ext = osp.splitext(osp.basename(path))[1].lower()
         fmt = DetectionApiPath.IMAGE_EXT_FORMAT.get(dst_ext)
         if not fmt:
             log.warning("Item '%s': can't find format string for the '%s' "

--- a/datumaro/plugins/tf_detection_api_format/converter.py
+++ b/datumaro/plugins/tf_detection_api_format/converter.py
@@ -15,7 +15,7 @@ from datumaro.components.extractor import (AnnotationType, DEFAULT_SUBSET_NAME,
     LabelCategories
 )
 from datumaro.components.converter import Converter
-from datumaro.util.image import encode_image, BytesImage
+from datumaro.util.image import encode_image, ByteImage
 from datumaro.util.annotation_util import (max_bbox,
     find_group_leader, find_instances)
 from datumaro.util.mask_tools import merge_masks
@@ -215,7 +215,7 @@ class TfDetectionApiConverter(Converter):
                 "image extension, the corresponding field will be empty." % \
                 (item.id, dst_ext))
 
-        if src_ext == dst_ext and isinstance(item.image, BytesImage):
+        if src_ext == dst_ext and isinstance(item.image, ByteImage):
             buffer = item.image.get_bytes()
         else:
             buffer = encode_image(item.image.data, dst_ext)

--- a/datumaro/plugins/tf_detection_api_format/extractor.py
+++ b/datumaro/plugins/tf_detection_api_format/extractor.py
@@ -11,7 +11,7 @@ import re
 from datumaro.components.extractor import (SourceExtractor, DatasetItem,
     AnnotationType, Bbox, Mask, LabelCategories
 )
-from datumaro.util.image import BytesImage, decode_image, lazy_image
+from datumaro.util.image import ByteImage, decode_image, lazy_image
 from datumaro.util.tf_util import import_tf as _import_tf
 
 from .format import DetectionApiPath
@@ -186,7 +186,7 @@ class TfDetectionApiExtractor(SourceExtractor):
 
             image = None
             if image_params:
-                image = BytesImage(**image_params, size=image_size)
+                image = ByteImage(**image_params, size=image_size)
 
             dataset_items.append(DatasetItem(id=item_id, subset=subset,
                 image=image, annotations=annotations,

--- a/datumaro/plugins/tf_detection_api_format/extractor.py
+++ b/datumaro/plugins/tf_detection_api_format/extractor.py
@@ -11,7 +11,7 @@ import re
 from datumaro.components.extractor import (SourceExtractor, DatasetItem,
     AnnotationType, Bbox, Mask, LabelCategories
 )
-from datumaro.util.image import Image, decode_image, lazy_image
+from datumaro.util.image import BytesImage, decode_image, lazy_image
 from datumaro.util.tf_util import import_tf as _import_tf
 
 from .format import DetectionApiPath
@@ -180,13 +180,13 @@ class TfDetectionApiExtractor(SourceExtractor):
 
             image_params = {}
             if frame_image:
-                image_params['data'] = lazy_image(frame_image, decode_image)
+                image_params['data'] = frame_image
             if frame_filename:
                 image_params['path'] = osp.join(images_dir, frame_filename)
 
             image = None
             if image_params:
-                image = Image(**image_params, size=image_size)
+                image = BytesImage(**image_params, size=image_size)
 
             dataset_items.append(DatasetItem(id=item_id, subset=subset,
                 image=image, annotations=annotations,

--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -204,15 +204,10 @@ class VocConverter(Converter):
 
                     if item.has_image:
                         h, w = item.image.size
-                        if item.image.has_data:
-                            image_shape = item.image.data.shape
-                            c = 1 if len(image_shape) == 2 else image_shape[2]
-                        else:
-                            c = 3
                         size_elem = ET.SubElement(root_elem, 'size')
                         ET.SubElement(size_elem, 'width').text = str(w)
                         ET.SubElement(size_elem, 'height').text = str(h)
-                        ET.SubElement(size_elem, 'depth').text = str(c)
+                        ET.SubElement(size_elem, 'depth').text = ''
 
                     item_segmented = 0 < len(masks)
                     ET.SubElement(root_elem, 'segmented').text = \
@@ -343,17 +338,17 @@ class VocConverter(Converter):
                     action_list[item.id] = None
                     segm_list[item.id] = None
 
-                if self._tasks & {VocTask.classification, VocTask.detection,
-                        VocTask.action_classification, VocTask.person_layout}:
-                    self.save_clsdet_lists(subset_name, clsdet_list)
-                    if self._tasks & {VocTask.classification}:
-                        self.save_class_lists(subset_name, class_lists)
-                if self._tasks & {VocTask.action_classification}:
-                    self.save_action_lists(subset_name, action_list)
-                if self._tasks & {VocTask.person_layout}:
-                    self.save_layout_lists(subset_name, layout_list)
-                if self._tasks & {VocTask.segmentation}:
-                    self.save_segm_lists(subset_name, segm_list)
+            if self._tasks & {VocTask.classification, VocTask.detection,
+                    VocTask.action_classification, VocTask.person_layout}:
+                self.save_clsdet_lists(subset_name, clsdet_list)
+                if self._tasks & {VocTask.classification}:
+                    self.save_class_lists(subset_name, class_lists)
+            if self._tasks & {VocTask.action_classification}:
+                self.save_action_lists(subset_name, action_list)
+            if self._tasks & {VocTask.person_layout}:
+                self.save_layout_lists(subset_name, layout_list)
+            if self._tasks & {VocTask.segmentation}:
+                self.save_segm_lists(subset_name, segm_list)
 
     def save_action_lists(self, subset_name, action_list):
         if not action_list:

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -253,7 +253,7 @@ class Image:
             (self.has_data and np.array_equal(self.data, other.data) or \
                 not self.has_data)
 
-class BytesImage(Image):
+class ByteImage(Image):
     def __init__(self, data=None, path=None, ext=None, cache=None, size=None):
         loader = None
         if data is not None:

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -220,6 +220,10 @@ class Image:
         return self._path
 
     @property
+    def ext(self):
+        return osp.splitext(osp.basename(self.path))[1]
+
+    @property
     def data(self):
         if callable(self._data):
             return self._data()
@@ -247,4 +251,45 @@ class Image:
             (np.array_equal(self.size, other.size)) and \
             (self.has_data == other.has_data) and \
             (self.has_data and np.array_equal(self.data, other.data) or \
+                not self.has_data)
+
+class BytesImage(Image):
+    def __init__(self, data=None, path=None, ext=None, cache=None, size=None):
+        loader = None
+        if data is not None:
+            if callable(data) and not isinstance(data, lazy_image):
+                data = lazy_image(path, loader=data, cache=cache)
+            loader = lambda _: decode_image(self.get_bytes())
+
+        super().__init__(path=path, size=size, loader=loader, cache=cache)
+        if data is None and loader is None:
+            # unset defaults for regular images
+            # to avoid random file reading to bytes
+            self._data = None
+
+        self._bytes_data = data
+        if ext:
+            ext = ext.lower()
+            if not ext.startswith('.'):
+                ext = '.' + ext
+        self._ext = ext
+
+    def get_bytes(self):
+        if callable(self._bytes_data):
+            return self._bytes_data()
+        return self._bytes_data
+
+    @property
+    def ext(self):
+        if self._ext:
+            return self._ext
+        return super().ext
+
+    def __eq__(self, other):
+        if not isinstance(other, __class__):
+            return super().__eq__(other)
+        return \
+            (np.array_equal(self.size, other.size)) and \
+            (self.has_data == other.has_data) and \
+            (self.has_data and self.get_bytes() == other.get_bytes() or \
                 not self.has_data)

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -9,8 +9,6 @@ import os.path as osp
 import shutil
 import tempfile
 
-import numpy as np
-
 from datumaro.components.extractor import AnnotationType
 from datumaro.util import find
 

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -9,6 +9,8 @@ import os.path as osp
 import shutil
 import tempfile
 
+import numpy as np
+
 from datumaro.components.extractor import AnnotationType
 from datumaro.util import find
 
@@ -80,7 +82,8 @@ def _compare_annotations(expected, actual, ignored_attrs=None):
     actual.attributes = b_attr
     return r
 
-def compare_datasets(test, expected, actual, ignored_attrs=None):
+def compare_datasets(test, expected, actual, ignored_attrs=None,
+        require_images=False):
     compare_categories(test, expected.categories(), actual.categories())
 
     test.assertEqual(sorted(expected.subsets()), sorted(actual.subsets()))
@@ -90,6 +93,10 @@ def compare_datasets(test, expected, actual, ignored_attrs=None):
             x.subset == item_a.subset)
         test.assertFalse(item_b is None, item_a.id)
         test.assertEqual(item_a.attributes, item_b.attributes)
+        if require_images or \
+                item_a.has_image and item_a.image.has_data and \
+                item_b.has_image and item_b.image.has_data:
+            test.assertEqual(item_a.image, item_b.image, item_a.id)
         test.assertEqual(len(item_a.annotations), len(item_b.annotations))
         for ann_a in item_a.annotations:
             # We might find few corresponding items, so check them all

--- a/tests/test_cvat_format.py
+++ b/tests/test_cvat_format.py
@@ -62,7 +62,7 @@ class CvatImporterTest(TestCase):
     def test_can_load_video(self):
         expected_dataset = Dataset.from_iterable([
             DatasetItem(id='frame_000010', subset='annotations',
-                image=np.ones((20, 25, 3)),
+                image=255 * np.ones((20, 25, 3)),
                 annotations=[
                     Bbox(3, 4, 7, 1, label=2,
                         id=0,
@@ -81,7 +81,7 @@ class CvatImporterTest(TestCase):
                         }),
                 ], attributes={'frame': 10}),
             DatasetItem(id='frame_000013', subset='annotations',
-                image=np.ones((20, 25, 3)),
+                image=255 * np.ones((20, 25, 3)),
                 annotations=[
                     Bbox(7, 6, 7, 2, label=2,
                         id=0,

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -99,8 +99,8 @@ class BytesImageTest(TestCase):
 
             for args in [
                 { 'data': image_bytes },
-                { 'data': lambda: image_bytes },
-                { 'data': lambda: image_bytes, 'ext': '.jpg' },
+                { 'data': lambda _: image_bytes },
+                { 'data': lambda _: image_bytes, 'ext': '.jpg' },
                 { 'data': image_bytes, 'path': path },
                 { 'data': image_bytes, 'path': path, 'size': (2, 4) },
                 { 'data': image_bytes, 'path': path, 'size': (2, 4) },

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -4,7 +4,8 @@ import os.path as osp
 from unittest import TestCase
 
 from datumaro.util.test_utils import TestDir
-from datumaro.util.image import lazy_image, load_image, save_image, Image
+from datumaro.util.image import (lazy_image, load_image, save_image, \
+    Image, BytesImage, encode_image)
 from datumaro.util.image_cache import ImageCache
 
 
@@ -47,7 +48,7 @@ class ImageCacheTest(TestCase):
 
 class ImageTest(TestCase):
     def test_lazy_image_shape(self):
-        data = np.ones((5, 6, 7))
+        data = np.ones((5, 6, 3))
 
         image_lazy = Image(data=data, size=(2, 4))
         image_eager = Image(data=data)
@@ -75,7 +76,47 @@ class ImageTest(TestCase):
                 with self.subTest(**args):
                     img = Image(**args)
                     # pylint: disable=pointless-statement
+                    self.assertTrue(img.has_data)
+                    self.assertEqual(img, image)
+                    self.assertEqual(img.size, tuple(image.shape[:2]))
+                    # pylint: enable=pointless-statement
+
+class BytesImageTest(TestCase):
+    def test_lazy_image_shape(self):
+        data = encode_image(np.ones((5, 6, 3)), 'png')
+
+        image_lazy = BytesImage(data=data, size=(2, 4))
+        image_eager = BytesImage(data=data)
+
+        self.assertEqual((2, 4), image_lazy.size)
+        self.assertEqual((5, 6), image_eager.size)
+
+    def test_ctors(self):
+        with TestDir() as test_dir:
+            path = osp.join(test_dir, 'path.png')
+            image = np.ones([2, 4, 3])
+            image_bytes = encode_image(image, 'png')
+
+            for args in [
+                { 'data': image_bytes },
+                { 'data': lambda: image_bytes },
+                { 'data': lambda: image_bytes, 'ext': '.jpg' },
+                { 'data': image_bytes, 'path': path },
+                { 'data': image_bytes, 'path': path, 'size': (2, 4) },
+                { 'data': image_bytes, 'path': path, 'size': (2, 4) },
+                { 'path': path },
+                { 'path': path, 'size': (2, 4) },
+            ]:
+                with self.subTest(**args):
+                    img = BytesImage(**args)
+                    # pylint: disable=pointless-statement
+                    self.assertEqual('data' in args, img.has_data)
                     if img.has_data:
-                        img.data
+                        self.assertEqual(img, image)
+                        self.assertEqual(img.get_bytes(), image_bytes)
                     img.size
+                    if 'size' in args:
+                        self.assertEqual(img.size, args['size'])
+                    if 'ext' in args or 'path' in args:
+                        self.assertEqual(img.ext, args.get('ext', '.png'))
                     # pylint: enable=pointless-statement

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from datumaro.util.test_utils import TestDir
 from datumaro.util.image import (lazy_image, load_image, save_image, \
-    Image, BytesImage, encode_image)
+    Image, ByteImage, encode_image)
 from datumaro.util.image_cache import ImageCache
 
 
@@ -85,8 +85,8 @@ class BytesImageTest(TestCase):
     def test_lazy_image_shape(self):
         data = encode_image(np.ones((5, 6, 3)), 'png')
 
-        image_lazy = BytesImage(data=data, size=(2, 4))
-        image_eager = BytesImage(data=data)
+        image_lazy = ByteImage(data=data, size=(2, 4))
+        image_eager = ByteImage(data=data)
 
         self.assertEqual((2, 4), image_lazy.size)
         self.assertEqual((5, 6), image_eager.size)
@@ -108,7 +108,7 @@ class BytesImageTest(TestCase):
                 { 'path': path, 'size': (2, 4) },
             ]:
                 with self.subTest(**args):
-                    img = BytesImage(**args)
+                    img = ByteImage(**args)
                     # pylint: disable=pointless-statement
                     self.assertEqual('data' in args, img.has_data)
                     if img.has_data:

--- a/tests/test_voc_format.py
+++ b/tests/test_voc_format.py
@@ -81,7 +81,7 @@ class VocImportTest(TestCase):
             def __iter__(self):
                 return iter([
                     DatasetItem(id='2007_000001', subset='train',
-                        image=Image(path='2007_000001.jpg', size=(20, 10)),
+                        image=Image(path='2007_000001.jpg', size=(10, 20)),
                         annotations=[
                             Label(self._label(l.name))
                             for l in VOC.VocLabel if l.value % 2 == 1
@@ -118,7 +118,7 @@ class VocImportTest(TestCase):
                         ]
                     ),
                     DatasetItem(id='2007_000002', subset='test',
-                        image=np.zeros((20, 10, 3))),
+                        image=np.ones((10, 20, 3))),
                 ])
 
         dataset = Project.import_from(DUMMY_DATASET_DIR, 'voc').make_dataset()


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

An optimization for images to avoid their decoding and encoding when it is unnecessary, but the data comes not from files on disk, e.g. video frames or downloaded data. In case of jpeg this allows to keep source quality.

Needed to implement raw data copying in CVAT (https://github.com/openvinotoolkit/cvat/pull/2229)

- Added `ByteImage` class to represent encoded images
- Added image data checks in tests, by default enabled when data is available 
- Fixed wrong indentation in VOC format converter, which led to extra disk writes for each image
- Removed `image/depth` field support in VOC converter to avoid unnecessary image reading
- Fixed image extension comparison when extensions in different cases

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

Unit tests

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
