### PR TITLE
Optimize mask merging and improve memory use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Fixed
-- High memory consumption when merging and exporting lots of masks, #53 (<https://github.com/openvinotoolkit/datumaro/pull/101>)
+- High memory consumption and low performance of mask import/export, #53 (<https://github.com/openvinotoolkit/datumaro/pull/101>)
 
 ### Security
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Added
+-
+
+### Changed
+-
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+- High memory consumption when merging and exporting lots of masks, #53 (<https://github.com/openvinotoolkit/datumaro/pull/101>)
+
+### Security
+-
+
 ## 01/23/2021 - Release v0.1.5
 ### Added
 - `WiderFace` dataset format (<https://github.com/openvinotoolkit/datumaro/pull/65>, <https://github.com/openvinotoolkit/datumaro/pull/90>)

--- a/datumaro/plugins/coco_format/converter.py
+++ b/datumaro/plugins/coco_format/converter.py
@@ -226,14 +226,14 @@ class _InstancesConverter(_TaskConverter):
             if masks:
                 if mask is not None:
                     masks += [mask]
-                mask = mask_tools.merge_masks([m.image for m in masks])
+                mask = mask_tools.merge_masks(m.image for m in masks)
 
             if mask is not None:
                 mask = mask_tools.mask_to_rle(mask)
             polygons = []
         else:
             if masks:
-                mask = mask_tools.merge_masks([m.image for m in masks])
+                mask = mask_tools.merge_masks(m.image for m in masks)
                 polygons += mask_tools.mask_to_polygons(mask)
             mask = None
 

--- a/datumaro/plugins/coco_format/converter.py
+++ b/datumaro/plugins/coco_format/converter.py
@@ -8,7 +8,7 @@ import logging as log
 import os
 import os.path as osp
 from enum import Enum
-from itertools import groupby
+from itertools import chain, groupby
 
 import pycocotools.mask as mask_utils
 
@@ -224,9 +224,10 @@ class _InstancesConverter(_TaskConverter):
                 mask = mask_tools.rles_to_mask(polygons, img_width, img_height)
 
             if masks:
+                masks = (m.image for m in masks)
                 if mask is not None:
-                    masks += [mask]
-                mask = mask_tools.merge_masks(m.image for m in masks)
+                    masks += chain(masks, [mask])
+                mask = mask_tools.merge_masks(masks)
 
             if mask is not None:
                 mask = mask_tools.mask_to_rle(mask)

--- a/datumaro/plugins/mots_format.py
+++ b/datumaro/plugins/mots_format.py
@@ -139,7 +139,7 @@ class MotsPngConverter(Converter):
         instance_ids = [int(a.attributes['track_id']) for a in masks]
         masks = sorted(zip(masks, instance_ids), key=lambda e: e[0].z_order)
         mask = merge_masks(
-            m.image * (MotsPath.MAX_INSTANCES * (1 + m.label) + id)
+            (m.image, MotsPath.MAX_INSTANCES * (1 + m.label) + id)
             for m, id in masks)
         save_image(osp.join(anno_dir, item.id + '.png'), mask,
             create_dir=True, dtype=np.uint16)

--- a/datumaro/plugins/mots_format.py
+++ b/datumaro/plugins/mots_format.py
@@ -138,8 +138,8 @@ class MotsPngConverter(Converter):
 
         instance_ids = [int(a.attributes['track_id']) for a in masks]
         masks = sorted(zip(masks, instance_ids), key=lambda e: e[0].z_order)
-        mask = merge_masks([
+        mask = merge_masks(
             m.image * (MotsPath.MAX_INSTANCES * (1 + m.label) + id)
-            for m, id in masks])
+            for m, id in masks)
         save_image(osp.join(anno_dir, item.id + '.png'), mask,
             create_dir=True, dtype=np.uint16)

--- a/datumaro/plugins/tf_detection_api_format/converter.py
+++ b/datumaro/plugins/tf_detection_api_format/converter.py
@@ -105,7 +105,7 @@ class TfDetectionApiConverter(Converter):
 
         mask = None
         if self._save_masks:
-            mask = merge_masks([m.image for m in masks])
+            mask = merge_masks(m.image for m in masks)
 
         return [leader, mask, bbox]
 

--- a/datumaro/plugins/transforms.py
+++ b/datumaro/plugins/transforms.py
@@ -130,6 +130,8 @@ class MergeInstanceSegments(Transform, CliPlugin):
         masks = [a for a in instance if a.type == AnnotationType.mask]
         if not polygons and not masks:
             return []
+        if not polygons and len(masks) == 1:
+            return masks
 
         leader = find_group_leader(polygons + masks)
         instance = []

--- a/datumaro/plugins/transforms.py
+++ b/datumaro/plugins/transforms.py
@@ -4,6 +4,7 @@
 
 from collections import Counter
 from enum import Enum
+from itertools import chain
 import logging as log
 import os.path as osp
 import random
@@ -143,9 +144,9 @@ class MergeInstanceSegments(Transform, CliPlugin):
             instance += polygons # keep unused polygons
 
         if masks:
-            masks = [m.image for m in masks]
+            masks = (m.image for m in masks)
             if mask is not None:
-                masks += [mask]
+                masks = chain(masks, [mask])
             mask = mask_tools.merge_masks(masks)
 
         if mask is None:

--- a/datumaro/util/mask_tools.py
+++ b/datumaro/util/mask_tools.py
@@ -104,8 +104,6 @@ def remap_mask(mask, map_fn):
     return np.array([map_fn(c) for c in range(256)], dtype=np.uint8)[mask]
 
 def make_index_mask(binary_mask, index, dtype=None):
-    if binary_mask.dtype.kind != 'b':
-        binary_mask = binary_mask.astype(bool)
     return binary_mask * np.array([index],
         dtype=dtype or np.min_scalar_type(index))
 

--- a/datumaro/util/mask_tools.py
+++ b/datumaro/util/mask_tools.py
@@ -284,15 +284,23 @@ def merge_masks(masks):
         Merges masks into one, mask order is responsible for z order.
         To avoid memory explosion on mask materialization, consider passing
         a generator.
+
+        Inputs: a sequence of index masks or (binary mask, index) pairs
+        Outputs: an index mask
     """
     it = iter(masks)
 
     try:
         merged_mask = next(it)
+        if isinstance(merged_mask, tuple) and len(merged_mask) == 2:
+            merged_mask = merged_mask[0] * merged_mask[1]
     except StopIteration:
         return None
 
     for m in it:
-        merged_mask = np.where(m, m, merged_mask)
+        if isinstance(m, tuple) and len(m) == 2:
+            merged_mask = np.where(m[0], m[1], merged_mask)
+        else:
+            merged_mask = np.where(m, m, merged_mask)
 
     return merged_mask

--- a/datumaro/util/mask_tools.py
+++ b/datumaro/util/mask_tools.py
@@ -104,14 +104,15 @@ def remap_mask(mask, map_fn):
     return np.array([map_fn(c) for c in range(256)], dtype=np.uint8)[mask]
 
 def make_index_mask(binary_mask, index, dtype=None):
-    if binary_mask.dtype.kind not in {'b', 'i', 'u'}:
+    if binary_mask.dtype.kind != 'b':
         binary_mask = binary_mask.astype(bool)
-    return np.choose(binary_mask,
-        np.array([0, index], dtype=dtype or np.min_scalar_type(index))
-    )
+    return binary_mask * np.array([index],
+        dtype=dtype or np.min_scalar_type(index))
 
 def make_binary_mask(mask):
-    return np.nonzero(mask)
+    if mask.dtype.kind == 'b':
+        return mask
+    return mask.astype(bool)
 
 
 def load_mask(path, inverse_colormap=None):
@@ -297,6 +298,6 @@ def merge_masks(masks):
         return None
 
     for m in it:
-        merged_mask = np.where(m != 0, m, merged_mask)
+        merged_mask = np.where(m, m, merged_mask)
 
     return merged_mask

--- a/tests/test_coco_format.py
+++ b/tests/test_coco_format.py
@@ -390,11 +390,11 @@ class CocoConverterTest(TestCase):
             DatasetItem(id=1, image=np.zeros((5, 10, 3)),
                 annotations=[
                     Polygon(
-                        [3.0, 2.5, 1.0, 0.0, 3.5, 0.0, 3.0, 2.5],
+                        [1, 0, 3, 2, 3, 0, 1, 0],
                         label=3, id=4, group=4,
                         attributes={ 'is_crowd': False }),
                     Polygon(
-                        [5.0, 3.5, 4.5, 0.0, 8.0, 0.0, 5.0, 3.5],
+                        [5, 0, 5, 3, 8, 0, 5, 0],
                         label=3, id=4, group=4,
                         attributes={ 'is_crowd': False }),
                 ], attributes={'id': 1}

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -45,8 +45,8 @@ class TransformsTest(TestCase):
 
         expected = Dataset.from_iterable([
             DatasetItem(id=1, image=np.zeros((5, 10, 3)), annotations=[
-                Polygon([3.0, 2.5, 1.0, 0.0, 3.5, 0.0, 3.0, 2.5]),
-                Polygon([5.0, 3.5, 4.5, 0.0, 8.0, 0.0, 5.0, 3.5]),
+                Polygon([1, 0, 3, 2, 3, 0, 1, 0]),
+                Polygon([5, 0, 5, 3, 8, 0, 5, 0]),
             ]),
         ])
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Added more memory control for mask merging and mask materialization operations
- `merge_masks` can now receive an iterator, which can be helpful for reducing memory consumption
- Improved the memory situation in and fixed #53
  - Memory for masks should not be an issue anymore
  - There is still can be a problem with low performance, when merging lots of masks (or polygons into masks)
- Significantly improved performance:
  - of `masks_to_polygons` (10k x 10k image & 250 masks experiment: 200s -> 30s)
  - of `CompiledMask` building (10k x 10k image & 250 masks experiment: 200s -> 80s)

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
