### PR TITLE
[WIP] Support arbitrary image extensions in formats

### DIFF
--- a/datumaro/plugins/camvid_format.py
+++ b/datumaro/plugins/camvid_format.py
@@ -136,11 +136,14 @@ def make_camvid_categories(label_map=None):
 
 
 class CamvidExtractor(SourceExtractor):
-    def __init__(self, path):
+    def __init__(self, path, subset=None):
         assert osp.isfile(path), path
         self._path = path
         self._dataset_dir = osp.dirname(path)
-        super().__init__(subset=osp.splitext(osp.basename(path))[0])
+
+        if not subset:
+            subset = osp.splitext(osp.basename(path))[0]
+        super().__init__(subset=subset)
 
         self._categories = self._load_categories(self._dataset_dir)
         self._items = list(self._load_items(path).values())
@@ -157,33 +160,36 @@ class CamvidExtractor(SourceExtractor):
 
     def _load_items(self, path):
         items = {}
+
+        labels = self._categories[AnnotationType.label]._indices
+        labels = { labels[label_name]: label_name
+            for label_name in labels }
+
         with open(path, encoding='utf-8') as f:
             for line in f:
                 objects = line.split()
                 image = objects[0]
-                item_id = ('/'.join(image.split('/')[2:]))[:-len(CamvidPath.IMAGE_EXT)]
-                image_path = osp.join(self._dataset_dir,
-                    (image, image[1:])[image[0] == '/'])
+                item_id = osp.splitext(osp.join(*image.split('/')[2:]))[0]
+                image_path = osp.join(self._dataset_dir, image.lstrip('/'))
+
                 item_annotations = []
                 if 1 < len(objects):
                     gt = objects[1]
-                    gt_path = osp.join(self._dataset_dir,
-                        (gt, gt[1:]) [gt[0] == '/'])
-                    inverse_cls_colormap = \
-                        self._categories[AnnotationType.mask].inverse_colormap
-                    mask = lazy_mask(gt_path, inverse_cls_colormap)
-                    # loading mask through cache
-                    mask = mask()
+                    gt_path = osp.join(self._dataset_dir, gt.lstrip('/'))
+                    mask = lazy_mask(gt_path,
+                        self._categories[AnnotationType.mask].inverse_colormap)
+                    mask = mask() # loading mask through cache
+
                     classes = np.unique(mask)
-                    labels = self._categories[AnnotationType.label]._indices
-                    labels = { labels[label_name]: label_name
-                        for label_name in labels }
                     for label_id in classes:
                         if labels[label_id] in self._labels:
                             image = self._lazy_extract_mask(mask, label_id)
-                            item_annotations.append(Mask(image=image, label=label_id))
+                            item_annotations.append(
+                                Mask(image=image, label=label_id))
+
                 items[item_id] = DatasetItem(id=item_id, subset=self._subset,
                     image=image_path, annotations=item_annotations)
+
         return items
 
     @staticmethod

--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -21,11 +21,15 @@ from .format import CocoTask, CocoPath
 
 
 class _CocoExtractor(SourceExtractor):
-    def __init__(self, path, task, merge_instance_polygons=False):
+    _NOTSET = object()
+
+    def __init__(self, path, task, merge_instance_polygons=False,
+            subset=_NOTSET):
         assert osp.isfile(path), path
 
-        subset = osp.splitext(osp.basename(path))[0].rsplit('_', maxsplit=1)
-        subset = subset[1] if len(subset) == 2 else None
+        if subset is self._NOTSET:
+            subset = osp.splitext(osp.basename(path))[0].rsplit('_', maxsplit=1)
+            subset = subset[1] if len(subset) == 2 else None
         super().__init__(subset=subset)
 
         rootpath = ''

--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -21,13 +21,10 @@ from .format import CocoTask, CocoPath
 
 
 class _CocoExtractor(SourceExtractor):
-    _NOTSET = object()
-
-    def __init__(self, path, task, merge_instance_polygons=False,
-            subset=_NOTSET):
+    def __init__(self, path, task, merge_instance_polygons=False, subset=None):
         assert osp.isfile(path), path
 
-        if subset is self._NOTSET:
+        if not subset:
             subset = osp.splitext(osp.basename(path))[0].rsplit('_', maxsplit=1)
             subset = subset[1] if len(subset) == 2 else None
         super().__init__(subset=subset)

--- a/datumaro/plugins/cvat_format/converter.py
+++ b/datumaro/plugins/cvat_format/converter.py
@@ -11,7 +11,8 @@ from xml.sax.saxutils import XMLGenerator
 
 from datumaro.components.converter import Converter
 from datumaro.components.dataset import ItemStatus
-from datumaro.components.extractor import AnnotationType, DatasetItem
+from datumaro.components.extractor import (AnnotationType, DatasetItem,
+    LabelCategories)
 from datumaro.util import cast, pairs
 
 from .format import CvatPath
@@ -190,7 +191,8 @@ class _SubsetWriter:
         self._writer.close_image()
 
     def _write_meta(self):
