### PR TITLE
Add splitter for segmentation task 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for escaping in attribiute values in LabelMe format (<https://github.com/openvinotoolkit/datumaro/issues/49>)
+- Support for Segmentation Splitting (<https://github.com/openvinotoolkit/datumaro/pull/223>)
 
 ### Changed
 - LabelMe format saves dataset items with their relative paths by subsets without changing names (<https://github.com/openvinotoolkit/datumaro/pull/200>)

--- a/datumaro/plugins/splitter.py
+++ b/datumaro/plugins/splitter.py
@@ -15,7 +15,7 @@ from datumaro.util import cast
 NEAR_ZERO = 1e-7
 
 SplitTask = Enum(
-    "split", ["classification", "detection", "segmentation", "reidentification"]
+    "split", ["classification", "detection", "segmentation", "reid"]
 )
 
 
@@ -30,8 +30,8 @@ class Split(Transform, CliPlugin):
     Each image can have multiple object annotations -
     (bbox, mask, polygon). Since an image shouldn't be included
     in multiple subsets at the same time, and image annotations
-    shoudln't be split, in general, dataset annotations are unlikely to be split
-    exactly in the specified ratio. |n
+    shoudln't be split, in general, dataset annotations are unlikely
+    to be split exactly in the specified ratio. |n
     This split tries to split dataset images as close as possible
     to the specified ratio, keeping the initial class distribution.|n
     |n
@@ -50,19 +50,20 @@ class Split(Transform, CliPlugin):
     |n
     Notes:|n
     - Each image is expected to have only one Annotation. Unlabeled or
-    multi-labeled images will be split into subsets randomly(or 'not-supported' in reidentification). |n
+    multi-labeled images will be split into subsets randomly. |n
     - If Labels also have attributes, also splits by attribute values.|n
     - If there is not enough images in some class or attributes group,
     the split ratio can't be guaranteed.|n
-    - Object ID can be described by Label, or by attribute (--attr parameter) in reidentification task|n
-    - The splits of the test set are controlled by '--query' parameter in reidentification task. |n
+    In reidentification task, |n
+    - Object ID can be described by Label, or by attribute (--attr parameter)|n
+    - The splits of the test set are controlled by '--query' parameter |n
     |s|sGallery ratio would be 1.0 - query.|n
     |n
     Example:|n
     |s|s%(prog)s -t classification --subset train:.5 --subset val:.2 --subset test:.3 |n
     |s|s%(prog)s -t detection --subset train:.5 --subset val:.2 --subset test:.3 |n
     |s|s%(prog)s -t segmentation --subset train:.5 --subset val:.2 --subset test:.3 |n
-    |s|s%(prog)s -t reidentification --subset train:.5 --subset val:.2 --subset test:.3 --query .5 |n
+    |s|s%(prog)s -t reid --subset train:.5 --subset val:.2 --subset test:.3 --query .5 |n
     Example: use 'person_id' attribute for splitting|n
     |s|s%(prog)s --attr person_id
     """
@@ -138,7 +139,7 @@ class Split(Transform, CliPlugin):
             splitter = _InstanceSpecificSplit(
                 dataset=dataset, splits=splits, seed=seed, task=task
             )
-        elif task == SplitTask.reidentification.name:
+        elif task == SplitTask.reid.name:
             splitter = _ReidentificationSplit(
                 dataset=dataset,
                 splits=splits,

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1048,7 +1048,7 @@ datum transform -t split -- \
     -t segmentation --subset train:.5 --subset val:.2 --subset test:.3
 
 datum transform -t split -- \
-    -t reidentification --subset train:.5 --subset val:.2 --subset test:.3 \
+    -t reid --subset train:.5 --subset val:.2 --subset test:.3 \
     --query .5
 ```
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1035,17 +1035,21 @@ datum transform -t random_split -- --subset train:.67 --subset test:.33
 ```
 
 Example: split a dataset in task-specific manner. Supported tasks are
-classification, detection, and re-identification.
+classification, detection, re-identification and segmentation.
 
 ``` bash
-datum transform -t classification_split -- \
-    --subset train:.5 --subset val:.2 --subset test:.3
+datum transform -t split -- \
+    -t classification --subset train:.5 --subset val:.2 --subset test:.3
 
-datum transform -t detection_split -- \
-    --subset train:.5 --subset val:.2 --subset test:.3
+datum transform -t split -- \
+    -t detection --subset train:.5 --subset val:.2 --subset test:.3
 
-datum transform -t reidentification_split -- \
-    --subset train:.5 --subset val:.2 --subset test:.3 --query .5
+datum transform -t split -- \
+    -t segmentation --subset train:.5 --subset val:.2 --subset test:.3
+
+datum transform -t split -- \
+    -t reidentification --subset train:.5 --subset val:.2 --subset test:.3 \
+    --query .5
 ```
 
 Example: convert polygons to masks, masks to boxes etc.:
@@ -1076,7 +1080,7 @@ datum transform -t rename -- -e '|frame_(\d+)|\\1|'
 
 Example: Sampling dataset items, subset `train` is divided into `sampled`(sampled_subset) and `unsampled`
 - `train` has 100 data, and 20 samples are selected. There are `sampled`(20 samples) and 80 `unsampled`(80 datas) subsets.
-- Remove `train` subset (if sample_name=`train` or unsample_name=`train`, still remain)
+- Remove `train` subset (if sampled_subset=`train` or unsampled_name=`train`, still remain)
 - There are five methods of sampling the m option.
     - `topk`: Return the k with high uncertainty data
     - `lowk`: Return the k with low uncertainty data
@@ -1087,9 +1091,9 @@ Example: Sampling dataset items, subset `train` is divided into `sampled`(sample
 ``` bash
 datum transform -t sampler -- \
     -a entropy \
-    -subset_name train \
-    -sample_name sampled \
-    -unsample_name unsampled \
+    -i train \
+    -o sampled \
+    -u unsampled \
     -m topk \
     -k 20
 ```

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -323,7 +323,7 @@ class SplitterTest(TestCase):
                 attr_for_id = None
             source = self._generate_dataset(config)
             splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
-            task = splitter.SplitTask.reidentification.name
+            task = splitter.SplitTask.reid.name
             query = 0.4 / 0.7
             actual = splitter.Split(source, task, splits, query, attr_for_id)
 
@@ -384,7 +384,7 @@ class SplitterTest(TestCase):
             counts[label] = count
             config[label] = {"attrs": None, "counts": count}
         source = self._generate_dataset(config)
-        task = splitter.SplitTask.reidentification.name
+        task = splitter.SplitTask.reid.name
         splits = [("train", 0.5), ("test", 0.5)]
         query = 0.4 / 0.7
         r1 = splitter.Split(source, task, splits, query, seed=1234)
@@ -402,7 +402,7 @@ class SplitterTest(TestCase):
             label = "label%03d" % i
             config[label] = {"attrs": None, "counts": 7}
         source = self._generate_dataset(config)
-        task = splitter.SplitTask.reidentification.name
+        task = splitter.SplitTask.reid.name
         splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
         query = 0.4 / 0.7
         actual = splitter.Split(source, task, splits, query)
@@ -414,7 +414,7 @@ class SplitterTest(TestCase):
 
     def test_split_for_reidentification_unlabeled(self):
         query = 0.5
-        task = splitter.SplitTask.reidentification.name
+        task = splitter.SplitTask.reid.name
 
         with self.subTest("no label"):
             iterable = [DatasetItem(i, annotations=[]) for i in range(10)]
@@ -434,7 +434,7 @@ class SplitterTest(TestCase):
 
     def test_split_for_reidentification_gives_error(self):
         query = 0.4 / 0.7  # valid query ratio
-        task = splitter.SplitTask.reidentification.name
+        task = splitter.SplitTask.reid.name
 
         counts = {i: (i % 3 + 1) * 7 for i in range(10)}
         config = {"person": {"attrs": ["PID"], "counts": counts}}

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -3,8 +3,15 @@ import numpy as np
 from unittest import TestCase
 
 from datumaro.components.project import Dataset
-from datumaro.components.extractor import (DatasetItem, Label, Bbox,
-    LabelCategories, AnnotationType)
+from datumaro.components.extractor import (
+    DatasetItem,
+    Label,
+    Bbox,
+    Mask,
+    Polygon,
+    LabelCategories,
+    AnnotationType,
+)
 
 import datumaro.plugins.splitter as splitter
 from datumaro.components.operations import compute_ann_statistics
@@ -40,20 +47,23 @@ class SplitterTest(TestCase):
                     for _ in range(count):
                         idx += 1
                         iterable.append(
-                            DatasetItem(idx, subset=self._get_subset(idx),
-                                annotations=[
-                                    Label(label_id, attributes=attributes)
-                                ],
-                                image=np.ones((1, 1, 3))
+                            DatasetItem(
+                                idx,
+                                subset=self._get_subset(idx),
+                                annotations=[Label(label_id, attributes=attributes)],
+                                image=np.ones((1, 1, 3)),
                             )
                         )
             else:
                 for _ in range(counts):
                     idx += 1
                     iterable.append(
-                        DatasetItem(idx, subset=self._get_subset(idx),
+                        DatasetItem(
+                            idx,
+                            subset=self._get_subset(idx),
                             annotations=[Label(label_id)],
-                            image=np.ones((1, 1, 3)))
+                            image=np.ones((1, 1, 3)),
+                        )
                     )
         categories = {AnnotationType.label: label_cat}
         dataset = Dataset.from_iterable(iterable, categories)
@@ -66,9 +76,10 @@ class SplitterTest(TestCase):
             "label3": {"attrs": None, "counts": 30},
         }
         source = self._generate_dataset(config)
+        task = splitter.SplitTask.classification.name
 
         splits = [("train", 0.7), ("test", 0.3)]
-        actual = splitter.ClassificationSplit(source, splits)
+        actual = splitter.Split(source, task, splits)
 
         self.assertEqual(42, len(actual.get_subset("train")))
         self.assertEqual(18, len(actual.get_subset("test")))
@@ -91,9 +102,10 @@ class SplitterTest(TestCase):
         counts = {0: 10, 1: 20, 2: 30}
         config = {"label": {"attrs": ["attr"], "counts": counts}}
         source = self._generate_dataset(config)
+        task = splitter.SplitTask.classification.name
 
         splits = [("train", 0.7), ("test", 0.3)]
-        actual = splitter.ClassificationSplit(source, splits)
+        actual = splitter.Split(source, task, splits)
 
         self.assertEqual(42, len(actual.get_subset("train")))
         self.assertEqual(18, len(actual.get_subset("test")))
@@ -124,10 +136,11 @@ class SplitterTest(TestCase):
         attrs = ["attr1", "attr2"]
         config = {"label": {"attrs": attrs, "counts": counts}}
         source = self._generate_dataset(config)
+        task = splitter.SplitTask.classification.name
 
         with self.subTest("zero remainder"):
             splits = [("train", 0.7), ("test", 0.3)]
-            actual = splitter.ClassificationSplit(source, splits)
+            actual = splitter.Split(source, task, splits)
 
             self.assertEqual(84, len(actual.get_subset("train")))
             self.assertEqual(36, len(actual.get_subset("test")))
@@ -152,7 +165,7 @@ class SplitterTest(TestCase):
 
         with self.subTest("non-zero remainder"):
             splits = [("train", 0.95), ("test", 0.05)]
-            actual = splitter.ClassificationSplit(source, splits)
+            actual = splitter.Split(source, task, splits)
 
             self.assertEqual(114, len(actual.get_subset("train")))
             self.assertEqual(6, len(actual.get_subset("test")))
@@ -173,9 +186,10 @@ class SplitterTest(TestCase):
             "label2": {"attrs": attr2, "counts": counts},
         }
         source = self._generate_dataset(config)
+        task = splitter.SplitTask.classification.name
 
         splits = [("train", 0.7), ("test", 0.3)]
-        actual = splitter.ClassificationSplit(source, splits)
+        actual = splitter.Split(source, task, splits)
 
         train = actual.get_subset("train")
         test = actual.get_subset("test")
@@ -213,12 +227,10 @@ class SplitterTest(TestCase):
         self.assertEqual(15, attr_test["attr3"]["distribution"]["2"][0])
 
         with self.subTest("random seed test"):
-            r1 = splitter.ClassificationSplit(source, splits, seed=1234)
-            r2 = splitter.ClassificationSplit(source, splits, seed=1234)
-            r3 = splitter.ClassificationSplit(source, splits, seed=4321)
-            self.assertEqual(
-                list(r1.get_subset("test")), list(r2.get_subset("test"))
-            )
+            r1 = splitter.Split(source, task, splits, seed=1234)
+            r2 = splitter.Split(source, task, splits, seed=1234)
+            r3 = splitter.Split(source, task, splits, seed=4321)
+            self.assertEqual(list(r1.get_subset("test")), list(r2.get_subset("test")))
             self.assertNotEqual(
                 list(r1.get_subset("test")), list(r3.get_subset("test"))
             )
@@ -229,8 +241,9 @@ class SplitterTest(TestCase):
         }
         source = self._generate_dataset(config)
         splits = [("train", 0.1), ("val", 0.9), ("test", 0.0)]
+        task = splitter.SplitTask.classification.name
 
-        actual = splitter.ClassificationSplit(source, splits)
+        actual = splitter.Split(source, task, splits)
 
         self.assertEqual(1, len(actual.get_subset("train")))
         self.assertEqual(4, len(actual.get_subset("val")))
@@ -241,7 +254,8 @@ class SplitterTest(TestCase):
             iterable = [DatasetItem(i, annotations=[]) for i in range(10)]
             source = Dataset.from_iterable(iterable, categories=["a", "b"])
             splits = [("train", 0.7), ("test", 0.3)]
-            actual = splitter.ClassificationSplit(source, splits)
+            task = splitter.SplitTask.classification.name
+            actual = splitter.Split(source, task, splits)
 
             self.assertEqual(7, len(actual.get_subset("train")))
             self.assertEqual(3, len(actual.get_subset("test")))
@@ -251,35 +265,41 @@ class SplitterTest(TestCase):
             iterable = [DatasetItem(i, annotations=anns) for i in range(10)]
             source = Dataset.from_iterable(iterable, categories=["a", "b"])
             splits = [("train", 0.7), ("test", 0.3)]
-            actual = splitter.ClassificationSplit(source, splits)
+            task = splitter.SplitTask.classification.name
+            actual = splitter.Split(source, task, splits)
 
             self.assertEqual(7, len(actual.get_subset("train")))
             self.assertEqual(3, len(actual.get_subset("test")))
 
     def test_split_for_classification_gives_error(self):
-        source = Dataset.from_iterable([
-            DatasetItem(1, annotations=[Label(0)]),
-            DatasetItem(2, annotations=[Label(1)]),
-        ], categories=["a", "b", "c"])
+        source = Dataset.from_iterable(
+            [
+                DatasetItem(1, annotations=[Label(0)]),
+                DatasetItem(2, annotations=[Label(1)]),
+            ],
+            categories=["a", "b", "c"],
+        )
+        task = splitter.SplitTask.classification.name
 
         with self.subTest("wrong ratio"):
             with self.assertRaisesRegex(Exception, "in the range"):
                 splits = [("train", -0.5), ("test", 1.5)]
-                splitter.ClassificationSplit(source, splits)
+                splitter.Split(source, task, splits)
 
             with self.assertRaisesRegex(Exception, "Sum of ratios"):
                 splits = [("train", 0.5), ("test", 0.5), ("val", 0.5)]
-                splitter.ClassificationSplit(source, splits)
+                splitter.Split(source, task, splits)
 
         with self.subTest("duplicated subset name"):
             with self.assertRaisesRegex(Exception, "duplicated"):
                 splits = [("train", 0.5), ("train", 0.2), ("test", 0.3)]
-                splitter.ClassificationSplit(source, splits)
+                splitter.Split(source, task, splits)
 
     def test_split_for_reidentification(self):
-        '''
+        """
         Test ReidentificationSplit using Dataset with label (ImageNet style)
-        '''
+        """
+
         def _get_present(stat):
             values_present = []
             for label, dist in stat["distribution"].items():
@@ -303,9 +323,9 @@ class SplitterTest(TestCase):
                 attr_for_id = None
             source = self._generate_dataset(config)
             splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
+            task = splitter.SplitTask.reidentification.name
             query = 0.4 / 0.7
-            actual = splitter.ReidentificationSplit(source,
-                splits, query, attr_for_id)
+            actual = splitter.Split(source, task, splits, query, attr_for_id)
 
             stats = dict()
             for sname in ["train", "val", "test-query", "test-gallery"]:
@@ -353,9 +373,9 @@ class SplitterTest(TestCase):
                 self.assertEqual(int(total * 0.4 / 0.7), dist_query[pid][0])
 
     def test_split_for_reidentification_randomseed(self):
-        '''
+        """
         Test randomseed for reidentification
-        '''
+        """
         counts = {}
         config = dict()
         for i in range(10):
@@ -364,30 +384,28 @@ class SplitterTest(TestCase):
             counts[label] = count
             config[label] = {"attrs": None, "counts": count}
         source = self._generate_dataset(config)
+        task = splitter.SplitTask.reidentification.name
         splits = [("train", 0.5), ("test", 0.5)]
         query = 0.4 / 0.7
-        r1 = splitter.ReidentificationSplit(source, splits, query, seed=1234)
-        r2 = splitter.ReidentificationSplit(source, splits, query, seed=1234)
-        r3 = splitter.ReidentificationSplit(source, splits, query, seed=4321)
-        self.assertEqual(
-            list(r1.get_subset("train")), list(r2.get_subset("train"))
-        )
-        self.assertNotEqual(
-            list(r1.get_subset("train")), list(r3.get_subset("train"))
-        )
+        r1 = splitter.Split(source, task, splits, query, seed=1234)
+        r2 = splitter.Split(source, task, splits, query, seed=1234)
+        r3 = splitter.Split(source, task, splits, query, seed=4321)
+        self.assertEqual(list(r1.get_subset("train")), list(r2.get_subset("train")))
+        self.assertNotEqual(list(r1.get_subset("train")), list(r3.get_subset("train")))
 
     def test_split_for_reidentification_rebalance(self):
-        '''
+        """
         rebalance function shouldn't gives error when there's no exchange
-        '''
+        """
         config = dict()
         for i in range(100):
             label = "label%03d" % i
             config[label] = {"attrs": None, "counts": 7}
         source = self._generate_dataset(config)
+        task = splitter.SplitTask.reidentification.name
         splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
         query = 0.4 / 0.7
-        actual = splitter.ReidentificationSplit(source, splits, query)
+        actual = splitter.Split(source, task, splits, query)
 
         self.assertEqual(350, len(actual.get_subset("train")))
         self.assertEqual(140, len(actual.get_subset("val")))
@@ -396,12 +414,13 @@ class SplitterTest(TestCase):
 
     def test_split_for_reidentification_unlabeled(self):
         query = 0.5
+        task = splitter.SplitTask.reidentification.name
 
         with self.subTest("no label"):
             iterable = [DatasetItem(i, annotations=[]) for i in range(10)]
             source = Dataset.from_iterable(iterable, categories=["a", "b"])
             splits = [("train", 0.6), ("test", 0.4)]
-            actual = splitter.ReidentificationSplit(source, splits, query)
+            actual = splitter.Split(source, task, splits, query)
             self.assertEqual(10, len(actual.get_subset("not-supported")))
 
         with self.subTest("multi label"):
@@ -409,12 +428,13 @@ class SplitterTest(TestCase):
             iterable = [DatasetItem(i, annotations=anns) for i in range(10)]
             source = Dataset.from_iterable(iterable, categories=["a", "b"])
             splits = [("train", 0.6), ("test", 0.4)]
-            actual = splitter.ReidentificationSplit(source, splits, query)
+            actual = splitter.Split(source, task, splits, query)
 
             self.assertEqual(10, len(actual.get_subset("not-supported")))
 
     def test_split_for_reidentification_gives_error(self):
         query = 0.4 / 0.7  # valid query ratio
+        task = splitter.SplitTask.reidentification.name
 
         counts = {i: (i % 3 + 1) * 7 for i in range(10)}
         config = {"person": {"attrs": ["PID"], "counts": counts}}
@@ -422,35 +442,35 @@ class SplitterTest(TestCase):
         with self.subTest("wrong ratio"):
             with self.assertRaisesRegex(Exception, "in the range"):
                 splits = [("train", -0.5), ("val", 0.2), ("test", 0.3)]
-                splitter.ReidentificationSplit(source, splits, query)
+                splitter.Split(source, task, splits, query)
 
             with self.assertRaisesRegex(Exception, "Sum of ratios"):
                 splits = [("train", 0.6), ("val", 0.2), ("test", 0.3)]
-                splitter.ReidentificationSplit(source, splits, query)
+                splitter.Split(source, task, splits, query)
 
             with self.assertRaisesRegex(Exception, "in the range"):
                 splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
-                actual = splitter.ReidentificationSplit(source, splits, -query)
+                actual = splitter.Split(source, task, splits, -query)
 
         with self.subTest("duplicated subset name"):
             with self.assertRaisesRegex(Exception, "duplicated"):
                 splits = [("train", 0.5), ("train", 0.2), ("test", 0.3)]
-                splitter.ReidentificationSplit(source, splits, query)
+                splitter.Split(source, task, splits, query)
 
         with self.subTest("wrong subset name"):
             with self.assertRaisesRegex(Exception, "Subset name"):
                 splits = [("_train", 0.5), ("val", 0.2), ("test", 0.3)]
-                splitter.ReidentificationSplit(source, splits, query)
+                splitter.Split(source, task, splits, query)
 
         with self.subTest("wrong attribute name for person id"):
             splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
-            actual = splitter.ReidentificationSplit(source, splits, query)
+            actual = splitter.Split(source, task, splits, query)
 
             with self.assertRaisesRegex(Exception, "Unknown subset"):
                 actual.get_subset("test")
 
-    def _generate_detection_dataset(self, **kwargs):
-        append_bbox = kwargs.get("append_bbox")
+    def _generate_detection_segmentation_dataset(self, **kwargs):
+        annotation_type = kwargs.get("annotation_type")
         with_attr = kwargs.get("with_attr", False)
         nimages = kwargs.get("nimages", 10)
 
@@ -479,10 +499,18 @@ class SplitterTest(TestCase):
                     attributes["attr0"] = attr_val % 3
                     attributes["attr%d" % (label_id + 1)] = attr_val % 2
                 for ann_id in range(count):
-                    append_bbox(annotations, label_id=label_id, ann_id=ann_id,
-                        attributes=attributes)
-            item = DatasetItem(img_id, subset=self._get_subset(img_id),
-                annotations=annotations, attributes={"id": img_id})
+                    annotation_type(
+                        annotations,
+                        label_id=label_id,
+                        ann_id=ann_id,
+                        attributes=attributes,
+                    )
+            item = DatasetItem(
+                img_id,
+                subset=self._get_subset(img_id),
+                annotations=annotations,
+                attributes={"id": img_id},
+            )
             iterable.append(item)
 
         dataset = Dataset.from_iterable(iterable, categories)
@@ -492,7 +520,12 @@ class SplitterTest(TestCase):
     def _get_append_bbox(dataset_type):
         def append_bbox_coco(annotations, **kwargs):
             annotations.append(
-                Bbox(1, 1, 2, 2, label=kwargs["label_id"],
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"],
                     id=kwargs["ann_id"],
                     attributes=kwargs["attributes"],
                     group=kwargs["ann_id"],
@@ -504,7 +537,12 @@ class SplitterTest(TestCase):
 
         def append_bbox_voc(annotations, **kwargs):
             annotations.append(
-                Bbox(1, 1, 2, 2, label=kwargs["label_id"],
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"],
                     id=kwargs["ann_id"] + 1,
                     attributes=kwargs["attributes"],
                     group=kwargs["ann_id"],
@@ -514,7 +552,12 @@ class SplitterTest(TestCase):
                 Label(kwargs["label_id"], attributes=kwargs["attributes"])
             )
             annotations.append(
-                Bbox(1, 1, 2, 2, label=kwargs["label_id"] + 3,
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"] + 3,
                     group=kwargs["ann_id"],
                 )
             )  # part
@@ -530,7 +573,12 @@ class SplitterTest(TestCase):
 
         def append_bbox_cvat(annotations, **kwargs):
             annotations.append(
-                Bbox(1, 1, 2, 2, label=kwargs["label_id"],
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"],
                     id=kwargs["ann_id"],
                     attributes=kwargs["attributes"],
                     group=kwargs["ann_id"],
@@ -543,7 +591,12 @@ class SplitterTest(TestCase):
 
         def append_bbox_labelme(annotations, **kwargs):
             annotations.append(
-                Bbox(1, 1, 2, 2, label=kwargs["label_id"],
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"],
                     id=kwargs["ann_id"],
                     attributes=kwargs["attributes"],
                 )
@@ -554,7 +607,12 @@ class SplitterTest(TestCase):
 
         def append_bbox_mot(annotations, **kwargs):
             annotations.append(
-                Bbox(1, 1, 2, 2, label=kwargs["label_id"],
+                Bbox(
+                    1,
+                    1,
+                    2,
+                    2,
+                    label=kwargs["label_id"],
                     attributes=kwargs["attributes"],
                 )
             )
@@ -563,9 +621,7 @@ class SplitterTest(TestCase):
             )
 
         def append_bbox_widerface(annotations, **kwargs):
-            annotations.append(
-                Bbox(1, 1, 2, 2, attributes=kwargs["attributes"])
-            )
+            annotations.append(Bbox(1, 1, 2, 2, attributes=kwargs["attributes"]))
             annotations.append(Label(0, attributes=kwargs["attributes"]))
 
         functions = {
@@ -581,8 +637,169 @@ class SplitterTest(TestCase):
         func = functions.get(dataset_type, append_bbox_cvat)
         return func
 
+    @staticmethod
+    def _get_append_mask(dataset_type):
+        def append_mask_coco(annotations, **kwargs):
+            annotations.append(
+                Mask(
+                    np.array([[0, 0, 0, 1, 0]]),
+                    label=kwargs["label_id"],
+                    id=kwargs["ann_id"],
+                    attributes=kwargs["attributes"],
+                    group=kwargs["ann_id"],
+                )
+            )
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
+        def append_mask_voc(annotations, **kwargs):
+            annotations.append(
+                Mask(
+                    np.array([[0, 0, 0, 1, 0]]),
+                    label=kwargs["label_id"],
+                    id=kwargs["ann_id"] + 1,
+                    attributes=kwargs["attributes"],
+                    group=kwargs["ann_id"],
+                )
+            )  # obj
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+            annotations.append(
+                Mask(
+                    np.array([[0, 0, 0, 1, 0]]),
+                    label=kwargs["label_id"] + 3,
+                    group=kwargs["ann_id"],
+                )
+            )  # part
+            annotations.append(
+                Label(kwargs["label_id"] + 3, attributes=kwargs["attributes"])
+            )
+
+        def append_mask_labelme(annotations, **kwargs):
+            annotations.append(
+                Mask(
+                    np.array([[0, 0, 0, 1, 0]]),
+                    label=kwargs["label_id"],
+                    id=kwargs["ann_id"],
+                    attributes=kwargs["attributes"],
+                )
+            )
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
+        def append_mask_mot(annotations, **kwargs):
+            annotations.append(
+                Mask(
+                    np.array([[0, 0, 0, 1, 0]]),
+                    label=kwargs["label_id"],
+                    attributes=kwargs["attributes"],
+                )
+            )
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
+        functions = {
+            "coco": append_mask_coco,
+            "voc": append_mask_voc,
+            "labelme": append_mask_labelme,
+            "mot": append_mask_mot,
+        }
+
+        func = functions.get(dataset_type, append_mask_coco)
+        return func
+
+    @staticmethod
+    def _get_append_polygon(dataset_type):
+        def append_polygon_coco(annotations, **kwargs):
+            annotations.append(
+                Polygon(
+                    [0, 0, 1, 0, 1, 2, 0, 2],
+                    label=kwargs["label_id"],
+                    id=kwargs["ann_id"],
+                    attributes=kwargs["attributes"],
+                    group=kwargs["ann_id"],
+                )
+            )
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
+        def append_polygon_voc(annotations, **kwargs):
+            annotations.append(
+                Polygon(
+                    [0, 0, 1, 0, 1, 2, 0, 2],
+                    label=kwargs["label_id"],
+                    id=kwargs["ann_id"] + 1,
+                    attributes=kwargs["attributes"],
+                    group=kwargs["ann_id"],
+                )
+            )  # obj
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+            annotations.append(
+                Polygon(
+                    [0, 0, 1, 0, 1, 2, 0, 2],
+                    label=kwargs["label_id"] + 3,
+                    group=kwargs["ann_id"],
+                )
+            )  # part
+            annotations.append(
+                Label(kwargs["label_id"] + 3, attributes=kwargs["attributes"])
+            )
+
+        def append_polygon_yolo(annotations, **kwargs):
+            annotations.append(Bbox(1, 1, 2, 2, label=kwargs["label_id"]))
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
+        def append_polygon_cvat(annotations, **kwargs):
+            annotations.append(
+                Polygon(
+                    [0, 0, 1, 0, 1, 2, 0, 2],
+                    label=kwargs["label_id"],
+                    id=kwargs["ann_id"],
+                    attributes=kwargs["attributes"],
+                    group=kwargs["ann_id"],
+                    z_order=kwargs["ann_id"],
+                )
+            )
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
+        def append_polygon_labelme(annotations, **kwargs):
+            annotations.append(
+                Polygon(
+                    [0, 0, 1, 0, 1, 2, 0, 2],
+                    label=kwargs["label_id"],
+                    id=kwargs["ann_id"],
+                    attributes=kwargs["attributes"],
+                )
+            )
+            annotations.append(
+                Label(kwargs["label_id"], attributes=kwargs["attributes"])
+            )
+
+        functions = {
+            "coco": append_polygon_coco,
+            "voc": append_polygon_voc,
+            "yolo": append_polygon_yolo,
+            "cvat": append_polygon_cvat,
+            "labelme": append_polygon_labelme,
+        }
+
+        func = functions.get(dataset_type, append_polygon_coco)
+        return func
+
     def test_split_for_detection(self):
         dtypes = ["coco", "voc", "yolo", "cvat", "labelme", "mot", "widerface"]
+        task = splitter.SplitTask.detection.name
         params = []
         for dtype in dtypes:
             for with_attr in [False, True]:
@@ -590,8 +807,8 @@ class SplitterTest(TestCase):
                 params.append((dtype, with_attr, 10, 7, 0, 3))
 
         for dtype, with_attr, nimages, train, val, test in params:
-            source, _ = self._generate_detection_dataset(
-                append_bbox=self._get_append_bbox(dtype),
+            source, _ = self._generate_detection_segmentation_dataset(
+                annotation_type=self._get_append_bbox(dtype),
                 with_attr=with_attr,
                 nimages=nimages,
             )
@@ -608,34 +825,31 @@ class SplitterTest(TestCase):
                 train=train,
                 val=val,
                 test=test,
+                task=task,
             ):
-                actual = splitter.DetectionSplit(source, splits)
+                actual = splitter.Split(source, task, splits)
 
                 self.assertEqual(train, len(actual.get_subset("train")))
                 self.assertEqual(val, len(actual.get_subset("val")))
                 self.assertEqual(test, len(actual.get_subset("test")))
 
         # random seed test
-        source, _ = self._generate_detection_dataset(
-            append_bbox=self._get_append_bbox("cvat"),
+        source, _ = self._generate_detection_segmentation_dataset(
+            annotation_type=self._get_append_bbox("cvat"),
             with_attr=True,
             nimages=10,
         )
 
         splits = [("train", 0.5), ("test", 0.5)]
-        r1 = splitter.DetectionSplit(source, splits, seed=1234)
-        r2 = splitter.DetectionSplit(source, splits, seed=1234)
-        r3 = splitter.DetectionSplit(source, splits, seed=4321)
-        self.assertEqual(
-            list(r1.get_subset("test")), list(r2.get_subset("test"))
-        )
-        self.assertNotEqual(
-            list(r1.get_subset("test")), list(r3.get_subset("test"))
-        )
+        r1 = splitter.Split(source, task, splits, seed=1234)
+        r2 = splitter.Split(source, task, splits, seed=1234)
+        r3 = splitter.Split(source, task, splits, seed=4321)
+        self.assertEqual(list(r1.get_subset("test")), list(r2.get_subset("test")))
+        self.assertNotEqual(list(r1.get_subset("test")), list(r3.get_subset("test")))
 
     def test_split_for_detection_with_unlabeled(self):
-        source, _ = self._generate_detection_dataset(
-            append_bbox=self._get_append_bbox("cvat"),
+        source, _ = self._generate_detection_segmentation_dataset(
+            annotation_type=self._get_append_bbox("cvat"),
             with_attr=True,
             nimages=10,
         )
@@ -643,42 +857,48 @@ class SplitterTest(TestCase):
             source.put(DatasetItem(i + 10, annotations={}))
 
         splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
-        actual = splitter.DetectionSplit(source, splits)
+        task = splitter.SplitTask.detection.name
+        actual = splitter.Split(source, task, splits)
         self.assertEqual(10, len(actual.get_subset("train")))
         self.assertEqual(4, len(actual.get_subset("val")))
         self.assertEqual(6, len(actual.get_subset("test")))
 
     def test_split_for_detection_gives_error(self):
-        source, _ = self._generate_detection_dataset(
-            append_bbox=self._get_append_bbox("cvat"),
+        source, _ = self._generate_detection_segmentation_dataset(
+            annotation_type=self._get_append_bbox("cvat"),
             with_attr=True,
             nimages=5,
         )
+        task = splitter.SplitTask.detection.name
 
         with self.subTest("wrong ratio"):
             with self.assertRaisesRegex(Exception, "in the range"):
                 splits = [("train", -0.5), ("test", 1.5)]
-                splitter.DetectionSplit(source, splits)
+                splitter.Split(source, task, splits)
 
             with self.assertRaisesRegex(Exception, "Sum of ratios"):
                 splits = [("train", 0.5), ("test", 0.5), ("val", 0.5)]
-                splitter.DetectionSplit(source, splits)
+                splitter.Split(source, task, splits)
 
         with self.subTest("duplicated subset name"):
             with self.assertRaisesRegex(Exception, "duplicated"):
                 splits = [("train", 0.5), ("train", 0.2), ("test", 0.3)]
-                splitter.DetectionSplit(source, splits)
+                splitter.Split(source, task, splits)
 
     def test_no_subset_name_and_count_restriction(self):
-        splits = [("_train", 0.5), ("valid", 0.1), ("valid2", 0.1),
-            ("test*", 0.2), ("test2", 0.1)]
+        splits = [
+            ("_train", 0.5),
+            ("valid", 0.1),
+            ("valid2", 0.1),
+            ("test*", 0.2),
+            ("test2", 0.1),
+        ]
 
         with self.subTest("classification"):
-            config = {
-                "label1": {"attrs": None, "counts": 10}
-            }
+            config = {"label1": {"attrs": None, "counts": 10}}
+            task = splitter.SplitTask.classification.name
             source = self._generate_dataset(config)
-            actual = splitter.ClassificationSplit(source, splits)
+            actual = splitter.Split(source, task, splits)
             self.assertEqual(5, len(actual.get_subset("_train")))
             self.assertEqual(1, len(actual.get_subset("valid")))
             self.assertEqual(1, len(actual.get_subset("valid2")))
@@ -686,14 +906,227 @@ class SplitterTest(TestCase):
             self.assertEqual(1, len(actual.get_subset("test2")))
 
         with self.subTest("detection"):
-            source, _ = self._generate_detection_dataset(
-                append_bbox=self._get_append_bbox("cvat"),
+            source, _ = self._generate_detection_segmentation_dataset(
+                annotation_type=self._get_append_bbox("cvat"),
                 with_attr=True,
                 nimages=10,
             )
-            actual = splitter.DetectionSplit(source, splits)
+            task = splitter.SplitTask.detection.name
+            actual = splitter.Split(source, task, splits)
             self.assertEqual(5, len(actual.get_subset("_train")))
             self.assertEqual(1, len(actual.get_subset("valid")))
             self.assertEqual(1, len(actual.get_subset("valid2")))
             self.assertEqual(2, len(actual.get_subset("test*")))
             self.assertEqual(1, len(actual.get_subset("test2")))
+
+        with self.subTest("segmentation"):
+            source, _ = self._generate_detection_segmentation_dataset(
+                annotation_type=self._get_append_mask("coco"),
+                with_attr=True,
+                nimages=10,
+            )
+            task = splitter.SplitTask.detection.name
+            actual = splitter.Split(source, task, splits)
+            self.assertEqual(5, len(actual.get_subset("_train")))
+            self.assertEqual(1, len(actual.get_subset("valid")))
+            self.assertEqual(1, len(actual.get_subset("valid2")))
+            self.assertEqual(2, len(actual.get_subset("test*")))
+            self.assertEqual(1, len(actual.get_subset("test2")))
+
+            source, _ = self._generate_detection_segmentation_dataset(
+                annotation_type=self._get_append_polygon("coco"),
+                with_attr=True,
+                nimages=10,
+            )
+            actual = splitter.Split(source, task, splits)
+            self.assertEqual(5, len(actual.get_subset("_train")))
+            self.assertEqual(1, len(actual.get_subset("valid")))
+            self.assertEqual(1, len(actual.get_subset("valid2")))
+            self.assertEqual(2, len(actual.get_subset("test*")))
+            self.assertEqual(1, len(actual.get_subset("test2")))
+
+    def test_split_for_segmentation(self):
+
+        with self.subTest("mask annotation"):
+            dtypes = ["coco", "voc", "labelme", "mot"]
+            task = splitter.SplitTask.segmentation.name
+            params = []
+            for dtype in dtypes:
+                for with_attr in [False, True]:
+                    params.append((dtype, with_attr, 10, 5, 3, 2))
+                    params.append((dtype, with_attr, 10, 7, 0, 3))
+
+            for dtype, with_attr, nimages, train, val, test in params:
+                source, _ = self._generate_detection_segmentation_dataset(
+                    annotation_type=self._get_append_mask(dtype),
+                    with_attr=with_attr,
+                    nimages=nimages,
+                )
+                total = np.sum([train, val, test])
+                splits = [
+                    ("train", train / total),
+                    ("val", val / total),
+                    ("test", test / total),
+                ]
+                with self.subTest(
+                    dtype=dtype,
+                    with_attr=with_attr,
+                    nimage=nimages,
+                    train=train,
+                    val=val,
+                    test=test,
+                    task=task,
+                ):
+                    actual = splitter.Split(source, task, splits)
+
+                    self.assertEqual(train, len(actual.get_subset("train")))
+                    self.assertEqual(val, len(actual.get_subset("val")))
+                    self.assertEqual(test, len(actual.get_subset("test")))
+
+            # random seed test
+            source, _ = self._generate_detection_segmentation_dataset(
+                annotation_type=self._get_append_mask("coco"),
+                with_attr=True,
+                nimages=10,
+            )
+
+            splits = [("train", 0.5), ("test", 0.5)]
+            r1 = splitter.Split(source, task, splits, seed=1234)
+            r2 = splitter.Split(source, task, splits, seed=1234)
+            r3 = splitter.Split(source, task, splits, seed=4321)
+            self.assertEqual(list(r1.get_subset("test")), list(r2.get_subset("test")))
+            self.assertNotEqual(
+                list(r1.get_subset("test")), list(r3.get_subset("test"))
+            )
+
+        with self.subTest("polygon annotation"):
+            dtypes = ["coco", "voc", "labelme", "yolo", "cvat"]
+            task = splitter.SplitTask.segmentation.name
+            params = []
+            for dtype in dtypes:
+                for with_attr in [False, True]:
+                    params.append((dtype, with_attr, 10, 5, 3, 2))
+                    params.append((dtype, with_attr, 10, 7, 0, 3))
+
+            for dtype, with_attr, nimages, train, val, test in params:
+                source, _ = self._generate_detection_segmentation_dataset(
+                    annotation_type=self._get_append_polygon(dtype),
+                    with_attr=with_attr,
+                    nimages=nimages,
+                )
+                total = np.sum([train, val, test])
+                splits = [
+                    ("train", train / total),
+                    ("val", val / total),
+                    ("test", test / total),
+                ]
+                with self.subTest(
+                    dtype=dtype,
+                    with_attr=with_attr,
+                    nimage=nimages,
+                    train=train,
+                    val=val,
+                    test=test,
+                    task=task,
+                ):
+                    actual = splitter.Split(source, task, splits)
+
+                    self.assertEqual(train, len(actual.get_subset("train")))
+                    self.assertEqual(val, len(actual.get_subset("val")))
+                    self.assertEqual(test, len(actual.get_subset("test")))
+
+            # random seed test
+            source, _ = self._generate_detection_segmentation_dataset(
+                annotation_type=self._get_append_polygon("coco"),
+                with_attr=True,
+                nimages=10,
+            )
+
+            splits = [("train", 0.5), ("test", 0.5)]
+            r1 = splitter.Split(source, task, splits, seed=1234)
+            r2 = splitter.Split(source, task, splits, seed=1234)
+            r3 = splitter.Split(source, task, splits, seed=4321)
+            self.assertEqual(list(r1.get_subset("test")), list(r2.get_subset("test")))
+            self.assertNotEqual(
+                list(r1.get_subset("test")), list(r3.get_subset("test"))
+            )
+
+    def test_split_for_segmentation_with_unlabeled(self):
+
+        with self.subTest("mask annotation"):
+            source, _ = self._generate_detection_segmentation_dataset(
+                annotation_type=self._get_append_mask("coco"),
+                with_attr=True,
+                nimages=10,
+            )
+            for i in range(10):
+                source.put(DatasetItem(i + 10, annotations={}))
+
+            splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
+            task = splitter.SplitTask.segmentation.name
+            actual = splitter.Split(source, task, splits)
+            self.assertEqual(10, len(actual.get_subset("train")))
+            self.assertEqual(4, len(actual.get_subset("val")))
+            self.assertEqual(6, len(actual.get_subset("test")))
+
+        with self.subTest("polygon annotation"):
+            source, _ = self._generate_detection_segmentation_dataset(
+                annotation_type=self._get_append_polygon("coco"),
+                with_attr=True,
+                nimages=10,
+            )
+            for i in range(10):
+                source.put(DatasetItem(i + 10, annotations={}))
+
+            splits = [("train", 0.5), ("val", 0.2), ("test", 0.3)]
+            task = splitter.SplitTask.segmentation.name
+            actual = splitter.Split(source, task, splits)
+            self.assertEqual(10, len(actual.get_subset("train")))
+            self.assertEqual(4, len(actual.get_subset("val")))
+            self.assertEqual(6, len(actual.get_subset("test")))
+
+    def test_split_for_segmentation_gives_error(self):
+
+        with self.subTest("mask annotation"):
+            source, _ = self._generate_detection_segmentation_dataset(
+                annotation_type=self._get_append_mask("coco"),
+                with_attr=True,
+                nimages=5,
+            )
+            task = splitter.SplitTask.segmentation.name
+
+            with self.subTest("wrong ratio"):
+                with self.assertRaisesRegex(Exception, "in the range"):
+                    splits = [("train", -0.5), ("test", 1.5)]
+                    splitter.Split(source, task, splits)
+
+                with self.assertRaisesRegex(Exception, "Sum of ratios"):
+                    splits = [("train", 0.5), ("test", 0.5), ("val", 0.5)]
+                    splitter.Split(source, task, splits)
+
+            with self.subTest("duplicated subset name"):
+                with self.assertRaisesRegex(Exception, "duplicated"):
+                    splits = [("train", 0.5), ("train", 0.2), ("test", 0.3)]
+                    splitter.Split(source, task, splits)
+
+        with self.subTest("polygon annotation"):
+            source, _ = self._generate_detection_segmentation_dataset(
+                annotation_type=self._get_append_polygon("coco"),
+                with_attr=True,
+                nimages=5,
+            )
+            task = splitter.SplitTask.segmentation.name
+
+            with self.subTest("wrong ratio"):
+                with self.assertRaisesRegex(Exception, "in the range"):
+                    splits = [("train", -0.5), ("test", 1.5)]
+                    splitter.Split(source, task, splits)
+
+                with self.assertRaisesRegex(Exception, "Sum of ratios"):
+                    splits = [("train", 0.5), ("test", 0.5), ("val", 0.5)]
+                    splitter.Split(source, task, splits)
+
+            with self.subTest("duplicated subset name"):
+                with self.assertRaisesRegex(Exception, "duplicated"):
+                    splits = [("train", 0.5), ("train", 0.2), ("test", 0.3)]
+                    splitter.Split(source, task, splits)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->
This PR includes

- Contains splitting for Segmentation Task (Mask and Polygon Annotated Datasets).
- It integrates each splitter plugin into one. (classification_split, detection_split, etc -> split)
- I modified some bugs. Fixed a bug that was calculated as the entire data set length to the labeled data set length.
- Added test code corresponding to segmentation task.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
`python3 -m unittest -v tests/test_splitter.py`

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [x] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
