### PR TITLE
Fixes in ICDAR and Market-1501 dataset formats

### DIFF
--- a/datumaro/plugins/icdar_format/converter.py
+++ b/datumaro/plugins/icdar_format/converter.py
@@ -72,16 +72,14 @@ class _TextSegmentationConverter:
         anns = [a for a in item.annotations
             if a.type == AnnotationType.mask]
         if anns:
-            is_not_index = len([p for p in anns
-                if 'index' not in p.attributes])
+            is_not_index = len([p for p in anns if 'index' not in p.attributes])
             if is_not_index:
-                raise Exception("Item %s: mask must have"
-                    "index attribute" % item.id)
+                raise Exception("Item %s: a mask must have"
+                    "'index' attribute" % item.id)
             anns = sorted(anns, key=lambda a: a.attributes['index'])
             group = anns[0].group
             for ann in anns:
-                if ann.group != group or \
-                        (ann.group == 0 and anns[0].group != 0):
+                if ann.group != group or (not ann.group and anns[0].group != 0):
                     annotation += '\n'
                 text = ''
                 if ann.attributes:
@@ -92,11 +90,12 @@ class _TextSegmentationConverter:
                     if 'color' in ann.attributes and \
                             len(ann.attributes['color'].split()) == 3:
                         color = ann.attributes['color'].split()
-                        colormap.append((int(color[0]), int(color[1]), int(color[2])))
+                        colormap.append(
+                            (int(color[0]), int(color[1]), int(color[2])))
                         annotation += ' '.join(p for p in color)
                     else:
-                        raise Exception("Item %s: mask must have "
-                            "a three-digit color attribute" % item.id)
+                        raise Exception("Item %s: a mask must have "
+                            "an RGB color attribute, e. g. '10 7 50'" % item.id)
                     if 'center' in ann.attributes:
                         annotation += ' %s' % ann.attributes['center']
                     else:

--- a/datumaro/plugins/icdar_format/extractor.py
+++ b/datumaro/plugins/icdar_format/extractor.py
@@ -151,7 +151,7 @@ class _IcdarExtractor(SourceExtractor):
                     if len(objects) != 10:
                         continue
 
-                    centers.append([float(objects[3]), float(objects[4])])
+                    centers.append(objects[3] + ' ' + objects[4])
                     groups.append(group)
                     colors.append(tuple(int(o) for o in objects[:3]))
                     char = objects[9]
@@ -177,10 +177,10 @@ class _IcdarExtractor(SourceExtractor):
                     if label_id == 0:
                         continue
                     i = int(label_id)