-        label_cat = self._extractor.categories()[AnnotationType.label]
+        label_cat = self._extractor.categories().get(
+            AnnotationType.label, LabelCategories())
         meta = OrderedDict([
             ("task", OrderedDict([
                 ("id", ""),
@@ -222,6 +224,8 @@ class _SubsetWriter:
         self._writer.write_meta(meta)
 
     def _get_label(self, label_id):
+        if label_id is None:
+            return ""
         label_cat = self._extractor.categories()[AnnotationType.label]
         return label_cat.items[label_id]
 

--- a/datumaro/plugins/cvat_format/extractor.py
+++ b/datumaro/plugins/cvat_format/extractor.py
@@ -18,8 +18,9 @@ from .format import CvatPath
 
 class CvatExtractor(SourceExtractor):
     _SUPPORTED_SHAPES = ('box', 'polygon', 'polyline', 'points')
+    _NOTSET = object()
 
-    def __init__(self, path):
+    def __init__(self, path, subset=_NOTSET):
         assert osp.isfile(path), path
         rootpath = osp.dirname(path)
         images_dir = ''
@@ -28,7 +29,9 @@ class CvatExtractor(SourceExtractor):
         self._images_dir = images_dir
         self._path = path
 
-        super().__init__(subset=osp.splitext(osp.basename(path))[0])
+        if subset is self._NOTSET:
+            subset = osp.splitext(osp.basename(path))[0]
+        super().__init__(subset=subset)
 
         items, categories = self._parse(path)
         self._items = list(self._load_items(items).values())

--- a/datumaro/plugins/cvat_format/extractor.py
+++ b/datumaro/plugins/cvat_format/extractor.py
@@ -18,9 +18,8 @@ from .format import CvatPath
 
 class CvatExtractor(SourceExtractor):
     _SUPPORTED_SHAPES = ('box', 'polygon', 'polyline', 'points')
-    _NOTSET = object()
 
-    def __init__(self, path, subset=_NOTSET):
+    def __init__(self, path, subset=None):
         assert osp.isfile(path), path
         rootpath = osp.dirname(path)
         images_dir = ''
@@ -29,7 +28,7 @@ class CvatExtractor(SourceExtractor):
         self._images_dir = images_dir
         self._path = path
 
-        if subset is self._NOTSET:
+        if not subset:
             subset = osp.splitext(osp.basename(path))[0]
         super().__init__(subset=subset)
 

--- a/datumaro/plugins/icdar_format/converter.py
+++ b/datumaro/plugins/icdar_format/converter.py
@@ -72,21 +72,19 @@ class _TextSegmentationConverter:
         anns = [a for a in item.annotations
             if a.type == AnnotationType.mask]
         if anns:
-            is_not_index = len([p for p in anns if 'index' not in p.attributes])
-            if is_not_index:
-                raise Exception("Item %s: a mask must have"
-                    "'index' attribute" % item.id)
-            anns = sorted(anns, key=lambda a: a.attributes['index'])
+            anns = sorted(anns, key=lambda a: int(a.attributes.get('index', 0)))
             group = anns[0].group
             for ann in anns:
                 if ann.group != group or (not ann.group and anns[0].group != 0):
                     annotation += '\n'
+
                 text = ''
                 if ann.attributes:
                     if 'text' in ann.attributes:
                         text = ann.attributes['text']
                     if text == ' ':
                         annotation += '#'
+
                     if 'color' in ann.attributes and \
                             len(ann.attributes['color'].split()) == 3:
                         color = ann.attributes['color'].split()
@@ -96,15 +94,18 @@ class _TextSegmentationConverter:
                     else:
                         raise Exception("Item %s: a mask must have "
                             "an RGB color attribute, e. g. '10 7 50'" % item.id)
+
                     if 'center' in ann.attributes:
                         annotation += ' %s' % ann.attributes['center']
                     else:
                         annotation += ' - -'
+
                 bbox = ann.get_bbox()
                 annotation += ' %s %s %s %s' % (bbox[0], bbox[1],
                     bbox[0] + bbox[2], bbox[1] + bbox[3])
                 annotation += ' \"%s\"' % text
                 annotation += '\n'
+
                 group = ann.group
 
             mask = CompiledMask.from_instance_masks(anns,

--- a/datumaro/plugins/icdar_format/extractor.py
+++ b/datumaro/plugins/icdar_format/extractor.py
@@ -9,13 +9,16 @@ import numpy as np
 
 from datumaro.components.extractor import (Bbox, Caption, DatasetItem,
     Importer, Mask, MaskCategories, Polygon, SourceExtractor)
+from datumaro.util.image import find_images
 from datumaro.util.mask_tools import lazy_mask
 
 from .format import IcdarPath, IcdarTask
 
 
 class _IcdarExtractor(SourceExtractor):
-    def __init__(self, path, task):
+    _NOTSET = object()
+
+    def __init__(self, path, task, subset=_NOTSET):
         self._path = path
         self._task = task
 
@@ -23,7 +26,11 @@ class _IcdarExtractor(SourceExtractor):
             if not osp.isfile(path):
                 raise FileNotFoundError(
                     "Can't read annotation file '%s'" % path)
-            super().__init__(subset=osp.basename(osp.dirname(path)))
+
+            if subset is self._NOTSET:
+                subset = osp.basename(osp.dirname(path))
+            super().__init__(subset=subset)
+
             self._dataset_dir = osp.dirname(osp.dirname(path))
 
             self._items = list(self._load_recognition_items().values())
@@ -31,13 +38,17 @@ class _IcdarExtractor(SourceExtractor):
             if not osp.isdir(path):
                 raise NotADirectoryError(
                     "Can't open folder with annotation files '%s'" % path)
-            super().__init__(subset=osp.basename(path))
+
+            if subset is self._NOTSET:
+                subset = osp.basename(path)
+            super().__init__(subset=subset)
+
             self._dataset_dir = osp.dirname(path)
+
             if task is IcdarTask.text_localization:
                 self._items = list(self._load_localization_items().values())
             else:
                 self._items = list(self._load_segmentation_items().values())
-
 
     def _load_recognition_items(self):
         items = {}
@@ -52,7 +63,7 @@ class _IcdarExtractor(SourceExtractor):
                     image = objects[0][:-1]
                     captions = []
 
-                item_id = image[:-len(IcdarPath.IMAGE_EXT)]
+                item_id = osp.splitext(image)[0]
                 image_path = osp.join(osp.dirname(self._path),
                     IcdarPath.IMAGES_DIR, image)
                 if item_id not in items:
@@ -69,15 +80,20 @@ class _IcdarExtractor(SourceExtractor):
     def _load_localization_items(self):
         items = {}
 
+        image_dir = osp.join(self._path, IcdarPath.IMAGES_DIR)
+        if osp.isdir(image_dir):
+            images = { osp.splitext(osp.relpath(p, image_dir))[0]: p
+                for p in find_images(image_dir, recursive=True) }
+        else:
+            images = {}
+
         for path in glob(osp.join(self._path, '*.txt')):
             item_id = osp.splitext(osp.basename(path))[0]
             if item_id.startswith('gt_'):
                 item_id = item_id[3:]
-            image_path = osp.join(self._path, IcdarPath.IMAGES_DIR,
-                item_id + IcdarPath.IMAGE_EXT)
             if item_id not in items:
                 items[item_id] = DatasetItem(item_id, subset=self._subset,
-                    image=image_path)
+                    image=images.get(item_id))
             annotations = items[item_id].annotations
 
             with open(path, encoding='utf-8') as f:
@@ -89,12 +105,14 @@ class _IcdarExtractor(SourceExtractor):
 
                     if 8 <= len(objects):
                         points = [float(p) for p in objects[:8]]
+
                         attributes = {}
                         if len(objects) == 9:
                             text = objects[8]
                             if text[0] == '\"' and text[-1] == '\"':
                                 text = text[1:-1]
                             attributes['text'] = text
+
                         annotations.append(
                             Polygon(points, attributes=attributes))
                     elif 4 <= len(objects):
@@ -102,12 +120,14 @@ class _IcdarExtractor(SourceExtractor):
                         y = float(objects[1])
                         w = float(objects[2]) - x
                         h = float(objects[3]) - y
+
                         attributes = {}
                         if len(objects) == 5:
                             text = objects[4]
                             if text[0] == '\"' and text[-1] == '\"':
                                 text = text[1:-1]
                             attributes['text'] = text
+
                         annotations.append(
                             Bbox(x, y, w, h, attributes=attributes))
         return items
@@ -115,15 +135,20 @@ class _IcdarExtractor(SourceExtractor):
     def _load_segmentation_items(self):
         items = {}
 
+        image_dir = osp.join(self._path, IcdarPath.IMAGES_DIR)
+        if osp.isdir(image_dir):
+            images = { osp.splitext(osp.relpath(p, image_dir))[0]: p
+                for p in find_images(image_dir, recursive=True) }
+        else:
+            images = {}
+
         for path in glob(osp.join(self._path, '*.txt')):
             item_id = osp.splitext(osp.basename(path))[0]
             if item_id.endswith('_GT'):
                 item_id = item_id[:-3]
-            image_path = osp.join(self._path, IcdarPath.IMAGES_DIR,
-                item_id + IcdarPath.IMAGE_EXT)
             if item_id not in items:
                 items[item_id] = DatasetItem(item_id, subset=self._subset,
-                    image=image_path)
+                    image=images.get(item_id))
             annotations = items[item_id].annotations
 
             colors = [(255, 255, 255)]
@@ -179,7 +204,8 @@ class _IcdarExtractor(SourceExtractor):
                     i = int(label_id)
                     annotations.append(Mask(group=groups[i],
                         image=self._lazy_extract_mask(mask, label_id),
-                        attributes={ 'index': i - 1, 'color': ' '.join(str(p) for p in colors[i]),
+                        attributes={ 'index': i - 1,
+                            'color': ' '.join(str(p) for p in colors[i]),
                             'text': chars[i], 'center': centers[i] }
                     ))
         return items
@@ -213,19 +239,23 @@ class IcdarImporter(Importer):
     @classmethod
     def find_sources(cls, path):
         sources = []
+
         paths = [path]
         if osp.basename(path) not in IcdarPath.TASK_DIR.values():
             paths = [p for p in glob(osp.join(path, '**'))
                 if osp.basename(p) in IcdarPath.TASK_DIR.values()]
+
         for path in paths:
             for task, extractor_type, task_dir in cls._TASKS:
                 if not osp.isdir(path) or osp.basename(path) != task_dir:
                     continue
+
                 if task is IcdarTask.word_recognition:
                     ext = '.txt'
                 elif task is IcdarTask.text_localization or \
                         task is IcdarTask.text_segmentation:
                     ext = ''
+
                 sources += cls._find_sources_recursive(path, ext,
                     extractor_type, file_filter=lambda p:
                         osp.basename(p) != IcdarPath.VOCABULARY_FILE)

--- a/datumaro/plugins/icdar_format/extractor.py
+++ b/datumaro/plugins/icdar_format/extractor.py
@@ -16,9 +16,7 @@ from .format import IcdarPath, IcdarTask
 
 
 class _IcdarExtractor(SourceExtractor):
-    _NOTSET = object()
-
-    def __init__(self, path, task, subset=_NOTSET):
+    def __init__(self, path, task, subset=None):
         self._path = path
         self._task = task
 
@@ -27,7 +25,7 @@ class _IcdarExtractor(SourceExtractor):
                 raise FileNotFoundError(
                     "Can't read annotation file '%s'" % path)
 
-            if subset is self._NOTSET:
+            if not subset:
                 subset = osp.basename(osp.dirname(path))
             super().__init__(subset=subset)
 
@@ -39,7 +37,7 @@ class _IcdarExtractor(SourceExtractor):
                 raise NotADirectoryError(
                     "Can't open folder with annotation files '%s'" % path)
 
-            if subset is self._NOTSET:
+            if not subset:
                 subset = osp.basename(path)
             super().__init__(subset=subset)
 

--- a/datumaro/plugins/image_dir_format.py
+++ b/datumaro/plugins/image_dir_format.py
@@ -9,7 +9,7 @@ import os.path as osp
 
 from datumaro.components.extractor import DatasetItem, SourceExtractor, Importer
 from datumaro.components.converter import Converter
-from datumaro.util.os_util import walk
+from datumaro.util.image import find_images
 
 
 class ImageDirImporter(Importer):
@@ -20,21 +20,15 @@ class ImageDirImporter(Importer):
         return [{ 'url': path, 'format': 'image_dir' }]
 
 class ImageDirExtractor(SourceExtractor):
-    IMAGE_EXT_FORMATS = {'.jpg', '.jpeg', '.png', '.ppm', '.bmp',
-        '.pgm', '.tif', '.tiff'}
-
-    def __init__(self, url, max_depth=10):
-        super().__init__()
+    def __init__(self, url, subset=None, max_depth=None):
+        super().__init__(subset=subset)
 
         assert osp.isdir(url), url
 
-        for dirpath, _, filenames in walk(url, max_depth=max_depth):
-            for name in filenames:
-                if not osp.splitext(name)[-1] in self.IMAGE_EXT_FORMATS:
-                    continue
-                path = osp.join(dirpath, name)
-                item_id = osp.relpath(osp.splitext(path)[0], url)
-                self._items.append(DatasetItem(id=item_id, image=path))
+        for path in find_images(url, recursive=True, max_depth=max_depth):
+            item_id = osp.relpath(osp.splitext(path)[0], url)
+            self._items.append(DatasetItem(id=item_id, subset=self._subset,
+                image=path))
 
 class ImageDirConverter(Converter):
     DEFAULT_IMAGE_EXT = '.jpg'

--- a/datumaro/plugins/imagenet_format.py
+++ b/datumaro/plugins/imagenet_format.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-from glob import glob
 import logging as log
 import os
 import os.path as osp
@@ -12,13 +11,11 @@ from datumaro.components.extractor import (DatasetItem, Label,
     LabelCategories, AnnotationType, SourceExtractor, Importer
 )
 from datumaro.components.converter import Converter
+from datumaro.util.image import find_images
 
 
 class ImagenetPath:
-    DEFAULT_IMAGE_EXT = '.jpg'
-    IMAGE_EXT_FORMATS = {'.jpg', '.jpeg', '.png', '.ppm', '.bmp',
-        '.pgm', '.tif', '.tiff'}
-    IMAGES_DIR_NO_LABEL = 'no_label'
+    IMAGE_DIR_NO_LABEL = 'no_label'
 
 
 class ImagenetExtractor(SourceExtractor):
@@ -31,29 +28,31 @@ class ImagenetExtractor(SourceExtractor):
 
     def _load_categories(self, path):
         label_cat = LabelCategories()
-        for images_dir in sorted(os.listdir(path)):
-            if images_dir != ImagenetPath.IMAGES_DIR_NO_LABEL:
-                label_cat.add(images_dir)
+        for dirname in sorted(os.listdir(path)):
+            if dirname != ImagenetPath.IMAGE_DIR_NO_LABEL:
+                label_cat.add(dirname)
         return { AnnotationType.label: label_cat }
 
     def _load_items(self, path):
         items = {}
-        for image_path in glob(osp.join(path, '*', '*')):
-            if not osp.isfile(image_path) or \
-                    osp.splitext(image_path)[-1].lower() not in \
-                        ImagenetPath.IMAGE_EXT_FORMATS:
-                continue
+
+        for image_path in find_images(path, recursive=True, max_depth=1):
             label = osp.basename(osp.dirname(image_path))
-            image_name = osp.splitext(osp.basename(image_path))[0][len(label) + 1:]
+            image_name = osp.splitext(osp.basename(image_path))[0]
+            if image_name.startswith(label + '_'):
+                image_name = image_name[len(label) + 1:]
+
             item = items.get(image_name)
             if item is None:
                 item = DatasetItem(id=image_name, subset=self._subset,
                     image=image_path)
+                items[image_name] = item
             annotations = item.annotations
-            if label != ImagenetPath.IMAGES_DIR_NO_LABEL:
+
+            if label != ImagenetPath.IMAGE_DIR_NO_LABEL:
                 label = self._categories[AnnotationType.label].find(label)[0]
                 annotations.append(Label(label=label))
-            items[image_name] = item
+
         return items
 
 
@@ -66,27 +65,27 @@ class ImagenetImporter(Importer):
 
 
 class ImagenetConverter(Converter):
-    DEFAULT_IMAGE_EXT = ImagenetPath.DEFAULT_IMAGE_EXT
+    DEFAULT_IMAGE_EXT = '.jpg'
 
     def apply(self):
         if 1 < len(self._extractor.subsets()):
-            log.warning("ImageNet format supports exporting only a single "
+            log.warning("ImageNet format only supports exporting a single "
                 "subset, subset information will not be used.")
 
         subset_dir = self._save_dir
         extractor = self._extractor
         labels = {}
         for item in self._extractor:
-            image_name = item.id
-            labels[image_name] = [p.label for p in item.annotations
-                if p.type == AnnotationType.label]
-            for label in labels[image_name]:
+            labels = set(p.label for p in item.annotations
+                if p.type == AnnotationType.label)
+
+            for label in labels:
                 label_name = extractor.categories()[AnnotationType.label][label].name
                 self._save_image(item, osp.join(subset_dir, label_name,
                     '%s_%s' %  (label_name, self._make_image_filename(item))))
 
-            if not labels[image_name]:
+            if not labels:
                 self._save_image(item, osp.join(subset_dir,
-                    ImagenetPath.IMAGES_DIR_NO_LABEL,
-                    ImagenetPath.IMAGES_DIR_NO_LABEL + '_'
-                    + self._make_image_filename(item)))
+                    ImagenetPath.IMAGE_DIR_NO_LABEL,
+                    ImagenetPath.IMAGE_DIR_NO_LABEL + '_' + \
+                    self._make_image_filename(item)))

--- a/datumaro/plugins/imagenet_txt_format.py
+++ b/datumaro/plugins/imagenet_txt_format.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-from glob import glob
 import os
 import os.path as osp
 
@@ -11,18 +10,22 @@ from datumaro.components.extractor import (DatasetItem, Label,
     LabelCategories, AnnotationType, SourceExtractor, Importer
 )
 from datumaro.components.converter import Converter
+from datumaro.util.image import find_images
 
 
 class ImagenetTxtPath:
-    DEFAULT_IMAGE_EXT = '.jpg'
-    IMAGE_EXT_FORMAT = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif']
     LABELS_FILE = 'synsets.txt'
     IMAGE_DIR = 'images'
 
 class ImagenetTxtExtractor(SourceExtractor):
-    def __init__(self, path, labels=None, image_dir=None):
+    _NOTSET = object()
+
+    def __init__(self, path, labels=None, image_dir=None, subset=_NOTSET):
         assert osp.isfile(path), path
-        super().__init__(subset=osp.splitext(osp.basename(path))[0])
+
+        if subset is self._NOTSET:
+            subset = osp.splitext(osp.basename(path))[0]
+        super().__init__(subset=subset)
 
         if not image_dir:
             image_dir = ImagenetTxtPath.IMAGE_DIR
@@ -33,8 +36,8 @@ class ImagenetTxtExtractor(SourceExtractor):
             labels = self._parse_labels(labels)
         else:
             assert all(isinstance(e, str) for e in labels)
-
         self._categories = self._load_categories(labels)
+
         self._items = list(self._load_items(path).values())
 
     @staticmethod
@@ -47,25 +50,30 @@ class ImagenetTxtExtractor(SourceExtractor):
 
     def _load_items(self, path):
         items = {}
+
+        image_dir = self.image_dir
+        if osp.isdir(image_dir):
+            images = { osp.splitext(osp.relpath(p, image_dir))[0]: p
+                for p in find_images(image_dir, recursive=True) }
+        else:
+            images = {}
+
         with open(path, encoding='utf-8') as f:
             for line in f:
                 item = line.split()
                 item_id = item[0]
                 label_ids = [int(id) for id in item[1:]]
+
                 anno = []
                 for label in label_ids:
                     assert 0 <= label and \
                         label < len(self._categories[AnnotationType.label]), \
                         "Image '%s': unknown label id '%s'" % (item_id, label)
                     anno.append(Label(label))
-                image_path = osp.join(self.image_dir, item_id +
-                    ImagenetTxtPath.DEFAULT_IMAGE_EXT)
-                for path in glob(osp.join(self.image_dir, item_id + '*')):
-                    if osp.splitext(path)[1] in ImagenetTxtPath.IMAGE_EXT_FORMAT:
-                        image_path = path
-                        break
+
                 items[item_id] = DatasetItem(id=item_id, subset=self._subset,
-                    image=image_path, annotations=anno)
+                    image=images.get(item_id), annotations=anno)
+
         return items
 
 
@@ -78,7 +86,7 @@ class ImagenetTxtImporter(Importer):
 
 
 class ImagenetTxtConverter(Converter):
-    DEFAULT_IMAGE_EXT = ImagenetTxtPath.DEFAULT_IMAGE_EXT
+    DEFAULT_IMAGE_EXT = '.jpg'
 
     def apply(self):
         subset_dir = self._save_dir
@@ -87,20 +95,25 @@ class ImagenetTxtConverter(Converter):
         extractor = self._extractor
         for subset_name, subset in self._extractor.subsets().items():
             annotation_file = osp.join(subset_dir, '%s.txt' % subset_name)
+
             labels = {}
             for item in subset:
-                labels[item.id] = [str(p.label) for p in item.annotations
-                    if p.type == AnnotationType.label]
+                labels[item.id] = set(p.label for p in item.annotations
+                    if p.type == AnnotationType.label)
 
                 if self._save_images and item.has_image:
                     self._save_image(item, subdir=ImagenetTxtPath.IMAGE_DIR)
 
             with open(annotation_file, 'w', encoding='utf-8') as f:
-                f.writelines(['%s %s\n' % (item_id, ' '.join(labels[item_id]))
+                f.writelines(['%s %s\n' % (
+                        item_id,
+                        ' '.join(str(l) for l in sorted(labels[item_id]))
+                    )
                     for item_id in labels])
 
         labels_file = osp.join(subset_dir, ImagenetTxtPath.LABELS_FILE)
         with open(labels_file, 'w', encoding='utf-8') as f:
-            f.write('\n'.join(l.name
-                for l in extractor.categories()[AnnotationType.label])
+            f.writelines(l.name + '\n'
+                for l in extractor.categories().get(
+                    AnnotationType.label, LabelCategories())
             )

--- a/datumaro/plugins/imagenet_txt_format.py
+++ b/datumaro/plugins/imagenet_txt_format.py
@@ -18,12 +18,10 @@ class ImagenetTxtPath:
     IMAGE_DIR = 'images'
 
 class ImagenetTxtExtractor(SourceExtractor):
-    _NOTSET = object()
-
-    def __init__(self, path, labels=None, image_dir=None, subset=_NOTSET):
+    def __init__(self, path, labels=None, image_dir=None, subset=None):
         assert osp.isfile(path), path
 
-        if subset is self._NOTSET:
+        if not subset:
             subset = osp.splitext(osp.basename(path))[0]
         super().__init__(subset=subset)
 

--- a/datumaro/plugins/labelme_format.py
+++ b/datumaro/plugins/labelme_format.py
@@ -22,9 +22,9 @@ class LabelMePath:
     IMAGE_EXT = '.jpg'
 
 class LabelMeExtractor(SourceExtractor):
-    def __init__(self, path, subset_name=None):
+    def __init__(self, path, subset=None):
         assert osp.isdir(path), path
-        super().__init__(subset=subset_name)
+        super().__init__(subset=subset)
 
         items, categories = self._parse(path)
         self._categories = categories
@@ -243,7 +243,7 @@ class LabelMeImporter(Importer):
                 d = osp.join(path, d)
                 if osp.isdir(d) and has_annotations(d):
                     subset_paths.append({'url': d, 'format': cls.EXTRACTOR,
-                        'options': {'subset_name': subset}
+                        'options': {'subset': subset}
                     })
         return subset_paths
 

--- a/datumaro/plugins/lfw_format.py
+++ b/datumaro/plugins/lfw_format.py
@@ -9,6 +9,7 @@ import re
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import (AnnotationType, DatasetItem,
     Importer, Points, SourceExtractor)
+from datumaro.util.image import find_images
 
 
 class LfwPath:
@@ -32,7 +33,14 @@ class LfwExtractor(SourceExtractor):
 
     def _load_items(self, path):
         items = {}
+
         images_dir = osp.join(self._dataset_dir, self._subset, LfwPath.IMAGES_DIR)
+        if osp.isdir(images_dir):
+            images = { osp.splitext(osp.relpath(p, images_dir))[0]: p
+                for p in find_images(images_dir, recursive=True) }
+        else:
+            images = {}
+
         with open(path, encoding='utf-8') as f:
             for line in f:
                 pair = line.strip().split()
@@ -41,29 +49,29 @@ class LfwExtractor(SourceExtractor):
                     image2 = self.get_image_name(pair[0], pair[2])
                     if image1 not in items:
                         items[image1] = DatasetItem(id=image1, subset=self._subset,
-                            image=osp.join(images_dir, image1 + LfwPath.IMAGE_EXT),
+                            image=images.get(image1),
                             attributes={'positive_pairs': [], 'negative_pairs': []})
                     if image2 not in items:
                         items[image2] = DatasetItem(id=image2, subset=self._subset,
-                            image=osp.join(images_dir, image2 + LfwPath.IMAGE_EXT),
+                            image=images.get(image2),
                             attributes={'positive_pairs': [], 'negative_pairs': []})
 
-                    attributes = items[image1].attributes
-                    attributes['positive_pairs'].append(image2)
+                    # pairs form a directed graph
+                    items[image1].attributes['positive_pairs'].append(image2)
                 elif len(pair) == 4:
                     image1 = self.get_image_name(pair[0], pair[1])
                     image2 = self.get_image_name(pair[2], pair[3])
                     if image1 not in items:
                         items[image1] = DatasetItem(id=image1, subset=self._subset,
-                            image=osp.join(images_dir, image1 + LfwPath.IMAGE_EXT),
+                            image=images.get(image1),
                             attributes={'positive_pairs': [], 'negative_pairs': []})
                     if image2 not in items:
                         items[image2] = DatasetItem(id=image2, subset=self._subset,
-                            image=osp.join(images_dir, image2 + LfwPath.IMAGE_EXT),
+                            image=images.get(image2),
                             attributes={'positive_pairs': [], 'negative_pairs': []})
 
-                    attributes = items[image1].attributes
-                    attributes['negative_pairs'].append(image2)
+                    # pairs form a directed graph
+                    items[image1].attributes['negative_pairs'].append(image2)
 
         landmarks_file = osp.join(self._dataset_dir, self._subset,
             LfwPath.LANDMARKS_FILE)
@@ -72,9 +80,7 @@ class LfwExtractor(SourceExtractor):
                 for line in f:
                     line = line.split('\t')
 
-                    item_id = line[0]
-                    if item_id.endswith(LfwPath.IMAGE_EXT):
-                        item_id = item_id[:-len(LfwPath.IMAGE_EXT)]
+                    item_id = osp.splitext(line[0])[0]
                     if item_id not in items:
                         items[item_id] = DatasetItem(id=item_id, subset=self._subset,
                             image=osp.join(images_dir, line[0]),
@@ -82,6 +88,7 @@ class LfwExtractor(SourceExtractor):
 
                     annotations = items[item_id].annotations
                     annotations.append(Points([float(p) for p in line[1:]]))
+
         return items
 
     @staticmethod
@@ -94,17 +101,18 @@ class LfwImporter(Importer):
         return cls._find_sources_recursive(path, LfwPath.PAIRS_FILE, 'lfw')
 
 class LfwConverter(Converter):
-    DEFAULT_IMAGE_EXT = '.jpg'
+    DEFAULT_IMAGE_EXT = LfwPath.IMAGE_EXT
 
     def apply(self):
         for subset_name, subset in self._extractor.subsets().items():
             positive_pairs = []
             negative_pairs = []
             landmarks = []
+
             for item in subset:
-                if item.has_image and self._save_images:
-                    self._save_image(item, osp.join(self._save_dir, subset_name,
-                        LfwPath.IMAGES_DIR, item.id + LfwPath.IMAGE_EXT))
+                if self._save_images and item.has_image:
+                    self._save_image(item,
+                        subdir=osp.join(subset_name, LfwPath.IMAGES_DIR))
 
                 person1, num1 = LfwPath.PATTERN.search(item.id).groups()
                 num1 = int(num1)

--- a/datumaro/plugins/lfw_format.py
+++ b/datumaro/plugins/lfw_format.py
@@ -19,10 +19,14 @@ class LfwPath:
     PATTERN = re.compile(r'([\w]+)_([-\d]+)')
 
 class LfwExtractor(SourceExtractor):
-    def __init__(self, path):
+    def __init__(self, path, subset=None):
         if not osp.isfile(path):
-            raise NotADirectoryError("Can't read annotation file '%s'" % path)
-        super().__init__(subset=osp.basename(osp.dirname(path)))
+            raise FileNotFoundError("Can't read annotation file '%s'" % path)
+
+        if not subset:
+            subset = osp.basename(osp.dirname(path))
+        super().__init__(subset=subset)
+
         self._dataset_dir = osp.dirname(osp.dirname(path))
         self._items = list(self._load_items(path).values())
 

--- a/datumaro/plugins/market1501_format.py
+++ b/datumaro/plugins/market1501_format.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import logging as log
 import os
 import os.path as osp
 import re

--- a/datumaro/plugins/market1501_format.py
+++ b/datumaro/plugins/market1501_format.py
@@ -131,12 +131,8 @@ class Market1501Converter(Converter):
 
                 image_path = self._make_image_filename(item,
                     name=image_name, subdir=dirname)
-                if self._save_images:
-                    if item.has_image and item.image.has_data:
-                        self._save_image(item,
-                            osp.join(self._save_dir, image_path))
-                    else:
-                        log.debug("Item '%s' has no image", item.id)
+                if self._save_images and item.has_image:
+                    self._save_image(item, osp.join(self._save_dir, image_path))
 
                 annotation += '%s\n' % image_path
 

--- a/datumaro/plugins/market1501_format.py
+++ b/datumaro/plugins/market1501_format.py
@@ -20,19 +20,23 @@ class Market1501Path:
     IMAGE_NAMES = 'images_'
 
 class Market1501Extractor(SourceExtractor):
-    def __init__(self, path):
+    def __init__(self, path, subset=None):
         if not osp.isdir(path):
             raise NotADirectoryError(
                 "Can't open folder with annotation files '%s'" % path)
 
-        subset = ''
-        for dirname in glob(osp.join(path, '*')):
-            if osp.basename(dirname).startswith(Market1501Path.BBOX_DIR):
-                subset = osp.basename(dirname).replace(Market1501Path.BBOX_DIR, '')
-            if osp.basename(dirname).startswith(Market1501Path.IMAGE_NAMES):
-                subset = osp.basename(dirname).replace(Market1501Path.IMAGE_NAMES, '')
-                subset = osp.splitext(subset)[0]
-                break
+        if not subset:
+            subset = ''
+            for dirname in glob(osp.join(path, '*')):
+                if osp.basename(dirname).startswith(Market1501Path.BBOX_DIR):
+                    subset = osp.basename(dirname) \
+                        .replace(Market1501Path.BBOX_DIR, '')
+                    break
+                if osp.basename(dirname).startswith(Market1501Path.IMAGE_NAMES):
+                    subset = osp.basename(dirname) \
+                        .replace(Market1501Path.IMAGE_NAMES, '')
+                    subset = osp.splitext(subset)[0]
+                    break
         super().__init__(subset=subset)
 
         self._path = path
@@ -86,7 +90,7 @@ class Market1501Importer(Importer):
         return [{ 'url': path, 'format': 'market1501' }]
 
 class Market1501Converter(Converter):
-    DEFAULT_IMAGE_EXT = '.jpg'
+    DEFAULT_IMAGE_EXT = Market1501Path.IMAGE_EXT
 
     def apply(self):
         for subset_name, subset in self._extractor.subsets().items():
@@ -108,6 +112,7 @@ class Market1501Converter(Converter):
                         query = strtobool(query)
                     if query:
                         dirname = Market1501Path.QUERY_DIR
+
                 image_path = osp.join(self._save_dir, dirname,
                     image_name + Market1501Path.IMAGE_EXT)
                 if item.has_image and self._save_images:

--- a/datumaro/plugins/mot_format.py
+++ b/datumaro/plugins/mot_format.py
@@ -17,8 +17,8 @@ from datumaro.components.extractor import (SourceExtractor, Importer,
     DatasetItem, AnnotationType, Bbox, LabelCategories
 )
 from datumaro.components.converter import Converter
-from datumaro.util import cast
-from datumaro.util.image import Image
+from datumaro.util import cast, str_to_bool
+from datumaro.util.image import Image, find_images
 
 
 MotLabel = Enum('MotLabel', [
@@ -133,14 +133,10 @@ class MotSeqExtractor(SourceExtractor):
                     )
                 )
         elif osp.isdir(self._image_dir):
-            for p in os.listdir(self._image_dir):
-                if p.endswith(MotPath.IMAGE_EXT):
-                    frame_id = int(osp.splitext(p)[0])
-                    items[frame_id] = DatasetItem(
-                        id=frame_id,
-                        subset=self._subset,
-                        image=osp.join(self._image_dir, p),
-                    )
+            for p in find_images(self._image_dir):
+                frame_id = int(osp.splitext(osp.relpath(p, self._image_dir))[0])
+                items[frame_id] = DatasetItem(id=frame_id, subset=self._subset,
+                    image=p)
 
         with open(path, newline='', encoding='utf-8') as csv_file:
             # NOTE: Different MOT files have different count of fields

--- a/datumaro/plugins/mot_format.py
+++ b/datumaro/plugins/mot_format.py
@@ -17,7 +17,7 @@ from datumaro.components.extractor import (SourceExtractor, Importer,
     DatasetItem, AnnotationType, Bbox, LabelCategories
 )
 from datumaro.components.converter import Converter
-from datumaro.util import cast, str_to_bool
+from datumaro.util import cast
 from datumaro.util.image import Image, find_images
 
 

--- a/datumaro/plugins/mot_format.py
+++ b/datumaro/plugins/mot_format.py
@@ -59,8 +59,9 @@ class MotPath:
 
 
 class MotSeqExtractor(SourceExtractor):
-    def __init__(self, path, labels=None, occlusion_threshold=0, is_gt=None):
-        super().__init__()
+    def __init__(self, path, labels=None, occlusion_threshold=0, is_gt=None,
+            subset=None):
+        super().__init__(subset=subset)
 
         assert osp.isfile(path)
         seq_root = osp.dirname(osp.dirname(path))

--- a/datumaro/plugins/mots_format.py
+++ b/datumaro/plugins/mots_format.py
@@ -15,7 +15,7 @@ from datumaro.components.extractor import (SourceExtractor, Importer,
     DatasetItem, AnnotationType, Mask, LabelCategories
 )
 from datumaro.components.converter import Converter
-from datumaro.util.image import load_image, save_image
+from datumaro.util.image import find_images, load_image, save_image
 from datumaro.util.mask_tools import merge_masks
 
 
@@ -40,9 +40,9 @@ class MotsPngExtractor(SourceExtractor):
             return [{'url': path, 'format': 'mots_png'}]
         return []
 
-    def __init__(self, path, subset_name=None):
+    def __init__(self, path, subset=None):
         assert osp.isdir(path), path
-        super().__init__(subset=subset_name)
+        super().__init__(subset=subset)
         self._images_dir = osp.join(path, 'images')
         self._anno_dir = osp.join(path, MotsPath.MASKS_DIR)
         self._categories = self._parse_categories(
@@ -59,11 +59,19 @@ class MotsPngExtractor(SourceExtractor):
 
     def _parse_items(self):
         items = []
+
+        image_dir = self._images_dir
+        if osp.isdir(image_dir):
+            images = { osp.splitext(osp.relpath(p, image_dir))[0]: p
+                for p in find_images(image_dir, recursive=True) }
+        else:
+            images = {}
+
         for p in sorted(p for p in
                 glob(self._anno_dir + '/**/*.png', recursive=True)):
             item_id = osp.splitext(osp.relpath(p, self._anno_dir))[0]
             items.append(DatasetItem(id=item_id, subset=self._subset,
-                image=osp.join(self._images_dir, item_id + MotsPath.IMAGE_EXT),
+                image=images.get(item_id),
                 annotations=self._parse_annotations(p)))
         return items
 
@@ -100,7 +108,7 @@ class MotsImporter(Importer):
             for p in os.listdir(path):
                 detected = MotsPngExtractor.detect_dataset(osp.join(path, p))
                 for s in detected:
-                    s.setdefault('options', {})['subset_name'] = p
+                    s.setdefault('options', {})['subset'] = p
                 subsets.extend(detected)
         return subsets
 

--- a/datumaro/plugins/mots_format.py
+++ b/datumaro/plugins/mots_format.py
@@ -5,7 +5,7 @@
 # Implements MOTS format https://www.vision.rwth-aachen.de/page/mots
 
 from enum import Enum
-from glob import glob
+from glob import iglob
 import logging as log
 import numpy as np
 import os
@@ -67,8 +67,7 @@ class MotsPngExtractor(SourceExtractor):
         else:
             images = {}
 
-        for p in sorted(p for p in
-                glob(self._anno_dir + '/**/*.png', recursive=True)):
+        for p in sorted(iglob(self._anno_dir + '/**/*.png', recursive=True)):
             item_id = osp.splitext(osp.relpath(p, self._anno_dir))[0]
             items.append(DatasetItem(id=item_id, subset=self._subset,
                 image=images.get(item_id),

--- a/datumaro/plugins/tf_detection_api_format/extractor.py
+++ b/datumaro/plugins/tf_detection_api_format/extractor.py
@@ -22,7 +22,7 @@ def clamp(value, _min, _max):
     return max(min(_max, value), _min)
 
 class TfDetectionApiExtractor(SourceExtractor):
-    def __init__(self, path):
+    def __init__(self, path, subset=None):
         assert osp.isfile(path), path
         images_dir = ''
         root_dir = osp.dirname(osp.abspath(path))
@@ -32,7 +32,9 @@ class TfDetectionApiExtractor(SourceExtractor):
             if not osp.isdir(images_dir):
                 images_dir = ''
 
-        super().__init__(subset=osp.splitext(osp.basename(path))[0])
+        if not subset:
+            subset = osp.splitext(osp.basename(path))[0]
+        super().__init__(subset=subset)
 
         items, labels = self._parse_tfrecord_file(path, self._subset, images_dir)
         self._items = items

--- a/datumaro/plugins/vgg_face2_format.py
+++ b/datumaro/plugins/vgg_face2_format.py
@@ -20,15 +20,16 @@ class VggFace2Path:
     IMAGES_DIR_NO_LABEL = 'no_label'
 
 class VggFace2Extractor(SourceExtractor):
-    def __init__(self, path):
+    def __init__(self, path, subset=None):
         if not osp.isfile(path):
             raise Exception("Can't read .csv annotation file '%s'" % path)
         self._path = path
         self._dataset_dir = osp.dirname(osp.dirname(path))
 
-        subset = osp.splitext(osp.basename(path))[0]
-        if subset.startswith(VggFace2Path.LANDMARKS_FILE):
-            subset = subset.split('_')[2]
+        if not subset:
+            subset = osp.splitext(osp.basename(path))[0]
+            if subset.startswith(VggFace2Path.LANDMARKS_FILE):
+                subset = subset.split('_')[2]
         super().__init__(subset=subset)
 
         self._categories = self._load_categories()

--- a/datumaro/plugins/vgg_face2_format.py
+++ b/datumaro/plugins/vgg_face2_format.py
@@ -70,7 +70,7 @@ class VggFace2Extractor(SourceExtractor):
 
         items = {}
 
-        image_dir = osp.join(self._dataset_dir, )
+        image_dir = osp.join(self._dataset_dir, self._subset)
         if osp.isdir(image_dir):
             images = { osp.splitext(osp.relpath(p, image_dir))[0]: p
                 for p in find_images(image_dir, recursive=True) }
@@ -86,10 +86,8 @@ class VggFace2Extractor(SourceExtractor):
                 item_id, label = _split_item_path(item_id)
 
             if item_id not in items:
-                image_path = osp.join(self._dataset_dir, self._subset,
-                    row['NAME_ID'] + VggFace2Path.IMAGE_EXT)
                 items[item_id] = DatasetItem(id=item_id, subset=self._subset,
-                    image=image_path)
+                    image=images.get(row['NAME_ID']))
 
             annotations = items[item_id].annotations
             if [a for a in annotations if a.type == AnnotationType.points]:
@@ -114,10 +112,8 @@ class VggFace2Extractor(SourceExtractor):
                     item_id, label = _split_item_path(item_id)
 
                 if item_id not in items:
-                    image_path = osp.join(self._dataset_dir, self._subset,
-                        row['NAME_ID'] + VggFace2Path.IMAGE_EXT)
                     items[item_id] = DatasetItem(id=item_id, subset=self._subset,
-                        image=image_path)
+                        image=images.get(row['NAME_ID']))
 
                 annotations = items[item_id].annotations
                 if [a for a in annotations if a.type == AnnotationType.bbox]:

--- a/datumaro/plugins/vgg_face2_format.py
+++ b/datumaro/plugins/vgg_face2_format.py
@@ -9,6 +9,7 @@ import os.path as osp
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import (AnnotationType, Bbox, DatasetItem,
     Importer, Label, LabelCategories, Points, SourceExtractor)
+from datumaro.util.image import find_images
 
 
 class VggFace2Path:
@@ -68,6 +69,13 @@ class VggFace2Extractor(SourceExtractor):
             return item_id, label
 
         items = {}
+
+        image_dir = osp.join(self._dataset_dir, )
+        if osp.isdir(image_dir):
+            images = { osp.splitext(osp.relpath(p, image_dir))[0]: p
+                for p in find_images(image_dir, recursive=True) }
+        else:
+            images = {}
 
         with open(path) as content:
             landmarks_table = list(csv.DictReader(content))

--- a/datumaro/plugins/voc_format/extractor.py
+++ b/datumaro/plugins/voc_format/extractor.py
@@ -12,7 +12,7 @@ from defusedxml import ElementTree
 from datumaro.components.extractor import (SourceExtractor, DatasetItem,
     AnnotationType, Label, Mask, Bbox, CompiledMask
 )
-from datumaro.util import dir_items
+from datumaro.util.os_util import dir_items
 from datumaro.util.image import Image, find_images
 from datumaro.util.mask_tools import lazy_mask, invert_colormap
 

--- a/datumaro/plugins/voc_format/extractor.py
+++ b/datumaro/plugins/voc_format/extractor.py
@@ -13,7 +13,7 @@ from datumaro.components.extractor import (SourceExtractor, DatasetItem,
     AnnotationType, Label, Mask, Bbox, CompiledMask
 )
 from datumaro.util import dir_items
-from datumaro.util.image import Image
+from datumaro.util.image import Image, find_images
 from datumaro.util.mask_tools import lazy_mask, invert_colormap
 
 from .format import (
@@ -64,13 +64,19 @@ class _VocExtractor(SourceExtractor):
 class VocClassificationExtractor(_VocExtractor):
     def __iter__(self):
         raw_anns = self._load_annotations()
+
+        image_dir = osp.join(self._dataset_dir, VocPath.IMAGES_DIR)
+        if osp.isdir(image_dir):
+            images = { osp.splitext(osp.relpath(p, image_dir))[0]: p
+                for p in find_images(image_dir, recursive=True) }
+        else:
+            images = {}
+
         for item_id in self._items:
             log.debug("Reading item '%s'" % item_id)
-            image = osp.join(self._dataset_dir, VocPath.IMAGES_DIR,
-                item_id + VocPath.IMAGE_EXT)
             anns = self._parse_annotations(raw_anns, item_id)
             yield DatasetItem(id=item_id, subset=self._subset,
-                image=image, annotations=anns)
+                image=images.get(item_id), annotations=anns)
 
     def _load_annotations(self):
         annotations = defaultdict(list)
@@ -231,13 +237,18 @@ class VocActionExtractor(_VocXmlExtractor):
 
 class VocSegmentationExtractor(_VocExtractor):
     def __iter__(self):
+        image_dir = osp.join(self._dataset_dir, VocPath.IMAGES_DIR)
+        if osp.isdir(image_dir):
+            images = { osp.splitext(osp.relpath(p, image_dir))[0]: p
+                for p in find_images(image_dir, recursive=True) }
+        else:
+            images = {}
+
         for item_id in self._items:
             log.debug("Reading item '%s'" % item_id)
-            image = osp.join(self._dataset_dir, VocPath.IMAGES_DIR,
-                item_id + VocPath.IMAGE_EXT)
             anns = self._load_annotations(item_id)
             yield DatasetItem(id=item_id, subset=self._subset,
-                image=image, annotations=anns)
+                image=images.get(item_id), annotations=anns)
 
     @staticmethod
     def _lazy_extract_mask(mask, c):

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -66,15 +66,18 @@ class WiderFaceExtractor(SourceExtractor):
         with open(path, 'r') as f:
             lines = f.readlines()
 
-        image_ids = [image_id for image_id, line in enumerate(lines)
-            if WiderFacePath.IMAGE_EXT in line]
+        line_ids = [line_idx for line_idx, line in enumerate(lines)
+            if ('/' in line or '\\' in line) and '.' in line] \
+            # a heuristic for paths
 
-        for image_id in image_ids:
-            image = lines[image_id]
+        for line_idx in line_ids:
+            image_path = lines[line_idx].strip()
+            item_id = osp.splitext(image_path)[0]
+
             image_path = osp.join(self._dataset_dir,
                 WiderFacePath.SUBSET_DIR + self._subset,
-                WiderFacePath.IMAGES_DIR, image[:-1])
-            item_id = image[:-(len(WiderFacePath.IMAGE_EXT) + 1)]
+                WiderFacePath.IMAGES_DIR, image_path)
+
             annotations = []
             if '/' in item_id:
                 label_name = item_id.split('/')[0]
@@ -86,8 +89,15 @@ class WiderFaceExtractor(SourceExtractor):
                     annotations.append(Label(label=label))
                 item_id = item_id[len(item_id.split('/')[0]) + 1:]
 
-            bbox_count = lines[image_id + 1]
-            bbox_lines = lines[image_id + 2 : image_id + int(bbox_count) + 2]
+            items[item_id] = DatasetItem(id=item_id, subset=self._subset,
+                image=image_path, annotations=annotations)
+
+            try:
+                bbox_count = int(lines[line_idx + 1]) # can be the next image
+            except ValueError:
+                continue
+
+            bbox_lines = lines[line_idx + 2 : line_idx + bbox_count + 2]
             for bbox in bbox_lines:
                 bbox_list = bbox.split()
                 if 4 <= len(bbox_list):
@@ -112,8 +122,6 @@ class WiderFaceExtractor(SourceExtractor):
                         attributes=attributes, label=label
                     ))
 
-            items[item_id] = DatasetItem(id=item_id, subset=self._subset,
-                image=image_path, annotations=annotations)
         return items
 
 class WiderFaceImporter(Importer):

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -23,15 +23,16 @@ class WiderFacePath:
         'occluded', 'pose', 'invalid']
 
 class WiderFaceExtractor(SourceExtractor):
-    def __init__(self, path):
+    def __init__(self, path, subset=None):
         if not osp.isfile(path):
             raise Exception("Can't read annotation file '%s'" % path)
         self._path = path
         self._dataset_dir = osp.dirname(osp.dirname(path))
 
-        subset = osp.splitext(osp.basename(path))[0]
-        if re.fullmatch(r'wider_face_\S+_bbx_gt', subset):
-            subset = subset.split('_')[2]
+        if not subset:
+            subset = osp.splitext(osp.basename(path))[0]
+            if re.fullmatch(r'wider_face_\S+_bbx_gt', subset):
+                subset = subset.split('_')[2]
         super().__init__(subset=subset)
 
         self._categories = self._load_categories()

--- a/datumaro/plugins/yolo_format/extractor.py
+++ b/datumaro/plugins/yolo_format/extractor.py
@@ -106,7 +106,11 @@ class YoloExtractor(SourceExtractor):
 
     @staticmethod
     def localize_path(path):
-        return osp.normpath(path).strip().lstrip('data' + osp.sep)
+        path = osp.normpath(path).strip()
+        default_prefix = 'data' + osp.sep
+        if path.startswith(default_prefix):
+            path = path[len(default_prefix):]
+        return path
 
     @classmethod
     def name_from_path(cls, path):

--- a/datumaro/plugins/yolo_format/extractor.py
+++ b/datumaro/plugins/yolo_format/extractor.py
@@ -55,7 +55,7 @@ class YoloExtractor(SourceExtractor):
             with open(image_info) as f:
                 image_info = {}
                 for line in f:
-                    image_name, h, w = line.strip().split()
+                    image_name, h, w = line.strip().rsplit(maxsplit=2)
                     image_info[image_name] = (int(h), int(w))
         self._image_info = image_info
 

--- a/datumaro/plugins/yolo_format/extractor.py
+++ b/datumaro/plugins/yolo_format/extractor.py
@@ -10,7 +10,7 @@ import re
 from datumaro.components.extractor import (SourceExtractor, Extractor,
     DatasetItem, AnnotationType, Bbox, LabelCategories, Importer
 )
-from datumaro.util import split_path
+from datumaro.util.os_util import split_path
 from datumaro.util.image import Image
 
 from .format import YoloPath
@@ -106,20 +106,16 @@ class YoloExtractor(SourceExtractor):
 
     @staticmethod
     def localize_path(path):
-        path = osp.normpath(path).strip()
-        default_base = osp.join('data', '')
-        if path.startswith(default_base): # default path
-            path = path[len(default_base) : ]
-        return path
+        return osp.normpath(path).strip().lstrip('data' + osp.sep)
 
     @classmethod
     def name_from_path(cls, path):
         path = cls.localize_path(path)
         parts = split_path(path)
         if 1 < len(parts) and not osp.isabs(path):
-            # NOTE: when path is like [data/]<subset_obj>/<image_name>
+            # NOTE: when path is like [data/]<subset>_obj/<image_name>
             # drop everything but <image name>
-            # <image name> can be <a/b/c/filename.ext>, so no just basename()
+            # <image name> can be <a/b/c/filename.ext>, so not just basename()
             path = osp.join(*parts[1:])
         return osp.splitext(path)[0]
 

--- a/datumaro/util/__init__.py
+++ b/datumaro/util/__init__.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 import attr
-import os
-import os.path as osp
 from contextlib import ExitStack
 from functools import partial, wraps
 from itertools import islice
@@ -13,32 +11,6 @@ from itertools import islice
 
 def find(iterable, pred=lambda x: True, default=None):
     return next((x for x in iterable if pred(x)), default)
-
-def dir_items(path, ext, truncate_ext=False):
-    items = []
-    for f in os.listdir(path):
-        ext_pos = f.rfind(ext)
-        if ext_pos != -1:
-            if truncate_ext:
-                f = f[:ext_pos]
-            items.append(f)
-    return items
-
-def split_path(path):
-    path = osp.normpath(path)
-    parts = []
-
-    while True:
-        path, part = osp.split(path)
-        if part:
-            parts.append(part)
-        else:
-            if path:
-                parts.append(path)
-            break
-    parts.reverse()
-
-    return parts
 
 def cast(value, type_conv, default=None):
     if value is None:

--- a/datumaro/util/os_util.py
+++ b/datumaro/util/os_util.py
@@ -46,3 +46,29 @@ def walk(path, max_depth=None):
             dirnames.clear() # topdown=True allows to modify the list
 
         yield dirpath, dirnames, filenames
+
+def dir_items(path, ext, truncate_ext=False):
+    items = []
+    for f in os.listdir(path):
+        ext_pos = f.rfind(ext)
+        if ext_pos != -1:
+            if truncate_ext:
+                f = f[:ext_pos]
+            items.append(f)
+    return items
+
+def split_path(path):
+    path = osp.normpath(path)
+    parts = []
+
+    while True:
+        path, part = osp.split(path)
+        if part:
+            parts.append(part)
+        else:
+            if path:
+                parts.append(path)
+            break
+    parts.reverse()
+
+    return parts

--- a/datumaro/util/os_util.py
+++ b/datumaro/util/os_util.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 
 
+DEFAULT_MAX_DEPTH = 10
+
 def check_instruction_set(instruction):
     return instruction == str.strip(
         # Let's ignore a warning from bandit about using shell=True.
@@ -34,6 +36,9 @@ def import_foreign_module(name, path, package=None):
     return module
 
 def walk(path, max_depth=None):
+    if max_depth is None:
+        max_depth = DEFAULT_MAX_DEPTH
+
     baselevel = path.count(osp.sep)
     for dirpath, dirnames, filenames in os.walk(path, topdown=True):
         curlevel = dirpath.count(osp.sep)

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -144,7 +144,7 @@ def compare_datasets_strict(test, expected, actual):
                 (idx, item_a, item_b))
 
 def test_save_and_load(test, source_dataset, converter, test_dir, importer,
-        target_dataset=None, importer_args=None, compare=None):
+        target_dataset=None, importer_args=None, compare=None, **kwargs):
     converter(source_dataset, test_dir)
 
     if importer_args is None:
@@ -156,4 +156,4 @@ def test_save_and_load(test, source_dataset, converter, test_dir, importer,
 
     if not compare:
         compare = compare_datasets
-    compare(test, expected=target_dataset, actual=parsed_dataset)
+    compare(test, expected=target_dataset, actual=parsed_dataset, **kwargs)

--- a/tests/test_camvid_format.py
+++ b/tests/test_camvid_format.py
@@ -235,11 +235,50 @@ class CamvidConverterTest(TestCase):
                 return iter([
                     DatasetItem(id='q/1', image=Image(path='q/1.JPEG',
                         data=np.zeros((4, 3, 3)))),
-                    DatasetItem(id='a/b/c/2', image=Image(path='a/b/c/2.bmp',
-                        data=np.zeros((3, 4, 3)))),
+                    DatasetItem(id='a/b/c/2', image=Image(
+                            path='a/b/c/2.bmp', data=np.ones((1, 5, 3))
+                        ),
+                        annotations=[
+                            Mask(np.array([[0, 0, 0, 1, 0]]),
+                                label=self._label('a')),
+                            Mask(np.array([[0, 1, 1, 0, 0]]),
+                                label=self._label('b')),
+                        ])
                 ])
+
+            def categories(self):
+                label_map = OrderedDict()
+                label_map['a'] = None
+                label_map['b'] = None
+                return Camvid.make_camvid_categories(label_map)
+
+        class DstExtractor(TestExtractorBase):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id='q/1', image=Image(path='q/1.JPEG',
+                        data=np.zeros((4, 3, 3)))),
+                    DatasetItem(id='a/b/c/2', image=Image(
+                            path='a/b/c/2.bmp', data=np.ones((1, 5, 3))
+                        ),
+                        annotations=[
+                            Mask(np.array([[1, 0, 0, 0, 1]]),
+                                label=self._label('background')),
+                            Mask(np.array([[0, 0, 0, 1, 0]]),
+                                label=self._label('a')),
+                            Mask(np.array([[0, 1, 1, 0, 0]]),
+                                label=self._label('b')),
+                        ])
+                ])
+
+            def categories(self):
+                label_map = OrderedDict()
+                label_map['background'] = None
+                label_map['a'] = None
+                label_map['b'] = None
+                return Camvid.make_camvid_categories(label_map)
 
         with TestDir() as test_dir:
             self._test_save_and_load(SrcExtractor(),
                 partial(CamvidConverter.convert, save_images=True),
-                test_dir, require_images=True)
+                test_dir, require_images=True,
+                target_dataset=DstExtractor())

