### PR TITLE
Support arbitrary image extensions in formats (base + ImageNet, ImageDir)

### DIFF
--- a/datumaro/plugins/image_dir_format.py
+++ b/datumaro/plugins/image_dir_format.py
@@ -9,7 +9,7 @@ import os.path as osp
 
 from datumaro.components.extractor import DatasetItem, SourceExtractor, Importer
 from datumaro.components.converter import Converter
-from datumaro.util.os_util import walk
+from datumaro.util.image import find_images
 
 
 class ImageDirImporter(Importer):
@@ -20,21 +20,15 @@ class ImageDirImporter(Importer):
         return [{ 'url': path, 'format': 'image_dir' }]
 
 class ImageDirExtractor(SourceExtractor):
-    IMAGE_EXT_FORMATS = {'.jpg', '.jpeg', '.png', '.ppm', '.bmp',
-        '.pgm', '.tif', '.tiff'}
-
-    def __init__(self, url, max_depth=10):
-        super().__init__()
+    def __init__(self, url, subset=None, max_depth=None):
+        super().__init__(subset=subset)
 
         assert osp.isdir(url), url
 
-        for dirpath, _, filenames in walk(url, max_depth=max_depth):
-            for name in filenames:
-                if not osp.splitext(name)[-1] in self.IMAGE_EXT_FORMATS:
-                    continue
-                path = osp.join(dirpath, name)
-                item_id = osp.relpath(osp.splitext(path)[0], url)
-                self._items.append(DatasetItem(id=item_id, image=path))
+        for path in find_images(url, recursive=True, max_depth=max_depth):
+            item_id = osp.relpath(osp.splitext(path)[0], url)
+            self._items.append(DatasetItem(id=item_id, subset=self._subset,
+                image=path))
 
 class ImageDirConverter(Converter):
     DEFAULT_IMAGE_EXT = '.jpg'

--- a/datumaro/plugins/imagenet_format.py
+++ b/datumaro/plugins/imagenet_format.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-from glob import glob
 import logging as log
 import os
 import os.path as osp
@@ -12,13 +11,11 @@ from datumaro.components.extractor import (DatasetItem, Label,
     LabelCategories, AnnotationType, SourceExtractor, Importer
 )
 from datumaro.components.converter import Converter
+from datumaro.util.image import find_images
 
 
 class ImagenetPath:
-    DEFAULT_IMAGE_EXT = '.jpg'
-    IMAGE_EXT_FORMATS = {'.jpg', '.jpeg', '.png', '.ppm', '.bmp',
-        '.pgm', '.tif', '.tiff'}
-    IMAGES_DIR_NO_LABEL = 'no_label'
+    IMAGE_DIR_NO_LABEL = 'no_label'
 
 
 class ImagenetExtractor(SourceExtractor):
@@ -31,29 +28,31 @@ class ImagenetExtractor(SourceExtractor):
 
     def _load_categories(self, path):
         label_cat = LabelCategories()
-        for images_dir in sorted(os.listdir(path)):
-            if images_dir != ImagenetPath.IMAGES_DIR_NO_LABEL:
-                label_cat.add(images_dir)
+        for dirname in sorted(os.listdir(path)):
+            if dirname != ImagenetPath.IMAGE_DIR_NO_LABEL:
+                label_cat.add(dirname)
         return { AnnotationType.label: label_cat }
 
     def _load_items(self, path):
         items = {}
-        for image_path in glob(osp.join(path, '*', '*')):
-            if not osp.isfile(image_path) or \
-                    osp.splitext(image_path)[-1].lower() not in \
-                        ImagenetPath.IMAGE_EXT_FORMATS:
-                continue
+
+        for image_path in find_images(path, recursive=True, max_depth=1):
             label = osp.basename(osp.dirname(image_path))
-            image_name = osp.splitext(osp.basename(image_path))[0][len(label) + 1:]
+            image_name = osp.splitext(osp.basename(image_path))[0]
+            if image_name.startswith(label + '_'):
+                image_name = image_name[len(label) + 1:]
+
             item = items.get(image_name)
             if item is None:
                 item = DatasetItem(id=image_name, subset=self._subset,
                     image=image_path)
+                items[image_name] = item
             annotations = item.annotations
