### PR TITLE
Fix saving attribute in WiderFace extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allowed adding "difficult", "truncated", "occluded" attributes when converting to Pascal VOC if these attributes are not present (<https://github.com/openvinotoolkit/datumaro/pull/216>)
 - Empty lines in YOLO annotations are ignored (<https://github.com/openvinotoolkit/datumaro/pull/221>)
 - Export in VOC format when no image info is available (<https://github.com/openvinotoolkit/datumaro/pull/239>)
+- Fixed saving attribute in WiderFace extractor (<https://github.com/openvinotoolkit/datumaro/pull/251>)
 
 ### Security
 -

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -6,11 +6,11 @@
 import os
 import os.path as osp
 import re
-from distutils.util import strtobool
 
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import (AnnotationType, Bbox, DatasetItem,
     Importer, Label, LabelCategories, SourceExtractor)
+from datumaro.util import str_to_bool
 
 
 class WiderFacePath:
@@ -121,7 +121,7 @@ class WiderFaceExtractor(SourceExtractor):
                         for attr in WiderFacePath.BBOX_ATTRIBUTES:
                             if bbox_list[i] != '-':
                                 if bbox_list[i] in ['True', 'False']:
-                                    attributes[attr] = strtobool(bbox_list[i])
+                                    attributes[attr] = str_to_bool(bbox_list[i])
                                 else:
                                     attributes[attr] = bbox_list[i]
                             i += 1

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -6,6 +6,7 @@
 import os
 import os.path as osp
 import re
+from distutils.util import strtobool
 
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import (AnnotationType, Bbox, DatasetItem,
@@ -119,7 +120,10 @@ class WiderFaceExtractor(SourceExtractor):
                         i = 4
                         for attr in WiderFacePath.BBOX_ATTRIBUTES:
                             if bbox_list[i] != '-':
-                                attributes[attr] = bbox_list[i]
+                                if bbox_list[i] in ['True', 'False']:
+                                    attributes[attr] = strtobool(bbox_list[i])
+                                else:
+                                    attributes[attr] = bbox_list[i]
                             i += 1
 
                     annotations.append(Bbox(

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -43,7 +43,9 @@ class WiderFaceFormatTest(TestCase):
                         'blur': '2', 'expression': '1', 'illumination': '0',
                         'occluded': '0', 'pose': '1', 'invalid': '0'}),
                     Bbox(0, 2, 3, 2, label=0, attributes={
-                        'occluded': 'False'}),
+                        'occluded': False}),
+                    Bbox(0, 3, 4, 2, label=0, attributes={
+                        'occluded': True}),
                     Bbox(0, 2, 4, 2, label=0),
                     Bbox(0, 7, 3, 2, label=0, attributes={
                         'blur': '2', 'expression': '1', 'illumination': '0',


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
Resolves openvinotoolkit/cvat#2944:
- Numeric attributes are stored as string, boolean attributes are stored as boolean.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
test

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