--- a/tests/test_coco_format.py
+++ b/tests/test_coco_format.py
@@ -148,10 +148,10 @@ class CocoImporterTest(TestCase):
 
 class CocoConverterTest(TestCase):
     def _test_save_and_load(self, source_dataset, converter, test_dir,
-            target_dataset=None, importer_args=None):
+            target_dataset=None, importer_args=None, **kwargs):
         return test_save_and_load(self, source_dataset, converter, test_dir,
             importer='coco',
-            target_dataset=target_dataset, importer_args=importer_args)
+            target_dataset=target_dataset, importer_args=importer_args, **kwargs)
 
     def test_can_save_and_load_captions(self):
         expected_dataset = Dataset.from_iterable([
@@ -544,7 +544,21 @@ class CocoConverterTest(TestCase):
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
-                partial(CocoImageInfoConverter.convert, save_images=True), test_dir)
+                partial(CocoImageInfoConverter.convert, save_images=True),
+                test_dir, require_images=True)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        expected = Dataset.from_iterable([
+            DatasetItem(id='q/1', image=Image(path='q/1.JPEG',
+                data=np.zeros((4, 3, 3))), attributes={'id': 1}),
+            DatasetItem(id='a/b/c/2', image=Image(path='a/b/c/2.bmp',
+                data=np.zeros((3, 4, 3))), attributes={'id': 2}),
+        ])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(expected,
+                partial(CocoConverter.convert, save_images=True),
+                test_dir, require_images=True)
 
     def test_preserve_coco_ids(self):
         expected_dataset = Dataset.from_iterable([
@@ -554,7 +568,8 @@ class CocoConverterTest(TestCase):
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
-                partial(CocoImageInfoConverter.convert, save_images=True), test_dir)
+                partial(CocoImageInfoConverter.convert, save_images=True),
+                test_dir, require_images=True)
 
     def test_annotation_attributes(self):
         expected_dataset = Dataset.from_iterable([

--- a/tests/test_cvat_format.py
+++ b/tests/test_cvat_format.py
@@ -142,10 +142,10 @@ class CvatImporterTest(TestCase):
 
 class CvatConverterTest(TestCase):
     def _test_save_and_load(self, source_dataset, converter, test_dir,
-            target_dataset=None, importer_args=None):
+            target_dataset=None, importer_args=None, **kwargs):
         return test_save_and_load(self, source_dataset, converter, test_dir,
             importer='cvat',
-            target_dataset=target_dataset, importer_args=importer_args)
+            target_dataset=target_dataset, importer_args=importer_args, **kwargs)
 
     def test_can_save_and_load(self):
         label_categories = LabelCategories()
