### PR TITLE
Adding "difficult", "truncated", "occluded" attributes when converting to Pascal VOC if they are not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for auto-merging (joining) of datasets with no labels and having labels (<https://github.com/openvinotoolkit/datumaro/pull/200>)
 - Allowed explicit label removal in `remap_labels` transform (<https://github.com/openvinotoolkit/datumaro/pull/203>)
 - Image extension in CVAT format export (<https://github.com/openvinotoolkit/datumaro/pull/214>)
-
+- Allowed adding "difficult", "truncated", "occluded" attributes when converting to Pascal VOC if these attributes are not present (<https://github.com/openvinotoolkit/datumaro/pull/216>)
 ### Security
 -
 

--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -236,16 +236,14 @@ class VocConverter(Converter):
                             ET.SubElement(obj_elem, 'pose').text = \
                                 str(attr['pose'])
 
-                        if 'truncated' in attr:
-                            truncated = _convert_attr('truncated', attr, int, 0)
-                            ET.SubElement(obj_elem, 'truncated').text = \
-                                '%d' % truncated
+                        truncated = _convert_attr('truncated', attr, int, 0)
+                        ET.SubElement(obj_elem, 'truncated').text = \
+                            '%d' % truncated
 
-                        if 'occluded' in attr:
-                            occluded = _convert_attr('occluded', attr, int, 0)
-                            ET.SubElement(obj_elem, 'occluded').text = \
-                                '%d' % occluded
-                        
+                        occluded = _convert_attr('occluded', attr, int, 0)
+                        ET.SubElement(obj_elem, 'occluded').text = \
+                            '%d' % occluded
+
                         difficult = _convert_attr('difficult', attr, int, 0)
                         ET.SubElement(obj_elem, 'difficult').text = \
                             '%d' % difficult

--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -236,17 +236,12 @@ class VocConverter(Converter):
                             ET.SubElement(obj_elem, 'pose').text = \
                                 str(attr['pose'])
 
-                        truncated = _convert_attr('truncated', attr, int, 0)
                         ET.SubElement(obj_elem, 'truncated').text = \
-                            '%d' % truncated
-
-                        occluded = _convert_attr('occluded', attr, int, 0)
+                            '%d' % _convert_attr('truncated', attr, int, 0)
                         ET.SubElement(obj_elem, 'occluded').text = \
-                            '%d' % occluded
-
-                        difficult = _convert_attr('difficult', attr, int, 0)
+                            '%d' % _convert_attr('occluded', attr, int, 0)
                         ET.SubElement(obj_elem, 'difficult').text = \
-                            '%d' % difficult
+                            '%d' % _convert_attr('difficult', attr, int, 0)
 
                         bbox = obj.get_bbox()
                         if bbox is not None:

--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -241,15 +241,14 @@ class VocConverter(Converter):
                             ET.SubElement(obj_elem, 'truncated').text = \
                                 '%d' % truncated
 
-                        if 'difficult' in attr:
-                            difficult = _convert_attr('difficult', attr, int, 0)
-                            ET.SubElement(obj_elem, 'difficult').text = \
-                                '%d' % difficult
-
                         if 'occluded' in attr:
                             occluded = _convert_attr('occluded', attr, int, 0)
                             ET.SubElement(obj_elem, 'occluded').text = \
                                 '%d' % occluded
+                        
+                        difficult = _convert_attr('difficult', attr, int, 0)
+                        ET.SubElement(obj_elem, 'difficult').text = \
+                            '%d' % difficult
 
                         bbox = obj.get_bbox()
                         if bbox is not None:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
Allowed adding "difficult", "truncated", "occluded" attributes when converting to Pascal VOC if these attributes are not present

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
