### PR TITLE
Fixed WiderFace

### DIFF
--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -18,7 +18,7 @@ class WiderFacePath:
     IMAGES_DIR = 'images'
     SUBSET_DIR = 'WIDER_'
     BBOX_ATTRIBUTES = ['blur', 'expression', 'illumination',
-        'occlusion', 'pose', 'invalid']
+        'occluded', 'pose', 'invalid']
 
 class WiderFaceExtractor(SourceExtractor):
     def __init__(self, path):

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -59,7 +59,8 @@ class WiderFaceExtractor(SourceExtractor):
                     if len(bbox_list) == 10:
                         i = 4
                         for attr in WiderFacePath.BBOX_ATTRIBUTES:
-                            attributes[attr] = int(bbox_list[i])
+                            if bbox_list[i] != '-':
+                                attributes[attr] = int(bbox_list[i])
                             i += 1
                     annotations.append(Bbox(
                         int(bbox_list[0]), int(bbox_list[1]),
@@ -103,11 +104,16 @@ class WiderFaceConverter(Converter):
                     wider_bb = ' '.join('%d' % p for p in bbox.get_bbox())
                     wider_annotation += '%s ' % wider_bb
                     if bbox.attributes:
+                        wider_attr = ''
+                        attr_counter = 0
                         for attr in WiderFacePath.BBOX_ATTRIBUTES:
-                            if bbox.attributes[attr]:
-                                wider_annotation += '%s ' % bbox.attributes[attr]
+                            if attr in bbox.attributes:
+                                wider_attr += '%s ' % bbox.attributes[attr]
+                                attr_counter += 1
                             else:
-                                wider_annotation += '0 '
+                                wider_attr += '- '
+                        if attr_counter > 0:
+                            wider_annotation += wider_attr
                     wider_annotation  += '\n'
             annotation_path = osp.join(save_dir, WiderFacePath.ANNOTATIONS_DIR,
                 'wider_face_' + subset_name + '_bbx_gt.txt')

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -16,20 +16,20 @@ class WiderFaceFormatTest(TestCase):
                     Bbox(0, 2, 4, 2),
                     Bbox(0, 1, 2, 3, attributes = {
                         'blur': 2, 'expression': 0, 'illumination': 0,
-                        'occlusion': 0, 'pose': 2, 'invalid': 0}),
+                        'occluded': 0, 'pose': 2, 'invalid': 0}),
                 ]
             ),
             DatasetItem(id='2', subset='train', image=np.ones((10, 10, 3)),
                 annotations=[
                     Bbox(0, 2, 4, 2, attributes = {
                         'blur': 2, 'expression': 0, 'illumination': 1,
-                        'occlusion': 0, 'pose': 1, 'invalid': 0}),
+                        'occluded': 0, 'pose': 1, 'invalid': 0}),
                     Bbox(3, 3, 2, 3, attributes = {
                         'blur': 0, 'expression': 1, 'illumination': 0,
-                        'occlusion': 0, 'pose': 2, 'invalid': 0}),
+                        'occluded': 0, 'pose': 2, 'invalid': 0}),
                     Bbox(2, 1, 2, 3, attributes = {
                         'blur': 2, 'expression': 0, 'illumination': 0,
-                        'occlusion': 0, 'pose': 0, 'invalid': 1}),
+                        'occluded': 0, 'pose': 0, 'invalid': 1}),
                 ]
             ),
 
@@ -37,12 +37,12 @@ class WiderFaceFormatTest(TestCase):
                 annotations=[
                     Bbox(0, 1, 5, 2, attributes = {
                         'blur': 2, 'expression': 1, 'illumination': 0,
-                        'occlusion': 0, 'pose': 1, 'invalid': 0}),
+                        'occluded': 0, 'pose': 1, 'invalid': 0}),
                     Bbox(0, 2, 3, 2),
                     Bbox(0, 2, 4, 2),
                     Bbox(0, 7, 3, 2, attributes = {
                         'blur': 2, 'expression': 1, 'illumination': 0,
-                        'occlusion': 0, 'pose': 1, 'invalid': 0}),
+                        'occluded': 0, 'pose': 1, 'invalid': 0}),
                 ]
             ),
 
