### PR TITLE
Fix voc and mots converters

### DIFF
--- a/datumaro/plugins/mots_format.py
+++ b/datumaro/plugins/mots_format.py
@@ -113,6 +113,7 @@ class MotsPngConverter(Converter):
             subset_dir = osp.join(self._save_dir, subset_name)
             images_dir = osp.join(subset_dir, MotsPath.IMAGE_DIR)
             anno_dir = osp.join(subset_dir, MotsPath.MASKS_DIR)
+            os.makedirs(anno_dir, exist_ok=True)
 
             for item in subset:
                 log.debug("Converting item '%s'", item.id)

--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -103,7 +103,7 @@ class VocConverter(Converter):
         self._allow_attributes = allow_attributes
 
         if label_map is None:
-            label_map = LabelmapType.source
+            label_map = LabelmapType.source.name
         self._load_categories(label_map)
 
     def apply(self):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Fixed default parameter value for label map in VOC converter
- Fixed exporting empty subsets in MOTS format

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