@@ -235,14 +235,14 @@ class CvatConverterTest(TestCase):
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
                 partial(CvatConverter.convert, save_images=True), test_dir,
-                target_dataset=target_dataset)
+                target_dataset=target_dataset, require_images=True)
 
     def test_relative_paths(self):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='1', image=np.ones((4, 2, 3))),
             DatasetItem(id='subdir1/1', image=np.ones((2, 6, 3))),
             DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3))),
-        ], categories={ AnnotationType.label: LabelCategories() })
+        ])
 
         target_dataset = Dataset.from_iterable([
             DatasetItem(id='1', image=np.ones((4, 2, 3)),
@@ -251,22 +251,31 @@ class CvatConverterTest(TestCase):
                 attributes={'frame': 1}),
             DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3)),
                 attributes={'frame': 2}),
-        ], categories={
-            AnnotationType.label: LabelCategories()
-        })
+        ], categories={ AnnotationType.label: LabelCategories() })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
                 partial(CvatConverter.convert, save_images=True), test_dir,
-                target_dataset=target_dataset)
+                target_dataset=target_dataset, require_images=True)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        expected = Dataset.from_iterable([
+            DatasetItem(id='q/1', image=Image(path='q/1.JPEG',
+                data=np.zeros((4, 3, 3))), attributes={'frame': 1}),
+            DatasetItem(id='a/b/c/2', image=Image(path='a/b/c/2.bmp',
+                data=np.zeros((3, 4, 3))), attributes={'frame': 2}),
+        ], categories={ AnnotationType.label: LabelCategories() })
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(expected,
+                partial(CvatConverter.convert, save_images=True),
+                test_dir, require_images=True)
 
     def test_preserve_frame_ids(self):
         expected_dataset = Dataset.from_iterable([
             DatasetItem(id='some/name1', image=np.ones((4, 2, 3)),
                 attributes={'frame': 40}),
-        ], categories={
-            AnnotationType.label: LabelCategories()
-        })
+        ], categories={ AnnotationType.label: LabelCategories() })
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
@@ -276,7 +285,7 @@ class CvatConverterTest(TestCase):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='some/name1', image=np.ones((4, 2, 3)),
                 attributes={'frame': 40}),
