### PR TITLE
Avoid unnecessary image loading in Datumaro format on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The ability to work with file names containing Cyrillic and spaces (<https://github.com/openvinotoolkit/datumaro/pull/148>)
+- Unnecessary image loading on dataset saving (<https://github.com/openvinotoolkit/datumaro/pull/176>)
 
 ### Security
 -

--- a/datumaro/plugins/datumaro_format/converter.py
+++ b/datumaro/plugins/datumaro_format/converter.py
@@ -62,9 +62,10 @@ class _SubsetWriter:
                 self._context._save_image(item, path)
 
             item_desc['image'] = {
-                'size': item.image.size,
                 'path': path,
             }
+            if item.image.has_size:
+                item_desc['size'] = item.image.size # avoid occasional loading
         self.items.append(item_desc)
 
         for ann in item.annotations:

--- a/datumaro/plugins/datumaro_format/converter.py
+++ b/datumaro/plugins/datumaro_format/converter.py
@@ -64,8 +64,8 @@ class _SubsetWriter:
             item_desc['image'] = {
                 'path': path,
             }
-            if item.image.has_size:
-                item_desc['size'] = item.image.size # avoid occasional loading
+            if item.image.has_size: # avoid occasional loading
+                item_desc['image']['size'] = item.image.size
         self.items.append(item_desc)
 
         for ann in item.annotations:

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -264,8 +264,13 @@ class Image:
     @property
     def data(self):
         if callable(self._data):
-            return self._data()
-        return self._data
+            data = self._data()
+        else:
+            data = self._data
+
+        if self._size is None:
+            self._size = data.shape[:2]
+        return data
 
     @property
     def has_data(self):

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -250,6 +250,9 @@ class Image:
                 data = lazy_image(path, loader=loader, cache=cache)
         self._data = data
 
+        if not self._size and isinstance(data, np.ndarray):
+            self._size = data.shape[:2]
+
     @property
     def path(self):
         return self._path
@@ -267,6 +270,10 @@ class Image:
     @property
     def has_data(self):
         return self._data is not None
+
+    @property
+    def has_size(self):
+        return self._size is not None or isinstance(self._data, np.ndarray)
 
     @property
     def size(self):

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -268,7 +268,7 @@ class Image:
         else:
             data = self._data
 
-        if self._size is None:
+        if self._size is None and data is not None:
             self._size = data.shape[:2]
         return data
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -564,6 +564,25 @@ class DatasetTest(TestCase):
 
             self.assertFalse(dataset.is_modified)
 
+    def test_does_not_load_images_on_saving(self):
+        # Issue https://github.com/openvinotoolkit/datumaro/issues/177
+        # Missing image metadata (size etc.) can lead to image loading on
+        # dataset save without image saving
+
+        called = False
+        def test_loader():
+            nonlocal called
+            called = True
+
+        dataset = Dataset.from_iterable([
+            DatasetItem(1, image=test_loader)
+        ])
+
+        with TestDir() as test_dir:
+            dataset.save(test_dir)
+
+        self.assertFalse(called)
+
 
 class DatasetItemTest(TestCase):
     def test_ctor_requires_id(self):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Fixed the problem with occasional image loading in Datumaro format

The problem is that transforms for inputs, providing no image metainfo (`size` etc.), can require image loading for loading size data. Unless image saving is not required, it should not be done.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
