### PR TITLE
Fix image saving in cvat format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Added support for auto-merging (joining) of datasets with no labels and having labels (<https://github.com/openvinotoolkit/datumaro/pull/200>)
 - Allowed explicit label removal in `remap_labels` transform (<https://github.com/openvinotoolkit/datumaro/pull/203>)
+- Image extension in CVAT format export (<https://github.com/openvinotoolkit/datumaro/pull/214>)
 
 ### Security
 -

--- a/datumaro/plugins/cvat_format/converter.py
+++ b/datumaro/plugins/cvat_format/converter.py
@@ -164,7 +164,7 @@ class _SubsetWriter:
         if not self._context._reindex:
             index = cast(item.attributes.get('frame'), int, index)
         image_info = OrderedDict([ ("id", str(index)), ])
-        filename = item.id + CvatPath.IMAGE_EXT
+        filename = self._context._make_image_filename(item)
         image_info["name"] = filename
         if item.has_image:
             size = item.image.size

--- a/tests/test_cvat_format.py
+++ b/tests/test_cvat_format.py
@@ -326,6 +326,10 @@ class CvatConverterTest(TestCase):
             self._test_save_and_load(expected,
                 partial(CvatConverter.convert, save_images=True),
                 test_dir, require_images=True)
+            self.assertTrue(osp.isfile(
+                osp.join(test_dir, 'images', 'q', '1.JPEG')))
+            self.assertTrue(osp.isfile(
+                osp.join(test_dir, 'images', 'a', 'b', 'c', '2.bmp')))
 
     def test_preserve_frame_ids(self):
         expected_dataset = Dataset.from_iterable([


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Fixes #213 

- Fixed output image format in CVAT export (after #166, affected releases 0.1.7, 0.1.8)

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
