### PR TITLE
tests/requirements.py: remove the test_wrapper functions

### DIFF
--- a/tests/requirements.py
+++ b/tests/requirements.py
@@ -2,31 +2,11 @@
 #
 # SPDX-License-Identifier: MIT
 
+import typing
+
+from attr import attrs
+
 import pytest
-
-
-def mark_requirement(requirement):
-    def wrapper(test_func):
-        @pytest.mark.components(DatumaroComponent.Datumaro)
-        @pytest.mark.component
-        @pytest.mark.priority_medium
-        @pytest.mark.reqids(requirement)
-        def test_wrapper(*args, **kwargs):
-            return test_func(*args, **kwargs)
-        return test_wrapper
-    return wrapper
-
-def mark_bug(bugs):
-    def wrapper(test_func):
-        @pytest.mark.components(DatumaroComponent.Datumaro)
-        @pytest.mark.component
-        @pytest.mark.priority_medium
-        @pytest.mark.bugs(bugs)
-        def test_wrapper(*args, **kwargs):
-            return test_func(*args, **kwargs)
-        return test_wrapper
-    return wrapper
-
 
 class DatumaroComponent:
     Datumaro = "datumaro"
@@ -47,3 +27,33 @@ class Requirements:
 
 class SkipMessages:
     NOT_IMPLEMENTED = "NOT IMPLEMENTED"
+
+
+@attrs(auto_attribs=True)
+class _CombinedDecorator:
+    decorators: typing.List[typing.Callable]
+
+    def __call__(self, function):
+        for d in reversed(self.decorators):
+            function = d(function)
+
+        return function
+
+
+_SHARED_DECORATORS = [
+    pytest.mark.components(DatumaroComponent.Datumaro),
+    pytest.mark.component,
+    pytest.mark.priority_medium,
+]
+
+def mark_requirement(requirement):
+    return _CombinedDecorator([
+        *_SHARED_DECORATORS,
+        pytest.mark.reqids(requirement),
+    ])
+
+def mark_bug(bugs):
+    return _CombinedDecorator([
+        *_SHARED_DECORATORS,
+        pytest.mark.bugs(bugs),
+    ])


### PR DESCRIPTION
### Summary

When a test fails, Pytest prints the failing test function (with an arrow pointing to the line where the failure occurred). However, with the previous implementation of `mark_requirement`/`mark_bug`, Pytest considers `test_wrapper` as the test function, and so it prints the code of `test_wrapper`, which is useless to the developers.

I rewrote the implementation of `mark_requirement` and `mark_bug` so that an extra wrapper function is no longer created. I also took the opportunity to factor out the decorators applied in both functions.

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
Just run the unit tests.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)~~ N/A - no user-facing changes
- ~~[ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly~~ N/A
- ~~[ ] I have added tests to cover my changes~~ N/A
- ~~[ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)~~ N/A

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
