### PR TITLE
bugfix - ignore subsets of near-zero-ratio

### DIFF
--- a/datumaro/plugins/splitter.py
+++ b/datumaro/plugins/splitter.py
@@ -81,8 +81,11 @@ class _TaskSpecificSplit(Transform, CliPlugin):
             assert 0.0 <= ratio and ratio <= 1.0, \
                 "Ratio is expected to be in the range " \
                 "[0, 1], but got %s for %s" % (ratio, subset)
-            snames.append(subset)
-            ratios.append(float(ratio))
+            # ignore near_zero ratio because it may produce partition error.
+            if ratio > NEAR_ZERO:
+                snames.append(subset)
+                ratios.append(float(ratio))
+                
         ratios = np.array(ratios)
 
         total_ratio = np.sum(ratios)
@@ -91,6 +94,7 @@ class _TaskSpecificSplit(Transform, CliPlugin):
                 "Sum of ratios is expected to be 1, got %s, which is %s"
                 % (splits, total_ratio)
             )
+
         return snames, ratios
 
     @staticmethod
@@ -100,6 +104,7 @@ class _TaskSpecificSplit(Transform, CliPlugin):
             if NEAR_ZERO < i and i < min_value:
                 min_value = i
         required = int(np.around(1.0) / min_value)
+        
         return required
 
     @staticmethod

--- a/datumaro/plugins/splitter.py
+++ b/datumaro/plugins/splitter.py
@@ -85,7 +85,6 @@ class _TaskSpecificSplit(Transform, CliPlugin):
             if ratio > NEAR_ZERO:
                 snames.append(subset)
                 ratios.append(float(ratio))
-                
         ratios = np.array(ratios)
 
         total_ratio = np.sum(ratios)
@@ -104,7 +103,6 @@ class _TaskSpecificSplit(Transform, CliPlugin):
             if NEAR_ZERO < i and i < min_value:
                 min_value = i
         required = int(np.around(1.0) / min_value)
-        
         return required
 
     @staticmethod

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -219,7 +219,11 @@ class SplitterTest(TestCase):
         }
         source = self._generate_dataset(config)
         splits = [("train", 0.1), ("val", 0.9), ("test", 0.0)]
+        
         actual = splitter.ClassificationSplit(source, splits)
+        
+        self.assertEqual(1, len(actual.get_subset("train")))
+        self.assertEqual(4, len(actual.get_subset("val")))
         self.assertEqual(0, len(actual.get_subset("test")))
 
     def test_split_for_classification_gives_error(self):

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -219,7 +219,7 @@ class SplitterTest(TestCase):
         }
         source = self._generate_dataset(config)
         splits = [("train", 0.1), ("val", 0.9), ("test", 0.0)]
-        
+
         actual = splitter.ClassificationSplit(source, splits)
         
         self.assertEqual(1, len(actual.get_subset("train")))

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -213,6 +213,16 @@ class SplitterTest(TestCase):
                 list(r1.get_subset("test")), list(r3.get_subset("test"))
             )
 
+    def test_split_for_classification_zero_ratio(self):              
+        config = {
+            "label1": {"attrs": None, "counts": 5},
+        }
+        source = self._generate_dataset(config)
+        
+        splits = [("train", 0.1), ("val", 0.9), ("test", 0.0)]
+        actual = splitter.ClassificationSplit(source, splits)
+        self.assertEqual(0, len(actual.get_subset("test")))
+
     def test_split_for_classification_gives_error(self):
         with self.subTest("no label"):
             source = Dataset.from_iterable([

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -213,12 +213,11 @@ class SplitterTest(TestCase):
                 list(r1.get_subset("test")), list(r3.get_subset("test"))
             )
 
-    def test_split_for_classification_zero_ratio(self):              
+    def test_split_for_classification_zero_ratio(self):
         config = {
             "label1": {"attrs": None, "counts": 5},
         }
         source = self._generate_dataset(config)
-        
         splits = [("train", 0.1), ("val", 0.9), ("test", 0.0)]
         actual = splitter.ClassificationSplit(source, splits)
         self.assertEqual(0, len(actual.get_subset("test")))


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
When dataset size is 5 and split ratio is \[train=0.1, val=0.9, test=0.0\], the splitter splits the dataset into [1, 3, 1] instead of [1, 4, 0].
This is a special case of incorrect partitioning due to the inexact round function of python. 
So I fix this bug by ignoring subsets with a near-zero ratio.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