-            if label != ImagenetPath.IMAGES_DIR_NO_LABEL:
+
+            if label != ImagenetPath.IMAGE_DIR_NO_LABEL:
                 label = self._categories[AnnotationType.label].find(label)[0]
                 annotations.append(Label(label=label))
-            items[image_name] = item
+
         return items
 
 
@@ -66,27 +65,27 @@ class ImagenetImporter(Importer):
 
 
 class ImagenetConverter(Converter):
-    DEFAULT_IMAGE_EXT = ImagenetPath.DEFAULT_IMAGE_EXT
+    DEFAULT_IMAGE_EXT = '.jpg'
 
     def apply(self):
         if 1 < len(self._extractor.subsets()):
-            log.warning("ImageNet format supports exporting only a single "
+            log.warning("ImageNet format only supports exporting a single "
                 "subset, subset information will not be used.")
 
         subset_dir = self._save_dir
         extractor = self._extractor
         labels = {}
         for item in self._extractor:
-            image_name = item.id
-            labels[image_name] = [p.label for p in item.annotations
-                if p.type == AnnotationType.label]
-            for label in labels[image_name]:
+            labels = set(p.label for p in item.annotations
+                if p.type == AnnotationType.label)
+
+            for label in labels:
                 label_name = extractor.categories()[AnnotationType.label][label].name
                 self._save_image(item, osp.join(subset_dir, label_name,
                     '%s_%s' %  (label_name, self._make_image_filename(item))))
 
-            if not labels[image_name]:
+            if not labels:
                 self._save_image(item, osp.join(subset_dir,
-                    ImagenetPath.IMAGES_DIR_NO_LABEL,
-                    ImagenetPath.IMAGES_DIR_NO_LABEL + '_'
-                    + self._make_image_filename(item)))
+                    ImagenetPath.IMAGE_DIR_NO_LABEL,
+                    ImagenetPath.IMAGE_DIR_NO_LABEL + '_' + \
+                    self._make_image_filename(item)))

--- a/datumaro/plugins/imagenet_txt_format.py
+++ b/datumaro/plugins/imagenet_txt_format.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-from glob import glob
 import os
 import os.path as osp
 
@@ -11,18 +10,20 @@ from datumaro.components.extractor import (DatasetItem, Label,
     LabelCategories, AnnotationType, SourceExtractor, Importer
 )
 from datumaro.components.converter import Converter
+from datumaro.util.image import find_images
 
 
 class ImagenetTxtPath:
-    DEFAULT_IMAGE_EXT = '.jpg'
-    IMAGE_EXT_FORMAT = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif']
     LABELS_FILE = 'synsets.txt'
     IMAGE_DIR = 'images'
 
 class ImagenetTxtExtractor(SourceExtractor):
-    def __init__(self, path, labels=None, image_dir=None):
+    def __init__(self, path, labels=None, image_dir=None, subset=None):
         assert osp.isfile(path), path
-        super().__init__(subset=osp.splitext(osp.basename(path))[0])
+
+        if not subset:
+            subset = osp.splitext(osp.basename(path))[0]
+        super().__init__(subset=subset)
 
         if not image_dir:
             image_dir = ImagenetTxtPath.IMAGE_DIR
@@ -33,8 +34,8 @@ class ImagenetTxtExtractor(SourceExtractor):
             labels = self._parse_labels(labels)
         else:
             assert all(isinstance(e, str) for e in labels)
-
         self._categories = self._load_categories(labels)
+
         self._items = list(self._load_items(path).values())
 
     @staticmethod
@@ -47,25 +48,30 @@ class ImagenetTxtExtractor(SourceExtractor):
 
     def _load_items(self, path):
         items = {}
+
+        image_dir = self.image_dir
+        if osp.isdir(image_dir):
+            images = { osp.splitext(osp.relpath(p, image_dir))[0]: p
+                for p in find_images(image_dir, recursive=True) }
+        else:
+            images = {}
+
         with open(path, encoding='utf-8') as f:
             for line in f:
                 item = line.split()
                 item_id = item[0]
                 label_ids = [int(id) for id in item[1:]]
