### PR TITLE
Refactor image saving in formats, fix vggface2 and widerface

### DIFF
--- a/datumaro/components/converter.py
+++ b/datumaro/components/converter.py
@@ -57,15 +57,23 @@ class Converter(CliPlugin):
 
         return self._image_ext or src_ext or self._default_image_ext
 
-    def _make_image_filename(self, item):
-        return item.id + self._find_image_ext(item)
+    def _make_image_filename(self, item, *, name=None, subdir=None):
+        name = name or item.id
+        subdir = subdir or ''
+        return osp.join(subdir, name + self._find_image_ext(item))
 
-    def _save_image(self, item, path=None):
+    def _save_image(self, item, path=None, *,
+            name=None, subdir=None, basedir=None):
+        assert not ((subdir or name or basedir) and path), \
+            "Can't use both subdir or name or basedir and path arguments"
+
         if not item.image.has_data:
             log.warning("Item '%s' has no image", item.id)
             return
 
-        path = path or self._make_image_filename(item)
+        basedir = basedir or self._save_dir
+        path = path or osp.join(basedir,
+            self._make_image_filename(item, name=name, subdir=subdir))
         path = osp.abspath(path)
 
         src_ext = item.image.ext.lower()

--- a/datumaro/plugins/image_dir.py
+++ b/datumaro/plugins/image_dir.py
@@ -44,7 +44,6 @@ class ImageDirConverter(Converter):
 
         for item in self._extractor:
             if item.has_image:
-                self._save_image(item,
-                    osp.join(self._save_dir, self._make_image_filename(item)))
+                self._save_image(item)
             else:
                 log.debug("Item '%s' has no image info", item.id)

--- a/datumaro/plugins/imagenet_txt_format.py
+++ b/datumaro/plugins/imagenet_txt_format.py
@@ -93,9 +93,7 @@ class ImagenetTxtConverter(Converter):
                     if p.type == AnnotationType.label]
 
                 if self._save_images and item.has_image:
-                    self._save_image(item,
-                        osp.join(self._save_dir, ImagenetTxtPath.IMAGE_DIR,
-                            self._make_image_filename(item)))
+                    self._save_image(item, subdir=ImagenetTxtPath.IMAGE_DIR)
 
             with open(annotation_file, 'w', encoding='utf-8') as f:
                 f.writelines(['%s %s\n' % (item_id, ' '.join(labels[item_id]))

--- a/datumaro/plugins/mot_format.py
+++ b/datumaro/plugins/mot_format.py
@@ -214,9 +214,8 @@ class MotSeqGtConverter(Converter):
     def apply(self):
         extractor = self._extractor
 
-        images_dir = osp.join(self._save_dir, MotPath.IMAGE_DIR)
-        os.makedirs(images_dir, exist_ok=True)
-        self._images_dir = images_dir
+        image_dir = osp.join(self._save_dir, MotPath.IMAGE_DIR)
+        os.makedirs(image_dir, exist_ok=True)
 
         anno_dir = osp.join(self._save_dir, 'gt')
         os.makedirs(anno_dir, exist_ok=True)
@@ -259,8 +258,8 @@ class MotSeqGtConverter(Converter):
 
                 if self._save_images:
                     if item.has_image and item.image.has_data:
-                        self._save_image(item, osp.join(self._images_dir,
-                            '%06d%s' % (frame_id, self._find_image_ext(item))))
+                        self._save_image(item, subdir=image_dir,
+                            name='%06d' % frame_id)
                     else:
                         log.debug("Item '%s' has no image", item.id)
 

--- a/datumaro/plugins/mots_format.py
+++ b/datumaro/plugins/mots_format.py
@@ -111,7 +111,7 @@ class MotsPngConverter(Converter):
     def apply(self):
         for subset_name, subset in self._extractor.subsets().items():
             subset_dir = osp.join(self._save_dir, subset_name)
-            images_dir = osp.join(subset_dir, MotsPath.IMAGE_DIR)
+            image_dir = osp.join(subset_dir, MotsPath.IMAGE_DIR)
             anno_dir = osp.join(subset_dir, MotsPath.MASKS_DIR)
             os.makedirs(anno_dir, exist_ok=True)
 
@@ -120,8 +120,7 @@ class MotsPngConverter(Converter):
 
                 if self._save_images:
                     if item.has_image and item.image.has_data:
-                        self._save_image(item,
-                            osp.join(images_dir, self._make_image_filename(item)))
+                        self._save_image(item, subdir=image_dir)
                     else:
                         log.debug("Item '%s' has no image", item.id)
 

--- a/datumaro/plugins/vgg_face2_format.py
+++ b/datumaro/plugins/vgg_face2_format.py
@@ -129,7 +129,7 @@ class VggFace2Importer(Importer):
                 not osp.basename(p).startswith(VggFace2Path.BBOXES_FILE))
 
 class VggFace2Converter(Converter):
-    DEFAULT_IMAGE_EXT = '.jpg'
+    DEFAULT_IMAGE_EXT = VggFace2Path.IMAGE_EXT
 
     def apply(self):
         save_dir = self._save_dir
@@ -148,7 +148,6 @@ class VggFace2Converter(Converter):
         label_categories = self._extractor.categories()[AnnotationType.label]
 
         for subset_name, subset in self._extractor.subsets().items():
-            subset_dir = osp.join(save_dir, subset_name)
             bboxes_table = []
             landmarks_table = []
             for item in subset:
@@ -157,13 +156,11 @@ class VggFace2Converter(Converter):
                         if getattr(p, 'label') != None)
                     if labels:
                         for label in labels:
