### PR TITLE
Kate/handling multiple attributes and speed up detection split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Changed
--
+- Allowed arbitrary subset count and names in classification and detection splitters (<https://github.com/openvinotoolkit/datumaro/pull/207>)
 
 ### Deprecated
 -

--- a/datumaro/plugins/splitter.py
+++ b/datumaro/plugins/splitter.py
@@ -9,6 +9,7 @@ from math import gcd
 from datumaro.components.extractor import (Transform, AnnotationType,
     DEFAULT_SUBSET_NAME)
 from datumaro.components.cli_plugin import CliPlugin
+from datumaro.util import cast
 
 NEAR_ZERO = 1e-7
 
@@ -154,14 +155,15 @@ class _TaskSpecificSplit(Transform, CliPlugin):
         """
 
         # float--> numerical, others(int, string, bool) --> categorical
-        def _is_number(value):
+        def _is_float(value):
             if isinstance(value, str):
-                try:
-                    float(value)
-                    return True
-                except ValueError:
-                    return False
+                casted = cast(value, float)
+                if casted is not None:
+                    if cast(casted, str) == value:
+                        return True
+                return False
             elif isinstance(value, float):
+                cast(value, float)
                 return True
             return False
 
@@ -171,7 +173,7 @@ class _TaskSpecificSplit(Transform, CliPlugin):
             # ignore numeric attributes
             filtered = {}
             for k, v in ann.attributes.items():
-                if _is_number(v):
+                if _is_float(v):
                     continue
                 filtered[k] = v
             attributes = tuple(sorted(filtered.items()))

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -44,6 +44,7 @@ class SplitterTest(TestCase):
                                 annotations=[
                                     Label(label_id, attributes=attributes)
                                 ],
+                                image=np.ones((1, 1, 3))
                             )
                         )
             else:
@@ -51,7 +52,8 @@ class SplitterTest(TestCase):
                     idx += 1
                     iterable.append(
                         DatasetItem(idx, subset=self._get_subset(idx),
-                            annotations=[Label(label_id)])
+                            annotations=[Label(label_id)],
+                            image=np.ones((1, 1, 3)))
                     )
         categories = {AnnotationType.label: label_cat}
         dataset = Dataset.from_iterable(iterable, categories)
@@ -221,7 +223,7 @@ class SplitterTest(TestCase):
         splits = [("train", 0.1), ("val", 0.9), ("test", 0.0)]
 
         actual = splitter.ClassificationSplit(source, splits)
-        
+
         self.assertEqual(1, len(actual.get_subset("train")))
         self.assertEqual(4, len(actual.get_subset("val")))
         self.assertEqual(0, len(actual.get_subset("test")))

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -670,8 +670,9 @@ class SplitterTest(TestCase):
                 splits = [("train", 0.5), ("train", 0.2), ("test", 0.3)]
                 splitter.DetectionSplit(source, splits)
 
-    def test_no_subsetname_restriction(self):
-        splits = [("_train", 0.5), ("valid", 0.2), ("test*", 0.3)]
+    def test_no_subset_name_and_count_restriction(self):
+        splits = [("_train", 0.5), ("valid", 0.1), ("valid2", 0.1),
+            ("test*", 0.2), ("test2", 0.1)]
 
         with self.subTest("classification"):
             config = {
@@ -680,8 +681,10 @@ class SplitterTest(TestCase):
             source = self._generate_dataset(config)
             actual = splitter.ClassificationSplit(source, splits)
             self.assertEqual(5, len(actual.get_subset("_train")))
-            self.assertEqual(2, len(actual.get_subset("valid")))
-            self.assertEqual(3, len(actual.get_subset("test*")))
+            self.assertEqual(1, len(actual.get_subset("valid")))
+            self.assertEqual(1, len(actual.get_subset("valid2")))
+            self.assertEqual(2, len(actual.get_subset("test*")))
+            self.assertEqual(1, len(actual.get_subset("test2")))
 
         with self.subTest("detection"):
             source, _ = self._generate_detection_dataset(
@@ -691,5 +694,7 @@ class SplitterTest(TestCase):
             )
             actual = splitter.DetectionSplit(source, splits)
             self.assertEqual(5, len(actual.get_subset("_train")))
-            self.assertEqual(2, len(actual.get_subset("valid")))
-            self.assertEqual(3, len(actual.get_subset("test*")))
+            self.assertEqual(1, len(actual.get_subset("valid")))
+            self.assertEqual(1, len(actual.get_subset("valid2")))
+            self.assertEqual(2, len(actual.get_subset("test*")))
+            self.assertEqual(1, len(actual.get_subset("test2")))

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -125,29 +125,37 @@ class SplitterTest(TestCase):
         config = {"label": {"attrs": attrs, "counts": counts}}
         source = self._generate_dataset(config)
 
-        splits = [("train", 0.7), ("test", 0.3)]
-        actual = splitter.ClassificationSplit(source, splits)
+        with self.subTest("zero remainder"):
+            splits = [("train", 0.7), ("test", 0.3)]
+            actual = splitter.ClassificationSplit(source, splits)
 
-        self.assertEqual(84, len(actual.get_subset("train")))
-        self.assertEqual(36, len(actual.get_subset("test")))
+            self.assertEqual(84, len(actual.get_subset("train")))
+            self.assertEqual(36, len(actual.get_subset("test")))
 
-        # check stats for train
-        stat_train = compute_ann_statistics(actual.get_subset("train"))
-        attr_train = stat_train["annotations"]["labels"]["attributes"]
-        self.assertEqual(49, attr_train["attr1"]["distribution"]["0"][0])
-        self.assertEqual(35, attr_train["attr1"]["distribution"]["1"][0])
-        self.assertEqual(28, attr_train["attr2"]["distribution"]["0"][0])
-        self.assertEqual(21, attr_train["attr2"]["distribution"]["1"][0])
-        self.assertEqual(35, attr_train["attr2"]["distribution"]["2"][0])
+            # check stats for train
+            stat_train = compute_ann_statistics(actual.get_subset("train"))
+            attr_train = stat_train["annotations"]["labels"]["attributes"]
+            self.assertEqual(49, attr_train["attr1"]["distribution"]["0"][0])
+            self.assertEqual(35, attr_train["attr1"]["distribution"]["1"][0])
+            self.assertEqual(28, attr_train["attr2"]["distribution"]["0"][0])
+            self.assertEqual(21, attr_train["attr2"]["distribution"]["1"][0])
+            self.assertEqual(35, attr_train["attr2"]["distribution"]["2"][0])
 
-        # check stats for test
-        stat_test = compute_ann_statistics(actual.get_subset("test"))
-        attr_test = stat_test["annotations"]["labels"]["attributes"]
-        self.assertEqual(21, attr_test["attr1"]["distribution"]["0"][0])
-        self.assertEqual(15, attr_test["attr1"]["distribution"]["1"][0])
-        self.assertEqual(12, attr_test["attr2"]["distribution"]["0"][0])
-        self.assertEqual(9, attr_test["attr2"]["distribution"]["1"][0])
-        self.assertEqual(15, attr_test["attr2"]["distribution"]["2"][0])
+            # check stats for test
+            stat_test = compute_ann_statistics(actual.get_subset("test"))
+            attr_test = stat_test["annotations"]["labels"]["attributes"]
+            self.assertEqual(21, attr_test["attr1"]["distribution"]["0"][0])
+            self.assertEqual(15, attr_test["attr1"]["distribution"]["1"][0])
+            self.assertEqual(12, attr_test["attr2"]["distribution"]["0"][0])
+            self.assertEqual(9, attr_test["attr2"]["distribution"]["1"][0])
+            self.assertEqual(15, attr_test["attr2"]["distribution"]["2"][0])
+
+        with self.subTest("non-zero remainder"):
+            splits = [("train", 0.95), ("test", 0.05)]
+            actual = splitter.ClassificationSplit(source, splits)
+
+            self.assertEqual(114, len(actual.get_subset("train")))
+            self.assertEqual(6, len(actual.get_subset("test")))
 
     def test_split_for_classification_multi_label_with_attr(self):
         counts = {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
While handling multi-attributes, we've found that task-specific splitters are mishandling them.
This fix includes,
1. better handling of the multi-attributes case 
2. speed up & OOM issue is fixed for the detection_split

### How to test


### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
