### PR TITLE
split unlabeled data into subsets for task-specific splitters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - LabelMe format saves dataset items with their relative paths by subsets without changing names (<https://github.com/openvinotoolkit/datumaro/pull/200>)
 - Allowed arbitrary subset count and names in classification and detection splitters (<https://github.com/openvinotoolkit/datumaro/pull/207>)
+- Annotation-less dataset elements are now participate in subset splitting (<https://github.com/openvinotoolkit/datumaro/pull/211>)
 
 ### Deprecated
 -

--- a/datumaro/plugins/splitter.py
+++ b/datumaro/plugins/splitter.py
@@ -49,8 +49,7 @@ class _TaskSpecificSplit(Transform, CliPlugin):
         self._seed = seed
 
         # remove subset name restriction
-        # regarding https://github.com/openvinotoolkit/datumaro/issues/194
-        # self._subsets = {"train", "val", "test"}  # output subset names
+        # https://github.com/openvinotoolkit/datumaro/issues/194
         self._subsets = subsets
         self._parts = []
         self._length = "parent"
@@ -74,8 +73,6 @@ class _TaskSpecificSplit(Transform, CliPlugin):
                 annotations.append(labels[0])
             else:
                 unlabeled_or_multi.append(idx)
-                # raise Exception("Item '%s' contains %s labels, "
-                #     "but exactly one is expected" % (item.id, len(labels)))
 
         return annotations, unlabeled_or_multi
 
@@ -85,9 +82,9 @@ class _TaskSpecificSplit(Transform, CliPlugin):
         ratios = []
         subsets = set()
         valid = ["train", "val", "test"]
-        # remove subset name restriction
-        # regarding https://github.com/openvinotoolkit/datumaro/issues/194
         for subset, ratio in splits:
+            # remove subset name restriction
+            # https://github.com/openvinotoolkit/datumaro/issues/194
             if restrict:
                 assert subset in valid, \
                     "Subset name must be one of %s, got %s" % (valid, subset)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Resolve #202 
classification: split unlabeled + multi-labeled data into subsets randomly
detection: split unlabled data into subsets randomly
reidentification: group unlabeled + multi-labeled data as 'not-supported' subset.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