-                    annotations.append(Mask(id=i, group=groups[i],
+                    annotations.append(Mask(group=groups[i],
                         image=self._lazy_extract_mask(mask, label_id),
-                        attributes={ 'color': colors[i], 'text': chars[i],
-                            'center': centers[i] }
+                        attributes={ 'index': i - 1, 'color': ' '.join(str(p) for p in colors[i]),
+                            'text': chars[i], 'center': centers[i] }
                     ))
         return items
 
@@ -229,4 +229,4 @@ class IcdarImporter(Importer):
                 sources += cls._find_sources_recursive(path, ext,
                     extractor_type, file_filter=lambda p:
                         osp.basename(p) != IcdarPath.VOCABULARY_FILE)
-            return sources
+        return sources

--- a/datumaro/plugins/market1501_format.py
+++ b/datumaro/plugins/market1501_format.py
@@ -16,6 +16,7 @@ class Market1501Path:
     BBOX_DIR = 'bounding_box_'
     IMAGE_EXT = '.jpg'
     PATTERN = re.compile(r'([-\d]+)_c(\d)')
+    IMAGE_NAMES = 'images.txt'
 
 class Market1501Extractor(SourceExtractor):
     def __init__(self, path):
@@ -36,14 +37,26 @@ class Market1501Extractor(SourceExtractor):
         paths = glob(osp.join(path, Market1501Path.QUERY_DIR, '*'))
         paths += glob(osp.join(path, Market1501Path.BBOX_DIR + self._subset, '*'))
 
+        if len(paths) == 0 and osp.isfile(osp.join(path, Market1501Path.IMAGE_NAMES)):
+            with open(osp.join(path, Market1501Path.IMAGE_NAMES), encoding='utf-8') as f:
+                for line in f:
+                    line = line.strip()
+                    paths.append(line)
+
         for image_path in paths:
-            if not osp.isfile(image_path) or \
-                    osp.splitext(image_path)[-1] != Market1501Path.IMAGE_EXT:
+            if osp.splitext(image_path)[-1] != Market1501Path.IMAGE_EXT:
                 continue
 
             item_id = osp.splitext(osp.basename(image_path))[0]
-            attributes = {}
-            pid, camid = map(int, Market1501Path.PATTERN.search(image_path).groups())
+            pid, camid = -1, -1
+            search = Market1501Path.PATTERN.search(image_path)
+            if search:
+                pid, camid = map(int, search.groups())
+                if 19 < len(item_id):
+                    item_id = item_id[19:]
+            items[item_id] = DatasetItem(id=item_id, subset=self._subset,
+                image=image_path)
+            attributes = items[item_id].attributes
             if pid == -1:
                 continue
 
@@ -54,8 +67,6 @@ class Market1501Extractor(SourceExtractor):
                 attributes['query'] = True
             else:
                 attributes['query'] = False
-            items[item_id] = DatasetItem(id=item_id, subset=self._subset,
-                image=image_path, attributes=attributes)
         return items
 
 class Market1501Importer(Importer):
@@ -70,12 +81,28 @@ class Market1501Converter(Converter):
 
     def apply(self):
         for subset_name, subset in self._extractor.subsets().items():
+            annotation = ''
             for item in subset:
+                image_name = item.id
+                if Market1501Path.PATTERN.search(image_name) == None:
+                    if 'person_id' in item.attributes and \
+                            'camera_id' in item.attributes:
+                        image_pattern = '{}{}_c{}s1_000000_00{}'
+                        pid = int(item.attributes.get('person_id'))
+                        camid = int(item.attributes.get('camera_id')) + 1
+                        image_name = image_pattern.format('0' * (4 - len(str(pid))),
+                            pid, camid, item.id)
+                dirname = Market1501Path.BBOX_DIR + subset_name
+                if 'query' in item.attributes and \
+                        str(item.attributes.get('query')) == 'True':
+                    dirname = Market1501Path.QUERY_DIR
+                image_path = osp.join(self._save_dir, dirname,
+                    image_name + Market1501Path.IMAGE_EXT)
                 if item.has_image and self._save_images:
-                    if item.attributes and 'query' in item.attributes:
-                        if item.attributes.get('query'):
-                            dirname = Market1501Path.QUERY_DIR
-                        else:
-                            dirname = Market1501Path.BBOX_DIR + subset_name
-                        self._save_image(item, osp.join(self._save_dir,
-                            dirname, item.id + Market1501Path.IMAGE_EXT))
+                    self._save_image(item, image_path)
+                else:
+                    annotation += '%s\n' % image_path
+        if 0 < len(annotation):
+            annotation_file = osp.join(self._save_dir, Market1501Path.IMAGE_NAMES)
+            with open(annotation_file, 'w') as f:
+                f.write(annotation)

--- a/datumaro/plugins/market1501_format.py
+++ b/datumaro/plugins/market1501_format.py
@@ -16,7 +16,7 @@ class Market1501Path:
     BBOX_DIR = 'bounding_box_'
     IMAGE_EXT = '.jpg'
     PATTERN = re.compile(r'([-\d]+)_c(\d)')
-    IMAGE_NAMES = 'images.txt'
+    IMAGE_NAMES = 'images_'
 
 class Market1501Extractor(SourceExtractor):
     def __init__(self, path):
@@ -26,6 +26,9 @@ class Market1501Extractor(SourceExtractor):
         for dirname in glob(osp.join(path, '*')):
             if osp.basename(dirname).startswith(Market1501Path.BBOX_DIR):
                 subset = osp.basename(dirname).replace(Market1501Path.BBOX_DIR, '')
+            if osp.basename(dirname).startswith(Market1501Path.IMAGE_NAMES):
+                subset = osp.basename(dirname).replace(Market1501Path.IMAGE_NAMES, '')
+                subset = osp.splitext(subset)[0]
                 break
         super().__init__(subset=subset)
         self._path = path
@@ -37,8 +40,9 @@ class Market1501Extractor(SourceExtractor):
         paths = glob(osp.join(path, Market1501Path.QUERY_DIR, '*'))
         paths += glob(osp.join(path, Market1501Path.BBOX_DIR + self._subset, '*'))
 
-        if len(paths) == 0 and osp.isfile(osp.join(path, Market1501Path.IMAGE_NAMES)):
-            with open(osp.join(path, Market1501Path.IMAGE_NAMES), encoding='utf-8') as f:
+        anno_file = osp.join(path, Market1501Path.IMAGE_NAMES + self._subset + '.txt')
+        if len(paths) == 0 and osp.isfile(anno_file):
+            with open(anno_file, encoding='utf-8') as f:
                 for line in f:
                     line = line.strip()
                     paths.append(line)
@@ -102,7 +106,8 @@ class Market1501Converter(Converter):
                     self._save_image(item, image_path)
                 else:
                     annotation += '%s\n' % image_path
-        if 0 < len(annotation):
-            annotation_file = osp.join(self._save_dir, Market1501Path.IMAGE_NAMES)
-            with open(annotation_file, 'w') as f:
-                f.write(annotation)
+            if 0 < len(annotation):
+                annotation_file = osp.join(self._save_dir,
+                    Market1501Path.IMAGE_NAMES + subset_name + '.txt')
+                with open(annotation_file, 'w') as f:
+                    f.write(annotation)

--- a/datumaro/plugins/market1501_format.py
+++ b/datumaro/plugins/market1501_format.py
@@ -4,6 +4,7 @@
 
 import os.path as osp
 import re
+from distutils.util import strtobool
 from glob import glob
 
 from datumaro.components.converter import Converter
@@ -91,15 +92,17 @@ class Market1501Converter(Converter):
                 if Market1501Path.PATTERN.search(image_name) == None:
                     if 'person_id' in item.attributes and \
                             'camera_id' in item.attributes:
-                        image_pattern = '{}{}_c{}s1_000000_00{}'
+                        image_pattern = '{:04d}_c{}s1_000000_00{}'
                         pid = int(item.attributes.get('person_id'))
                         camid = int(item.attributes.get('camera_id')) + 1
-                        image_name = image_pattern.format('0' * (4 - len(str(pid))),
-                            pid, camid, item.id)
+                        image_name = image_pattern.format(pid, camid, item.id)
                 dirname = Market1501Path.BBOX_DIR + subset_name
-                if 'query' in item.attributes and \
-                        str(item.attributes.get('query')) == 'True':
-                    dirname = Market1501Path.QUERY_DIR
+                if 'query' in item.attributes:
+                    query = item.attributes.get('query')
+                    if isinstance(query, str):
+                        query = strtobool(query)
+                    if query:
+                        dirname = Market1501Path.QUERY_DIR
                 image_path = osp.join(self._save_dir, dirname,
                     image_name + Market1501Path.IMAGE_EXT)
                 if item.has_image and self._save_images:

--- a/datumaro/plugins/market1501_format.py
+++ b/datumaro/plugins/market1501_format.py
@@ -22,7 +22,9 @@ class Market1501Path:
 class Market1501Extractor(SourceExtractor):
     def __init__(self, path):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't open folder with annotation files '%s'" % path)
+            raise NotADirectoryError(
+                "Can't open folder with annotation files '%s'" % path)
+
         subset = ''
         for dirname in glob(osp.join(path, '*')):
             if osp.basename(dirname).startswith(Market1501Path.BBOX_DIR):
@@ -32,6 +34,7 @@ class Market1501Extractor(SourceExtractor):
                 subset = osp.splitext(subset)[0]
                 break
         super().__init__(subset=subset)
+
         self._path = path
         self._items = list(self._load_items(path).values())
 
@@ -41,12 +44,12 @@ class Market1501Extractor(SourceExtractor):
         paths = glob(osp.join(path, Market1501Path.QUERY_DIR, '*'))
         paths += glob(osp.join(path, Market1501Path.BBOX_DIR + self._subset, '*'))
 
-        anno_file = osp.join(path, Market1501Path.IMAGE_NAMES + self._subset + '.txt')
+        anno_file = osp.join(path,
+            Market1501Path.IMAGE_NAMES + self._subset + '.txt')
         if len(paths) == 0 and osp.isfile(anno_file):
             with open(anno_file, encoding='utf-8') as f:
                 for line in f:
-                    line = line.strip()
-                    paths.append(line)
+                    paths.append(line.strip())
 
         for image_path in paths:
             if osp.splitext(image_path)[-1] != Market1501Path.IMAGE_EXT:
@@ -61,10 +64,11 @@ class Market1501Extractor(SourceExtractor):
                     item_id = item_id[19:]
             items[item_id] = DatasetItem(id=item_id, subset=self._subset,
                 image=image_path)
-            attributes = items[item_id].attributes
+
             if pid == -1:
                 continue
 
+            attributes = items[item_id].attributes
             camid -= 1
             attributes['person_id'] = pid
             attributes['camera_id'] = camid
@@ -96,6 +100,7 @@ class Market1501Converter(Converter):
                         pid = int(item.attributes.get('person_id'))
                         camid = int(item.attributes.get('camera_id')) + 1
                         image_name = image_pattern.format(pid, camid, item.id)
+
                 dirname = Market1501Path.BBOX_DIR + subset_name
                 if 'query' in item.attributes:
                     query = item.attributes.get('query')
@@ -109,6 +114,7 @@ class Market1501Converter(Converter):
                     self._save_image(item, image_path)
                 else:
                     annotation += '%s\n' % image_path
+
             if 0 < len(annotation):
                 annotation_file = osp.join(self._save_dir,
                     Market1501Path.IMAGE_NAMES + subset_name + '.txt')

--- a/tests/test_icdar_format.py
+++ b/tests/test_icdar_format.py
@@ -69,20 +69,20 @@ class IcdarImporterTest(TestCase):
             DatasetItem(id='1', subset='train',
                 image=np.ones((2, 5, 3)),
                 annotations=[
-                    Mask(id=1, group=0,
+                    Mask(group=0,
                         image=np.array([[0, 1, 1, 0, 0], [0, 0, 0, 0, 0]]),
-                        attributes={ 'color': (108, 225, 132),
-                            'text': 'F', 'center': [0, 1]
+                        attributes={ 'index': 0, 'color': '108 225 132',
+                            'text': 'F', 'center': '0 1'
                         }),
-                    Mask(id=2, group=1,
+                    Mask(group=1,
                         image=np.array([[0, 0, 0, 1, 0], [0, 0, 0, 1, 0]]),
-                        attributes = { 'color': (82, 174, 214),
-                            'text': 'T', 'center': [1, 3]
+                        attributes={ 'index': 1, 'color': '82 174 214',
+                            'text': 'T', 'center': '1 3'
                         }),
-                    Mask(id=3, group=1,
+                    Mask(group=1,
                         image=np.array([[0, 0, 0, 0, 0], [0, 0, 0, 0, 1]]),
-                        attributes = { 'color': (241, 73, 144),
-                            'text': 'h', 'center': [1, 4]
+                        attributes={ 'index': 2, 'color': '241 73 144',
+                            'text': 'h', 'center': '1 4'
                         }),
                 ]
             ),
@@ -145,27 +145,27 @@ class IcdarConverterTest(TestCase):
         expected_dataset = Dataset.from_iterable([
             DatasetItem(id=1, subset='train',
                 annotations=[
-                    Mask(id=2, image=np.array([[0, 0, 0, 1, 1]]), group=1,
-                        attributes={ 'color': (82, 174, 214), 'text': 'j',
-                            'center': [0, 3] }),
-                    Mask(id=1, image=np.array([[0, 1, 1, 0, 0]]), group=1,
-                        attributes={ 'color': (108, 225, 132), 'text': 'F',
-                            'center': [0, 1] }),
+                    Mask(image=np.array([[0, 0, 0, 1, 1]]), group=1,
+                        attributes={ 'index': 1, 'color': '82 174 214', 'text': 'j',
+                            'center': '0 3' }),
+                    Mask(image=np.array([[0, 1, 1, 0, 0]]), group=1,
+                        attributes={ 'index': 0, 'color': '108 225 132', 'text': 'F',
+                            'center': '0 1' }),
                 ]),
             DatasetItem(id=2, subset='train',
                 annotations=[
-                    Mask(id=4, image=np.array([[0, 0, 0, 0, 0, 1]]), group=0,
-                        attributes={ 'color': (183, 6, 28), 'text': ' ',
-                            'center': [0, 5] }),
-                    Mask(id=1, image=np.array([[1, 0, 0, 0, 0, 0]]), group=1,
-                        attributes={ 'color': (108, 225, 132), 'text': 'L',
-                            'center': [0, 0] }),
-                    Mask(id=2, image=np.array([[0, 0, 0, 1, 1, 0]]), group=1,
-                        attributes={ 'color': (82, 174, 214), 'text': 'o',
-                            'center': [0, 3] }),
-                    Mask(id=3, image=np.array([[0, 1, 1, 0, 0, 0]]), group=0,
-                        attributes={ 'color': (241, 73, 144), 'text': 'P',
-                            'center': [0, 1] }),
+                    Mask(image=np.array([[0, 0, 0, 0, 0, 1]]), group=0,
+                        attributes={ 'index': 3, 'color': '183 6 28', 'text': ' ',
+                            'center': '0 5' }),
+                    Mask(image=np.array([[1, 0, 0, 0, 0, 0]]), group=1,
+                        attributes={ 'index': 0, 'color': '108 225 132', 'text': 'L',
+                            'center': '0 0' }),
+                    Mask(image=np.array([[0, 0, 0, 1, 1, 0]]), group=1,
+                        attributes={ 'index': 1, 'color': '82 174 214', 'text': 'o',
+                            'center': '0 3' }),
+                    Mask(image=np.array([[0, 1, 1, 0, 0, 0]]), group=0,
+                        attributes={ 'index': 2, 'color': '241 73 144', 'text': 'P',
+                            'center': '0 1' }),
                 ]),
         ])
 

--- a/tests/test_market1501_format.py
+++ b/tests/test_market1501_format.py
@@ -62,6 +62,32 @@ class Market1501FormatTest(TestCase):
 
             compare_datasets(self, source_dataset, parsed_dataset)
 
+    def test_can_save_dataset_with_no_save_images(self):
+        source_dataset = Dataset.from_iterable([
+            DatasetItem(id='0001_c2s3_000001_00',
+                image=np.ones((2, 5, 3)),
+                attributes = {
+                    'camera_id': 1,
+                    'person_id': 1,
+                    'query': True
+                }
+            ),
+            DatasetItem(id='test1',
+                image=np.ones((2, 5, 3)),
+                attributes = {
+                    'camera_id': 1,
+                    'person_id': 2,
+                    'query': False
+                }
+            ),
+        ])
+
+        with TestDir() as test_dir:
+            Market1501Converter.convert(source_dataset, test_dir, save_images=False)
+            parsed_dataset = Dataset.import_from(test_dir, 'market1501')
+
+            compare_datasets(self, source_dataset, parsed_dataset)
+
 DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'market1501_dataset')
 
 class Market1501ImporterTest(TestCase):

--- a/tests/test_market1501_format.py
+++ b/tests/test_market1501_format.py
@@ -65,7 +65,7 @@ class Market1501FormatTest(TestCase):
     def test_can_save_dataset_with_no_save_images(self):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='0001_c2s3_000001_00',
-                image=np.ones((2, 5, 3)),
+                subset='test', image=np.ones((2, 5, 3)),
                 attributes = {
                     'camera_id': 1,
                     'person_id': 1,
@@ -73,7 +73,7 @@ class Market1501FormatTest(TestCase):
                 }
             ),
             DatasetItem(id='test1',
-                image=np.ones((2, 5, 3)),
+                subset='test', image=np.ones((2, 5, 3)),
                 attributes = {
                     'camera_id': 1,
                     'person_id': 2,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
ICDAR:
- id replaced with index attribute
- made the color and center attributes to strings
- added checks

Market-1501:
- added saving the file with the names of the images, if `save_images = False`
- added checks

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