@@ -62,7 +62,7 @@ class WiderFaceFormatTest(TestCase):
                     Bbox(0, 2, 4, 2),
                     Bbox(0, 1, 2, 3, attributes = {
                         'blur': 2, 'expression': 0, 'illumination': 0,
-                        'occlusion': 0, 'pose': 2, 'invalid': 0}),
+                        'occluded': 0, 'pose': 2, 'invalid': 0}),
                 ]
             ),
         ])
@@ -117,7 +117,7 @@ class WiderFaceImporterTest(TestCase):
                 annotations=[
                     Bbox(1, 2, 2, 2, attributes = {
                         'blur': 0, 'expression': 0, 'illumination': 0,
-                        'occlusion': 0, 'pose': 0, 'invalid': 0}),
+                        'occluded': 0, 'pose': 0, 'invalid': 0}),
                 ]
             ),
             DatasetItem(id='1--Handshaking/1_Handshaking_image_02', subset='train',
@@ -125,10 +125,10 @@ class WiderFaceImporterTest(TestCase):
                 annotations=[
                     Bbox(1, 1, 2, 2, attributes = {
                         'blur': 0, 'expression': 0, 'illumination': 1,
-                        'occlusion': 0, 'pose': 0, 'invalid': 0}),
+                        'occluded': 0, 'pose': 0, 'invalid': 0}),
                     Bbox(5, 1, 2, 2, attributes = {
                         'blur': 0, 'expression': 0, 'illumination': 1,
-                        'occlusion': 0, 'pose': 0, 'invalid': 0}),
+                        'occluded': 0, 'pose': 0, 'invalid': 0}),
                 ]
             ),
             DatasetItem(id='0--Parade/0_Parade_image_03', subset='val',
@@ -136,13 +136,13 @@ class WiderFaceImporterTest(TestCase):
                 annotations=[
                     Bbox(0, 0, 1, 1, attributes = {
                         'blur': 2, 'expression': 0, 'illumination': 0,
-                        'occlusion': 0, 'pose': 2, 'invalid': 0}),
+                        'occluded': 0, 'pose': 2, 'invalid': 0}),
                     Bbox(3, 2, 1, 2, attributes = {
                         'blur': 0, 'expression': 0, 'illumination': 0,
-                        'occlusion': 1, 'pose': 0, 'invalid': 0}),
+                        'occluded': 1, 'pose': 0, 'invalid': 0}),
                     Bbox(5, 6, 1, 1, attributes = {
                         'blur': 2, 'expression': 0, 'illumination': 0,
-                        'occlusion': 0, 'pose': 2, 'invalid': 0}),
+                        'occluded': 0, 'pose': 2, 'invalid': 0}),
                 ]
             ),
         ])

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -73,6 +73,37 @@ class WiderFaceFormatTest(TestCase):
 
             compare_datasets(self, source_dataset, parsed_dataset)
 
+    def test_can_save_dataset_with_non_widerface_attributes(self):
+        source_dataset = Dataset.from_iterable([
+            DatasetItem(id='a/b/1', image=np.ones((8, 8, 3)),
+                annotations=[
+                    Bbox(0, 2, 4, 2),
+                    Bbox(0, 1, 2, 3, attributes = {
+                        'non-widerface attribute': 0,
+                        'blur': 1, 'invalid': 1}),
+                    Bbox(1, 1, 2, 2, attributes = {
+                        'non-widerface attribute': 0}),
+                ]
+            ),
+        ])
+
+        target_dataset = Dataset.from_iterable([
+            DatasetItem(id='a/b/1', image=np.ones((8, 8, 3)),
+                annotations=[
+                    Bbox(0, 2, 4, 2),
+                    Bbox(0, 1, 2, 3, attributes = {
+                        'blur': 1, 'invalid': 1}),
+                    Bbox(1, 1, 2, 2),
+                ]
+            ),
+        ])
+
+        with TestDir() as test_dir:
+            WiderFaceConverter.convert(source_dataset, test_dir, save_images=True)
+            parsed_dataset = WiderFaceImporter()(test_dir).make_dataset()
+
+            compare_datasets(self, target_dataset, parsed_dataset)
+
 DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'widerface_dataset')
 
 class WiderFaceImporterTest(TestCase):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
Fixed converter and extractor to work correctly with non-WiderFace attributes

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