-                            self._save_image(item, osp.join(subset_dir,
-                                label_categories[label].name + '/' \
-                                + item.id + VggFace2Path.IMAGE_EXT))
+                            self._save_image(item, subdir=osp.join(subset_name,
+                                label_categories[label].name))
                     else:
-                        self._save_image(item, osp.join(subset_dir,
-                            VggFace2Path.IMAGES_DIR_NO_LABEL,
-                            item.id + VggFace2Path.IMAGE_EXT))
+                        self._save_image(item, subdir=osp.join(subset_name,
+                            VggFace2Path.IMAGES_DIR_NO_LABEL))
 
                 landmarks = [a for a in item.annotations
                     if a.type == AnnotationType.points]

--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -17,6 +17,7 @@ from datumaro.components.dataset import ItemStatus
 from datumaro.components.extractor import (AnnotationType,
     CompiledMask, DatasetItem, LabelCategories)
 from datumaro.util import find, str_to_bool
+from datumaro.util.annotation_util import make_label_id_mapping
 from datumaro.util.image import save_image
 from datumaro.util.mask_tools import paint_mask, remap_mask
 
@@ -562,22 +563,12 @@ class VocConverter(Converter):
         return label_desc[2]
 
     def _make_label_id_map(self):
-        source_labels = {
-            id: label.name for id, label in
-            enumerate(self._extractor.categories().get(
-                AnnotationType.label, LabelCategories()).items)
-        }
-        target_labels = {
-            label.name: id for id, label in
-            enumerate(self._categories[AnnotationType.label].items)
-        }
-        id_mapping = {
-            src_id: target_labels.get(src_label, 0)
-            for src_id, src_label in source_labels.items()
-        }
+        map_id, id_mapping, src_labels, dst_labels = make_label_id_mapping(
+            self._extractor.categories().get(AnnotationType.label),
+            self._categories[AnnotationType.label])
 
-        void_labels = [src_label for src_id, src_label in source_labels.items()
-            if src_label not in target_labels]
+        void_labels = [src_label for src_id, src_label in src_labels.items()
+            if src_label not in dst_labels]
         if void_labels:
             log.warning("The following labels are remapped to background: %s" %
                 ', '.join(void_labels))
@@ -588,12 +579,10 @@ class VocConverter(Converter):
                     self._categories[AnnotationType.label] \
                         .items[id_mapping[src_id]].name
                 )
-                for src_id, src_label in source_labels.items()
+                for src_id, src_label in src_labels.items()
             ])
         )
 
-        def map_id(src_id):
-            return id_mapping.get(src_id, 0)
         return map_id
 
     def _remap_mask(self, mask):

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -122,7 +122,7 @@ class WiderFaceImporter(Importer):
             dirname=WiderFacePath.ANNOTATIONS_DIR)
 
 class WiderFaceConverter(Converter):
-    DEFAULT_IMAGE_EXT = '.jpg'
+    DEFAULT_IMAGE_EXT = WiderFacePath.IMAGE_EXT
 
     def apply(self):
         save_dir = self._save_dir
@@ -143,12 +143,12 @@ class WiderFaceConverter(Converter):
                 labels = [a.label for a in item.annotations
                     if a.type == AnnotationType.label]
                 if labels:
-                    image_path = '%s--%s/%s' % (
-                        labels[0], label_categories[labels[0]].name,
-                        item.id + WiderFacePath.IMAGE_EXT)
+                    image_path = self._make_image_filename(item,
+                        subdir='%s--%s' % (
+                            labels[0], label_categories[labels[0]].name))
                 else:
-                    image_path = '%s/%s' % (WiderFacePath.IMAGES_DIR_NO_LABEL,
-                        item.id + WiderFacePath.IMAGE_EXT)
+                    image_path = self._make_image_filename(item,
+                        subdir=WiderFacePath.IMAGES_DIR_NO_LABEL)
                 wider_annotation += image_path + '\n'
                 if item.has_image and self._save_images:
                     self._save_image(item, osp.join(save_dir, subset_dir,

--- a/datumaro/util/annotation_util.py
+++ b/datumaro/util/annotation_util.py
@@ -6,7 +6,8 @@ from itertools import groupby
 
 import numpy as np
 
-from datumaro.components.extractor import _Shape, Mask, AnnotationType, RleMask
+from datumaro.components.extractor import (LabelCategories, _Shape, Mask,
+    AnnotationType, RleMask)
 from datumaro.util.mask_tools import mask_to_rle
 
 
@@ -210,3 +211,19 @@ def smooth_line(points, segments):
         new_points[new_segment] = prev_p * (1 - r) + next_p * r
 
     return new_points, step
+
+def make_label_id_mapping(
+        src_labels: LabelCategories, dst_labels: LabelCategories, fallback=0):
+    source_labels = { id: label.name
+        for id, label in enumerate(src_labels or LabelCategories().items)
+    }
+    target_labels = { label.name: id
+        for id, label in enumerate(dst_labels or LabelCategories().items)
+    }
+    id_mapping = { src_id: target_labels.get(src_label, fallback)
+        for src_id, src_label in source_labels.items()
+    }
+
+    def map_id(src_id):
+        return id_mapping.get(src_id, fallback)
+    return map_id, id_mapping, source_labels, target_labels


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Fixed image saving in VggFace2 and Widerface. Formats should not convert extensions, unless requested
- Refactored image saving in formats

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