-        ], categories={ AnnotationType.label: LabelCategories() })
+        ])
 
         expected_dataset = Dataset.from_iterable([
             DatasetItem(id='some/name1', image=np.ones((4, 2, 3)),
@@ -295,7 +304,7 @@ class CvatConverterTest(TestCase):
                 DatasetItem(1, subset='a'),
                 DatasetItem(2, subset='b'),
                 DatasetItem(3, subset='c', image=np.ones((2, 2, 3))),
-            ], categories=[])
+            ])
             dataset.export(path, 'cvat', save_images=True)
             os.unlink(osp.join(path, 'a.xml'))
             os.unlink(osp.join(path, 'b.xml'))

--- a/tests/test_cvat_format.py
+++ b/tests/test_cvat_format.py
@@ -251,7 +251,7 @@ class CvatConverterTest(TestCase):
                 attributes={'frame': 1}),
             DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3)),
                 attributes={'frame': 2}),
-        ], categories={ AnnotationType.label: LabelCategories() })
+        ], categories=[])
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -260,11 +260,11 @@ class CvatConverterTest(TestCase):
 
     def test_can_save_and_load_image_with_arbitrary_extension(self):
         expected = Dataset.from_iterable([
-            DatasetItem(id='q/1', image=Image(path='q/1.JPEG',
+            DatasetItem('q/1', image=Image(path='q/1.JPEG',
                 data=np.zeros((4, 3, 3))), attributes={'frame': 1}),
-            DatasetItem(id='a/b/c/2', image=Image(path='a/b/c/2.bmp',
+            DatasetItem('a/b/c/2', image=Image(path='a/b/c/2.bmp',
                 data=np.zeros((3, 4, 3))), attributes={'frame': 2}),
-        ], categories={ AnnotationType.label: LabelCategories() })
+        ], categories=[])
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected,
@@ -275,7 +275,7 @@ class CvatConverterTest(TestCase):
         expected_dataset = Dataset.from_iterable([
             DatasetItem(id='some/name1', image=np.ones((4, 2, 3)),
                 attributes={'frame': 40}),
-        ], categories={ AnnotationType.label: LabelCategories() })
+        ], categories=[])
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
@@ -290,7 +290,7 @@ class CvatConverterTest(TestCase):
         expected_dataset = Dataset.from_iterable([
             DatasetItem(id='some/name1', image=np.ones((4, 2, 3)),
                 attributes={'frame': 0}),
-        ], categories={ AnnotationType.label: LabelCategories() })
+        ], categories=[])
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,

