### PR TITLE
Fix loading file and image processing in CIFAR

### DIFF
--- a/datumaro/plugins/cifar_format.py
+++ b/datumaro/plugins/cifar_format.py
@@ -69,7 +69,7 @@ class CifarExtractor(SourceExtractor):
         # 'filenames': list
         # 'labels': list
         with open(path, 'rb') as anno_file:
-            annotation_dict = pickle.load(anno_file)
+            annotation_dict = pickle.load(anno_file, encoding='latin1')
 
         labels = annotation_dict.get('labels', [])
         filenames = annotation_dict.get('filenames', [])
@@ -94,11 +94,13 @@ class CifarExtractor(SourceExtractor):
             if 0 < len(images_data):
                 image = images_data[i]
                 if size is not None and image is not None:
-                    image = image.reshape(size[i][0],
-                        size[i][1], 3).astype(np.uint8)
+                    image = image.reshape(3, size[i][0],
+                        size[i][1]).astype(np.uint8)
+                    image = np.transpose(image, (1, 2, 0))
                 elif image is not None:
-                    image = image.reshape(CifarPath.IMAGE_SIZE,
-                        CifarPath.IMAGE_SIZE, 3).astype(np.uint8)
+                    image = image.reshape(3, CifarPath.IMAGE_SIZE,
+                        CifarPath.IMAGE_SIZE).astype(np.uint8)
+                    image = np.transpose(image, (1, 2, 0))
 
             items[item_id] = DatasetItem(id=item_id, subset=self._subset,
                 image=image, annotations=annotations)
@@ -150,7 +152,8 @@ class CifarConverter(Converter):
                         data.append(None)
                     else:
                         image = image.data
-                        data.append(image.reshape(-1).astype(np.uint8))
+                        data.append(np.transpose(image, \
+                            (2, 0, 1)).reshape(-1).astype(np.uint8))
                         if image.shape[0] != CifarPath.IMAGE_SIZE or \
                                 image.shape[1] != CifarPath.IMAGE_SIZE:
                             image_sizes[len(data) - 1] = (image.shape[0], image.shape[1])


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Fixed loading file in export (`UnicodeDecodeError: 'ascii' codec can't decode byte 0x9e in position 0: ordinal not in range(128)`)
- Fixed image processing

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
