### PR TITLE
Relax importer for Pascal VOC dataset (seach in subdirectories)

### DIFF
--- a/datumaro/plugins/voc_format/importer.py
+++ b/datumaro/plugins/voc_format/importer.py
@@ -56,10 +56,10 @@ class VocImporter(Importer):
         return project
 
     @classmethod
-    def find_sources(cls, root_path):
+    def find_sources(cls, path):
         subset_paths = []
         for task, extractor_type, task_dir in cls._TASKS:
-            task_path = find_path(root_path, osp.join(VocPath.SUBSETS_DIR, task_dir))
+            task_path = find_path(path, osp.join(VocPath.SUBSETS_DIR, task_dir))
 
             if not task_path:
                 continue

--- a/datumaro/plugins/voc_format/importer.py
+++ b/datumaro/plugins/voc_format/importer.py
@@ -57,11 +57,19 @@ class VocImporter(Importer):
 
     @classmethod
     def find_sources(cls, path):
+        # find root path for the dataset
+        root_path = path
+        for task, extractor_type, task_dir in cls._TASKS:
+            task_path = find_path(root_path, osp.join(VocPath.SUBSETS_DIR, task_dir))
+            if task_path:
+                root_path = osp.dirname(osp.dirname(task_path))
+                break
+
         subset_paths = []
         for task, extractor_type, task_dir in cls._TASKS:
-            task_path = find_path(path, osp.join(VocPath.SUBSETS_DIR, task_dir))
+            task_path = osp.join(root_path, VocPath.SUBSETS_DIR, task_dir)
 
-            if not task_path:
+            if not osp.isdir(task_path):
                 continue
             task_subsets = [p for p in glob(osp.join(task_path, '*.txt'))
                 if '_' not in osp.basename(p)]


### PR DESCRIPTION
In some cases developers don't want to specify the exact path to Pascal VOC.
Now you have to specify VOCtrainval_11-May-2012/VOCdevkit/VOC2012/. After the
patch it will be possible to specify VOCtrainval_11-May-2012/.

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
