### PR TITLE
Fix converter for Pascal VOC format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a label "face" for bounding boxes in Wider Face (<https://github.com/openvinotoolkit/datumaro/pull/215>)
 - Allowed adding "difficult", "truncated", "occluded" attributes when converting to Pascal VOC if these attributes are not present (<https://github.com/openvinotoolkit/datumaro/pull/216>)
 - Empty lines in YOLO annotations are ignored (<https://github.com/openvinotoolkit/datumaro/pull/221>)
+- Export in VOC format when no image info is available (<https://github.com/openvinotoolkit/datumaro/pull/239>)
 
 ### Security
 -

--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -201,7 +201,7 @@ class VocConverter(Converter):
                     ET.SubElement(source_elem, 'annotation').text = 'Unknown'
                     ET.SubElement(source_elem, 'image').text = 'Unknown'
 
-                    if item.has_image and item.image.has_data:
+                    if item.has_image and item.image.has_size:
                         h, w = item.image.size
                         size_elem = ET.SubElement(root_elem, 'size')
                         ET.SubElement(size_elem, 'width').text = str(w)

--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -201,7 +201,7 @@ class VocConverter(Converter):
                     ET.SubElement(source_elem, 'annotation').text = 'Unknown'
                     ET.SubElement(source_elem, 'image').text = 'Unknown'
 
-                    if item.has_image:
+                    if item.has_image and item.image.has_data:
                         h, w = item.image.size
                         size_elem = ET.SubElement(root_elem, 'size')
                         ET.SubElement(size_elem, 'width').text = str(w)

--- a/tests/test_voc_format.py
+++ b/tests/test_voc_format.py
@@ -764,3 +764,29 @@ class VocConverterTest(TestCase):
                 osp.join(path, 'SegmentationObject', '3.png')))
             self.assertFalse(osp.isfile(
                 osp.join(path, 'SegmentationClass', '3.png')))
+
+    def test_can_save_dataset_with_no_data_images(self):
+        class TestExtractor(TestExtractorBase):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id='frame1', subset='test',
+                        image=Image(path='frame1.jpg'),
+                        annotations=[
+                            Bbox(1.0, 2.0, 3.0, 4.0,
+                                attributes={
+                                    'difficult': False,
+                                    'truncated': False,
+                                    'occluded': False
+                                },
+                                id=1, label=0, group=1
+                            )
+                        ]
+                    )
+                ])
+
+            def categories(self):
+                return VOC.make_voc_categories()
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(TestExtractor(),
+                partial(VocConverter.convert, label_map='voc'), test_dir)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Fixed converting to Pascal VOC format for dataset without image data
https://github.com/openvinotoolkit/datumaro/issues/236
### How to test
Follow the steps to reproduce the bug described in the issue

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