+
                 anno = []
                 for label in label_ids:
                     assert 0 <= label and \
                         label < len(self._categories[AnnotationType.label]), \
                         "Image '%s': unknown label id '%s'" % (item_id, label)
                     anno.append(Label(label))
-                image_path = osp.join(self.image_dir, item_id +
-                    ImagenetTxtPath.DEFAULT_IMAGE_EXT)
-                for path in glob(osp.join(self.image_dir, item_id + '*')):
-                    if osp.splitext(path)[1] in ImagenetTxtPath.IMAGE_EXT_FORMAT:
-                        image_path = path
-                        break
+
                 items[item_id] = DatasetItem(id=item_id, subset=self._subset,
-                    image=image_path, annotations=anno)
+                    image=images.get(item_id), annotations=anno)
+
         return items
 
 
@@ -78,7 +84,7 @@ class ImagenetTxtImporter(Importer):
 
 
 class ImagenetTxtConverter(Converter):
-    DEFAULT_IMAGE_EXT = ImagenetTxtPath.DEFAULT_IMAGE_EXT
+    DEFAULT_IMAGE_EXT = '.jpg'
 
     def apply(self):
         subset_dir = self._save_dir
@@ -87,20 +93,25 @@ class ImagenetTxtConverter(Converter):
         extractor = self._extractor
         for subset_name, subset in self._extractor.subsets().items():
             annotation_file = osp.join(subset_dir, '%s.txt' % subset_name)
+
             labels = {}
             for item in subset:
-                labels[item.id] = [str(p.label) for p in item.annotations
-                    if p.type == AnnotationType.label]
+                labels[item.id] = set(p.label for p in item.annotations
+                    if p.type == AnnotationType.label)
 
                 if self._save_images and item.has_image:
                     self._save_image(item, subdir=ImagenetTxtPath.IMAGE_DIR)
 
             with open(annotation_file, 'w', encoding='utf-8') as f:
-                f.writelines(['%s %s\n' % (item_id, ' '.join(labels[item_id]))
+                f.writelines(['%s %s\n' % (
+                        item_id,
+                        ' '.join(str(l) for l in sorted(labels[item_id]))
+                    )
                     for item_id in labels])
 
         labels_file = osp.join(subset_dir, ImagenetTxtPath.LABELS_FILE)
         with open(labels_file, 'w', encoding='utf-8') as f:
-            f.write('\n'.join(l.name
-                for l in extractor.categories()[AnnotationType.label])
+            f.writelines(l.name + '\n'
+                for l in extractor.categories().get(
+                    AnnotationType.label, LabelCategories())
             )

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -155,8 +155,11 @@ def decode_image(image_bytes, dtype=np.float32):
         assert image.shape[2] in {3, 4}
     return image
 
-IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.ppm', '.bmp',
-    '.pgm', '.tif', '.tiff'}
+IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.jpe', '.jp2',
+    '.png', '.bmp', '.dib', '.tif', '.tiff', '.tga', '.webp', '.pfm',
+    '.sr', '.ras', '.exr', '.hdr', '.pic',
+    '.pbm', '.pgm', '.ppm', '.pxm', '.pnm',
+}
 
 def find_images(dirpath: str, exts: Union[str, Iterable[str]] = None,
         recursive: bool = False, max_depth: int = None) -> Iterator[str]:

--- a/datumaro/util/os_util.py
+++ b/datumaro/util/os_util.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 
 
+DEFAULT_MAX_DEPTH = 10
+
 def check_instruction_set(instruction):
     return instruction == str.strip(
         # Let's ignore a warning from bandit about using shell=True.
@@ -34,6 +36,9 @@ def import_foreign_module(name, path, package=None):
     return module
 
 def walk(path, max_depth=None):
+    if max_depth is None:
+        max_depth = DEFAULT_MAX_DEPTH
+
     baselevel = path.count(osp.sep)
     for dirpath, dirnames, filenames in os.walk(path, topdown=True):
         curlevel = dirpath.count(osp.sep)

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -144,7 +144,7 @@ def compare_datasets_strict(test, expected, actual):
                 (idx, item_a, item_b))
 
 def test_save_and_load(test, source_dataset, converter, test_dir, importer,
-        target_dataset=None, importer_args=None, compare=None):
+        target_dataset=None, importer_args=None, compare=None, **kwargs):
     converter(source_dataset, test_dir)
 
     if importer_args is None:
