### PR TITLE
Label "face" for bounding boxes in Wider Face

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for auto-merging (joining) of datasets with no labels and having labels (<https://github.com/openvinotoolkit/datumaro/pull/200>)
 - Allowed explicit label removal in `remap_labels` transform (<https://github.com/openvinotoolkit/datumaro/pull/203>)
 - Image extension in CVAT format export (<https://github.com/openvinotoolkit/datumaro/pull/214>)
+- Added a label "face" for bounding boxes in Wider Face (<https://github.com/openvinotoolkit/datumaro/pull/215>)
 
 ### Security
 -

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -92,7 +92,8 @@ class WiderFaceExtractor(SourceExtractor):
                     label_name = label_name.split('--')[1]
                 if label_name != WiderFacePath.IMAGES_DIR_NO_LABEL:
                     label = label_categories.find(label_name)[0]
-                    annotations.append(Label(label=label))
+                    if label != None:
+                        annotations.append(Label(label=label))
                 item_id = item_id[len(item_id.split('/')[0]) + 1:]
 
             items[item_id] = DatasetItem(id=item_id, subset=self._subset,

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -41,15 +41,13 @@ class WiderFaceExtractor(SourceExtractor):
 
     def _load_categories(self):
         label_cat = LabelCategories()
-        label_cat.add(WiderFacePath.DEFAULT_LABEL)
         path = osp.join(self._dataset_dir, WiderFacePath.LABELS_FILE)
         if osp.isfile(path):
             with open(path, encoding='utf-8') as labels_file:
                 for line in labels_file:
-                    label_name = line.strip()
-                    if label_name != WiderFacePath.DEFAULT_LABEL:
-                        label_cat.add(label_name)
+                    label_cat.add(line.strip())
         else:
+            label_cat.add(WiderFacePath.DEFAULT_LABEL)
             subset_path = osp.join(self._dataset_dir,
                 WiderFacePath.SUBSET_DIR + self._subset,
                 WiderFacePath.IMAGES_DIR)
@@ -61,8 +59,8 @@ class WiderFaceExtractor(SourceExtractor):
                             images_dir = images_dir.split('--')[1]
                         if images_dir != WiderFacePath.DEFAULT_LABEL:
                             label_cat.add(images_dir)
-        if len(label_cat) == 1:
-            label_cat = LabelCategories()
+            if len(label_cat) == 1:
+                label_cat = LabelCategories()
         return { AnnotationType.label: label_cat }
 
     def _load_items(self, path):

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -21,6 +21,7 @@ class WiderFacePath:
     IMAGES_DIR_NO_LABEL = 'no_label'
     BBOX_ATTRIBUTES = ['blur', 'expression', 'illumination',
         'occluded', 'pose', 'invalid']
+    DEFAULT_LABEL = 'face'
 
 class WiderFaceExtractor(SourceExtractor):
     def __init__(self, path, subset=None):
@@ -40,12 +41,14 @@ class WiderFaceExtractor(SourceExtractor):
 
     def _load_categories(self):
         label_cat = LabelCategories()
-
+        label_cat.add(WiderFacePath.DEFAULT_LABEL)
         path = osp.join(self._dataset_dir, WiderFacePath.LABELS_FILE)
         if osp.isfile(path):
             with open(path, encoding='utf-8') as labels_file:
                 for line in labels_file:
-                    label_cat.add(line.strip())
+                    label_name = line.strip()
+                    if label_name != WiderFacePath.DEFAULT_LABEL:
+                        label_cat.add(label_name)
         else:
             subset_path = osp.join(self._dataset_dir,
                 WiderFacePath.SUBSET_DIR + self._subset,
@@ -56,12 +59,15 @@ class WiderFaceExtractor(SourceExtractor):
                             images_dir != WiderFacePath.IMAGES_DIR_NO_LABEL:
                         if '--' in images_dir:
                             images_dir = images_dir.split('--')[1]
-                        label_cat.add(images_dir)
-
+                        if images_dir != WiderFacePath.DEFAULT_LABEL:
+                            label_cat.add(images_dir)
+        if len(label_cat) == 1:
+            label_cat = LabelCategories()
         return { AnnotationType.label: label_cat }
 
     def _load_items(self, path):
         items = {}
+        label_categories = self._categories[AnnotationType.label]
 
         with open(path, 'r', encoding='utf-8') as f:
             lines = f.readlines()
@@ -73,6 +79,7 @@ class WiderFaceExtractor(SourceExtractor):
         for line_idx in line_ids:
             image_path = lines[line_idx].strip()
             item_id = osp.splitext(image_path)[0]
+            item_id = item_id.replace('\\', '/')
 
             image_path = osp.join(self._dataset_dir,
                 WiderFacePath.SUBSET_DIR + self._subset,
@@ -84,8 +91,7 @@ class WiderFaceExtractor(SourceExtractor):
                 if '--' in label_name:
                     label_name = label_name.split('--')[1]
                 if label_name != WiderFacePath.IMAGES_DIR_NO_LABEL:
-                    label = \
-                        self._categories[AnnotationType.label].find(label_name)[0]
+                    label = label_categories.find(label_name)[0]
                     annotations.append(Label(label=label))
                 item_id = item_id[len(item_id.split('/')[0]) + 1:]
 
@@ -101,21 +107,22 @@ class WiderFaceExtractor(SourceExtractor):
             for bbox in bbox_lines:
                 bbox_list = bbox.split()
                 if 4 <= len(bbox_list):
-                    attributes = {}
-                    label = None
+                    label = label_categories.find(WiderFacePath.DEFAULT_LABEL)[0]
                     if len(bbox_list) == 5 or len(bbox_list) == 11:
-                        if len(bbox_list) == 5:
-                            label_name = bbox_list[4]
-                        else:
-                            label_name = bbox_list[10]
-                        label = \
-                            self._categories[AnnotationType.label].find(label_name)[0]
+                        label_name = bbox_list[-1]
+                        label = label_categories.find(label_name)[0]
+                    if label == None and len(label_categories) == 0:
+                        label_categories.add(WiderFacePath.DEFAULT_LABEL)
+                        label = label_categories.find(WiderFacePath.DEFAULT_LABEL)[0]
+
+                    attributes = {}
                     if 10 <= len(bbox_list):
                         i = 4
                         for attr in WiderFacePath.BBOX_ATTRIBUTES:
                             if bbox_list[i] != '-':
                                 attributes[attr] = bbox_list[i]
                             i += 1
+
                     annotations.append(Bbox(
                         float(bbox_list[0]), float(bbox_list[1]),
                         float(bbox_list[2]), float(bbox_list[3]),
@@ -180,7 +187,8 @@ class WiderFaceConverter(Converter):
                                 wider_attr += '- '
                         if 0 < attr_counter:
                             wider_annotation += wider_attr
-                    if bbox.label is not None:
+                    if label_categories[bbox.label].name != WiderFacePath.DEFAULT_LABEL and \
+                            bbox.label is not None:
                         wider_annotation += '%s' % label_categories[bbox.label].name
                     wider_annotation  += '\n'
 

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -152,40 +152,40 @@ class WiderFaceImporterTest(TestCase):
             DatasetItem(id='0_Parade_image_01', subset='train',
                 image=np.ones((10, 15, 3)),
                 annotations=[
-                    Bbox(1, 2, 2, 2, label=0, attributes={
+                    Bbox(1, 2, 2, 2, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '0', 'invalid': '0'}),
-                    Label(1),
+                    Label(0),
                 ]
             ),
             DatasetItem(id='1_Handshaking_image_02', subset='train',
                 image=np.ones((10, 15, 3)),
                 annotations=[
-                    Bbox(1, 1, 2, 2, label=0, attributes={
+                    Bbox(1, 1, 2, 2, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '1',
                         'occluded': '0', 'pose': '0', 'invalid': '0'}),
-                    Bbox(5, 1, 2, 2, label=0, attributes={
+                    Bbox(5, 1, 2, 2, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '1',
                         'occluded': '0', 'pose': '0', 'invalid': '0'}),
-                    Label(2),
+                    Label(1),
                 ]
             ),
             DatasetItem(id='0_Parade_image_03', subset='val',
                 image=np.ones((10, 15, 3)),
                 annotations=[
-                    Bbox(0, 0, 1, 1, label=0, attributes={
+                    Bbox(0, 0, 1, 1, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
-                    Bbox(3, 2, 1, 2, label=0, attributes={
+                    Bbox(3, 2, 1, 2, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '0',
                         'occluded': '1', 'pose': '0', 'invalid': '0'}),
-                    Bbox(5, 6, 1, 1, label=0, attributes={
+                    Bbox(5, 6, 1, 1, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
-                    Label(1),
+                    Label(0),
                 ]
             ),
-        ], categories= ['face', 'Parade', 'Handshaking'])
+        ], categories= ['Parade', 'Handshaking'])
 
         dataset = Dataset.import_from(DUMMY_DATASET_DIR, 'wider_face')
 

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -15,47 +15,44 @@ class WiderFaceFormatTest(TestCase):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='1', subset='train', image=np.ones((8, 8, 3)),
                 annotations=[
-                    Bbox(0, 2, 4, 2),
-                    Bbox(0, 1, 2, 3, attributes={
+                    Bbox(0, 2, 4, 2, label=0),
+                    Bbox(0, 1, 2, 3, label=0, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
-                    Label(0),
+                    Label(1),
                 ]
             ),
             DatasetItem(id='2', subset='train', image=np.ones((10, 10, 3)),
                 annotations=[
-                    Bbox(0, 2, 4, 2, attributes={
+                    Bbox(0, 2, 4, 2, label=0, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '1',
                         'occluded': '0', 'pose': '1', 'invalid': '0'}),
-                    Bbox(3, 3, 2, 3, attributes={
+                    Bbox(3, 3, 2, 3, label=0, attributes={
                         'blur': '0', 'expression': '1', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
-                    Bbox(2, 1, 2, 3, attributes={
+                    Bbox(2, 1, 2, 3, label=0, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '0', 'invalid': '1'}),
-                    Label(1),
+                    Label(2),
                 ]
             ),
 
             DatasetItem(id='3', subset='val', image=np.ones((8, 8, 3)),
                 annotations=[
-                    Bbox(0, 1.1, 5.3, 2.1, attributes={
+                    Bbox(0, 1.1, 5.3, 2.1, label=0, attributes={
                         'blur': '2', 'expression': '1', 'illumination': '0',
                         'occluded': '0', 'pose': '1', 'invalid': '0'}),
-                    Bbox(0, 2, 3, 2, attributes={
+                    Bbox(0, 2, 3, 2, label=0, attributes={
                         'occluded': 'False'}),
-                    Bbox(0, 2, 4, 2),
-                    Bbox(0, 7, 3, 2, attributes={
+                    Bbox(0, 2, 4, 2, label=0),
+                    Bbox(0, 7, 3, 2, label=0, attributes={
                         'blur': '2', 'expression': '1', 'illumination': '0',
                         'occluded': '0', 'pose': '1', 'invalid': '0'}),
                 ]
             ),
 
             DatasetItem(id='4', subset='val', image=np.ones((8, 8, 3))),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                'label_' + str(i) for i in range(3)),
-        })
+        ], categories=['face', 'label_0', 'label_1'])
 
         with TestDir() as test_dir:
             WiderFaceConverter.convert(source_dataset, test_dir, save_images=True)
@@ -73,10 +70,7 @@ class WiderFaceFormatTest(TestCase):
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
                 ]
             ),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                'label_' + str(i) for i in range(3)),
-        })
+        ], categories=['face', 'label_0', 'label_1'])
 
         with TestDir() as test_dir:
             WiderFaceConverter.convert(source_dataset, test_dir, save_images=True)
@@ -88,15 +82,12 @@ class WiderFaceFormatTest(TestCase):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='кириллица с пробелом', image=np.ones((8, 8, 3)),
                 annotations=[
-                    Bbox(0, 1, 2, 3, label=1, attributes = {
+                    Bbox(0, 1, 2, 3, label=0, attributes = {
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
                 ]
             ),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                'label_' + str(i) for i in range(3)),
-        })
+        ], categories=['face'])
 
         with TestDir() as test_dir:
             WiderFaceConverter.convert(source_dataset, test_dir, save_images=True)
@@ -109,26 +100,26 @@ class WiderFaceFormatTest(TestCase):
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='a/b/1', image=np.ones((8, 8, 3)),
                 annotations=[
-                    Bbox(0, 2, 4, 2),
-                    Bbox(0, 1, 2, 3, attributes={
+                    Bbox(0, 2, 4, 2, label=0),
+                    Bbox(0, 1, 2, 3, label=0, attributes={
                         'non-widerface attribute': '0',
                         'blur': 1, 'invalid': '1'}),
-                    Bbox(1, 1, 2, 2, attributes={
+                    Bbox(1, 1, 2, 2, label=0, attributes={
                         'non-widerface attribute': '0'}),
                 ]
             ),
-        ], categories=[])
+        ], categories=['face'])
 
         target_dataset = Dataset.from_iterable([
             DatasetItem(id='a/b/1', image=np.ones((8, 8, 3)),
                 annotations=[
-                    Bbox(0, 2, 4, 2),
-                    Bbox(0, 1, 2, 3, attributes={
+                    Bbox(0, 2, 4, 2, label=0),
+                    Bbox(0, 1, 2, 3, label=0, attributes={
                         'blur': '1', 'invalid': '1'}),
-                    Bbox(1, 1, 2, 2),
+                    Bbox(1, 1, 2, 2, label=0),
                 ]
             ),
-        ], categories=[])
+        ], categories=['face'])
 
         with TestDir() as test_dir:
             WiderFaceConverter.convert(source_dataset, test_dir, save_images=True)
@@ -161,40 +152,40 @@ class WiderFaceImporterTest(TestCase):
             DatasetItem(id='0_Parade_image_01', subset='train',
                 image=np.ones((10, 15, 3)),
                 annotations=[
-                    Bbox(1, 2, 2, 2, attributes={
+                    Bbox(1, 2, 2, 2, label=0, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '0', 'invalid': '0'}),
-                    Label(0),
+                    Label(1),
                 ]
             ),
             DatasetItem(id='1_Handshaking_image_02', subset='train',
                 image=np.ones((10, 15, 3)),
                 annotations=[
-                    Bbox(1, 1, 2, 2, attributes={
+                    Bbox(1, 1, 2, 2, label=0, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '1',
                         'occluded': '0', 'pose': '0', 'invalid': '0'}),
-                    Bbox(5, 1, 2, 2, attributes={
+                    Bbox(5, 1, 2, 2, label=0, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '1',
                         'occluded': '0', 'pose': '0', 'invalid': '0'}),
-                    Label(1),
+                    Label(2),
                 ]
             ),
             DatasetItem(id='0_Parade_image_03', subset='val',
                 image=np.ones((10, 15, 3)),
                 annotations=[
-                    Bbox(0, 0, 1, 1, attributes={
+                    Bbox(0, 0, 1, 1, label=0, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
-                    Bbox(3, 2, 1, 2, attributes={
+                    Bbox(3, 2, 1, 2, label=0, attributes={
                         'blur': '0', 'expression': '0', 'illumination': '0',
                         'occluded': '1', 'pose': '0', 'invalid': '0'}),
-                    Bbox(5, 6, 1, 1, attributes={
+                    Bbox(5, 6, 1, 1, label=0, attributes={
                         'blur': '2', 'expression': '0', 'illumination': '0',
                         'occluded': '0', 'pose': '2', 'invalid': '0'}),
-                    Label(0),
+                    Label(1),
                 ]
             ),
-        ], categories= ['Parade', 'Handshaking'])
+        ], categories= ['face', 'Parade', 'Handshaking'])
 
         dataset = Dataset.import_from(DUMMY_DATASET_DIR, 'wider_face')
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
Added a label "face" for bounding boxes in Wider Face.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