--- a/tests/test_datumaro_format.py
+++ b/tests/test_datumaro_format.py
@@ -102,6 +102,19 @@ class DatumaroConverterTest(TestCase):
             self._test_save_and_load(test_dataset,
                 partial(DatumaroConverter.convert, save_images=True), test_dir)
 
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        expected = Dataset.from_iterable([
+            DatasetItem(id='q/1', image=Image(path='q/1.JPEG',
+                data=np.zeros((4, 3, 3))), attributes={'frame': 1}),
+            DatasetItem(id='a/b/c/2', image=Image(path='a/b/c/2.bmp',
+                data=np.zeros((3, 4, 3))), attributes={'frame': 2}),
+        ])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(expected,
+                partial(DatumaroConverter.convert, save_images=True),
+                test_dir)
+
     def test_inplace_save_writes_only_updated_data(self):
         with TestDir() as path:
             # generate initial dataset

--- a/tests/test_image_dir_format.py
+++ b/tests/test_image_dir_format.py
@@ -4,7 +4,8 @@ from unittest import TestCase
 
 from datumaro.components.project import Dataset
 from datumaro.components.extractor import DatasetItem
-from datumaro.plugins.image_dir import ImageDirConverter
+from datumaro.plugins.image_dir_format import ImageDirConverter
+from datumaro.util.image import Image
 from datumaro.util.test_utils import TestDir, test_save_and_load
 
 
@@ -17,7 +18,7 @@ class ImageDirFormatTest(TestCase):
 
         with TestDir() as test_dir:
             test_save_and_load(self, dataset, ImageDirConverter.convert,
-                test_dir, importer='image_dir')
+                test_dir, importer='image_dir', require_images=True)
 
     def test_relative_paths(self):
         dataset = Dataset.from_iterable([
@@ -28,4 +29,16 @@ class ImageDirFormatTest(TestCase):
 
         with TestDir() as test_dir:
             test_save_and_load(self, dataset, ImageDirConverter.convert,
-                test_dir, importer='image_dir')
+                test_dir, importer='image_dir', require_images=True)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem(id='q/1', image=Image(path='q/1.JPEG',
+                data=np.zeros((4, 3, 3)))),
+            DatasetItem(id='a/b/c/2', image=Image(path='a/b/c/2.bmp',
+                data=np.zeros((3, 4, 3)))),
+        ])
+
+        with TestDir() as test_dir:
+            test_save_and_load(self, dataset, ImageDirConverter.convert,
+                test_dir, importer='image_dir', require_images=True)

--- a/tests/test_imagenet_format.py
+++ b/tests/test_imagenet_format.py
@@ -8,6 +8,7 @@ from datumaro.components.extractor import (DatasetItem, Label,
     LabelCategories, AnnotationType
 )
 from datumaro.plugins.imagenet_format import ImagenetConverter, ImagenetImporter
+from datumaro.util.image import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 class ImagenetFormatTest(TestCase):
@@ -21,17 +22,9 @@ class ImagenetFormatTest(TestCase):
                 image=np.ones((10, 10, 3)),
                 annotations=[Label(1)]
             ),
-            DatasetItem(id='3',
-                image=np.ones((10, 10, 3)),
-                annotations=[Label(0)]
-            ),
-            DatasetItem(id='4',
-                image=np.ones((8, 8, 3)),
-                annotations=[Label(2)]
-            ),
         ], categories={
             AnnotationType.label: LabelCategories.from_iterable(
-                'label_' + str(label) for label in range(3)),
+                'label_' + str(label) for label in range(2)),
         })
 
         with TestDir() as test_dir:
@@ -46,33 +39,14 @@ class ImagenetFormatTest(TestCase):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='1',
                 image=np.ones((8, 8, 3)),
-                annotations=[Label(0), Label(1)]
+                annotations=[Label(0), Label(1), Label(2)]
             ),
             DatasetItem(id='2',
-                image=np.ones((10, 10, 3)),
-                annotations=[Label(0), Label(1)]
-            ),
-            DatasetItem(id='3',
-                image=np.ones((10, 10, 3)),
-                annotations=[Label(0), Label(2)]
-            ),
-            DatasetItem(id='4',
-                image=np.ones((8, 8, 3)),
-                annotations=[Label(2), Label(4)]
-            ),
-            DatasetItem(id='5',
-                image=np.ones((10, 10, 3)),
-                annotations=[Label(3), Label(4)]
-            ),
-            DatasetItem(id='6',
-                image=np.ones((10, 10, 3)),
-            ),
-            DatasetItem(id='7',
                 image=np.ones((8, 8, 3))
             ),
         ], categories={
             AnnotationType.label: LabelCategories.from_iterable(
-                'label_' + str(label) for label in range(5)),
+                'label_' + str(label) for label in range(3)),
         })
 
         with TestDir() as test_dir:
@@ -81,6 +55,22 @@ class ImagenetFormatTest(TestCase):
             parsed_dataset = Dataset.import_from(test_dir, 'imagenet')
 
             compare_datasets(self, source_dataset, parsed_dataset,
+                require_images=True)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem(id='a', image=Image(path='a.JPEG',
+                data=np.zeros((4, 3, 3)))),
+            DatasetItem(id='b', image=Image(path='b.bmp',
+                data=np.zeros((3, 4, 3)))),
+        ], categories=[])
+
+        with TestDir() as test_dir:
+            ImagenetConverter.convert(dataset, test_dir, save_images=True)
+
+            parsed_dataset = Dataset.import_from(test_dir, 'imagenet')
+
+            compare_datasets(self, dataset, parsed_dataset,
                 require_images=True)
 
 

--- a/tests/test_imagenet_txt_format.py
+++ b/tests/test_imagenet_txt_format.py
@@ -9,6 +9,7 @@ from datumaro.components.extractor import (DatasetItem, Label,
 )
 from datumaro.plugins.imagenet_txt_format import \
     ImagenetTxtConverter, ImagenetTxtImporter
+from datumaro.util.image import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 
@@ -18,24 +19,12 @@ class ImagenetTxtFormatTest(TestCase):
             DatasetItem(id='1', subset='train',
                 annotations=[Label(0)]
             ),
-            DatasetItem(id='2', subset='train',
-                annotations=[Label(0)]
-            ),
-            DatasetItem(id='3', subset='train', image=np.zeros((8, 8, 3)),
-                annotations=[Label(0)]
-            ),
-            DatasetItem(id='4', subset='train',
+            DatasetItem(id='2', subset='train', image=np.zeros((8, 8, 3)),
                 annotations=[Label(1)]
-            ),
-            DatasetItem(id='5', subset='train', image=np.zeros((4, 8, 3)),
-                annotations=[Label(1)]
-            ),
-            DatasetItem(id='6', subset='train',
-                annotations=[Label(5)]
             ),
         ], categories={
             AnnotationType.label: LabelCategories.from_iterable(
-                'label_' + str(label) for label in range(10)),
+                'label_' + str(label) for label in range(4)),
         })
 
         with TestDir() as test_dir:
