### PR TITLE
Fix numpy version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ lxml>=4.4.1
 matplotlib>=3.3.1
 opencv-python-headless>=4.1.0.25
 Pillow>=6.1.0
-pycocotools>=2.0.0
+pycocotools>=2.0.0 --no-binary=pycocotools # https://github.com/openvinotoolkit/datumaro/issues/253
 PyYAML>=5.3.1
 scikit-image>=0.15.0
 tensorboardX>=1.8

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,17 @@ def get_requirements():
         'matplotlib',
         'numpy>=1.17.3',
         'Pillow',
-        'pycocotools; platform_system != "Windows"',
+
+        # Avoid 2.0.2 Linux binary distribution because of
+        # a conflict in numpy versions with TensorFlow:
+        # - TF is compiled with numpy 1.19 ABI
+        # - pycocotools is compiled with numpy 1.20 ABI
+        # Using a previous version allows to force package rebuilding.
+        #
+        # https://github.com/openvinotoolkit/datumaro/issues/253
+        'pycocotools!=2.0.2; platform_system != "Windows"',
         'pycocotools-windows; platform_system == "Windows"',
+
         'PyYAML',
         'scikit-image',
         'tensorboardX',


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Avoid 2.0.2 Linux binary distribution because of a conflict in numpy versions with TensorFlow:
 - TF is compiled with numpy 1.19 ABI
 - pycocotools is compiled with numpy 1.20 ABI
 
Using a previous version allows to force pycocotools rebuilding, which uses the existing numpy version.


- Fixed #253 

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
