### PR TITLE
Optimize masks 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - High memory consumption and low performance of mask import/export, #53 (<https://github.com/openvinotoolkit/datumaro/pull/101>)
+- Masks, covered by class 0 (background), should be exported holes inside (<https://github.com/openvinotoolkit/datumaro/pull/104>)
 
 ### Security
 -

--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -158,6 +158,10 @@ class Mask(Annotation):
         default=None, kw_only=True)
     z_order = attrib(default=0, validator=default_if_none(int), kw_only=True)
 
+    def __attrs_post_init__(self):
+        if isinstance(self._image, np.ndarray):
+            self._image = self._image.astype(bool)
+
     @property
     def image(self):
         if callable(self._image):
@@ -238,7 +242,7 @@ class CompiledMask:
 
         instance_masks = sorted(enumerate(instance_masks),
             key=lambda m: m[1].z_order)
-        instance_masks = ((m.image,
+        instance_masks = ((m.image, 1 + j,
                 instance_ids[i] if instance_ids[i] is not None else 1 + j,
                 instance_labels[i] if instance_labels[i] is not None else m.label
             ) for j, (i, m) in enumerate(instance_masks))
@@ -247,13 +251,26 @@ class CompiledMask:
         # 2. Optimize materialization calls
         it = iter(instance_masks)
 
-        m, instance_id, class_id = next(it)
-        merged_instance_mask = make_index_mask(m, instance_id)
-        merged_class_mask = make_index_mask(m, class_id)
+        instance_map = [0]
+        class_map = [0]
 
-        for m, instance_id, class_id in it:
-            merged_instance_mask = np.where(m, instance_id, merged_instance_mask)
-            merged_class_mask = np.where(m, class_id, merged_class_mask)
+        m, idx, instance_id, class_id = next(it)
+        index_mask = make_index_mask(m, idx)
+        instance_map.append(instance_id)
+        class_map.append(class_id)
+
+        for m, idx, instance_id, class_id in it:
+            index_mask = np.where(m, idx, index_mask)
+            instance_map.append(instance_id)
+            class_map.append(class_id)
+
+        if np.array_equal(instance_map, range(idx + 1)):
+            merged_instance_mask = index_mask
+        else:
+            merged_instance_mask = np.array(instance_map,
+                dtype=np.min_scalar_type(instance_map))[index_mask]
+        merged_class_mask = np.array(class_map,
+            dtype=np.min_scalar_type(class_map))[index_mask]
 
         return __class__(class_mask=merged_class_mask,
             instance_mask=merged_instance_mask)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Follow-up for https://github.com/openvinotoolkit/datumaro/pull/101
- Further optimized mask merging / exporting (10k x 10k image & 250 masks test, 80s -> 60s)
- Masks, covered by other masks with class = 0 (typically - `background`) are now exported correctly with holes inside

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