@@ -50,12 +39,9 @@ class ImagenetTxtFormatTest(TestCase):
     def test_can_save_and_load_with_multiple_labels(self):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='1', subset='train',
-                annotations=[Label(1), Label(3)]
+                annotations=[Label(1), Label(2), Label(3)]
             ),
-            DatasetItem(id='2', subset='train', image=np.zeros((8, 6, 3)),
-                annotations=[Label(0)]
-            ),
-            DatasetItem(id='3', subset='train', image=np.zeros((2, 8, 3)),
+            DatasetItem(id='2', subset='train', image=np.zeros((2, 8, 3)),
             ),
         ], categories={
             AnnotationType.label: LabelCategories.from_iterable(
@@ -89,6 +75,23 @@ class ImagenetTxtFormatTest(TestCase):
 
             compare_datasets(self, source_dataset, parsed_dataset,
                 require_images=True)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem(id='a/1', image=Image(path='a/1.JPEG',
+                data=np.zeros((4, 3, 3)))),
+            DatasetItem(id='b/c/d/2', image=Image(path='b/c/d/2.bmp',
+                data=np.zeros((3, 4, 3)))),
+        ], categories=[])
+
+        with TestDir() as test_dir:
+            ImagenetTxtConverter.convert(dataset, test_dir, save_images=True)
+
+            parsed_dataset = Dataset.import_from(test_dir, 'imagenet_txt')
+
+            compare_datasets(self, dataset, parsed_dataset,
+                require_images=True)
+
 
 DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'imagenet_txt_dataset')
 

--- a/tests/test_labelme_format.py
+++ b/tests/test_labelme_format.py
@@ -8,16 +8,17 @@ from datumaro.components.extractor import (DatasetItem,
     AnnotationType, Bbox, Mask, Polygon, LabelCategories
 )
 from datumaro.plugins.labelme_format import LabelMeImporter, LabelMeConverter
+from datumaro.util.image import Image
 from datumaro.util.test_utils import (TestDir, compare_datasets,
     test_save_and_load)
 
 
 class LabelMeConverterTest(TestCase):
     def _test_save_and_load(self, source_dataset, converter, test_dir,
-            target_dataset=None, importer_args=None):
+            target_dataset=None, importer_args=None, **kwargs):
         return test_save_and_load(self, source_dataset, converter, test_dir,
             importer='label_me',
-            target_dataset=target_dataset, importer_args=importer_args)
+            target_dataset=target_dataset, importer_args=importer_args, **kwargs)
 
     def test_can_save_and_load(self):
         source_dataset = Dataset.from_iterable([
@@ -85,7 +86,20 @@ class LabelMeConverterTest(TestCase):
             self._test_save_and_load(
                 source_dataset,
                 partial(LabelMeConverter.convert, save_images=True),
-                test_dir, target_dataset=target_dataset)
+                test_dir, target_dataset=target_dataset, require_images=True)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem(id='a/1', image=Image(path='a/1.JPEG',
+                data=np.zeros((4, 3, 3)))),
+            DatasetItem(id='b/c/d/2', image=Image(path='b/c/d/2.bmp',
+                data=np.zeros((3, 4, 3)))),
+        ], categories=[])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(dataset,
+                partial(LabelMeConverter.convert, save_images=True),
+                test_dir, require_images=True)
 
 
 DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'labelme_dataset')

--- a/tests/test_lfw_format.py
+++ b/tests/test_lfw_format.py
@@ -1,5 +1,4 @@
 import os.path as osp
-from functools import partial
 from unittest import TestCase
 
 import numpy as np

--- a/tests/test_lfw_format.py
+++ b/tests/test_lfw_format.py
@@ -1,10 +1,12 @@
 import os.path as osp
+from functools import partial
 from unittest import TestCase
 
 import numpy as np
 from datumaro.components.dataset import Dataset
 from datumaro.components.extractor import DatasetItem, Points
 from datumaro.plugins.lfw_format import LfwConverter, LfwImporter
+from datumaro.util.image import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 
@@ -13,29 +15,29 @@ class LfwFormatTest(TestCase):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='name0/name0_0001',
                 subset='test', image=np.ones((2, 5, 3)),
-                attributes = {
+                attributes={
                     'positive_pairs': ['name0/name0_0002'],
                     'negative_pairs': []
                 }
             ),
             DatasetItem(id='name0/name0_0002',
                 subset='test', image=np.ones((2, 5, 3)),
-                attributes = {
-                    'positive_pairs': [],
+                attributes={
+                    'positive_pairs': ['name0/name0_0001'],
                     'negative_pairs': ['name1/name1_0001']
                 }
             ),
             DatasetItem(id='name1/name1_0001',
                 subset='test', image=np.ones((2, 5, 3)),
-                attributes = {
+                attributes={
                     'positive_pairs': ['name1/name1_0002'],
                     'negative_pairs': []
                 }
             ),
             DatasetItem(id='name1/name1_0002',
                 subset='test', image=np.ones((2, 5, 3)),
-                attributes = {
-                    'positive_pairs': [],
+                attributes={
+                    'positive_pairs': ['name1/name1_0002'],
                     'negative_pairs': ['name0/name0_0001']
                 }
             ),
@@ -51,7 +53,7 @@ class LfwFormatTest(TestCase):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='name0/name0_0001',
                 subset='test', image=np.ones((2, 5, 3)),
-                attributes = {
+                attributes={
                     'positive_pairs': ['name0/name0_0002'],
                     'negative_pairs': []
                 },
@@ -61,7 +63,7 @@ class LfwFormatTest(TestCase):
             ),
             DatasetItem(id='name0/name0_0002',
                 subset='test', image=np.ones((2, 5, 3)),
-                attributes = {
+                attributes={
                     'positive_pairs': [],
                     'negative_pairs': []
                 },
@@ -81,14 +83,14 @@ class LfwFormatTest(TestCase):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='name0/name0_0001',
                 image=np.ones((2, 5, 3)),
-                attributes = {
+                attributes={
                     'positive_pairs': ['name0/name0_0002'],
                     'negative_pairs': []
                 },
             ),
             DatasetItem(id='name0/name0_0002',
                 image=np.ones((2, 5, 3)),
-                attributes = {
+                attributes={
                     'positive_pairs': [],
                     'negative_pairs': []
                 },
@@ -101,6 +103,30 @@ class LfwFormatTest(TestCase):
 
             compare_datasets(self, source_dataset, parsed_dataset)
 
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem(id='name0/name0_0001', image=Image(
+                path='name0/name0_0001.JPEG', data=np.zeros((4, 3, 3))),
+                attributes={
+                    'positive_pairs': [],
+                    'negative_pairs': []
+                },
+            ),
+            DatasetItem(id='name0/name0_0002', image=Image(
+                path='name0/name0_0002.bmp', data=np.zeros((3, 4, 3))),
+                attributes={
+                    'positive_pairs': ['name0/name0_0001'],
+                    'negative_pairs': []
+                },
+            ),
+        ])
+
+        with TestDir() as test_dir:
+            LfwConverter.convert(dataset, test_dir, save_images=True)
+            parsed_dataset = Dataset.import_from(test_dir, 'lfw')
+
+            compare_datasets(self, dataset, parsed_dataset, require_images=True)
+
 DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'lfw_dataset')
 
 class LfwImporterTest(TestCase):
@@ -111,7 +137,7 @@ class LfwImporterTest(TestCase):
         expected_dataset = Dataset.from_iterable([
             DatasetItem(id='name0/name0_0001',
                 subset='test', image=np.ones((2, 5, 3)),
-                attributes = {
+                attributes={
                     'positive_pairs': [],
                     'negative_pairs': ['name1/name1_0001',
                         'name1/name1_0002']
@@ -122,7 +148,7 @@ class LfwImporterTest(TestCase):
             ),
             DatasetItem(id='name1/name1_0001',
                 subset='test', image=np.ones((2, 5, 3)),
-                attributes = {
+                attributes={
                     'positive_pairs': ['name1/name1_0002'],
                     'negative_pairs': []
                 },
@@ -132,7 +158,7 @@ class LfwImporterTest(TestCase):
             ),
             DatasetItem(id='name1/name1_0002',
                 subset='test', image=np.ones((2, 5, 3)),
-                attributes = {
+                attributes={
                     'positive_pairs': [],
                     'negative_pairs': []
                 },

--- a/tests/test_market1501_format.py
+++ b/tests/test_market1501_format.py
@@ -6,6 +6,7 @@ from datumaro.components.dataset import Dataset
 from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.market1501_format import (Market1501Converter,
     Market1501Importer)
+from datumaro.util.image import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 
@@ -87,6 +88,31 @@ class Market1501FormatTest(TestCase):
             parsed_dataset = Dataset.import_from(test_dir, 'market1501')
 
             compare_datasets(self, source_dataset, parsed_dataset)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        expected = Dataset.from_iterable([
+            DatasetItem(id='q/1', image=Image(
+                    path='q/1.JPEG', data=np.zeros((4, 3, 3))),
+                attributes={
+                    'camera_id': 1,
+                    'person_id': 1,
+                    'query': False
+                }),
+            DatasetItem(id='a/b/c/2', image=Image(
+                    path='a/b/c/2.bmp', data=np.zeros((3, 4, 3))),
+                attributes={
+                    'camera_id': 1,
+                    'person_id': 2,
+                    'query': True
+                }),
+        ])
+
+        with TestDir() as test_dir:
+            Market1501Converter.convert(expected, test_dir, save_images=True)
+            parsed_dataset = Dataset.import_from(test_dir, 'market1501')
+
+            compare_datasets(self, expected, parsed_dataset,
+                require_images=True)
 
 DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'market1501_dataset')
 

--- a/tests/test_mot_format.py
+++ b/tests/test_mot_format.py
@@ -8,16 +8,17 @@ from datumaro.components.extractor import (DatasetItem,
     AnnotationType, Bbox, LabelCategories
 )
 from datumaro.plugins.mot_format import MotSeqGtConverter, MotSeqImporter
+from datumaro.util.image import Image
 from datumaro.util.test_utils import (TestDir, compare_datasets,
     test_save_and_load)
 
 
 class MotConverterTest(TestCase):
     def _test_save_and_load(self, source_dataset, converter, test_dir,
-            target_dataset=None, importer_args=None):
+            target_dataset=None, importer_args=None, **kwargs):
         return test_save_and_load(self, source_dataset, converter, test_dir,
             importer='mot_seq',
-            target_dataset=target_dataset, importer_args=importer_args)
+            target_dataset=target_dataset, importer_args=importer_args, **kwargs)
 
     def test_can_save_bboxes(self):
         source_dataset = Dataset.from_iterable([
@@ -98,6 +99,27 @@ class MotConverterTest(TestCase):
                 partial(MotSeqGtConverter.convert, save_images=True),
                 test_dir, target_dataset=target_dataset)
 
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        expected = Dataset.from_iterable([
+            DatasetItem('1', image=Image(
+                path='1.JPEG', data=np.zeros((4, 3, 3))),
+                annotations=[
+                    Bbox(0, 4, 4, 8, label=0, attributes={
+                        'occluded': True,
+                        'visibility': 0.0,
+                        'ignored': False,
+                    }),
+                ]
+            ),
+            DatasetItem('2', image=Image(
+                path='2.bmp', data=np.zeros((3, 4, 3))),
+            ),
+        ], categories=['a'])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(expected,
+                partial(MotSeqGtConverter.convert, save_images=True),
+                test_dir, require_images=True)
 
 DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'mot_dataset')
 

--- a/tests/test_tfrecord_format.py
+++ b/tests/test_tfrecord_format.py
@@ -37,10 +37,10 @@ except ImportError:
 @skipIf(import_failed, "Failed to import tensorflow")
 class TfrecordConverterTest(TestCase):
     def _test_save_and_load(self, source_dataset, converter, test_dir,
-            target_dataset=None, importer_args=None):
+            target_dataset=None, importer_args=None, **kwargs):
         return test_save_and_load(self, source_dataset, converter, test_dir,
             importer='tf_detection_api',
-            target_dataset=target_dataset, importer_args=importer_args)
+            target_dataset=target_dataset, importer_args=importer_args, **kwargs)
 
     def test_can_save_bboxes(self):
         test_dataset = Dataset.from_iterable([
@@ -127,9 +127,7 @@ class TfrecordConverterTest(TestCase):
                 image=Image(path='1/q.e', size=(10, 15)),
                 attributes={'source_id': ''}
             )
-        ], categories={
-            AnnotationType.label: LabelCategories(),
-        })
+        ], categories=[])
 
         with TestDir() as test_dir:
             self._test_save_and_load(test_dataset,
@@ -147,12 +145,27 @@ class TfrecordConverterTest(TestCase):
                     ext='qwe'),
                 attributes={'source_id': ''}
             )
-        ], categories={ AnnotationType.label: LabelCategories(), })
+        ], categories=[])
 
         with TestDir() as test_dir:
             self._test_save_and_load(test_dataset,
                 partial(TfDetectionApiConverter.convert, save_images=True),
                 test_dir)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem('q/1', subset='train',
+                image=Image(path='q/1.JPEG', data=np.zeros((4, 3, 3))),
+                attributes={'source_id': ''}),
+            DatasetItem('a/b/c/2', subset='valid',
+                image=Image(path='a/b/c/2.bmp', data=np.zeros((3, 4, 3))),
+                attributes={'source_id': ''}),
+        ], categories=[])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(dataset,
+                partial(TfDetectionApiConverter.convert, save_images=True),
+                test_dir, require_images=True)
 
     def test_inplace_save_writes_only_updated_data(self):
         with TestDir() as path:

