### PR TITLE
Kate/splitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Task-specific Splitter (<https://github.com/openvinotoolkit/datumaro/pull/68>)
 - `WiderFace` dataset format (<https://github.com/openvinotoolkit/datumaro/pull/65>)
 - Function to transform annotations to labels (<https://github.com/openvinotoolkit/datumaro/pull/66>)
 - `VGGFace2` dataset format (<https://github.com/openvinotoolkit/datumaro/pull/69>)

--- a/datumaro/plugins/splitter.py
+++ b/datumaro/plugins/splitter.py
@@ -495,7 +495,7 @@ class DetectionSplit(_TaskSpecificSplit):
             )
 
         by_splits = dict()
-        for sname in subsets:
+        for sname in self._subsets:
             by_splits[sname] = []
 
         total = len(self._extractor)

--- a/datumaro/plugins/splitter.py
+++ b/datumaro/plugins/splitter.py
@@ -1,0 +1,151 @@
+# Copyright (C) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import logging as log
+import random
+import numpy as np
+
+from datumaro.components.extractor import (Transform, AnnotationType)
+from datumaro.components.cli_plugin import CliPlugin
+
+class TaskSpecificSplitter(Transform):
+    # avoid https://bugs.python.org/issue16399
+    _default_split = [('train', 0.67), ('test', 0.33)]
+    _parts = []
+
+    def __init__(self, extractor, splits, seed):
+        super().__init__(extractor)
+        
+        random.seed(seed)   
+
+        if splits is None:
+            splits = self._default_split
+
+        assert 0 < len(splits), "Expected at least one split"
+        assert all(0.0 <= r and r <= 1.0 for _, r in splits), \
+            "Ratios are expected to be in the range [0; 1], but got %s" % splits
+
+        total_ratio = sum(s[1] for s in splits)
+        if not abs(total_ratio - 1.0) <= 1e-7:
+            raise Exception(
+                "Sum of ratios is expected to be 1, got %s, which is %s" %
+                (splits, total_ratio))
+    
+    def _get_split_size(self, dataset_size, ratio):
+        n_splits = [int(np.around(dataset_size * r)) for r in ratio[:-1]]
+        n_splits.append(dataset_size - np.sum(n_splits))
+
+        for ii in range(len(n_splits)):
+            # if there are splits with zero samples, 
+            # borrow one from the split who has one or more.
+            if n_splits[ii] == 0:
+                midx = np.argmax(n_splits)
+                if n_splits[midx] > 0:
+                    n_splits[ii] += 1
+                    n_splits[midx] -= 1   
+        return n_splits
+
+    def _find_split(self, index):
+        for subset_indices, subset in self._parts:
+            if index in subset_indices:
+                return subset
+        return subset # all the possible remainder goes to the last split
+
+    def __iter__(self):
+        for i, item in enumerate(self._extractor):
+            yield self.wrap_item(item, subset=self._find_split(i))
+
+class SplitforClassification(TaskSpecificSplitter, CliPlugin):
+    """
+    Joins all subsets into one and splits the result into few parts
+    in class-wise manner.
+    Single label for a DatasetItem is expected. 
+
+    It is expected that item ids are unique and subset ratios sum up to 1.|n
+    |n
+    Example:|n
+    |s|s%(prog)s --subset train:.67 --subset test:.33
+    If there are not enough images in some class or attributes group,
+    split ratio among subsets wouldn't be guaranteed.        
+    """
+    @staticmethod
+    def _split_arg(s):
+        parts = s.split(':')
+        if len(parts) != 2:
+            import argparse
+            raise argparse.ArgumentTypeError()
+        return (parts[0], float(parts[1]))
+
+    @classmethod
+    def build_cmdline_parser(cls, **kwargs):
+        parser = super().build_cmdline_parser(**kwargs)
+        parser.add_argument('-s', '--subset', action='append',
+            type=cls._split_arg, dest='splits',
+            help="Subsets in the form: '<subset>:<ratio>' "
+                "(repeatable, default: %s)" % dict(cls._default_split))
+        parser.add_argument('--seed', type=int, help="Random seed")
+        return parser
+
+    def __init__(self, extractor, splits, seed=None):
+        super().__init__(extractor, splits, seed)
+
+        ## support only single label for a DatasetItem    
+        ## 1. group by label
+        by_labels = dict()
+        for idx, item in enumerate(extractor):
+            labels = []
+            for ann in item.annotations:                
+                if ann.type == AnnotationType.label:
+                    labels.append(ann)
+            assert len(labels) == 1, \
+                "Expected exact one label for a DatasetItem"
+            ann = labels[0]
+            if not hasattr(ann, 'label') or ann.label is None:
+                label = None
+            else:
+                label = str(ann.label)
+            if label not in by_labels:
+                by_labels[label] = []
+            by_labels[label].append((idx, ann))
+        
+        subsets = [s[0] for s in splits]
+        sratio = np.array([float(s[1]) for s in splits])
+        n_required_samples = int (np.around(1.0) / np.min(sratio)) 
+
+        by_splits = dict()
+        for subset in subsets:
+            by_splits[subset] = []
+     
+        ## 2. group by attributes    
+        for label, items in by_labels.items():
+            random.shuffle(items)
+
+            by_attributes = dict()
+            for idx, ann in items:
+                attributes = tuple(sorted(ann.attributes.items()))
+                if attributes not in by_attributes:
+                    by_attributes[attributes] = []
+                by_attributes[attributes].append(idx)
+            
+            for attributes, indice in by_attributes.items():                    
+                filtered_size = len(indice)  
+                if n_required_samples > filtered_size:
+                    log.warning("There's not enough samples for filtered group\
+                        (label : {}, attributes: {})".format(label, attributes))
+                n_splits = super()._get_split_size(filtered_size, sratio)
+                
+                k = 0
+                for subset, ns in zip(subsets, n_splits):
+                    if ns > 0:
+                        by_splits[subset].extend(indice[k:k+ns])
+                        k += ns
+        
+        parts = []
+        for subset in subsets:
+            parts.append((set(by_splits[subset]), subset))
+
+        self._parts = parts
+        self._subsets = set(subsets)
+        self._length = 'parent'
+    

--- a/datumaro/plugins/splitter.py
+++ b/datumaro/plugins/splitter.py
@@ -5,20 +5,31 @@
 import logging as log
 import numpy as np
 
-from datumaro.components.dataset import Dataset
-from datumaro.components.extractor import (Transform, AnnotationType, \
-    DEFAULT_SUBSET_NAME)
+from datumaro.components.extractor import (
+    Transform,
+    AnnotationType,
+    DEFAULT_SUBSET_NAME,
+)
 
 NEAR_ZERO = 1e-7
+
+
 class _TaskSpecificSplit(Transform):
-    def __init__(self, dataset, seed):
+    def __init__(self, dataset, splits, seed):
         super().__init__(dataset)
 
-        np.random.seed(seed)
+        snames, sratio = self._validate_splits(splits)
 
-        self._subsets = {"train", "val", "test"} # output subset names
+        self._snames = snames
+        self._sratio = sratio
+
+        self._seed = seed
+
+        self._subsets = {"train", "val", "test"}  # output subset names
         self._parts = []
-        self._length = 'parent'
+        self._length = "parent"
+
+        self._initialized = False
 
     def _set_parts(self, by_splits):
         self._parts = []
@@ -26,26 +37,48 @@ class _TaskSpecificSplit(Transform):
             self._parts.append((set(by_splits[subset]), subset))
 
     @staticmethod
+    def _get_uniq_annotations(dataset):
+        annotations = []
+        for _, item in enumerate(dataset):
+            labels = []
+            for ann in item.annotations:
+                if ann.type == AnnotationType.label:
+                    labels.append(ann)
+            assert (
+                len(labels) == 1
+            ), "Expected exact one label for a DatasetItem"
+            ann = labels[0]
+            annotations.append(ann)
+        return annotations
+
+    @staticmethod
     def _validate_splits(splits, valid=None):
-        subsets = []
+        snames = []
         ratios = []
         if valid is None:
             valid = ["train", "val", "test"]
         for subset, ratio in splits:
-            assert subset in valid, "Subset name \
-                must be one of %s, but got %s" % (valid, subset)
-            assert ratio >= 0.0 and ratio <= 1.0, "Ratio is expected to be \
-                in the range [0, 1], but got %s for %s" % (ratio, subset)
-            subsets.append(subset)
+            assert subset in valid, (
+                "Subset name \
+                must be one of %s, but got %s"
+                % (valid, subset)
+            )
+            assert ratio >= 0.0 and ratio <= 1.0, (
+                "Ratio is expected to be \
+                in the range [0, 1], but got %s for %s"
+                % (ratio, subset)
+            )
+            snames.append(subset)
             ratios.append(float(ratio))
         ratios = np.array(ratios)
 
         total_ratio = np.sum(ratios)
         if not abs(total_ratio - 1.0) <= NEAR_ZERO:
             raise Exception(
-                "Sum of ratios is expected to be 1, got %s, which is %s" %
-                (splits, total_ratio))
-        return subsets, ratios
+                "Sum of ratios is expected to be 1, got %s, which is %s"
+                % (splits, total_ratio)
+            )
+        return snames, ratios
 
     @staticmethod
     def _get_required(ratio):
@@ -53,7 +86,7 @@ class _TaskSpecificSplit(Transform):
         for i in ratio:
             if i < min_value and i > NEAR_ZERO:
                 min_value = i
-        required = int (np.around(1.0) / min_value)
+        required = int(np.around(1.0) / min_value)
         return required
 
     @staticmethod
@@ -74,13 +107,13 @@ class _TaskSpecificSplit(Transform):
 
     @staticmethod
     def _group_by_attr(items):
-        '''
+        """
         Args:
             items: list of (idx, ann). ann is the annotation from Label object.
         Returns:
-            by_attributes: dict of { combination-of-attributes : list of index }
-        '''
-        ## group by attributes
+            by_attributes: dict of { combination-of-attrs : list of index }
+        """
+        # group by attributes
         by_attributes = dict()
         for idx, ann in items:
             attributes = tuple(sorted(ann.attributes.items()))
@@ -89,16 +122,17 @@ class _TaskSpecificSplit(Transform):
             by_attributes[attributes].append(idx)
         return by_attributes
 
-    def _split_by_attr(self, datasets, subsets, ratio, out_splits,
-                       dataset_key="label"):
+    def _split_by_attr(
+        self, datasets, snames, ratio, out_splits, dataset_key="label"
+    ):
         required = self._get_required(ratio)
         for key, items in datasets.items():
             np.random.shuffle(items)
             by_attributes = self._group_by_attr(items)
             for attributes, indice in by_attributes.items():
-                gname = '%s: %s, attrs: %s' % (dataset_key, key, attributes)
+                gname = "%s: %s, attrs: %s" % (dataset_key, key, attributes)
                 splits = self._split_indice(indice, gname, ratio, required)
-                for subset, split in zip(subsets, splits):
+                for subset, split in zip(snames, splits):
                     if len(split) > 0:
                         out_splits[subset].extend(split)
 
@@ -114,11 +148,19 @@ class _TaskSpecificSplit(Transform):
         for subset_indices, subset in self._parts:
             if index in subset_indices:
                 return subset
-        return DEFAULT_SUBSET_NAME # all the possible remainder --> default
+        return DEFAULT_SUBSET_NAME  # all the possible remainder --> default
+
+    def _split_dataset(self):
+        raise NotImplementedError()
 
     def __iter__(self):
+        # lazy splitting
+        if self._initialized is False:
+            self._split_dataset()
+            self._initialized = True
         for i, item in enumerate(self._extractor):
             yield self.wrap_item(item, subset=self._find_split(i))
+
 
 class ClassificationSplit(_TaskSpecificSplit):
     """
@@ -130,7 +172,7 @@ class ClassificationSplit(_TaskSpecificSplit):
       the split ratio can't be guaranteed.|n
     """
 
-    def __init__(self, dataset:Dataset, splits, seed=None):
+    def __init__(self, dataset, splits, seed=None):
         """
         Parameters
         ----------
@@ -141,26 +183,17 @@ class ClassificationSplit(_TaskSpecificSplit):
             The sum of ratios is expected to be 1.
         seed : int, optional
         """
-        super().__init__(dataset, seed)
+        super().__init__(dataset, splits, seed)
 
-        subsets, sratio = self._validate_splits(splits)
+    def _split_dataset(self):
+        np.random.seed(self._seed)
 
-        ## support only single label for a DatasetItem
-        ## 1. group by label
+        # support only single label for a DatasetItem
+        # 1. group by label
         by_labels = dict()
-
-        for idx, item in enumerate(self._extractor):
-            labels = []
-            for ann in item.annotations:
-                if ann.type == AnnotationType.label:
-                    labels.append(ann)
-            assert len(labels) == 1, \
-                "Expected exact one label for a DatasetItem"
-            ann = labels[0]
-            if not hasattr(ann, 'label') or ann.label is None:
-                label = None
-            else:
-                label = ann.label
+        annotations = self._get_uniq_annotations(self._extractor)
+        for idx, ann in enumerate(annotations):
+            label = ann.label if hasattr(ann, "label") else None
             if label not in by_labels:
                 by_labels[label] = []
             by_labels[label].append((idx, ann))
@@ -169,9 +202,10 @@ class ClassificationSplit(_TaskSpecificSplit):
         for subset in self._subsets:
             by_splits[subset] = []
 
-        ## 2. group by attributes
-        self._split_by_attr(by_labels, subsets, sratio, by_splits)
+        # 2. group by attributes
+        self._split_by_attr(by_labels, self._snames, self._sratio, by_splits)
         self._set_parts(by_splits)
+
 
 class MatchingReIDSplit(_TaskSpecificSplit):
     """
@@ -182,15 +216,17 @@ class MatchingReIDSplit(_TaskSpecificSplit):
     Then, splits 'train+val' into 'train'/'val' sets in the same way.|n
     Therefore, the final subsets would be 'train', 'val', 'test'. |n
     And 'gallery', 'query' are tagged using anntoation group.|n
-    You can get the 'gallery' and 'query' subsets using 'get_subset_by_group'.|n
+    You can get the 'gallery' and 'query' sets using 'get_subset_by_group'.|n
     Notes:|n
     - Single label is expected for each DatasetItem.|n
     - Each label is expected to have attribute representing the person id. |n
     """
+
     _group_map = dict()
 
-    def __init__(self, dataset, splits, test_splits,
-                 attr_pid="PID", seed=None):
+    def __init__(
+        self, dataset, splits, test_splits, pid_name="PID", seed=None
+    ):
         """
         Parameters
         ----------
@@ -203,30 +239,34 @@ class MatchingReIDSplit(_TaskSpecificSplit):
             A list of (subset(str), ratio(float))
             Subset is expected to be one of ["gallery", "query"].
             The sum of ratios is expected to be 1.
-        attr_pid: str
+        pid_name: str
             attribute name representing the person id. (default: PID)
         seed : int, optional
         """
-        super().__init__(dataset, seed)
+        super().__init__(dataset, splits, seed)
 
-        id_subsets, id_ratio = self._validate_splits(splits)
+        self._test_splits = test_splits
+        self._pid_name = pid_name
+
+    def _split_dataset(self):
+        np.random.seed(self._seed)
+
+        id_snames, id_ratio = self._snames, self._sratio
+
+        pid_name = self._pid_name
+        dataset = self._extractor
 
         groups = set()
 
-        ## group by PID(attr_pid)
+        # group by PID(pid_name)
         by_pid = dict()
-        for idx, item in enumerate(self._extractor):
-            labels = []
-            for ann in item.annotations:
-                if ann.type == AnnotationType.label:
-                    labels.append(ann)
-            assert len(labels) == 1, \
-                "Expected exact one label for a DatasetItem"
-            ann = labels[0]
+        annotations = self._get_uniq_annotations(dataset)
+        for idx, ann in enumerate(annotations):
             attributes = dict(ann.attributes.items())
-            assert attr_pid in attributes, \
-                "'%s' is expected as attribute name" % attr_pid
-            person_id = attributes[attr_pid]
+            assert pid_name in attributes, (
+                "'%s' is expected as attribute name" % pid_name
+            )
+            person_id = attributes[pid_name]
             if person_id not in by_pid:
                 by_pid[person_id] = []
             by_pid[person_id].append((idx, ann))
@@ -238,23 +278,26 @@ class MatchingReIDSplit(_TaskSpecificSplit):
 
         required = self._get_required(id_ratio)
         if len(by_pid) < required:
-            log.warning("There's not enough IDs, which is {}, \
-                so train/val/test ratio can't be guaranteed." % len(by_pid))
+            log.warning(
+                "There's not enough IDs, which is {}, \
+                so train/val/test ratio can't be guaranteed."
+                % len(by_pid)
+            )
 
-        ## 1. split dataset into trval and test
-        ##    IDs in test set should not exist in train/val set.
-        test = id_ratio[id_subsets.index("test")] if "test" in id_subsets else 0
-        if test > NEAR_ZERO: # has testset
-            split_ratio = np.array([test, 1.0-test])
+        # 1. split dataset into trval and test
+        #    IDs in test set should not exist in train/val set.
+        test = id_ratio[id_snames.index("test")] if "test" in id_snames else 0
+        if test > NEAR_ZERO:  # has testset
+            split_ratio = np.array([test, 1.0 - test])
             person_ids = list(by_pid.keys())
             np.random.shuffle(person_ids)
             sections = self._get_sections(len(person_ids), split_ratio)
             splits = np.array_split(person_ids, sections)
-            testset = { pid: by_pid[pid] for pid in splits[0] }
-            trval = { pid: by_pid[pid] for pid in splits[1] }
+            testset = {pid: by_pid[pid] for pid in splits[0]}
+            trval = {pid: by_pid[pid] for pid in splits[1]}
 
-            ## follow the ratio of datasetitems as possible.
-            ## naive heuristic: exchange the best item one by one.
+            # follow the ratio of datasetitems as possible.
+            # naive heuristic: exchange the best item one by one.
             expected_count = int(len(self._extractor) * split_ratio[0])
             testset_total = int(np.sum([len(v) for v in testset.values()]))
             self._rebalancing(testset, trval, expected_count, testset_total)
@@ -266,17 +309,23 @@ class MatchingReIDSplit(_TaskSpecificSplit):
         for subset in self._subsets:
             by_splits[subset] = []
 
-        ## 2. split 'test' into 'gallery' and 'query'
-        if len(testset)>0:
+        # 2. split 'test' into 'gallery' and 'query'
+        if len(testset) > 0:
             for person_id, items in testset.items():
                 indice = [idx for idx, _ in items]
-                by_splits['test'].extend(indice)
+                by_splits["test"].extend(indice)
 
             valid = ["gallery", "query"]
-            test_subsets, test_ratio = self._validate_splits(test_splits,valid)
-            by_groups = { s : [] for s in test_subsets }
-            self._split_by_attr(testset, test_subsets, test_ratio, by_groups,
-                                dataset_key=attr_pid)
+            test_splits = self._test_splits
+            test_snames, test_ratio = self._validate_splits(test_splits, valid)
+            by_groups = {s: [] for s in test_snames}
+            self._split_by_attr(
+                testset,
+                test_snames,
+                test_ratio,
+                by_groups,
+                dataset_key=pid_name,
+            )
 
             # tag using group
             for idx, item in enumerate(self._extractor):
@@ -286,12 +335,12 @@ class MatchingReIDSplit(_TaskSpecificSplit):
                         item.annotations[0].group = group_id
                         break
 
-        ## 3. split 'trval' into  'train' and 'val'
-        trval_subsets = ["train", "val"]
+        # 3. split 'trval' into  'train' and 'val'
+        trval_snames = ["train", "val"]
         trval_ratio = []
-        for subset in trval_subsets:
-            if subset in id_subsets:
-                val = id_ratio[id_subsets.index(subset)]
+        for subset in trval_snames:
+            if subset in id_snames:
+                val = id_ratio[id_snames.index(subset)]
             else:
                 val = 0.0
             trval_ratio.append(val)
@@ -301,11 +350,18 @@ class MatchingReIDSplit(_TaskSpecificSplit):
             trval_splits = list(zip(["train", "val"], trval_ratio))
             log.warning(
                 "Sum of ratios is expected to be positive,\
-                got %s, which is %s" % (trval_splits, total_ratio))
+                got %s, which is %s"
+                % (trval_splits, total_ratio)
+            )
         else:
-            trval_ratio /= total_ratio # normalize
-            self._split_by_attr(trval, trval_subsets, trval_ratio, by_splits,
-                                dataset_key=attr_pid)
+            trval_ratio /= total_ratio  # normalize
+            self._split_by_attr(
+                trval,
+                trval_snames,
+                trval_ratio,
+                by_splits,
+                dataset_key=pid_name,
+            )
 
         self._set_parts(by_splits)
 
@@ -317,8 +373,8 @@ class MatchingReIDSplit(_TaskSpecificSplit):
             for id_trval, items_trval in trval.items():
                 count_trval = len(items_trval)
                 diff = count_trval - count_test
-                if diff==0:
-                    continue # exchange has no effect
+                if diff == 0:
+                    continue  # exchange has no effect
                 if diff not in diffs:
                     diffs[diff] = [(id_test, id_trval)]
                 else:
@@ -330,7 +386,7 @@ class MatchingReIDSplit(_TaskSpecificSplit):
             keys = np.array(list(diffs.keys()))
             idx = (np.abs(keys - target_diff)).argmin()
             nearest = keys[idx]
-            if abs(target_diff-nearest) >= abs(target_diff):
+            if abs(target_diff - nearest) >= abs(target_diff):
                 break
             choice = np.random.choice(range(len(diffs[nearest])))
             pid_test, pid_trval = diffs[nearest][choice]
@@ -341,8 +397,8 @@ class MatchingReIDSplit(_TaskSpecificSplit):
                 for id1, id2 in person_ids:
                     if id1 == pid_test or id2 == pid_trval:
                         continue
-                    new_list.append((id1,id2))
-                if len(new_list)>0:
+                    new_list.append((id1, id2))
+                if len(new_list) > 0:
                     new_diffs[diff] = new_list
             diffs = new_diffs
             exchanges.append((pid_test, pid_trval))
@@ -351,13 +407,17 @@ class MatchingReIDSplit(_TaskSpecificSplit):
             test[pid_trval] = trval.pop(pid_trval)
             trval[pid_test] = test.pop(pid_test)
 
-    def get_subset_by_group(self, group:str):
+    def get_subset_by_group(self, group: str):
         available = list(self._group_map.keys())
-        assert group in self._group_map, \
-            "Unknown group '%s', available groups: %s" % (group, available)
+        assert (
+            group in self._group_map
+        ), "Unknown group '%s', available groups: %s" % (
+            group,
+            available,
+        )
         group_id = self._group_map[group]
-        subset = self.select(lambda item: item.annotations[0].group == group_id)
-        return subset
+        return self.select(lambda item: item.annotations[0].group == group_id)
+
 
 class DetectionSplit(_TaskSpecificSplit):
     """
@@ -384,43 +444,55 @@ class DetectionSplit(_TaskSpecificSplit):
             The sum of ratios is expected to be 1.
         seed : int, optional
         """
-        super().__init__(dataset, seed)
+        super().__init__(dataset, splits, seed)
 
-        subsets, sratio = self._validate_splits(splits)
-
-        ## 1. group by bbox label
+    @staticmethod
+    def _group_by_bbox_labels(dataset):
         by_labels = dict()
-        for idx, item in enumerate(self._extractor):
+        for idx, item in enumerate(dataset):
             bbox_anns = []
             for ann in item.annotations:
                 if ann.type == AnnotationType.bbox:
                     bbox_anns.append(ann)
-            assert len(bbox_anns) > 0, "Expected more than one bbox annotation."
+            assert (
+                len(bbox_anns) > 0
+            ), "Expected more than one bbox annotation."
             for ann in bbox_anns:
-                label = ann.label if hasattr(ann, 'label') else None
+                label = ann.label if hasattr(ann, "label") else None
                 if label not in by_labels:
                     by_labels[label] = [(idx, ann)]
                 else:
                     by_labels[label].append((idx, ann))
+        return by_labels
 
-        ## 2. group by attributes
+    def _split_dataset(self):
+        np.random.seed(self._seed)
+
+        subsets, sratio = self._snames, self._sratio
+
+        # 1. group by bbox label
+        by_labels = self._group_by_bbox_labels(self._extractor)
+
+        # 2. group by attributes
         by_combinations = dict()
         for label, items in by_labels.items():
             by_attributes = self._group_by_attr(items)
             for attributes, indice in by_attributes.items():
-                gname = 'label: %s, attributes: %s' % (label, attributes)
+                gname = "label: %s, attributes: %s" % (label, attributes)
                 by_combinations[gname] = indice
 
-        ## total number of GT samples per label-attr combinations
-        NC = {k: len(v) for k, v in by_combinations.items()}
+        # total number of GT samples per label-attr combinations
+        n_combs = {k: len(v) for k, v in by_combinations.items()}
 
-        ## 3-1. initially count per-image GT samples
+        # 3-1. initially count per-image GT samples
         scores_all = {}
         init_scores = {}
-        for idx, item in enumerate(self._extractor):
-            counts = { k: v.count(idx) for k, v in by_combinations.items() }
+        for idx, _ in enumerate(self._extractor):
+            counts = {k: v.count(idx) for k, v in by_combinations.items()}
             scores_all[idx] = counts
-            init_scores[idx] = np.sum( [v / NC[k] for k, v in counts.items()] )
+            init_scores[idx] = np.sum(
+                [v / n_combs[k] for k, v in counts.items()]
+            )
 
         by_splits = dict()
         for sname in subsets:
@@ -428,41 +500,46 @@ class DetectionSplit(_TaskSpecificSplit):
 
         total = len(self._extractor)
         target_size = dict()
-        NC_all = [] # expected numbers of per split GT samples
-        for sname, ratio in zip (subsets, sratio):
+        expected = []  # expected numbers of per split GT samples
+        for sname, ratio in zip(subsets, sratio):
             target_size[sname] = total * ratio
-            NC_all.append((sname, {k: v * ratio for k, v in NC.items()}))
+            expected.append(
+                (sname, {k: v * ratio for k, v in n_combs.items()})
+            )
 
-        ###
-        # functions for keep the # of annotations not exceed the expected number
-        def compute_penalty(counts, NC):
+        ##
+        # functions for keep the # of annotations not exceed the expected num
+        def compute_penalty(counts, n_combs):
             p = 0
             for k, v in counts.items():
-                p += max(0, (v / NC[k]) - 1.0)
+                p += max(0, (v / n_combs[k]) - 1.0)
             return p
-        def update_nc(counts, NC):
+
+        def update_nc(counts, n_combs):
             for k, v in counts.items():
-                NC[k] = max(0, NC[k] - v)
-                if NC[k] == 0:
-                    NC[k] = -1
-            return NC
-        ###
+                n_combs[k] = max(0, n_combs[k] - v)
+                if n_combs[k] == 0:
+                    n_combs[k] = -1
+            return n_combs
+
+        ##
 
         # 3-2. assign each DatasetItem to a split, one by one
-        for idx, _ in sorted(init_scores.items(), \
-            key=lambda item: item[1], reverse=True):
+        for idx, _ in sorted(
+            init_scores.items(), key=lambda item: item[1], reverse=True
+        ):
             counts = scores_all[idx]
 
             # shuffling split order to add randomness
             # when two or more splits have the same penalty value
-            np.random.shuffle(NC_all)
+            np.random.shuffle(expected)
 
             pp = []
-            for sname, nc in NC_all:
+            for sname, nc in expected:
                 if len(by_splits[sname]) >= target_size[sname]:
                     # the split has enough images,
                     # stop adding more images to this split
-                    pp.append(1e+08)
+                    pp.append(1e08)
                 else:
                     # compute penalty based on the number of GT samples
                     # added in the split
@@ -471,7 +548,7 @@ class DetectionSplit(_TaskSpecificSplit):
             # we push an image to a split with the minimum penalty
             midx = np.argmin(pp)
 
-            sname, nc = NC_all[midx]
+            sname, nc = expected[midx]
             by_splits[sname].append(idx)
             update_nc(counts, nc)
 

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -11,83 +11,81 @@ import datumaro.plugins.splitter as splitter
 from datumaro.components.operations import compute_ann_statistics
 
 class SplitterTest(TestCase):
-        
-    def test_split_for_classification_multi_class_no_attr(self):
-        subsets = []
-        for subset, count in {"":30, "a":20, "b":10}.items():
-            subsets.extend([subset for _ in range(count)])
-        random.shuffle(subsets)
-                     
-        counts = {0:10, 1:20, 2:30}
-        label_id = 0 
+    def _generate_dataset(self, config):
+        # counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}
+        # attr1 = ['attr1', 'attr2']
+        # attr2 = ['attr1', 'attr3']
+        # config = { "label1": { "attrs": attr1, "counts": counts }, 
+        #            "label2": { "attrs": attr2, "counts": counts }}        
+        def _get_subset():                
+            return np.random.choice(['', 'a', 'b'], p = [0.5, 0.3, 0.2])
+
         iterable = []  
-        for label, count in counts.items():
-            for _ in range(count):
-                subset = subsets[label_id]
-                label_id += 1
-                iterable.append(DatasetItem(
-                    id=str(label_id),
-                    annotations=[Label(label)],
-                    subset=subset
-                ))
+        label_cat = LabelCategories()
+        idx = 0 
+        for label_id, label in enumerate(config.keys()): 
+            anames = config[label]['attrs']
+            counts = config[label]['counts']            
+            label_cat.add(label, attributes=anames)
+            if isinstance(counts, dict):
+                for attrs, count in counts.items():
+                    attributes = dict()
+                    if isinstance(attrs, tuple):
+                        for aname, value in zip(anames, attrs):
+                            attributes[aname] = value
+                    else:
+                        attributes[anames[0]] = attrs
+                    for _ in range(count):
+                        idx += 1
+                        iterable.append(DatasetItem(
+                            id=str(idx),
+                            annotations=[ Label(label_id, attributes=attributes) ],
+                            subset=_get_subset()
+                        ))
+            else:
+                for _ in range(counts):
+                    idx += 1
+                    iterable.append(DatasetItem(
+                        id=str(idx),
+                        annotations=[Label(label_id)],
+                        subset=_get_subset()
+                    ))
+        categories = { AnnotationType.label: label_cat }
+        dataset = Dataset.from_iterable(iterable, categories)
+        return dataset
 
-        categories = {
-            AnnotationType.label: LabelCategories.from_iterable(
-                'label_' + str(label) for label in range(3)
-            )}            
-        source_dataset = Dataset.from_iterable(iterable, categories)
+    def test_split_for_classification_multi_class_no_attr(self):
+        config = { "label1": { "attrs": None, "counts": 10 }, 
+                   "label2": { "attrs": None, "counts": 20 },
+                   "label3": { "attrs": None, "counts": 30 }}
+        source_dataset = self._generate_dataset(config)
         
-        actual = splitter.SplitforClassification(source_dataset, splits=[
-            ('train', 0.7),
-            ('test', 0.3),
-        ])
-
+        actual = splitter.SplitforClassification(source_dataset, 
+            train=0.7, test=0.3)            
         self.assertEqual(42, len(actual.get_subset('train')))
         self.assertEqual(18, len(actual.get_subset('test')))
 
         # check stats for train
         stat_train = compute_ann_statistics(actual.get_subset('train'))        
         dist_train = stat_train["annotations"]["labels"]["distribution"]
-        self.assertEqual(7, dist_train["label_0"][0])
-        self.assertEqual(14, dist_train["label_1"][0])
-        self.assertEqual(21, dist_train["label_2"][0])
+        self.assertEqual(7, dist_train["label1"][0])
+        self.assertEqual(14, dist_train["label2"][0])
+        self.assertEqual(21, dist_train["label3"][0])
         
         # check stats for test
         stat_test = compute_ann_statistics(actual.get_subset('test'))        
         dist_test = stat_test["annotations"]["labels"]["distribution"]
-        self.assertEqual(3, dist_test["label_0"][0])
-        self.assertEqual(6, dist_test["label_1"][0])
-        self.assertEqual(9, dist_test["label_2"][0])
+        self.assertEqual(3, dist_test["label1"][0])
+        self.assertEqual(6, dist_test["label2"][0])
+        self.assertEqual(9, dist_test["label3"][0])
 
-    def test_split_for_classification_single_class_single_attr(self):
-        subsets = []
-        for subset, count in {"":30, "a":20, "b":10}.items():
-            subsets.extend([subset for _ in range(count)])
-        random.shuffle(subsets)
-        
-        counts = {0:10, 1:20, 2:30}
-        label_id = 0 
-        iterable = []  
-        for attr, count in counts.items():
-            for _ in range(count):
-                subset = subsets[label_id]
-                label_id += 1
-                iterable.append(DatasetItem(
-                    id=str(label_id),
-                    annotations=[Label(0, attributes={'attr':attr})],
-                    subset=subset
-                ))
-
-        label_cat = LabelCategories()
-        label_cat.add('label', attributes=['attr'])        
-        categories = { AnnotationType.label: label_cat }
-        
-        source_dataset = Dataset.from_iterable(iterable, categories)
-        
-        actual = splitter.SplitforClassification(source_dataset, splits=[
-            ('train', 0.7),
-            ('test', 0.3),
-        ])
+    def test_split_for_classification_single_class_single_attr(self):      
+        counts = {0:10, 1:20, 2:30}        
+        config = { "label": { "attrs": ['attr'], "counts": counts }}
+        source_dataset = self._generate_dataset(config) 
+       
+        actual = splitter.SplitforClassification(source_dataset, \
+            train=0.7, test=0.3)
 
         self.assertEqual(42, len(actual.get_subset('train')))
         self.assertEqual(18, len(actual.get_subset('test')))
@@ -107,43 +105,20 @@ class SplitterTest(TestCase):
         self.assertEqual(9, attr_test['attr']["distribution"]["2"][0])     
     
     def test_split_for_classification_single_class_multi_attr(self):
-        subsets = []
-        for subset, count in {"":60, "a":40, "b":20}.items():
-            subsets.extend([subset for _ in range(count)])
-        random.shuffle(subsets)
-        
         counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}
-        label_id = 0 
-        iterable = []  
-        for (attr1, attr2), count in counts.items():
-            for _ in range(count):
-                subset = subsets[label_id]
-                label_id += 1
-                iterable.append(DatasetItem(
-                    id=str(label_id),
-                    annotations=[Label(0, 
-                        attributes={'attr1':attr1, 'attr2':attr2})
-                    ],
-                    subset=subset
-                ))
-
-        label_cat = LabelCategories()
-        label_cat.add('label', attributes=['attr1', 'attr2'])        
-        categories = { AnnotationType.label: label_cat }
+        attrs = ['attr1', 'attr2']
+        config = { "label": { "attrs": attrs, "counts": counts }}
+        source_dataset = self._generate_dataset(config) 
         
-        source_dataset = Dataset.from_iterable(iterable, categories)
-        
-        actual = splitter.SplitforClassification(source_dataset, splits=[
-            ('train', 0.7),
-            ('test', 0.3),
-        ])
+        actual = splitter.SplitforClassification(source_dataset,
+            train=0.7, test=0.3)
 
         self.assertEqual(84, len(actual.get_subset('train')))
         self.assertEqual(36, len(actual.get_subset('test')))
         
         # check stats for train
         stat_train = compute_ann_statistics(actual.get_subset('train'))       
-        attr_train = stat_train["annotations"]["labels"]["attributes"] 
+        attr_train = stat_train["annotations"]["labels"]["attributes"]         
         self.assertEqual(49, attr_train["attr1"]["distribution"]["0"][0])
         self.assertEqual(35, attr_train["attr1"]["distribution"]["1"][0])
         self.assertEqual(28, attr_train["attr2"]["distribution"]["0"][0])        
@@ -159,40 +134,16 @@ class SplitterTest(TestCase):
         self.assertEqual( 9, attr_test["attr2"]["distribution"]["1"][0])        
         self.assertEqual(15, attr_test["attr2"]["distribution"]["2"][0])
             
-    def test_split_for_classification_multi_label_with_attr(self):
-        subsets = []
-        for subset, count in {"":120, "a":80, "b":40}.items():
-            subsets.extend([subset for _ in range(count)])
-        random.shuffle(subsets)
-       
-        counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}        
-        label_id = 0 
-        iterable = []  
-        for label in range(2):
-            for (attr1, attr2), count in counts.items():
-                if label==0:
-                    attributes = {'attr1':attr1, 'attr2':attr2}
-                else:
-                    attributes = {'attr1':attr1, 'attr3':attr2}
-                for _ in range(count):
-                    subset = subsets[label_id]
-                    label_id += 1
-                    iterable.append(DatasetItem(
-                        id=str(label_id),
-                        annotations=[ Label(label, attributes=attributes) ],
-                        subset=subset
-                    ))
-        label_cat = LabelCategories()
-        label_cat.add('label0', attributes=['attr1', 'attr2'])
-        label_cat.add('label1', attributes=['attr1', 'attr3'])                
-        categories = { AnnotationType.label: label_cat }
-        
-        source_dataset = Dataset.from_iterable(iterable, categories)
-    
-        actual = splitter.SplitforClassification(source_dataset, splits=[
-            ('train', 0.7),
-            ('test', 0.3),
-        ])
+    def test_split_for_classification_multi_label_with_attr(self): 
+        counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}
+        attr1 = ['attr1', 'attr2']
+        attr2 = ['attr1', 'attr3']
+        config = { "label1": { "attrs": attr1, "counts": counts }, 
+                   "label2": { "attrs": attr2, "counts": counts }}
+        source_dataset = self._generate_dataset(config) 
+
+        actual = splitter.SplitforClassification(source_dataset,
+            train=0.7, test=0.3)
 
         self.assertEqual(168, len(actual.get_subset('train')))
         self.assertEqual(72, len(actual.get_subset('test')))
@@ -200,8 +151,8 @@ class SplitterTest(TestCase):
         # check stats for train
         stat_train = compute_ann_statistics(actual.get_subset('train'))        
         dist_train = stat_train["annotations"]["labels"]["distribution"]
-        self.assertEqual(84, dist_train["label0"][0])
-        self.assertEqual(84, dist_train["label1"][0])    
+        self.assertEqual(84, dist_train["label1"][0])
+        self.assertEqual(84, dist_train["label2"][0])    
         attr_train = stat_train["annotations"]["labels"]["attributes"]         
         self.assertEqual(49*2, attr_train["attr1"]["distribution"]["0"][0])
         self.assertEqual(35*2, attr_train["attr1"]["distribution"]["1"][0])
@@ -215,8 +166,8 @@ class SplitterTest(TestCase):
         # check stats for test
         stat_test = compute_ann_statistics(actual.get_subset('test'))        
         dist_test = stat_test["annotations"]["labels"]["distribution"]
-        self.assertEqual(36, dist_test["label0"][0])
-        self.assertEqual(36, dist_test["label0"][0])    
+        self.assertEqual(36, dist_test["label1"][0])
+        self.assertEqual(36, dist_test["label2"][0])    
         attr_test = stat_test["annotations"]["labels"]["attributes"]        
         self.assertEqual(21*2, attr_test["attr1"]["distribution"]["0"][0])
         self.assertEqual(15*2, attr_test["attr1"]["distribution"]["1"][0])
@@ -227,7 +178,6 @@ class SplitterTest(TestCase):
         self.assertEqual( 9, attr_test["attr3"]["distribution"]["1"][0])        
         self.assertEqual(15, attr_test["attr3"]["distribution"]["2"][0])
             
-
     def test_split_for_classification_gives_error_on_multi_label(self):
         iterable = [
             DatasetItem(
@@ -247,26 +197,66 @@ class SplitterTest(TestCase):
             )}            
         source_dataset = Dataset.from_iterable(iterable, categories)
         with self.assertRaises(Exception):
-            actual = splitter.SplitforClassification(source_dataset, splits=[
-                ('train', 0.7),
-                ('test', 0.3),
-            ])
+            actual = splitter.SplitforClassification(source_dataset, 
+                train=0.7, test=0.3)
 
     def test_split_for_classification_gives_error_on_wrong_ratios(self):
         source_dataset = Dataset.from_iterable([DatasetItem(id=1)])
-
         with self.assertRaises(Exception):
-            splitter.SplitforClassification(source_dataset, splits=[
-                ('train', 0.5),
-                ('test', 0.7),
-            ])
+            splitter.SplitforClassification(source_dataset, 
+                train=-0.5, test=1.5)
+    
+    def test_split_for_matching_reid(self):
+        counts = { i:(i%3+1)*7 for i in range(10) }
+        config = { "person": { "attrs": ['PID'], "counts": counts }}
+        source_dataset = self._generate_dataset(config)
+                
+        actual = splitter.SplitforMatchingReID(source_dataset, \
+            train=0.5, val=0.2, test=0.3, query=0.4, gallery=0.3)
+        
+        stats = dict()
+        for sname in ['train', 'val', 'test']:
+            subset = actual.get_subset(sname)
+            stat_subset = compute_ann_statistics(subset)["annotations"]
+            stat_attr = stat_subset["labels"]["attributes"]["PID"]
+            stats[sname] = stat_attr
+        
+        for sname in ['gallery', 'query']:
+            subset = actual.get_subset_by_group(sname)
+            stat_subset = compute_ann_statistics(subset)["annotations"]
+            stat_attr = stat_subset["labels"]["attributes"]["PID"]
+            stats[sname] = stat_attr
+        
+        self.assertEqual(65, stats['train']['count'])   # depends on heuristic
+        self.assertEqual(26, stats['val']['count'])     # depends on heuristic
+        self.assertEqual(42, stats['test']['count'])    # depends on heuristic
+        
+        train_ids = stats['train']['values present']
+        self.assertEqual(7, len(train_ids))
+        self.assertEqual(train_ids, stats['val']['values present'])
+        
+        trainval = stats['train']['count'] + stats['val']['count']
+        self.assertEqual(int(trainval * 0.5 / 0.7), stats['train']['count'])
+        self.assertEqual(int(trainval * 0.2 / 0.7), stats['val']['count'])
 
-        with self.assertRaises(Exception):
-            splitter.SplitforClassification(source_dataset, splits=[])
-
-        with self.assertRaises(Exception):
-            splitter.SplitforClassification(source_dataset, splits=[
-                ('train', -0.5),
-                ('test', 1.5),
-            ])
-
+        dist_train = stats['train']['distribution']
+        dist_val = stats['val']['distribution']
+        for pid in train_ids:
+            total = counts[int(pid)]
+            self.assertEqual(int(total * 0.5 / 0.7), dist_train[pid][0])
+            self.assertEqual(int(total * 0.2 / 0.7), dist_val[pid][0])
+            
+        test_ids = stats['test']['values present']
+        self.assertEqual(3, len(test_ids))
+        self.assertEqual(test_ids, stats['gallery']['values present'])
+        self.assertEqual(test_ids, stats['query']['values present'])
+        
+        dist_test = stats['test']['distribution']
+        dist_gallery = stats['gallery']['distribution']
+        dist_query = stats['query']['distribution']
+        for pid in test_ids:
+            total = counts[int(pid)]
+            self.assertEqual(total, dist_test[pid][0])
+            self.assertEqual(int(total * 0.3 / 0.7), dist_gallery[pid][0])
+            self.assertEqual(int(total * 0.4 / 0.7), dist_query[pid][0])
+ 

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -3,17 +3,23 @@ import numpy as np
 from unittest import TestCase
 
 from datumaro.components.project import Dataset
-from datumaro.components.extractor import (DatasetItem,
-    Label, LabelCategories, AnnotationType, Bbox)
+from datumaro.components.extractor import (
+    DatasetItem,
+    Label,
+    LabelCategories,
+    AnnotationType,
+    Bbox,
+)
 
 import datumaro.plugins.splitter as splitter
 from datumaro.components.operations import compute_ann_statistics
 
+
 class SplitterTest(TestCase):
     @staticmethod
     def _get_subset(idx):
-            subsets = ['', 'a', 'b', '', '', 'a', '', 'b', '', 'a' ]
-            return subsets[idx % len(subsets)]
+        subsets = ["", "a", "b", "", "", "a", "", "b", "", "a"]
+        return subsets[idx % len(subsets)]
 
     def _generate_dataset(self, config):
         # counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}
@@ -25,8 +31,8 @@ class SplitterTest(TestCase):
         label_cat = LabelCategories()
         idx = 0
         for label_id, label in enumerate(config.keys()):
-            anames = config[label]['attrs']
-            counts = config[label]['counts']
+            anames = config[label]["attrs"]
+            counts = config[label]["counts"]
             label_cat.add(label, attributes=anames)
             if isinstance(counts, dict):
                 for attrs, count in counts.items():
@@ -38,88 +44,103 @@ class SplitterTest(TestCase):
                         attributes[anames[0]] = attrs
                     for _ in range(count):
                         idx += 1
-                        iterable.append(DatasetItem(
-                            id=idx,
-                            annotations=[ Label(label_id, attributes=attributes) ],
-                            subset=self._get_subset(idx)
-                        ))
+                        iterable.append(
+                            DatasetItem(
+                                id=idx,
+                                annotations=[
+                                    Label(label_id, attributes=attributes)
+                                ],
+                                subset=self._get_subset(idx),
+                            )
+                        )
             else:
                 for _ in range(counts):
                     idx += 1
-                    iterable.append(DatasetItem(
-                        id=idx,
-                        annotations=[Label(label_id)],
-                        subset=self._get_subset(idx)
-                    ))
-        categories = { AnnotationType.label: label_cat }
+                    iterable.append(
+                        DatasetItem(
+                            id=idx,
+                            annotations=[Label(label_id)],
+                            subset=self._get_subset(idx),
+                        )
+                    )
+        categories = {AnnotationType.label: label_cat}
         dataset = Dataset.from_iterable(iterable, categories)
         return dataset
 
     def test_split_for_classification_multi_class_no_attr(self):
-        config = { "label1": { "attrs": None, "counts": 10 },
-                   "label2": { "attrs": None, "counts": 20 },
-                   "label3": { "attrs": None, "counts": 30 }}
+        config = {
+            "label1": {"attrs": None, "counts": 10},
+            "label2": {"attrs": None, "counts": 20},
+            "label3": {"attrs": None, "counts": 30},
+        }
         source = self._generate_dataset(config)
 
-        splits = [('train',.7),('test',.3)]
-        actual = splitter.ClassificationSplit(source,splits)
+        splits = [("train", 0.7), ("test", 0.3)]
+        actual = splitter.ClassificationSplit(source, splits)
 
-        self.assertEqual(42, len(actual.get_subset('train')))
-        self.assertEqual(18, len(actual.get_subset('test')))
+        self.assertEqual(42, len(actual.get_subset("train")))
+        self.assertEqual(18, len(actual.get_subset("test")))
 
         # check stats for train
-        stat_train = compute_ann_statistics(actual.get_subset('train'))
+        stat_train = compute_ann_statistics(actual.get_subset("train"))
         dist_train = stat_train["annotations"]["labels"]["distribution"]
         self.assertEqual(7, dist_train["label1"][0])
         self.assertEqual(14, dist_train["label2"][0])
         self.assertEqual(21, dist_train["label3"][0])
 
         # check stats for test
-        stat_test = compute_ann_statistics(actual.get_subset('test'))
+        stat_test = compute_ann_statistics(actual.get_subset("test"))
         dist_test = stat_test["annotations"]["labels"]["distribution"]
         self.assertEqual(3, dist_test["label1"][0])
         self.assertEqual(6, dist_test["label2"][0])
         self.assertEqual(9, dist_test["label3"][0])
 
     def test_split_for_classification_single_class_single_attr(self):
-        counts = {0:10, 1:20, 2:30}
-        config = { "label": { "attrs": ['attr'], "counts": counts }}
+        counts = {0: 10, 1: 20, 2: 30}
+        config = {"label": {"attrs": ["attr"], "counts": counts}}
         source = self._generate_dataset(config)
 
-        splits = [('train',.7),('test',.3)]
-        actual = splitter.ClassificationSplit(source,splits)
+        splits = [("train", 0.7), ("test", 0.3)]
+        actual = splitter.ClassificationSplit(source, splits)
 
-        self.assertEqual(42, len(actual.get_subset('train')))
-        self.assertEqual(18, len(actual.get_subset('test')))
+        self.assertEqual(42, len(actual.get_subset("train")))
+        self.assertEqual(18, len(actual.get_subset("test")))
 
         # check stats for train
-        stat_train = compute_ann_statistics(actual.get_subset('train'))
+        stat_train = compute_ann_statistics(actual.get_subset("train"))
         attr_train = stat_train["annotations"]["labels"]["attributes"]
-        self.assertEqual(7, attr_train['attr']["distribution"]["0"][0])
-        self.assertEqual(14, attr_train['attr']["distribution"]["1"][0])
-        self.assertEqual(21, attr_train['attr']["distribution"]["2"][0])
+        self.assertEqual(7, attr_train["attr"]["distribution"]["0"][0])
+        self.assertEqual(14, attr_train["attr"]["distribution"]["1"][0])
+        self.assertEqual(21, attr_train["attr"]["distribution"]["2"][0])
 
         # check stats for test
-        stat_test = compute_ann_statistics(actual.get_subset('test'))
+        stat_test = compute_ann_statistics(actual.get_subset("test"))
         attr_test = stat_test["annotations"]["labels"]["attributes"]
-        self.assertEqual(3, attr_test['attr']["distribution"]["0"][0])
-        self.assertEqual(6, attr_test['attr']["distribution"]["1"][0])
-        self.assertEqual(9, attr_test['attr']["distribution"]["2"][0])
+        self.assertEqual(3, attr_test["attr"]["distribution"]["0"][0])
+        self.assertEqual(6, attr_test["attr"]["distribution"]["1"][0])
+        self.assertEqual(9, attr_test["attr"]["distribution"]["2"][0])
 
     def test_split_for_classification_single_class_multi_attr(self):
-        counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}
-        attrs = ['attr1', 'attr2']
-        config = { "label": { "attrs": attrs, "counts": counts }}
+        counts = {
+            (0, 0): 20,
+            (0, 1): 20,
+            (0, 2): 30,
+            (1, 0): 20,
+            (1, 1): 10,
+            (1, 2): 20,
+        }
+        attrs = ["attr1", "attr2"]
+        config = {"label": {"attrs": attrs, "counts": counts}}
         source = self._generate_dataset(config)
 
-        splits = [('train',.7),('test',.3)]
-        actual = splitter.ClassificationSplit(source,splits)
+        splits = [("train", 0.7), ("test", 0.3)]
+        actual = splitter.ClassificationSplit(source, splits)
 
-        self.assertEqual(84, len(actual.get_subset('train')))
-        self.assertEqual(36, len(actual.get_subset('test')))
+        self.assertEqual(84, len(actual.get_subset("train")))
+        self.assertEqual(36, len(actual.get_subset("test")))
 
         # check stats for train
-        stat_train = compute_ann_statistics(actual.get_subset('train'))
+        stat_train = compute_ann_statistics(actual.get_subset("train"))
         attr_train = stat_train["annotations"]["labels"]["attributes"]
         self.assertEqual(49, attr_train["attr1"]["distribution"]["0"][0])
         self.assertEqual(35, attr_train["attr1"]["distribution"]["1"][0])
@@ -128,36 +149,45 @@ class SplitterTest(TestCase):
         self.assertEqual(35, attr_train["attr2"]["distribution"]["2"][0])
 
         # check stats for test
-        stat_test = compute_ann_statistics(actual.get_subset('test'))
+        stat_test = compute_ann_statistics(actual.get_subset("test"))
         attr_test = stat_test["annotations"]["labels"]["attributes"]
         self.assertEqual(21, attr_test["attr1"]["distribution"]["0"][0])
         self.assertEqual(15, attr_test["attr1"]["distribution"]["1"][0])
         self.assertEqual(12, attr_test["attr2"]["distribution"]["0"][0])
-        self.assertEqual( 9, attr_test["attr2"]["distribution"]["1"][0])
+        self.assertEqual(9, attr_test["attr2"]["distribution"]["1"][0])
         self.assertEqual(15, attr_test["attr2"]["distribution"]["2"][0])
 
     def test_split_for_classification_multi_label_with_attr(self):
-        counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}
-        attr1 = ['attr1', 'attr2']
-        attr2 = ['attr1', 'attr3']
-        config = { "label1": { "attrs": attr1, "counts": counts },
-                   "label2": { "attrs": attr2, "counts": counts }}
+        counts = {
+            (0, 0): 20,
+            (0, 1): 20,
+            (0, 2): 30,
+            (1, 0): 20,
+            (1, 1): 10,
+            (1, 2): 20,
+        }
+        attr1 = ["attr1", "attr2"]
+        attr2 = ["attr1", "attr3"]
+        config = {
+            "label1": {"attrs": attr1, "counts": counts},
+            "label2": {"attrs": attr2, "counts": counts},
+        }
         source = self._generate_dataset(config)
 
-        splits = [('train',.7),('test',.3)]
-        actual = splitter.ClassificationSplit(source,splits)
+        splits = [("train", 0.7), ("test", 0.3)]
+        actual = splitter.ClassificationSplit(source, splits)
 
-        self.assertEqual(168, len(actual.get_subset('train')))
-        self.assertEqual(72, len(actual.get_subset('test')))
+        self.assertEqual(168, len(actual.get_subset("train")))
+        self.assertEqual(72, len(actual.get_subset("test")))
 
         # check stats for train
-        stat_train = compute_ann_statistics(actual.get_subset('train'))
+        stat_train = compute_ann_statistics(actual.get_subset("train"))
         dist_train = stat_train["annotations"]["labels"]["distribution"]
         self.assertEqual(84, dist_train["label1"][0])
         self.assertEqual(84, dist_train["label2"][0])
         attr_train = stat_train["annotations"]["labels"]["attributes"]
-        self.assertEqual(49*2, attr_train["attr1"]["distribution"]["0"][0])
-        self.assertEqual(35*2, attr_train["attr1"]["distribution"]["1"][0])
+        self.assertEqual(49 * 2, attr_train["attr1"]["distribution"]["0"][0])
+        self.assertEqual(35 * 2, attr_train["attr1"]["distribution"]["1"][0])
         self.assertEqual(28, attr_train["attr2"]["distribution"]["0"][0])
         self.assertEqual(21, attr_train["attr2"]["distribution"]["1"][0])
         self.assertEqual(35, attr_train["attr2"]["distribution"]["2"][0])
@@ -166,106 +196,117 @@ class SplitterTest(TestCase):
         self.assertEqual(35, attr_train["attr3"]["distribution"]["2"][0])
 
         # check stats for test
-        stat_test = compute_ann_statistics(actual.get_subset('test'))
+        stat_test = compute_ann_statistics(actual.get_subset("test"))
         dist_test = stat_test["annotations"]["labels"]["distribution"]
         self.assertEqual(36, dist_test["label1"][0])
         self.assertEqual(36, dist_test["label2"][0])
         attr_test = stat_test["annotations"]["labels"]["attributes"]
-        self.assertEqual(21*2, attr_test["attr1"]["distribution"]["0"][0])
-        self.assertEqual(15*2, attr_test["attr1"]["distribution"]["1"][0])
+        self.assertEqual(21 * 2, attr_test["attr1"]["distribution"]["0"][0])
+        self.assertEqual(15 * 2, attr_test["attr1"]["distribution"]["1"][0])
         self.assertEqual(12, attr_test["attr2"]["distribution"]["0"][0])
-        self.assertEqual( 9, attr_test["attr2"]["distribution"]["1"][0])
+        self.assertEqual(9, attr_test["attr2"]["distribution"]["1"][0])
         self.assertEqual(15, attr_test["attr2"]["distribution"]["2"][0])
         self.assertEqual(12, attr_test["attr3"]["distribution"]["0"][0])
-        self.assertEqual( 9, attr_test["attr3"]["distribution"]["1"][0])
+        self.assertEqual(9, attr_test["attr3"]["distribution"]["1"][0])
         self.assertEqual(15, attr_test["attr3"]["distribution"]["2"][0])
 
     def test_split_for_classification_gives_error(self):
         with self.subTest("no label"):
-            source = Dataset.from_iterable([
-                DatasetItem(1, annotations=[]),
-                DatasetItem(2, annotations=[])
-            ], categories=['a', 'b', 'c'])
+            source = Dataset.from_iterable(
+                [
+                    DatasetItem(1, annotations=[]),
+                    DatasetItem(2, annotations=[]),
+                ],
+                categories=["a", "b", "c"],
+            )
             with self.assertRaisesRegex(Exception, "exact one label"):
-                splits = [('train',.7),('test',.3)]
-                splitter.ClassificationSplit(source, splits)
+                splits = [("train", 0.7), ("test", 0.3)]
+                actual = splitter.ClassificationSplit(source, splits)
+                len(actual.get_subset("train"))
 
         with self.subTest("multi label"):
-            source = Dataset.from_iterable([
-                DatasetItem(1, annotations=[Label(0), Label(1)]),
-                DatasetItem(2, annotations=[Label(0), Label(2)])
-            ], categories=['a', 'b', 'c'])
+            source = Dataset.from_iterable(
+                [
+                    DatasetItem(1, annotations=[Label(0), Label(1)]),
+                    DatasetItem(2, annotations=[Label(0), Label(2)]),
+                ],
+                categories=["a", "b", "c"],
+            )
             with self.assertRaisesRegex(Exception, "exact one label"):
-                splits = [('train',.7),('test',.3)]
+                splits = [("train", 0.7), ("test", 0.3)]
                 splitter.ClassificationSplit(source, splits)
+                len(actual.get_subset("train"))
 
-        source = Dataset.from_iterable([
-            DatasetItem(1, annotations=[Label(0)]),
-            DatasetItem(2, annotations=[Label(1)])
-        ], categories=['a', 'b', 'c'])
+        source = Dataset.from_iterable(
+            [
+                DatasetItem(1, annotations=[Label(0)]),
+                DatasetItem(2, annotations=[Label(1)]),
+            ],
+            categories=["a", "b", "c"],
+        )
 
         with self.subTest("wrong ratio"):
             with self.assertRaisesRegex(Exception, "in the range"):
-                splits = [('train',-0.5),('test',1.5)]
+                splits = [("train", -0.5), ("test", 1.5)]
                 splitter.ClassificationSplit(source, splits)
             with self.assertRaisesRegex(Exception, "Sum of ratios"):
-                splits = [('train',0.5), ('test',0.5), ('val', 0.5)]
+                splits = [("train", 0.5), ("test", 0.5), ("val", 0.5)]
                 splitter.ClassificationSplit(source, splits)
 
         with self.subTest("wrong subset name"):
             with self.assertRaisesRegex(Exception, "Subset name"):
-                splits = [('train_',0.5),('val',0.2), ('test', 0.3)]
+                splits = [("train_", 0.5), ("val", 0.2), ("test", 0.3)]
                 splitter.ClassificationSplit(source, splits)
 
     def test_split_for_matching_reid(self):
-        counts = { i:(i%3+1)*7 for i in range(10) }
-        config = { "person": { "attrs": ['PID'], "counts": counts }}
+        counts = {i: (i % 3 + 1) * 7 for i in range(10)}
+        config = {"person": {"attrs": ["PID"], "counts": counts}}
         source = self._generate_dataset(config)
 
-        id_splits = [('train',0.5), ('val',0.2), ('test',0.3)]
-        test_splits = [('query',0.4/0.7),('gallery',0.3/0.7)]
+        id_splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
+        test_splits = [("query", 0.4 / 0.7), ("gallery", 0.3 / 0.7)]
         actual = splitter.MatchingReIDSplit(source, id_splits, test_splits)
 
         stats = dict()
-        for sname in ['train', 'val', 'test']:
+        for sname in ["train", "val", "test"]:
             subset = actual.get_subset(sname)
             stat_subset = compute_ann_statistics(subset)["annotations"]
             stat_attr = stat_subset["labels"]["attributes"]["PID"]
             stats[sname] = stat_attr
 
-        for sname in ['gallery', 'query']:
+        for sname in ["gallery", "query"]:
             subset = actual.get_subset_by_group(sname)
             stat_subset = compute_ann_statistics(subset)["annotations"]
             stat_attr = stat_subset["labels"]["attributes"]["PID"]
             stats[sname] = stat_attr
 
-        self.assertEqual(65, stats['train']['count'])   # depends on heuristic
-        self.assertEqual(26, stats['val']['count'])     # depends on heuristic
-        self.assertEqual(42, stats['test']['count'])    # depends on heuristic
+        self.assertEqual(65, stats["train"]["count"])  # depends on heuristic
+        self.assertEqual(26, stats["val"]["count"])  # depends on heuristic
+        self.assertEqual(42, stats["test"]["count"])  # depends on heuristic
 
-        train_ids = stats['train']['values present']
+        train_ids = stats["train"]["values present"]
         self.assertEqual(7, len(train_ids))
-        self.assertEqual(train_ids, stats['val']['values present'])
+        self.assertEqual(train_ids, stats["val"]["values present"])
 
-        trainval = stats['train']['count'] + stats['val']['count']
-        self.assertEqual(int(trainval * 0.5 / 0.7), stats['train']['count'])
-        self.assertEqual(int(trainval * 0.2 / 0.7), stats['val']['count'])
+        trainval = stats["train"]["count"] + stats["val"]["count"]
+        self.assertEqual(int(trainval * 0.5 / 0.7), stats["train"]["count"])
+        self.assertEqual(int(trainval * 0.2 / 0.7), stats["val"]["count"])
 
-        dist_train = stats['train']['distribution']
-        dist_val = stats['val']['distribution']
+        dist_train = stats["train"]["distribution"]
+        dist_val = stats["val"]["distribution"]
         for pid in train_ids:
             total = counts[int(pid)]
             self.assertEqual(int(total * 0.5 / 0.7), dist_train[pid][0])
             self.assertEqual(int(total * 0.2 / 0.7), dist_val[pid][0])
 
-        test_ids = stats['test']['values present']
+        test_ids = stats["test"]["values present"]
         self.assertEqual(3, len(test_ids))
-        self.assertEqual(test_ids, stats['gallery']['values present'])
-        self.assertEqual(test_ids, stats['query']['values present'])
+        self.assertEqual(test_ids, stats["gallery"]["values present"])
+        self.assertEqual(test_ids, stats["query"]["values present"])
 
-        dist_test = stats['test']['distribution']
-        dist_gallery = stats['gallery']['distribution']
-        dist_query = stats['query']['distribution']
+        dist_test = stats["test"]["distribution"]
+        dist_gallery = stats["gallery"]["distribution"]
+        dist_query = stats["query"]["distribution"]
         for pid in test_ids:
             total = counts[int(pid)]
             self.assertEqual(total, dist_test[pid][0])
@@ -274,59 +315,80 @@ class SplitterTest(TestCase):
 
     def test_split_for_matching_reid_gives_error(self):
         with self.subTest("no label"):
-            source = Dataset.from_iterable([
-                DatasetItem(1, annotations=[]),
-                DatasetItem(2, annotations=[])
-            ], categories=['a', 'b', 'c'])
+            source = Dataset.from_iterable(
+                [
+                    DatasetItem(1, annotations=[]),
+                    DatasetItem(2, annotations=[]),
+                ],
+                categories=["a", "b", "c"],
+            )
             with self.assertRaisesRegex(Exception, "exact one label"):
-                id_splits = [('train',0.5), ('val',0.2), ('test',0.3)]
-                test_splits = [('query',0.4/0.7),('gallery',0.3/0.7)]
-                splitter.MatchingReIDSplit(source, id_splits, test_splits)
+                id_splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
+                test_splits = [("query", 0.4 / 0.7), ("gallery", 0.3 / 0.7)]
+                actual = splitter.MatchingReIDSplit(
+                    source, id_splits, test_splits
+                )
+                len(actual.get_subset("train"))
 
         with self.subTest(msg="multi label"):
-            source = Dataset.from_iterable([
-                DatasetItem(1, annotations=[Label(0), Label(1)]),
-                DatasetItem(2, annotations=[Label(0), Label(2)])
-            ], categories=['a', 'b', 'c'])
+            source = Dataset.from_iterable(
+                [
+                    DatasetItem(1, annotations=[Label(0), Label(1)]),
+                    DatasetItem(2, annotations=[Label(0), Label(2)]),
+                ],
+                categories=["a", "b", "c"],
+            )
             with self.assertRaisesRegex(Exception, "exact one label"):
-                id_splits = [('train',0.5), ('val',0.2), ('test',0.3)]
-                test_splits = [('query',0.4/0.7),('gallery',0.3/0.7)]
-                splitter.MatchingReIDSplit(source, id_splits, test_splits)
+                id_splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
+                test_splits = [("query", 0.4 / 0.7), ("gallery", 0.3 / 0.7)]
+                actual = splitter.MatchingReIDSplit(
+                    source, id_splits, test_splits
+                )
+                len(actual.get_subset("train"))
 
-        counts = { i:(i%3+1)*7 for i in range(10) }
-        config = { "person": { "attrs": ['PID'], "counts": counts }}
+        counts = {i: (i % 3 + 1) * 7 for i in range(10)}
+        config = {"person": {"attrs": ["PID"], "counts": counts}}
         source = self._generate_dataset(config)
         with self.subTest("wrong ratio"):
             with self.assertRaisesRegex(Exception, "in the range"):
-                id_splits = [('train',-0.5), ('val',0.2), ('test',0.3)]
-                test_splits = [('query',0.4/0.7),('gallery',0.3/0.7)]
+                id_splits = [("train", -0.5), ("val", 0.2), ("test", 0.3)]
+                test_splits = [("query", 0.4 / 0.7), ("gallery", 0.3 / 0.7)]
+                splitter.MatchingReIDSplit(source, id_splits, test_splits)
+            with self.assertRaisesRegex(Exception, "Sum of ratios"):
+                id_splits = [("train", 0.6), ("val", 0.2), ("test", 0.3)]
+                test_splits = [("query", 0.4 / 0.7), ("gallery", 0.3 / 0.7)]
                 splitter.MatchingReIDSplit(source, id_splits, test_splits)
             with self.assertRaisesRegex(Exception, "in the range"):
-                id_splits = [('train',0.5), ('val',0.2), ('test',0.3)]
-                test_splits = [('query',-0.4/0.7),('gallery',0.3/0.7)]
-                splitter.MatchingReIDSplit(source, id_splits, test_splits)
+                id_splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
+                test_splits = [("query", -0.4 / 0.7), ("gallery", 0.3 / 0.7)]
+                actual = splitter.MatchingReIDSplit(
+                    source, id_splits, test_splits
+                )
+                len(actual.get_subset_by_group("query"))
             with self.assertRaisesRegex(Exception, "Sum of ratios"):
-                id_splits = [('train',0.6), ('val',0.2), ('test',0.3)]
-                test_splits = [('query',0.4/0.7),('gallery',0.3/0.7)]
-                splitter.MatchingReIDSplit(source, id_splits, test_splits)
-            with self.assertRaisesRegex(Exception, "Sum of ratios"):
-                id_splits = [('train',0.5), ('val',0.2), ('test',0.3)]
-                test_splits = [('query',0.5/0.7),('gallery',0.3/0.7)]
-                splitter.MatchingReIDSplit(source, id_splits, test_splits)
+                id_splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
+                test_splits = [("query", 0.5 / 0.7), ("gallery", 0.3 / 0.7)]
+                actual = splitter.MatchingReIDSplit(
+                    source, id_splits, test_splits
+                )
+                len(actual.get_subset_by_group("query"))
 
         with self.subTest("wrong subset name"):
             with self.assertRaisesRegex(Exception, "Subset name"):
-                id_splits = [('_train',0.5), ('val',0.2), ('test',0.3)]
-                test_splits = [('query',0.4/0.7),('gallery',0.3/0.7)]
+                id_splits = [("_train", 0.5), ("val", 0.2), ("test", 0.3)]
+                test_splits = [("query", 0.4 / 0.7), ("gallery", 0.3 / 0.7)]
                 splitter.MatchingReIDSplit(source, id_splits, test_splits)
             with self.assertRaisesRegex(Exception, "Subset name"):
-                id_splits = [('train',0.5), ('val',0.2), ('test',0.3)]
-                test_splits = [('_query',0.4/0.7),('gallery',0.3/0.7)]
-                splitter.MatchingReIDSplit(source, id_splits, test_splits)
+                id_splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
+                test_splits = [("_query", 0.4 / 0.7), ("gallery", 0.3 / 0.7)]
+                actual = splitter.MatchingReIDSplit(
+                    source, id_splits, test_splits
+                )
+                len(actual.get_subset_by_group("query"))
 
         with self.subTest("wrong attribute name for person id"):
-            id_splits = [('train',0.5), ('val',0.2), ('test',0.3)]
-            test_splits = [('query',0.4/0.7),('gallery',0.3/0.7)]
+            id_splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
+            test_splits = [("query", 0.4 / 0.7), ("gallery", 0.3 / 0.7)]
             actual = splitter.MatchingReIDSplit(source, id_splits, test_splits)
             with self.assertRaisesRegex(Exception, "Unknown group"):
                 actual.get_subset_by_group("_gallery")
@@ -338,18 +400,18 @@ class SplitterTest(TestCase):
 
         label_cat = LabelCategories()
         for i in range(6):
-            label = "label%d" % (i+1)
+            label = "label%d" % (i + 1)
             if with_attr is True:
-                attributes = {"attr0", "attr%d" % (i+1)}
+                attributes = {"attr0", "attr%d" % (i + 1)}
             else:
                 attributes = {}
-            label_cat.add(label, attributes = attributes)
-        categories = { AnnotationType.label: label_cat }
+            label_cat.add(label, attributes=attributes)
+        categories = {AnnotationType.label: label_cat}
 
         iterable = []
         attr_val = 0
         totals = np.zeros(3)
-        objects = [(1,5,2), (3,4,1), (2,3,4), (1,1,1), (2,4,2)]
+        objects = [(1, 5, 2), (3, 4, 1), (2, 3, 4), (1, 1, 1), (2, 4, 2)]
         for img_id in range(nimages):
             cnts = objects[img_id % len(objects)]
             totals += cnts
@@ -359,15 +421,19 @@ class SplitterTest(TestCase):
                 if with_attr:
                     attr_val += 1
                     attributes["attr0"] = attr_val % 3
-                    attributes["attr%d" % (label_id+1)] = attr_val % 2
+                    attributes["attr%d" % (label_id + 1)] = attr_val % 2
                 for ann_id in range(count):
-                    append_bbox(annotations, label_id=label_id, \
-                        ann_id=ann_id, attributes=attributes)
+                    append_bbox(
+                        annotations,
+                        label_id=label_id,
+                        ann_id=ann_id,
+                        attributes=attributes,
+                    )
             item = DatasetItem(
                 id=str(img_id),
                 annotations=annotations,
                 subset=self._get_subset(img_id),
-                attributes={"id":img_id}
+                attributes={"id": img_id},
             )
             iterable.append(item)
 
@@ -377,58 +443,121 @@ class SplitterTest(TestCase):
     @staticmethod
     def _get_append_bbox(dataset_type):
         def append_bbox_coco(annotations, **kwargs):
-            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id'],
-                                id=kwargs['ann_id'],
-                                attributes=kwargs['attributes'],
-                                group=kwargs['ann_id']))
-            annotations.append(Label(kwargs['label_id'],
-                                attributes=kwargs['attributes']))
+            annotations.append(
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"],
+                    id=kwargs["ann_id"],
+                    attributes=kwargs["attributes"],
+                    group=kwargs["ann_id"],
+                )
+            )
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
         def append_bbox_voc(annotations, **kwargs):
-            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id'],
-                                id=kwargs['ann_id']+1,
-                                attributes=kwargs['attributes'],
-                                group=kwargs['ann_id'])) # obj
-            annotations.append(Label(kwargs['label_id'],
-                                attributes=kwargs['attributes']))
-            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id']+3,
-                                group=kwargs['ann_id'])) # part
-            annotations.append(Label(kwargs['label_id']+3,
-                                attributes=kwargs['attributes']))
+            annotations.append(
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"],
+                    id=kwargs["ann_id"] + 1,
+                    attributes=kwargs["attributes"],
+                    group=kwargs["ann_id"],
+                )
+            )  # obj
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+            annotations.append(
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"] + 3,
+                    group=kwargs["ann_id"],
+                )
+            )  # part
+            annotations.append(
+                Label(kwargs["label_id"] + 3, attributes=kwargs["attributes"])
+            )
+
         def append_bbox_yolo(annotations, **kwargs):
-            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id']))
-            annotations.append(Label(kwargs['label_id'],
-                                attributes=kwargs['attributes']))
+            annotations.append(Bbox(1, 1, 2, 2, label=kwargs["label_id"]))
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
         def append_bbox_cvat(annotations, **kwargs):
-            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id'],
-                                id=kwargs['ann_id'],
-                                attributes=kwargs['attributes'],
-                                group=kwargs['ann_id'],
-                                z_order=kwargs['ann_id']))
-            annotations.append(Label(kwargs['label_id'],
-                                attributes=kwargs['attributes']))
+            annotations.append(
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"],
+                    id=kwargs["ann_id"],
+                    attributes=kwargs["attributes"],
+                    group=kwargs["ann_id"],
+                    z_order=kwargs["ann_id"],
+                )
+            )
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
         def append_bbox_labelme(annotations, **kwargs):
-            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id'],
-                                attributes=kwargs['attributes'],
-                                id=kwargs['ann_id']))
-            annotations.append(Label(kwargs['label_id'],
-                                attributes=kwargs['attributes']))
+            annotations.append(
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"],
+                    attributes=kwargs["attributes"],
+                    id=kwargs["ann_id"],
+                )
+            )
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
         def append_bbox_mot(annotations, **kwargs):
-            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id'],
-                                attributes=kwargs['attributes']))
-            annotations.append(Label(kwargs['label_id'],
-                                attributes=kwargs['attributes']))
+            annotations.append(
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"],
+                    attributes=kwargs["attributes"],
+                )
+            )
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
         def append_bbox_widerface(annotations, **kwargs):
-            annotations.append(Bbox(1,1,2,2, attributes=kwargs['attributes']))
-            annotations.append(Label(0, attributes=kwargs['attributes']))
+            annotations.append(
+                Bbox(1, 1, 2, 2, attributes=kwargs["attributes"])
+            )
+            annotations.append(Label(0, attributes=kwargs["attributes"]))
 
         functions = {
             "coco": append_bbox_coco,
-            "voc" : append_bbox_voc,
-            "yolo" : append_bbox_yolo,
-            "cvat" : append_bbox_cvat,
-            "labelme" : append_bbox_labelme,
+            "voc": append_bbox_voc,
+            "yolo": append_bbox_yolo,
+            "cvat": append_bbox_cvat,
+            "labelme": append_bbox_labelme,
             "mot": append_bbox_mot,
-            "widerface": append_bbox_widerface
+            "widerface": append_bbox_widerface,
         }
 
         func = functions.get(dataset_type, append_bbox_cvat)
@@ -444,43 +573,59 @@ class SplitterTest(TestCase):
 
         for dtype, with_attr, nimages, train, val, test in params:
             source, _ = self._generate_detection_dataset(
-                        append_bbox = self._get_append_bbox(dtype),
-                        with_attr=with_attr, nimages=nimages)
+                append_bbox=self._get_append_bbox(dtype),
+                with_attr=with_attr,
+                nimages=nimages,
+            )
             total = np.sum([train, val, test])
-            splits = [('train', train/total),
-                        ('val',   val/total),
-                        ('test',  test/total)]
-            with self.subTest(dtype=dtype, with_attr=with_attr, nimage=nimages,
-                              train=train, val=val, test=test):
+            splits = [
+                ("train", train / total),
+                ("val", val / total),
+                ("test", test / total),
+            ]
+            with self.subTest(
+                dtype=dtype,
+                with_attr=with_attr,
+                nimage=nimages,
+                train=train,
+                val=val,
+                test=test,
+            ):
                 actual = splitter.DetectionSplit(source, splits)
 
-                self.assertEqual(train, len(actual.get_subset('train')))
-                self.assertEqual(val, len(actual.get_subset('val')))
-                self.assertEqual(test, len(actual.get_subset('test')))
+                self.assertEqual(train, len(actual.get_subset("train")))
+                self.assertEqual(val, len(actual.get_subset("val")))
+                self.assertEqual(test, len(actual.get_subset("test")))
 
     def test_split_for_detection_gives_error(self):
         with self.subTest(msg="bbox annotation"):
-            source = Dataset.from_iterable([
-                DatasetItem(1, annotations=[Label(0), Label(1)]),
-                DatasetItem(2, annotations=[Label(0), Label(2)])
-            ], categories=['a', 'b', 'c'])
+            source = Dataset.from_iterable(
+                [
+                    DatasetItem(1, annotations=[Label(0), Label(1)]),
+                    DatasetItem(2, annotations=[Label(0), Label(2)]),
+                ],
+                categories=["a", "b", "c"],
+            )
             with self.assertRaisesRegex(Exception, "more than one bbox"):
-                splits = [('train',0.5), ('val',0.2), ('test',0.3)]
-                splitter.DetectionSplit(source, splits)
+                splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
+                actual = splitter.DetectionSplit(source, splits)
+                len(actual.get_subset("train"))
 
         source, _ = self._generate_detection_dataset(
-                append_bbox = self._get_append_bbox("cvat"),
-                with_attr=True, nimages=5)
+            append_bbox=self._get_append_bbox("cvat"),
+            with_attr=True,
+            nimages=5,
+        )
 
         with self.subTest("wrong ratio"):
             with self.assertRaisesRegex(Exception, "in the range"):
-                splits = [('train',-0.5),('test',1.5)]
+                splits = [("train", -0.5), ("test", 1.5)]
                 splitter.DetectionSplit(source, splits)
             with self.assertRaisesRegex(Exception, "Sum of ratios"):
-                splits = [('train',0.5), ('test',0.5), ('val', 0.5)]
+                splits = [("train", 0.5), ("test", 0.5), ("val", 0.5)]
                 splitter.DetectionSplit(source, splits)
 
         with self.subTest("wrong subset name"):
             with self.assertRaisesRegex(Exception, "Subset name"):
-                splits = [('train_',0.5),('val',0.2), ('test', 0.3)]
+                splits = [("train_", 0.5), ("val", 0.2), ("test", 0.3)]
                 splitter.DetectionSplit(source, splits)

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -3,9 +3,10 @@ import numpy as np
 import random
 
 from unittest import TestCase
+
 from datumaro.components.project import Dataset
-from datumaro.components.extractor import (DatasetItem, 
-    Label, LabelCategories, AnnotationType)
+from datumaro.components.extractor import (DatasetItem,
+    Label, LabelCategories, AnnotationType, Bbox)
 
 import datumaro.plugins.splitter as splitter
 from datumaro.components.operations import compute_ann_statistics
@@ -15,17 +16,17 @@ class SplitterTest(TestCase):
         # counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}
         # attr1 = ['attr1', 'attr2']
         # attr2 = ['attr1', 'attr3']
-        # config = { "label1": { "attrs": attr1, "counts": counts }, 
-        #            "label2": { "attrs": attr2, "counts": counts }}        
-        def _get_subset():                
+        # config = { "label1": { "attrs": attr1, "counts": counts },
+        #            "label2": { "attrs": attr2, "counts": counts }}
+        def _get_subset():
             return np.random.choice(['', 'a', 'b'], p = [0.5, 0.3, 0.2])
 
-        iterable = []  
+        iterable = []
         label_cat = LabelCategories()
-        idx = 0 
-        for label_id, label in enumerate(config.keys()): 
+        idx = 0
+        for label_id, label in enumerate(config.keys()):
             anames = config[label]['attrs']
-            counts = config[label]['counts']            
+            counts = config[label]['counts']
             label_cat.add(label, attributes=anames)
             if isinstance(counts, dict):
                 for attrs, count in counts.items():
@@ -55,35 +56,35 @@ class SplitterTest(TestCase):
         return dataset
 
     def test_split_for_classification_multi_class_no_attr(self):
-        config = { "label1": { "attrs": None, "counts": 10 }, 
+        config = { "label1": { "attrs": None, "counts": 10 },
                    "label2": { "attrs": None, "counts": 20 },
                    "label3": { "attrs": None, "counts": 30 }}
         source_dataset = self._generate_dataset(config)
-        
-        actual = splitter.SplitforClassification(source_dataset, 
-            train=0.7, test=0.3)            
+
+        actual = splitter.SplitforClassification(source_dataset,
+            train=0.7, test=0.3)
         self.assertEqual(42, len(actual.get_subset('train')))
         self.assertEqual(18, len(actual.get_subset('test')))
 
         # check stats for train
-        stat_train = compute_ann_statistics(actual.get_subset('train'))        
+        stat_train = compute_ann_statistics(actual.get_subset('train'))
         dist_train = stat_train["annotations"]["labels"]["distribution"]
         self.assertEqual(7, dist_train["label1"][0])
         self.assertEqual(14, dist_train["label2"][0])
         self.assertEqual(21, dist_train["label3"][0])
-        
+
         # check stats for test
-        stat_test = compute_ann_statistics(actual.get_subset('test'))        
+        stat_test = compute_ann_statistics(actual.get_subset('test'))
         dist_test = stat_test["annotations"]["labels"]["distribution"]
         self.assertEqual(3, dist_test["label1"][0])
         self.assertEqual(6, dist_test["label2"][0])
         self.assertEqual(9, dist_test["label3"][0])
 
-    def test_split_for_classification_single_class_single_attr(self):      
-        counts = {0:10, 1:20, 2:30}        
+    def test_split_for_classification_single_class_single_attr(self):
+        counts = {0:10, 1:20, 2:30}
         config = { "label": { "attrs": ['attr'], "counts": counts }}
-        source_dataset = self._generate_dataset(config) 
-       
+        source_dataset = self._generate_dataset(config)
+
         actual = splitter.SplitforClassification(source_dataset, \
             train=0.7, test=0.3)
 
@@ -91,56 +92,56 @@ class SplitterTest(TestCase):
         self.assertEqual(18, len(actual.get_subset('test')))
 
         # check stats for train
-        stat_train = compute_ann_statistics(actual.get_subset('train'))                        
+        stat_train = compute_ann_statistics(actual.get_subset('train'))
         attr_train = stat_train["annotations"]["labels"]["attributes"]
         self.assertEqual(7, attr_train['attr']["distribution"]["0"][0])
         self.assertEqual(14, attr_train['attr']["distribution"]["1"][0])
         self.assertEqual(21, attr_train['attr']["distribution"]["2"][0])
-        
+
         # check stats for test
-        stat_test = compute_ann_statistics(actual.get_subset('test'))        
+        stat_test = compute_ann_statistics(actual.get_subset('test'))
         attr_test = stat_test["annotations"]["labels"]["attributes"]
         self.assertEqual(3, attr_test['attr']["distribution"]["0"][0])
         self.assertEqual(6, attr_test['attr']["distribution"]["1"][0])
-        self.assertEqual(9, attr_test['attr']["distribution"]["2"][0])     
-    
+        self.assertEqual(9, attr_test['attr']["distribution"]["2"][0])
+
     def test_split_for_classification_single_class_multi_attr(self):
         counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}
         attrs = ['attr1', 'attr2']
         config = { "label": { "attrs": attrs, "counts": counts }}
-        source_dataset = self._generate_dataset(config) 
-        
+        source_dataset = self._generate_dataset(config)
+
         actual = splitter.SplitforClassification(source_dataset,
             train=0.7, test=0.3)
 
         self.assertEqual(84, len(actual.get_subset('train')))
         self.assertEqual(36, len(actual.get_subset('test')))
-        
+
         # check stats for train
-        stat_train = compute_ann_statistics(actual.get_subset('train'))       
-        attr_train = stat_train["annotations"]["labels"]["attributes"]         
+        stat_train = compute_ann_statistics(actual.get_subset('train'))
+        attr_train = stat_train["annotations"]["labels"]["attributes"]
         self.assertEqual(49, attr_train["attr1"]["distribution"]["0"][0])
         self.assertEqual(35, attr_train["attr1"]["distribution"]["1"][0])
-        self.assertEqual(28, attr_train["attr2"]["distribution"]["0"][0])        
-        self.assertEqual(21, attr_train["attr2"]["distribution"]["1"][0])        
+        self.assertEqual(28, attr_train["attr2"]["distribution"]["0"][0])
+        self.assertEqual(21, attr_train["attr2"]["distribution"]["1"][0])
         self.assertEqual(35, attr_train["attr2"]["distribution"]["2"][0])
-                
+
         # check stats for test
-        stat_test = compute_ann_statistics(actual.get_subset('test'))        
+        stat_test = compute_ann_statistics(actual.get_subset('test'))
         attr_test = stat_test["annotations"]["labels"]["attributes"]
         self.assertEqual(21, attr_test["attr1"]["distribution"]["0"][0])
         self.assertEqual(15, attr_test["attr1"]["distribution"]["1"][0])
-        self.assertEqual(12, attr_test["attr2"]["distribution"]["0"][0])        
-        self.assertEqual( 9, attr_test["attr2"]["distribution"]["1"][0])        
+        self.assertEqual(12, attr_test["attr2"]["distribution"]["0"][0])
+        self.assertEqual( 9, attr_test["attr2"]["distribution"]["1"][0])
         self.assertEqual(15, attr_test["attr2"]["distribution"]["2"][0])
-            
-    def test_split_for_classification_multi_label_with_attr(self): 
+
+    def test_split_for_classification_multi_label_with_attr(self):
         counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}
         attr1 = ['attr1', 'attr2']
         attr2 = ['attr1', 'attr3']
-        config = { "label1": { "attrs": attr1, "counts": counts }, 
+        config = { "label1": { "attrs": attr1, "counts": counts },
                    "label2": { "attrs": attr2, "counts": counts }}
-        source_dataset = self._generate_dataset(config) 
+        source_dataset = self._generate_dataset(config)
 
         actual = splitter.SplitforClassification(source_dataset,
             train=0.7, test=0.3)
@@ -149,35 +150,35 @@ class SplitterTest(TestCase):
         self.assertEqual(72, len(actual.get_subset('test')))
 
         # check stats for train
-        stat_train = compute_ann_statistics(actual.get_subset('train'))        
+        stat_train = compute_ann_statistics(actual.get_subset('train'))
         dist_train = stat_train["annotations"]["labels"]["distribution"]
         self.assertEqual(84, dist_train["label1"][0])
-        self.assertEqual(84, dist_train["label2"][0])    
-        attr_train = stat_train["annotations"]["labels"]["attributes"]         
+        self.assertEqual(84, dist_train["label2"][0])
+        attr_train = stat_train["annotations"]["labels"]["attributes"]
         self.assertEqual(49*2, attr_train["attr1"]["distribution"]["0"][0])
         self.assertEqual(35*2, attr_train["attr1"]["distribution"]["1"][0])
-        self.assertEqual(28, attr_train["attr2"]["distribution"]["0"][0])        
-        self.assertEqual(21, attr_train["attr2"]["distribution"]["1"][0])        
+        self.assertEqual(28, attr_train["attr2"]["distribution"]["0"][0])
+        self.assertEqual(21, attr_train["attr2"]["distribution"]["1"][0])
         self.assertEqual(35, attr_train["attr2"]["distribution"]["2"][0])
-        self.assertEqual(28, attr_train["attr3"]["distribution"]["0"][0])        
-        self.assertEqual(21, attr_train["attr3"]["distribution"]["1"][0])        
+        self.assertEqual(28, attr_train["attr3"]["distribution"]["0"][0])
+        self.assertEqual(21, attr_train["attr3"]["distribution"]["1"][0])
         self.assertEqual(35, attr_train["attr3"]["distribution"]["2"][0])
-        
+
         # check stats for test
-        stat_test = compute_ann_statistics(actual.get_subset('test'))        
+        stat_test = compute_ann_statistics(actual.get_subset('test'))
         dist_test = stat_test["annotations"]["labels"]["distribution"]
         self.assertEqual(36, dist_test["label1"][0])
-        self.assertEqual(36, dist_test["label2"][0])    
-        attr_test = stat_test["annotations"]["labels"]["attributes"]        
+        self.assertEqual(36, dist_test["label2"][0])
+        attr_test = stat_test["annotations"]["labels"]["attributes"]
         self.assertEqual(21*2, attr_test["attr1"]["distribution"]["0"][0])
         self.assertEqual(15*2, attr_test["attr1"]["distribution"]["1"][0])
-        self.assertEqual(12, attr_test["attr2"]["distribution"]["0"][0])        
-        self.assertEqual( 9, attr_test["attr2"]["distribution"]["1"][0])        
+        self.assertEqual(12, attr_test["attr2"]["distribution"]["0"][0])
+        self.assertEqual( 9, attr_test["attr2"]["distribution"]["1"][0])
         self.assertEqual(15, attr_test["attr2"]["distribution"]["2"][0])
-        self.assertEqual(12, attr_test["attr3"]["distribution"]["0"][0])        
-        self.assertEqual( 9, attr_test["attr3"]["distribution"]["1"][0])        
+        self.assertEqual(12, attr_test["attr3"]["distribution"]["0"][0])
+        self.assertEqual( 9, attr_test["attr3"]["distribution"]["1"][0])
         self.assertEqual(15, attr_test["attr3"]["distribution"]["2"][0])
-            
+
     def test_split_for_classification_gives_error_on_multi_label(self):
         iterable = [
             DatasetItem(
@@ -190,51 +191,51 @@ class SplitterTest(TestCase):
                 annotations=[Label(0), Label(2)],
                 subset=""
             )
-        ]  
+        ]
         categories = {
             AnnotationType.label: LabelCategories.from_iterable(
                 'label_' + str(label) for label in range(3)
-            )}            
+            )}
         source_dataset = Dataset.from_iterable(iterable, categories)
         with self.assertRaises(Exception):
-            actual = splitter.SplitforClassification(source_dataset, 
+            actual = splitter.SplitforClassification(source_dataset,
                 train=0.7, test=0.3)
 
     def test_split_for_classification_gives_error_on_wrong_ratios(self):
         source_dataset = Dataset.from_iterable([DatasetItem(id=1)])
         with self.assertRaises(Exception):
-            splitter.SplitforClassification(source_dataset, 
+            splitter.SplitforClassification(source_dataset,
                 train=-0.5, test=1.5)
-    
+
     def test_split_for_matching_reid(self):
         counts = { i:(i%3+1)*7 for i in range(10) }
         config = { "person": { "attrs": ['PID'], "counts": counts }}
         source_dataset = self._generate_dataset(config)
-                
+
         actual = splitter.SplitforMatchingReID(source_dataset, \
-            train=0.5, val=0.2, test=0.3, query=0.4, gallery=0.3)
-        
+            train=0.5, val=0.2, test=0.3, query=0.4/0.7, gallery=0.3/0.7)
+
         stats = dict()
         for sname in ['train', 'val', 'test']:
             subset = actual.get_subset(sname)
             stat_subset = compute_ann_statistics(subset)["annotations"]
             stat_attr = stat_subset["labels"]["attributes"]["PID"]
             stats[sname] = stat_attr
-        
+
         for sname in ['gallery', 'query']:
             subset = actual.get_subset_by_group(sname)
             stat_subset = compute_ann_statistics(subset)["annotations"]
             stat_attr = stat_subset["labels"]["attributes"]["PID"]
             stats[sname] = stat_attr
-        
+
         self.assertEqual(65, stats['train']['count'])   # depends on heuristic
         self.assertEqual(26, stats['val']['count'])     # depends on heuristic
         self.assertEqual(42, stats['test']['count'])    # depends on heuristic
-        
+
         train_ids = stats['train']['values present']
         self.assertEqual(7, len(train_ids))
         self.assertEqual(train_ids, stats['val']['values present'])
-        
+
         trainval = stats['train']['count'] + stats['val']['count']
         self.assertEqual(int(trainval * 0.5 / 0.7), stats['train']['count'])
         self.assertEqual(int(trainval * 0.2 / 0.7), stats['val']['count'])
@@ -245,12 +246,12 @@ class SplitterTest(TestCase):
             total = counts[int(pid)]
             self.assertEqual(int(total * 0.5 / 0.7), dist_train[pid][0])
             self.assertEqual(int(total * 0.2 / 0.7), dist_val[pid][0])
-            
+
         test_ids = stats['test']['values present']
         self.assertEqual(3, len(test_ids))
         self.assertEqual(test_ids, stats['gallery']['values present'])
         self.assertEqual(test_ids, stats['query']['values present'])
-        
+
         dist_test = stats['test']['distribution']
         dist_gallery = stats['gallery']['distribution']
         dist_query = stats['query']['distribution']
@@ -259,4 +260,130 @@ class SplitterTest(TestCase):
             self.assertEqual(total, dist_test[pid][0])
             self.assertEqual(int(total * 0.3 / 0.7), dist_gallery[pid][0])
             self.assertEqual(int(total * 0.4 / 0.7), dist_query[pid][0])
- 
+
+    def _generate_detection_dataset(self, style, with_attr=False, nimages=10):
+        def _get_subset():
+            return np.random.choice(['', 'a', 'b'], p = [0.5, 0.3, 0.2])
+
+        label_cat = LabelCategories()
+        for i in range(6):
+            label = "label{}".format(i+1)
+            if with_attr is True:
+                attributes = {"attr0", "attr{}".format(i+1)}
+            else:
+                attributes = {}
+            label_cat.add(label, attributes = attributes)
+        categories = { AnnotationType.label: label_cat }
+
+        iterable = []
+        def append_bbox_coco(annotations, **kwargs):
+            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id'],
+                                id=kwargs['ann_id'],
+                                attributes=kwargs['attributes'],
+                                group=kwargs['label_id']))
+            annotations.append(Label(kwargs['label_id'],
+                                attributes=kwargs['attributes']))
+        def append_bbox_voc(annotations, **kwargs):
+            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id'],
+                                id=kwargs['ann_id']+1,
+                                attributes=kwargs['attributes'],
+                                group=kwargs['label_id'])) # obj
+            annotations.append(Label(kwargs['label_id'],
+                                attributes=kwargs['attributes']))
+            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id']+3,
+                                group=kwargs['label_id'])) # part
+            annotations.append(Label(kwargs['label_id']+3,
+                                attributes=kwargs['attributes']))
+        def append_bbox_yolo(annotations, **kwargs):
+            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id']))
+            annotations.append(Label(kwargs['label_id'],
+                                attributes=kwargs['attributes']))
+        def append_bbox_cvat(annotations, **kwargs):
+            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id'],
+                                id=kwargs['ann_id'],
+                                attributes=kwargs['attributes'],
+                                group=kwargs['label_id'],
+                                z_order=kwargs['ann_id']))
+            annotations.append(Label(kwargs['label_id'],
+                                attributes=kwargs['attributes']))
+        def append_bbox_labelme(annotations, **kwargs):
+            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id'],
+                                attributes=kwargs['attributes'],
+                                id=kwargs['ann_id']))
+            annotations.append(Label(kwargs['label_id'],
+                                attributes=kwargs['attributes']))
+        def append_bbox_mot(annotations, **kwargs):
+            annotations.append(Bbox(1,1,2,2, label=kwargs['label_id'],
+                                attributes=kwargs['attributes']))
+            annotations.append(Label(kwargs['label_id'],
+                                attributes=kwargs['attributes']))
+        def append_bbox_widerface(annotations, **kwargs):
+            annotations.append(Bbox(1,1,2,2, attributes=kwargs['attributes']))
+            annotations.append(Label(0, attributes=kwargs['attributes']))
+
+        if style == "coco":
+            append_bbox = append_bbox_coco
+        elif style == "voc":
+            append_bbox = append_bbox_voc
+        elif style in ["yolo", "tf_detection"]:
+            append_bbox = append_bbox_yolo
+        elif style in ["datumaro", "cvat"]:
+            append_bbox = append_bbox_cvat
+        elif style == "labelme":
+            append_bbox = append_bbox_labelme
+        elif style == "mot":
+            append_bbox = append_bbox_mot
+        elif style == "widerface":
+            append_bbox = append_bbox_widerface
+
+        attr_val = 0
+        totals = np.zeros(3)
+        for img_id in range(nimages):
+            cnts = np.random.randint(0, 5, 3)
+            totals += cnts
+            annotations = []
+            for label_id, count in enumerate(cnts):
+                attributes = {}
+                if with_attr:
+                    attr_val += 1
+                    attributes["attr0"] = attr_val % 3
+                    attributes["attr{}".format(label_id+1)] = attr_val % 2
+                for ann_id in range(count):
+                    append_bbox(annotations, label_id=label_id, \
+                        ann_id=ann_id, attributes=attributes)
+            item = DatasetItem(
+                id=str(img_id),
+                annotations=annotations,
+                subset=_get_subset(),
+                attributes={"id":img_id}
+            )
+            iterable.append(item)
+
+        dataset = Dataset.from_iterable(iterable, categories)
+        return dataset, totals
+
+    def test_split_for_detection(self):
+        styles =  [
+            "coco", "voc", "yolo", "cvat", "labelme", "mot", "widerface"
+        ]
+        params = []
+        for style in styles:
+            for with_attr in [False, True]:
+                params.append((style, with_attr, 10, 5, 3, 2))
+                params.append((style, with_attr, 10, 7, 0, 3))
+
+        for style, with_attr, nimages, train, val, test in params:
+            with self.subTest(style=style, with_attr=with_attr, nimage=nimages,
+                              train=train, val=val, test=test):
+                source, _ = self._generate_detection_dataset(
+                            style, with_attr, nimages)
+                total = np.sum([train, val, test])
+                actual = splitter.SplitforDetection(source, \
+                    train=train/total, val=val/total, test=test/total)
+                subsets = dict()
+                for sname in ['train', 'val', 'test']:
+                    subset = actual.get_subset(sname)
+                    subsets[sname] = subset
+                self.assertEqual(train, len(subsets['train']))
+                self.assertEqual(val, len(subsets['val']))
+                self.assertEqual(test, len(subsets['test']))

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,0 +1,272 @@
+import logging as log
+import numpy as np
+import random
+
+from unittest import TestCase
+from datumaro.components.project import Dataset
+from datumaro.components.extractor import (DatasetItem, 
+    Label, LabelCategories, AnnotationType)
+
+import datumaro.plugins.splitter as splitter
+from datumaro.components.operations import compute_ann_statistics
+
+class SplitterTest(TestCase):
+        
+    def test_split_for_classification_multi_class_no_attr(self):
+        subsets = []
+        for subset, count in {"":30, "a":20, "b":10}.items():
+            subsets.extend([subset for _ in range(count)])
+        random.shuffle(subsets)
+                     
+        counts = {0:10, 1:20, 2:30}
+        label_id = 0 
+        iterable = []  
+        for label, count in counts.items():
+            for _ in range(count):
+                subset = subsets[label_id]
+                label_id += 1
+                iterable.append(DatasetItem(
+                    id=str(label_id),
+                    annotations=[Label(label)],
+                    subset=subset
+                ))
+
+        categories = {
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(label) for label in range(3)
+            )}            
+        source_dataset = Dataset.from_iterable(iterable, categories)
+        
+        actual = splitter.SplitforClassification(source_dataset, splits=[
+            ('train', 0.7),
+            ('test', 0.3),
+        ])
+
+        self.assertEqual(42, len(actual.get_subset('train')))
+        self.assertEqual(18, len(actual.get_subset('test')))
+
+        # check stats for train
+        stat_train = compute_ann_statistics(actual.get_subset('train'))        
+        dist_train = stat_train["annotations"]["labels"]["distribution"]
+        self.assertEqual(7, dist_train["label_0"][0])
+        self.assertEqual(14, dist_train["label_1"][0])
+        self.assertEqual(21, dist_train["label_2"][0])
+        
+        # check stats for test
+        stat_test = compute_ann_statistics(actual.get_subset('test'))        
+        dist_test = stat_test["annotations"]["labels"]["distribution"]
+        self.assertEqual(3, dist_test["label_0"][0])
+        self.assertEqual(6, dist_test["label_1"][0])
+        self.assertEqual(9, dist_test["label_2"][0])
+
+    def test_split_for_classification_single_class_single_attr(self):
+        subsets = []
+        for subset, count in {"":30, "a":20, "b":10}.items():
+            subsets.extend([subset for _ in range(count)])
+        random.shuffle(subsets)
+        
+        counts = {0:10, 1:20, 2:30}
+        label_id = 0 
+        iterable = []  
+        for attr, count in counts.items():
+            for _ in range(count):
+                subset = subsets[label_id]
+                label_id += 1
+                iterable.append(DatasetItem(
+                    id=str(label_id),
+                    annotations=[Label(0, attributes={'attr':attr})],
+                    subset=subset
+                ))
+
+        label_cat = LabelCategories()
+        label_cat.add('label', attributes=['attr'])        
+        categories = { AnnotationType.label: label_cat }
+        
+        source_dataset = Dataset.from_iterable(iterable, categories)
+        
+        actual = splitter.SplitforClassification(source_dataset, splits=[
+            ('train', 0.7),
+            ('test', 0.3),
+        ])
+
+        self.assertEqual(42, len(actual.get_subset('train')))
+        self.assertEqual(18, len(actual.get_subset('test')))
+
+        # check stats for train
+        stat_train = compute_ann_statistics(actual.get_subset('train'))                        
+        attr_train = stat_train["annotations"]["labels"]["attributes"]
+        self.assertEqual(7, attr_train['attr']["distribution"]["0"][0])
+        self.assertEqual(14, attr_train['attr']["distribution"]["1"][0])
+        self.assertEqual(21, attr_train['attr']["distribution"]["2"][0])
+        
+        # check stats for test
+        stat_test = compute_ann_statistics(actual.get_subset('test'))        
+        attr_test = stat_test["annotations"]["labels"]["attributes"]
+        self.assertEqual(3, attr_test['attr']["distribution"]["0"][0])
+        self.assertEqual(6, attr_test['attr']["distribution"]["1"][0])
+        self.assertEqual(9, attr_test['attr']["distribution"]["2"][0])     
+    
+    def test_split_for_classification_single_class_multi_attr(self):
+        subsets = []
+        for subset, count in {"":60, "a":40, "b":20}.items():
+            subsets.extend([subset for _ in range(count)])
+        random.shuffle(subsets)
+        
+        counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}
+        label_id = 0 
+        iterable = []  
+        for (attr1, attr2), count in counts.items():
+            for _ in range(count):
+                subset = subsets[label_id]
+                label_id += 1
+                iterable.append(DatasetItem(
+                    id=str(label_id),
+                    annotations=[Label(0, 
+                        attributes={'attr1':attr1, 'attr2':attr2})
+                    ],
+                    subset=subset
+                ))
+
+        label_cat = LabelCategories()
+        label_cat.add('label', attributes=['attr1', 'attr2'])        
+        categories = { AnnotationType.label: label_cat }
+        
+        source_dataset = Dataset.from_iterable(iterable, categories)
+        
+        actual = splitter.SplitforClassification(source_dataset, splits=[
+            ('train', 0.7),
+            ('test', 0.3),
+        ])
+
+        self.assertEqual(84, len(actual.get_subset('train')))
+        self.assertEqual(36, len(actual.get_subset('test')))
+        
+        # check stats for train
+        stat_train = compute_ann_statistics(actual.get_subset('train'))       
+        attr_train = stat_train["annotations"]["labels"]["attributes"] 
+        self.assertEqual(49, attr_train["attr1"]["distribution"]["0"][0])
+        self.assertEqual(35, attr_train["attr1"]["distribution"]["1"][0])
+        self.assertEqual(28, attr_train["attr2"]["distribution"]["0"][0])        
+        self.assertEqual(21, attr_train["attr2"]["distribution"]["1"][0])        
+        self.assertEqual(35, attr_train["attr2"]["distribution"]["2"][0])
+                
+        # check stats for test
+        stat_test = compute_ann_statistics(actual.get_subset('test'))        
+        attr_test = stat_test["annotations"]["labels"]["attributes"]
+        self.assertEqual(21, attr_test["attr1"]["distribution"]["0"][0])
+        self.assertEqual(15, attr_test["attr1"]["distribution"]["1"][0])
+        self.assertEqual(12, attr_test["attr2"]["distribution"]["0"][0])        
+        self.assertEqual( 9, attr_test["attr2"]["distribution"]["1"][0])        
+        self.assertEqual(15, attr_test["attr2"]["distribution"]["2"][0])
+            
+    def test_split_for_classification_multi_label_with_attr(self):
+        subsets = []
+        for subset, count in {"":120, "a":80, "b":40}.items():
+            subsets.extend([subset for _ in range(count)])
+        random.shuffle(subsets)
+       
+        counts = {(0,0):20, (0,1):20, (0,2):30, (1,0):20, (1,1):10, (1,2):20}        
+        label_id = 0 
+        iterable = []  
+        for label in range(2):
+            for (attr1, attr2), count in counts.items():
+                if label==0:
+                    attributes = {'attr1':attr1, 'attr2':attr2}
+                else:
+                    attributes = {'attr1':attr1, 'attr3':attr2}
+                for _ in range(count):
+                    subset = subsets[label_id]
+                    label_id += 1
+                    iterable.append(DatasetItem(
+                        id=str(label_id),
+                        annotations=[ Label(label, attributes=attributes) ],
+                        subset=subset
+                    ))
+        label_cat = LabelCategories()
+        label_cat.add('label0', attributes=['attr1', 'attr2'])
+        label_cat.add('label1', attributes=['attr1', 'attr3'])                
+        categories = { AnnotationType.label: label_cat }
+        
+        source_dataset = Dataset.from_iterable(iterable, categories)
+    
+        actual = splitter.SplitforClassification(source_dataset, splits=[
+            ('train', 0.7),
+            ('test', 0.3),
+        ])
+
+        self.assertEqual(168, len(actual.get_subset('train')))
+        self.assertEqual(72, len(actual.get_subset('test')))
+
+        # check stats for train
+        stat_train = compute_ann_statistics(actual.get_subset('train'))        
+        dist_train = stat_train["annotations"]["labels"]["distribution"]
+        self.assertEqual(84, dist_train["label0"][0])
+        self.assertEqual(84, dist_train["label1"][0])    
+        attr_train = stat_train["annotations"]["labels"]["attributes"]         
+        self.assertEqual(49*2, attr_train["attr1"]["distribution"]["0"][0])
+        self.assertEqual(35*2, attr_train["attr1"]["distribution"]["1"][0])
+        self.assertEqual(28, attr_train["attr2"]["distribution"]["0"][0])        
+        self.assertEqual(21, attr_train["attr2"]["distribution"]["1"][0])        
+        self.assertEqual(35, attr_train["attr2"]["distribution"]["2"][0])
+        self.assertEqual(28, attr_train["attr3"]["distribution"]["0"][0])        
+        self.assertEqual(21, attr_train["attr3"]["distribution"]["1"][0])        
+        self.assertEqual(35, attr_train["attr3"]["distribution"]["2"][0])
+        
+        # check stats for test
+        stat_test = compute_ann_statistics(actual.get_subset('test'))        
+        dist_test = stat_test["annotations"]["labels"]["distribution"]
+        self.assertEqual(36, dist_test["label0"][0])
+        self.assertEqual(36, dist_test["label0"][0])    
+        attr_test = stat_test["annotations"]["labels"]["attributes"]        
+        self.assertEqual(21*2, attr_test["attr1"]["distribution"]["0"][0])
+        self.assertEqual(15*2, attr_test["attr1"]["distribution"]["1"][0])
+        self.assertEqual(12, attr_test["attr2"]["distribution"]["0"][0])        
+        self.assertEqual( 9, attr_test["attr2"]["distribution"]["1"][0])        
+        self.assertEqual(15, attr_test["attr2"]["distribution"]["2"][0])
+        self.assertEqual(12, attr_test["attr3"]["distribution"]["0"][0])        
+        self.assertEqual( 9, attr_test["attr3"]["distribution"]["1"][0])        
+        self.assertEqual(15, attr_test["attr3"]["distribution"]["2"][0])
+            
+
+    def test_split_for_classification_gives_error_on_multi_label(self):
+        iterable = [
+            DatasetItem(
+                id='1',
+                annotations=[Label(0), Label(1)],
+                subset=""
+            ),
+            DatasetItem(
+                id='2',
+                annotations=[Label(0), Label(2)],
+                subset=""
+            )
+        ]  
+        categories = {
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(label) for label in range(3)
+            )}            
+        source_dataset = Dataset.from_iterable(iterable, categories)
+        with self.assertRaises(Exception):
+            actual = splitter.SplitforClassification(source_dataset, splits=[
+                ('train', 0.7),
+                ('test', 0.3),
+            ])
+
+    def test_split_for_classification_gives_error_on_wrong_ratios(self):
+        source_dataset = Dataset.from_iterable([DatasetItem(id=1)])
+
+        with self.assertRaises(Exception):
+            splitter.SplitforClassification(source_dataset, splits=[
+                ('train', 0.5),
+                ('test', 0.7),
+            ])
+
+        with self.assertRaises(Exception):
+            splitter.SplitforClassification(source_dataset, splits=[])
+
+        with self.assertRaises(Exception):
+            splitter.SplitforClassification(source_dataset, splits=[
+                ('train', -0.5),
+                ('test', 1.5),
+            ])
+


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Added task-specific annotation splitters.
- SplitforClassification
- SplitforMatchingReID
- SplitforDetection

### How to test
```bash
python -m unittest -v tests/test_splitter.py
```

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
