### PR TITLE
ability to install opencv-python-headless instead opencv-python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `CamVid` dataset format (<https://github.com/openvinotoolkit/datumaro/pull/57>)
+- Ability to install `opencv-python-headless` dependency with `DATUMARO_HEADLESS=1`
+  enviroment variable instead of `opencv-python` (<https://github.com/openvinotoolkit/datumaro/pull/62>)
 
 ### Changed
 -

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+from distutils.util import strtobool
 import os
 import os.path as osp
 import re
@@ -42,7 +43,7 @@ def get_requirements():
         'scikit-image',
         'tensorboardX',
     ]
-    if os.getenv('HEADLESS') == '1':
+    if strtobool(os.getenv('DATUMARO_HEADLESS', '0').lower()):
         requirements.append('opencv-python-headless')
     else:
         requirements.append('opencv-python')

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import os
 import os.path as osp
 import re
 import setuptools
@@ -27,6 +28,26 @@ def find_version(file_path=None):
     version = version_text[match.start(1) : match.end(1)]
     return version
 
+def get_requirements():
+    requirements = [
+        'attrs>=19.3.0',
+        'defusedxml',
+        'GitPython',
+        'lxml',
+        'matplotlib',
+        'numpy>=1.17.3',
+        'Pillow',
+        'pycocotools',
+        'PyYAML',
+        'scikit-image',
+        'tensorboardX',
+    ]
+    if os.getenv('HEADLESS') == '1':
+        requirements.append('opencv-python-headless')
+    else:
+        requirements.append('opencv-python')
+
+    return requirements
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()
@@ -51,20 +72,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.5',
-    install_requires=[
-        'attrs>=19.3.0',
-        'defusedxml',
-        'GitPython',
-        'lxml',
-        'matplotlib',
-        'numpy>=1.17.3',
-        'opencv-python',
-        'Pillow',
-        'pycocotools',
-        'PyYAML',
-        'scikit-image',
-        'tensorboardX',
-    ],
+    install_requires=get_requirements(),
     extras_require={
         'tf': ['tensorflow'],
         'tf-gpu': ['tensorflow-gpu'],


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
Added ability to install opencv-python-headless dependency instead opencv-python. This is needed for CVAT server Docker image.

### How to test
Manually

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