@@ -156,4 +156,4 @@ def test_save_and_load(test, source_dataset, converter, test_dir, importer,
 
     if not compare:
         compare = compare_datasets
-    compare(test, expected=target_dataset, actual=parsed_dataset)
+    compare(test, expected=target_dataset, actual=parsed_dataset, **kwargs)

--- a/tests/test_image_dir_format.py
+++ b/tests/test_image_dir_format.py
@@ -4,7 +4,8 @@ from unittest import TestCase
 
 from datumaro.components.project import Dataset
 from datumaro.components.extractor import DatasetItem
-from datumaro.plugins.image_dir import ImageDirConverter
+from datumaro.plugins.image_dir_format import ImageDirConverter
+from datumaro.util.image import Image
 from datumaro.util.test_utils import TestDir, test_save_and_load
 
 
@@ -17,7 +18,7 @@ class ImageDirFormatTest(TestCase):
 
         with TestDir() as test_dir:
             test_save_and_load(self, dataset, ImageDirConverter.convert,
-                test_dir, importer='image_dir')
+                test_dir, importer='image_dir', require_images=True)
 
     def test_relative_paths(self):
         dataset = Dataset.from_iterable([
@@ -28,4 +29,16 @@ class ImageDirFormatTest(TestCase):
 
         with TestDir() as test_dir:
             test_save_and_load(self, dataset, ImageDirConverter.convert,
-                test_dir, importer='image_dir')
+                test_dir, importer='image_dir', require_images=True)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem(id='q/1', image=Image(path='q/1.JPEG',
+                data=np.zeros((4, 3, 3)))),
+            DatasetItem(id='a/b/c/2', image=Image(path='a/b/c/2.bmp',
+                data=np.zeros((3, 4, 3)))),
+        ])
+
+        with TestDir() as test_dir:
+            test_save_and_load(self, dataset, ImageDirConverter.convert,
+                test_dir, importer='image_dir', require_images=True)

--- a/tests/test_imagenet_format.py
+++ b/tests/test_imagenet_format.py
@@ -8,6 +8,7 @@ from datumaro.components.extractor import (DatasetItem, Label,
     LabelCategories, AnnotationType
 )
 from datumaro.plugins.imagenet_format import ImagenetConverter, ImagenetImporter
+from datumaro.util.image import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 class ImagenetFormatTest(TestCase):
@@ -21,17 +22,9 @@ class ImagenetFormatTest(TestCase):
                 image=np.ones((10, 10, 3)),
                 annotations=[Label(1)]
             ),
-            DatasetItem(id='3',
-                image=np.ones((10, 10, 3)),
-                annotations=[Label(0)]
-            ),
-            DatasetItem(id='4',
-                image=np.ones((8, 8, 3)),
-                annotations=[Label(2)]
-            ),
         ], categories={
             AnnotationType.label: LabelCategories.from_iterable(
-                'label_' + str(label) for label in range(3)),
+                'label_' + str(label) for label in range(2)),
         })
 
         with TestDir() as test_dir:
@@ -46,33 +39,14 @@ class ImagenetFormatTest(TestCase):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='1',
                 image=np.ones((8, 8, 3)),
-                annotations=[Label(0), Label(1)]
+                annotations=[Label(0), Label(1), Label(2)]
             ),
             DatasetItem(id='2',
-                image=np.ones((10, 10, 3)),
-                annotations=[Label(0), Label(1)]
-            ),
-            DatasetItem(id='3',
-                image=np.ones((10, 10, 3)),
-                annotations=[Label(0), Label(2)]
-            ),
-            DatasetItem(id='4',
-                image=np.ones((8, 8, 3)),
-                annotations=[Label(2), Label(4)]
-            ),
-            DatasetItem(id='5',
-                image=np.ones((10, 10, 3)),
-                annotations=[Label(3), Label(4)]
-            ),
-            DatasetItem(id='6',
-                image=np.ones((10, 10, 3)),
-            ),
-            DatasetItem(id='7',
                 image=np.ones((8, 8, 3))
             ),
         ], categories={
             AnnotationType.label: LabelCategories.from_iterable(
-                'label_' + str(label) for label in range(5)),
+                'label_' + str(label) for label in range(3)),
         })
 
         with TestDir() as test_dir:
