### PR TITLE
Fix unknown formats in tf detection api export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Fixed
--
+- Supported unknown image formats in TF Detection API converter (<https://github.com/openvinotoolkit/datumaro/pull/40>)
 
 ### Security
 -

--- a/datumaro/plugins/tf_detection_api_format/converter.py
+++ b/datumaro/plugins/tf_detection_api_format/converter.py
@@ -199,7 +199,7 @@ class TfDetectionApiConverter(Converter):
     def _save_image(self, item, path=None):
         src_ext = item.image.ext.lower()
         dst_ext = osp.splitext(osp.basename(path))[1].lower()
-        fmt = DetectionApiPath.IMAGE_EXT_FORMAT.get(dst_ext)
+        fmt = DetectionApiPath.IMAGE_EXT_FORMAT.get(dst_ext, '')
         if not fmt:
             log.warning("Item '%s': can't find format string for the '%s' "
                 "image extension, the corresponding field will be empty." % \

--- a/datumaro/plugins/tf_detection_api_format/format.py
+++ b/datumaro/plugins/tf_detection_api_format/format.py
@@ -8,6 +8,6 @@ class DetectionApiPath:
     ANNOTATIONS_DIR = 'annotations'
 
     DEFAULT_IMAGE_EXT = '.jpg'
-    IMAGE_EXT_FORMAT = {'.jpg': 'jpeg', '.png': 'png'}
+    IMAGE_EXT_FORMAT = {'.jpg': 'jpeg', '.jpeg': 'jpeg', '.png': 'png'}
 
     LABELMAP_FILE = 'label_map.pbtxt'

--- a/tests/test_tfrecord_format.py
+++ b/tests/test_tfrecord_format.py
@@ -9,7 +9,7 @@ from datumaro.components.extractor import (DatasetItem,
     AnnotationType, Bbox, Mask, LabelCategories
 )
 from datumaro.components.project import Project
-from datumaro.util.image import Image
+from datumaro.util.image import Image, ByteImage, encode_image
 from datumaro.util.test_utils import (TestDir, compare_datasets,
     test_save_and_load)
 from datumaro.util.tf_util import check_import
@@ -134,6 +134,25 @@ class TfrecordConverterTest(TestCase):
         with TestDir() as test_dir:
             self._test_save_and_load(test_dataset,
                 TfDetectionApiConverter.convert, test_dir)
+
+    def test_can_save_dataset_with_unknown_image_formats(self):
+        test_dataset = Dataset.from_iterable([
+            DatasetItem(id=1,
+                image=ByteImage(data=encode_image(np.ones((5, 4, 3)), 'png'),
+                    path='1/q.e'),
+                attributes={'source_id': ''}
+            ),
+            DatasetItem(id=2,
+                image=ByteImage(data=encode_image(np.ones((6, 4, 3)), 'png'),
+                    ext='qwe'),
+                attributes={'source_id': ''}
+            )
+        ], categories={ AnnotationType.label: LabelCategories(), })
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(test_dataset,
+                partial(TfDetectionApiConverter.convert, save_images=True),
+                test_dir)
 
     def test_labelmap_parsing(self):
         text = """


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Related #35 

- Fixed unknown image formats on TF Detection API export - they should not lead to errors and produce an empty image format field
- Supported `jpeg` along with `jpg`

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
