### PR TITLE
Relax coco extractor (none for super category by default)

### DIFF
--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -81,7 +81,7 @@ class _CocoExtractor(SourceExtractor):
         label_map = {}
         for idx, cat in enumerate(cats):
             label_map[cat['id']] = idx
-            categories.add(name=cat['name'], parent=cat['supercategory'])
+            categories.add(name=cat['name'], parent=cat.get('supercategory'))
 
         return categories, label_map
     # pylint: enable=no-self-use


### PR DESCRIPTION
Now it is possible to load coco_instances dataset even if the annotation file doesn't have supercategory.

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

An internal team tries to load annotations which are generated by an OTE script (https://github.com/openvinotoolkit/training_extensions/blob/develop/pytorch_toolkit/object_detection/model_templates/face-detection/tools/wider_to_coco.py). OTE script doesn't generate supercategory field inside the json annotation file. Probably the field has to be optional.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