@@ -81,6 +55,22 @@ class ImagenetFormatTest(TestCase):
             parsed_dataset = Dataset.import_from(test_dir, 'imagenet')
 
             compare_datasets(self, source_dataset, parsed_dataset,
+                require_images=True)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem(id='a', image=Image(path='a.JPEG',
+                data=np.zeros((4, 3, 3)))),
+            DatasetItem(id='b', image=Image(path='b.bmp',
+                data=np.zeros((3, 4, 3)))),
+        ], categories=[])
+
+        with TestDir() as test_dir:
+            ImagenetConverter.convert(dataset, test_dir, save_images=True)
+
+            parsed_dataset = Dataset.import_from(test_dir, 'imagenet')
+
+            compare_datasets(self, dataset, parsed_dataset,
                 require_images=True)
 
 

--- a/tests/test_imagenet_txt_format.py
+++ b/tests/test_imagenet_txt_format.py
@@ -9,6 +9,7 @@ from datumaro.components.extractor import (DatasetItem, Label,
 )
 from datumaro.plugins.imagenet_txt_format import \
     ImagenetTxtConverter, ImagenetTxtImporter
+from datumaro.util.image import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 
@@ -18,24 +19,12 @@ class ImagenetTxtFormatTest(TestCase):
             DatasetItem(id='1', subset='train',
                 annotations=[Label(0)]
             ),
-            DatasetItem(id='2', subset='train',
-                annotations=[Label(0)]
-            ),
-            DatasetItem(id='3', subset='train', image=np.zeros((8, 8, 3)),
-                annotations=[Label(0)]
-            ),
-            DatasetItem(id='4', subset='train',
+            DatasetItem(id='2', subset='train', image=np.zeros((8, 8, 3)),
                 annotations=[Label(1)]
-            ),
-            DatasetItem(id='5', subset='train', image=np.zeros((4, 8, 3)),
-                annotations=[Label(1)]
-            ),
-            DatasetItem(id='6', subset='train',
-                annotations=[Label(5)]
             ),
         ], categories={
             AnnotationType.label: LabelCategories.from_iterable(
-                'label_' + str(label) for label in range(10)),
+                'label_' + str(label) for label in range(4)),
         })
 
         with TestDir() as test_dir:
@@ -50,12 +39,9 @@ class ImagenetTxtFormatTest(TestCase):
     def test_can_save_and_load_with_multiple_labels(self):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='1', subset='train',
-                annotations=[Label(1), Label(3)]
+                annotations=[Label(1), Label(2), Label(3)]
             ),
-            DatasetItem(id='2', subset='train', image=np.zeros((8, 6, 3)),
-                annotations=[Label(0)]
-            ),
-            DatasetItem(id='3', subset='train', image=np.zeros((2, 8, 3)),
+            DatasetItem(id='2', subset='train', image=np.zeros((2, 8, 3)),
             ),
         ], categories={
             AnnotationType.label: LabelCategories.from_iterable(
@@ -89,6 +75,23 @@ class ImagenetTxtFormatTest(TestCase):
 
             compare_datasets(self, source_dataset, parsed_dataset,
                 require_images=True)
+
+    def test_can_save_and_load_image_with_arbitrary_extension(self):
+        dataset = Dataset.from_iterable([
+            DatasetItem(id='a/1', image=Image(path='a/1.JPEG',
+                data=np.zeros((4, 3, 3)))),
+            DatasetItem(id='b/c/d/2', image=Image(path='b/c/d/2.bmp',
+                data=np.zeros((3, 4, 3)))),
+        ], categories=[])
+
+        with TestDir() as test_dir:
+            ImagenetTxtConverter.convert(dataset, test_dir, save_images=True)
+
+            parsed_dataset = Dataset.import_from(test_dir, 'imagenet_txt')
+
+            compare_datasets(self, dataset, parsed_dataset,
+                require_images=True)
+
 
 DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'imagenet_txt_dataset')
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Added image search function
- Renamed image dir to image dir format
- Supported arbitrary image extensions in ImageDir and ImageNet formats

Related #166 

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