--- a/tests/test_vgg_face2_format.py
+++ b/tests/test_vgg_face2_format.py
@@ -7,6 +7,7 @@ from datumaro.components.extractor import (AnnotationType, Bbox, DatasetItem,
     Label, LabelCategories, Points)
 from datumaro.plugins.vgg_face2_format import (VggFace2Converter,
     VggFace2Importer)
+from datumaro.util.image import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 
@@ -130,6 +131,26 @@ class VggFace2FormatTest(TestCase):
             parsed_dataset = Dataset.import_from(test_dir, 'vgg_face2')
 
             compare_datasets(self, target_dataset, parsed_dataset)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem('q/1', image=Image(path='q/1.JPEG',
+                data=np.zeros((4, 3, 3)))),
+            DatasetItem('a/b/c/2', image=Image(path='a/b/c/2.bmp',
+                    data=np.zeros((3, 4, 3))),
+                annotations=[
+                    Bbox(0, 2, 4, 2, label=0),
+                    Points([4.23, 4.32, 5.34, 4.45, 3.54,
+                        3.56, 4.52, 3.51, 4.78, 3.34], label=0),
+                ]
+            ),
+        ], categories=['a'])
+
+        with TestDir() as test_dir:
+            VggFace2Converter.convert(dataset, test_dir, save_images=True)
+            parsed_dataset = Dataset.import_from(test_dir, 'vgg_face2')
+
+            compare_datasets(self, dataset, parsed_dataset, require_images=True)
 
 DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'vgg_face2_dataset')
 

--- a/tests/test_voc_format.py
+++ b/tests/test_voc_format.py
@@ -132,10 +132,10 @@ class VocImportTest(TestCase):
 
 class VocConverterTest(TestCase):
     def _test_save_and_load(self, source_dataset, converter, test_dir,
-            target_dataset=None, importer_args=None):
+            target_dataset=None, importer_args=None, **kwargs):
         return test_save_and_load(self, source_dataset, converter, test_dir,
             importer='voc',
-            target_dataset=target_dataset, importer_args=importer_args)
+            target_dataset=target_dataset, importer_args=importer_args, **kwargs)
 
     def test_can_save_voc_cls(self):
         class TestExtractor(TestExtractorBase):
@@ -629,6 +629,23 @@ class VocConverterTest(TestCase):
                     partial(VocConverter.convert, label_map='voc', tasks=task),
                     test_dir)
 
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        class TestExtractor(TestExtractorBase):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id='q/1', image=Image(path='q/1.JPEG',
+                        data=np.zeros((4, 3, 3)))),
+                    DatasetItem(id='a/b/c/2', image=Image(path='a/b/c/2.bmp',
+                        data=np.zeros((3, 4, 3)))),
+                ])
+
+        for task in [None] + list(VOC.VocTask):
+            with self.subTest(subformat=task), TestDir() as test_dir:
+                self._test_save_and_load(TestExtractor(),
+                    partial(VocConverter.convert, label_map='voc', tasks=task,
+                        save_images=True),
+                    test_dir, require_images=True)
+
     def test_relative_paths(self):
         class TestExtractor(TestExtractorBase):
             def __iter__(self):
@@ -643,7 +660,7 @@ class VocConverterTest(TestCase):
                 self._test_save_and_load(TestExtractor(),
                     partial(VocConverter.convert,
                         label_map='voc', save_images=True, tasks=task),
-                    test_dir)
+                    test_dir, require_images=True)
 
     def test_can_save_attributes(self):
         class TestExtractor(TestExtractorBase):

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -6,6 +6,7 @@ from datumaro.components.extractor import (AnnotationType, Bbox, DatasetItem,
     Label, LabelCategories)
 from datumaro.components.dataset import Dataset
 from datumaro.plugins.widerface_format import WiderFaceConverter, WiderFaceImporter
+from datumaro.util.image import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 
@@ -15,7 +16,7 @@ class WiderFaceFormatTest(TestCase):
             DatasetItem(id='1', subset='train', image=np.ones((8, 8, 3)),
                 annotations=[
                     Bbox(0, 2, 4, 2),
-                    Bbox(0, 1, 2, 3, attributes = {
+                    Bbox(0, 1, 2, 3, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
                     Label(0),
@@ -23,13 +24,13 @@ class WiderFaceFormatTest(TestCase):
             ),
             DatasetItem(id='2', subset='train', image=np.ones((10, 10, 3)),
                 annotations=[
-                    Bbox(0, 2, 4, 2, attributes = {
+                    Bbox(0, 2, 4, 2, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '1',
                         'occluded': '0', 'pose': '1', 'invalid': '0'}),
-                    Bbox(3, 3, 2, 3, attributes = {
+                    Bbox(3, 3, 2, 3, attributes={
                         'blur': '0', 'expression': '1', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
-                    Bbox(2, 1, 2, 3, attributes = {
+                    Bbox(2, 1, 2, 3, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '0', 'invalid': '1'}),
                     Label(1),
@@ -38,13 +39,13 @@ class WiderFaceFormatTest(TestCase):
 
             DatasetItem(id='3', subset='val', image=np.ones((8, 8, 3)),
                 annotations=[
-                    Bbox(0, 1.1, 5.3, 2.1, attributes = {
+                    Bbox(0, 1.1, 5.3, 2.1, attributes={
                         'blur': '2', 'expression': '1', 'illumination': '0',
                         'occluded': '0', 'pose': '1', 'invalid': '0'}),
-                    Bbox(0, 2, 3, 2, attributes = {
+                    Bbox(0, 2, 3, 2, attributes={
                         'occluded': 'False'}),
                     Bbox(0, 2, 4, 2),
-                    Bbox(0, 7, 3, 2, attributes = {
+                    Bbox(0, 7, 3, 2, attributes={
                         'blur': '2', 'expression': '1', 'illumination': '0',
                         'occluded': '0', 'pose': '1', 'invalid': '0'}),
                 ]
@@ -67,7 +68,7 @@ class WiderFaceFormatTest(TestCase):
             DatasetItem(id='a/b/1', image=np.ones((8, 8, 3)),
                 annotations=[
                     Bbox(0, 2, 4, 2, label=2),
-                    Bbox(0, 1, 2, 3, label=1, attributes = {
+                    Bbox(0, 1, 2, 3, label=1, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
                 ]
@@ -88,10 +89,10 @@ class WiderFaceFormatTest(TestCase):
             DatasetItem(id='a/b/1', image=np.ones((8, 8, 3)),
                 annotations=[
                     Bbox(0, 2, 4, 2),
-                    Bbox(0, 1, 2, 3, attributes = {
+                    Bbox(0, 1, 2, 3, attributes={
                         'non-widerface attribute': '0',
                         'blur': 1, 'invalid': '1'}),
-                    Bbox(1, 1, 2, 2, attributes = {
+                    Bbox(1, 1, 2, 2, attributes={
                         'non-widerface attribute': '0'}),
                 ]
             ),
@@ -101,7 +102,7 @@ class WiderFaceFormatTest(TestCase):
             DatasetItem(id='a/b/1', image=np.ones((8, 8, 3)),
                 annotations=[
                     Bbox(0, 2, 4, 2),
-                    Bbox(0, 1, 2, 3, attributes = {
+                    Bbox(0, 1, 2, 3, attributes={
                         'blur': '1', 'invalid': '1'}),
                     Bbox(1, 1, 2, 2),
                 ]
@@ -114,6 +115,20 @@ class WiderFaceFormatTest(TestCase):
 
             compare_datasets(self, target_dataset, parsed_dataset)
 
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem('q/1', image=Image(path='q/1.JPEG',
+                data=np.zeros((4, 3, 3)))),
+            DatasetItem('a/b/c/2', image=Image(path='a/b/c/2.bmp',
+                data=np.zeros((3, 4, 3)))),
+        ], categories=[])
+
+        with TestDir() as test_dir:
+            WiderFaceConverter.convert(dataset, test_dir, save_images=True)
+            parsed_dataset = Dataset.import_from(test_dir, 'wider_face')
+
+            compare_datasets(self, dataset, parsed_dataset, require_images=True)
+
 DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'widerface_dataset')
 
 class WiderFaceImporterTest(TestCase):
@@ -125,7 +140,7 @@ class WiderFaceImporterTest(TestCase):
             DatasetItem(id='0_Parade_image_01', subset='train',
                 image=np.ones((10, 15, 3)),
                 annotations=[
-                    Bbox(1, 2, 2, 2, attributes = {
+                    Bbox(1, 2, 2, 2, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '0', 'invalid': '0'}),
                     Label(0),
@@ -134,10 +149,10 @@ class WiderFaceImporterTest(TestCase):
             DatasetItem(id='1_Handshaking_image_02', subset='train',
                 image=np.ones((10, 15, 3)),
                 annotations=[
-                    Bbox(1, 1, 2, 2, attributes = {
+                    Bbox(1, 1, 2, 2, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '1',
                         'occluded': '0', 'pose': '0', 'invalid': '0'}),
-                    Bbox(5, 1, 2, 2, attributes = {
+                    Bbox(5, 1, 2, 2, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '1',
                         'occluded': '0', 'pose': '0', 'invalid': '0'}),
                     Label(1),
@@ -146,13 +161,13 @@ class WiderFaceImporterTest(TestCase):
             DatasetItem(id='0_Parade_image_03', subset='val',
                 image=np.ones((10, 15, 3)),
                 annotations=[
-                    Bbox(0, 0, 1, 1, attributes = {
+                    Bbox(0, 0, 1, 1, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
-                    Bbox(3, 2, 1, 2, attributes = {
+                    Bbox(3, 2, 1, 2, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '0',
                         'occluded': '1', 'pose': '0', 'invalid': '0'}),
-                    Bbox(5, 6, 1, 1, attributes = {
+                    Bbox(5, 6, 1, 1, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
                     Label(0),

--- a/tests/test_yolo_format.py
+++ b/tests/test_yolo_format.py
@@ -98,9 +98,7 @@ class YoloFormatTest(TestCase):
                 image=np.ones((2, 6, 3))),
             DatasetItem(id='subdir2/1', subset='train',
                 image=np.ones((5, 4, 3))),
-        ], categories={
-            AnnotationType.label: LabelCategories(),
-        })
+        ], categories=[])
 
         for save_images in {True, False}:
             with self.subTest(save_images=save_images):
@@ -110,6 +108,20 @@ class YoloFormatTest(TestCase):
                     parsed_dataset = Dataset.import_from(test_dir, 'yolo')
 
                     compare_datasets(self, source_dataset, parsed_dataset)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem('q/1', subset='train',
+                image=Image(path='q/1.JPEG', data=np.zeros((4, 3, 3)))),
+            DatasetItem('a/b/c/2', subset='valid',
+                image=Image(path='a/b/c/2.bmp', data=np.zeros((3, 4, 3)))),
+        ], categories=[])
+
+        with TestDir() as test_dir:
+            YoloConverter.convert(dataset, test_dir, save_images=True)
+            parsed_dataset = Dataset.import_from(test_dir, 'yolo')
+
+            compare_datasets(self, dataset, parsed_dataset, require_images=True)
 
     def test_inplace_save_writes_only_updated_data(self):
         with TestDir() as path:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Added support arbitrary image extensions in formats
- Added an option to specify `subset` in several format extractors (to force a specific subset name in loaded items)
- Updated tests

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
