### PR TITLE
Convert most enum definitions from the functional style to the class style

### DIFF
--- a/datumaro/cli/contexts/project/diff.py
+++ b/datumaro/cli/contexts/project/diff.py
@@ -5,7 +5,7 @@
 
 from collections import Counter
 from itertools import zip_longest
-from enum import Enum
+from enum import Enum, auto
 import logging as log
 import os
 import os.path as osp
@@ -13,20 +13,19 @@ import os.path as osp
 import cv2
 import numpy as np
 
-_formats = ['simple']
-
 import warnings
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     import tensorboardX as tb
-    _formats.append('tensorboard')
 
 from datumaro.components.dataset import IDataset
 from datumaro.components.extractor import AnnotationType, LabelCategories
 from datumaro.util.image import save_image
 
 
-OutputFormat = Enum('Formats', _formats)
+class OutputFormat(Enum):
+    simple = auto()
+    tensorboard = auto()
 
 class DatasetDiffVisualizer:
     OutputFormat = OutputFormat

--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -5,7 +5,7 @@
 #pylint: disable=redefined-builtin
 
 from contextlib import contextmanager
-from enum import Enum
+from enum import Enum, auto
 from typing import Iterable, Iterator, Optional, Tuple, Union, Dict, List
 import logging as log
 import os
@@ -144,7 +144,10 @@ class DatasetItemStorageDatasetView(IDataset):
         return self._parent.get(id, subset=subset)
 
 
-ItemStatus = Enum('ItemStatus', ['added', 'modified', 'removed'])
+class ItemStatus(Enum):
+    added = auto()
+    modified = auto()
+    removed = auto()
 
 class DatasetPatch:
     def __init__(self, data: DatasetItemStorage,

--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from enum import Enum
+from enum import Enum, auto
 from glob import iglob
 from typing import Callable, Iterable, List, Dict, Optional
 import numpy as np
@@ -17,16 +17,14 @@ from datumaro.util.image import Image
 from datumaro.util.attrs_util import not_empty, default_if_none
 
 
-AnnotationType = Enum('AnnotationType',
-    [
-        'label',
-        'mask',
-        'points',
-        'polygon',
-        'polyline',
-        'bbox',
-        'caption',
-    ])
+class AnnotationType(Enum):
+    label = auto()
+    mask = auto()
+    points = auto()
+    polygon = auto()
+    polyline = auto()
+    bbox = auto()
+    caption = auto()
 
 _COORDINATE_ROUNDING_DIGITS = 2
 
@@ -468,11 +466,11 @@ class PointsCategories(Categories):
 
 @attrs
 class Points(_Shape):
-    Visibility = Enum('Visibility', [
-        ('absent', 0),
-        ('hidden', 1),
-        ('visible', 2),
-    ])
+    class Visibility(Enum):
+        absent = 0
+        hidden = 1
+        visible = 2
+
     _type = AnnotationType.points
 
     visibility = attrib(type=list, default=None)

--- a/datumaro/components/validator.py
+++ b/datumaro/components/validator.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from copy import deepcopy
-from enum import Enum
+from enum import Enum, auto
 from typing import Union
 
 import numpy as np
@@ -22,9 +22,14 @@ from datumaro.components.cli_plugin import CliPlugin
 from datumaro.util import parse_str_enum_value
 
 
-Severity = Enum('Severity', ['warning', 'error'])
+class Severity(Enum):
+    warning = auto()
+    error = auto()
 
-TaskType = Enum('TaskType', ['classification', 'detection', 'segmentation'])
+class TaskType(Enum):
+    classification = auto()
+    detection = auto()
+    segmentation = auto()
 
 
 class _Validator(CliPlugin):

--- a/datumaro/plugins/camvid_format.py
+++ b/datumaro/plugins/camvid_format.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -7,7 +7,7 @@ import logging as log
 import os
 import os.path as osp
 from collections import OrderedDict
-from enum import Enum
+from enum import Enum, auto
 
 import numpy as np
 
@@ -213,7 +213,9 @@ class CamvidImporter(Importer):
             file_filter=lambda p: osp.basename(p) != CamvidPath.LABELMAP_FILE)
 
 
-LabelmapType = Enum('LabelmapType', ['camvid', 'source'])
+class LabelmapType(Enum):
+    camvid = auto()
+    source = auto()
 
 class CamvidConverter(Converter):
     DEFAULT_IMAGE_EXT = CamvidPath.IMAGE_EXT

--- a/datumaro/plugins/cityscapes_format.py
+++ b/datumaro/plugins/cityscapes_format.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -7,7 +7,7 @@ import logging as log
 import os
 import os.path as osp
 from collections import OrderedDict
-from enum import Enum
+from enum import Enum, auto
 from glob import iglob
 
 import numpy as np
@@ -200,7 +200,9 @@ class CityscapesImporter(Importer):
             max_depth=1)
 
 
-LabelmapType = Enum('LabelmapType', ['cityscapes', 'source'])
+class LabelmapType(Enum):
+    cityscapes = auto()
+    source = auto()
 
 class CityscapesConverter(Converter):
     DEFAULT_IMAGE_EXT = '.png'

--- a/datumaro/plugins/coco_format/converter.py
+++ b/datumaro/plugins/coco_format/converter.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -8,7 +8,7 @@ import logging as log
 import numpy as np
 import os
 import os.path as osp
-from enum import Enum
+from enum import Enum, auto
 from itertools import chain, groupby
 
 import pycocotools.mask as mask_utils
@@ -24,7 +24,10 @@ from datumaro.util.image import save_image
 
 from .format import CocoPath, CocoTask
 
-SegmentationMode = Enum('SegmentationMode', ['guess', 'polygons', 'mask'])
+class SegmentationMode(Enum):
+    guess = auto()
+    polygons = auto()
+    mask = auto()
 
 class _TaskConverter:
     def __init__(self, context):

--- a/datumaro/plugins/coco_format/format.py
+++ b/datumaro/plugins/coco_format/format.py
@@ -1,20 +1,19 @@
 
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
-from enum import Enum
+from enum import Enum, auto
 
 
-CocoTask = Enum('CocoTask', [
-    'instances',
-    'person_keypoints',
-    'captions',
-    'labels', # extension, does not exist in the original COCO format
-    'image_info',
-    'panoptic',
-    'stuff',
-])
+class CocoTask(Enum):
+    instances = auto()
+    person_keypoints = auto()
+    captions = auto()
+    labels = auto() # extension, does not exist in the original COCO format
+    image_info = auto()
+    panoptic = auto()
+    stuff = auto()
 
 class CocoPath:
     IMAGES_DIR = 'images'

--- a/datumaro/plugins/icdar_format/format.py
+++ b/datumaro/plugins/icdar_format/format.py
@@ -1,15 +1,14 @@
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
-from enum import Enum
+from enum import Enum, auto
 
 
-IcdarTask = Enum('IcdarTask', [
-    'word_recognition',
-    'text_localization',
-    'text_segmentation',
-])
+class IcdarTask(Enum):
+    word_recognition = auto()
+    text_localization = auto()
+    text_segmentation = auto()
 
 class IcdarPath:
     IMAGE_EXT = '.png'

--- a/datumaro/plugins/kitti_format/converter.py
+++ b/datumaro/plugins/kitti_format/converter.py
@@ -7,7 +7,7 @@ import logging as log
 import os
 import os.path as osp
 from collections import OrderedDict
-from enum import Enum
+from enum import Enum, auto
 
 import numpy as np
 
@@ -24,7 +24,9 @@ from .format import (KittiTask, KittiPath, KittiLabelMap,
     parse_label_map, write_label_map,
 )
 
-LabelmapType = Enum('LabelmapType', ['kitti', 'source'])
+class LabelmapType(Enum):
+    kitti = auto()
+    source = auto()
 
 class KittiConverter(Converter):
     DEFAULT_IMAGE_EXT = KittiPath.IMAGE_EXT

--- a/datumaro/plugins/kitti_format/format.py
+++ b/datumaro/plugins/kitti_format/format.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 from collections import OrderedDict
-from enum import Enum
+from enum import Enum, auto
 
 from datumaro.components.extractor import (AnnotationType,
     LabelCategories, MaskCategories
@@ -13,10 +13,9 @@ from datumaro.components.extractor import (AnnotationType,
 from datumaro.util.mask_tools import generate_colormap
 
 
-KittiTask = Enum('KittiTask', [
-    'segmentation',
-    'detection'
-])
+class KittiTask(Enum):
+    segmentation = auto()
+    detection = auto()
 
 KittiLabelMap = OrderedDict([
     ('unlabeled', (0, 0, 0)),

--- a/datumaro/plugins/mots_format.py
+++ b/datumaro/plugins/mots_format.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -26,12 +26,11 @@ class MotsPath:
     LABELS_FILE = 'labels.txt'
     MAX_INSTANCES = 1000
 
-MotsLabels = Enum('MotsLabels', [
-    ('background', 0),
-    ('car', 1),
-    ('pedestrian', 2),
-    ('ignored', 10),
-])
+class MotsLabels(Enum):
+    background = 0
+    car = 1
+    pedestrian = 2
+    ignored = 10
 
 class MotsPngExtractor(SourceExtractor):
     @staticmethod

--- a/datumaro/plugins/ndr.py
+++ b/datumaro/plugins/ndr.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from enum import Enum
+from enum import Enum, auto
 import logging as log
 
 import cv2
@@ -14,11 +14,17 @@ from datumaro.components.cli_plugin import CliPlugin
 from datumaro.util import parse_str_enum_value
 
 
-Algorithm = Enum("Algorithm", ["gradient"]) # other algorithms will be added
+class Algorithm(Enum):
+    gradient = auto()
+    # other algorithms will be added
 
-OverSamplingMethod = Enum("OverSamplingMethod", ["random", "similarity"])
+class OverSamplingMethod(Enum):
+    random = auto()
+    similarity = auto()
 
-UnderSamplingMethod = Enum("UnderSamplingMethod", ["uniform", "inverse"])
+class UnderSamplingMethod(Enum):
+    uniform = auto()
+    inverse = auto()
 
 class NDR(Transform, CliPlugin):
     """

--- a/datumaro/plugins/sampler/algorithm/algorithm.py
+++ b/datumaro/plugins/sampler/algorithm/algorithm.py
@@ -2,13 +2,18 @@
 #
 # SPDX-License-Identifier: MIT
 
-from enum import Enum
+from enum import Enum, auto
 
 
-SamplingMethod = Enum("SamplingMethod",
-    ["topk", "lowk", "randk", "mixk", "randtopk"])
+class SamplingMethod(Enum):
+    topk = auto()
+    lowk = auto()
+    randk = auto()
+    mixk = auto()
+    randtopk = auto()
 
-Algorithm = Enum("Algorithm", ["entropy"])
+class Algorithm(Enum):
+    entropy = auto()
 
 class InferenceResultAnalyzer:
     """

--- a/datumaro/plugins/splitter.py
+++ b/datumaro/plugins/splitter.py
@@ -6,7 +6,7 @@ import logging as log
 import numpy as np
 import copy
 from math import gcd
-from enum import Enum
+from enum import Enum, auto
 
 from datumaro.components.extractor import (Transform, AnnotationType,
     DEFAULT_SUBSET_NAME)
@@ -15,9 +15,11 @@ from datumaro.util import cast
 
 NEAR_ZERO = 1e-7
 
-SplitTask = Enum(
-    "split", ["classification", "detection", "segmentation", "reid"]
-)
+class SplitTask(Enum):
+    classification = auto()
+    detection = auto()
+    segmentation = auto()
+    reid = auto()
 
 
 class Split(Transform, CliPlugin):

--- a/datumaro/plugins/transforms.py
+++ b/datumaro/plugins/transforms.py
@@ -1,9 +1,9 @@
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 from collections import Counter
-from enum import Enum
+from enum import Enum, auto
 from itertools import chain
 import logging as log
 import os.path as osp
@@ -454,7 +454,9 @@ class RemapLabels(Transform, CliPlugin):
     |s|sremap_labels -l person:car -l bus:bus -l cat:dog --default delete
     """
 
-    DefaultAction = Enum('DefaultAction', ['keep', 'delete'])
+    class DefaultAction(Enum):
+        keep = auto()
+        delete = auto()
 
     @staticmethod
     def _split_arg(s):

--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -7,7 +7,7 @@ import logging as log
 import os
 import os.path as osp
 from collections import OrderedDict, defaultdict
-from enum import Enum
+from enum import Enum, auto
 from itertools import chain
 
 from lxml import etree as ET
@@ -49,7 +49,9 @@ def _write_xml_bbox(bbox, parent_elem):
     return bbox_elem
 
 
-LabelmapType = Enum('LabelmapType', ['voc', 'source'])
+class LabelmapType(Enum):
+    voc = auto()
+    source = auto()
 
 class VocConverter(Converter):
     DEFAULT_IMAGE_EXT = VocPath.IMAGE_EXT

--- a/datumaro/plugins/voc_format/format.py
+++ b/datumaro/plugins/voc_format/format.py
@@ -1,10 +1,10 @@
 
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 from collections import OrderedDict
-from enum import Enum
+from enum import Enum, auto
 from itertools import chain
 import numpy as np
 
@@ -13,66 +13,61 @@ from datumaro.components.extractor import (AnnotationType,
 )
 
 
-VocTask = Enum('VocTask', [
-    'classification',
-    'detection',
-    'segmentation',
-    'action_classification',
-    'person_layout',
-])
+class VocTask(Enum):
+    classification = auto()
+    detection = auto()
+    segmentation = auto()
+    action_classification = auto()
+    person_layout = auto()
 
-VocLabel = Enum('VocLabel', [
-    ('background', 0),
-    ('aeroplane', 1),
-    ('bicycle', 2),
-    ('bird', 3),
-    ('boat', 4),
-    ('bottle', 5),
-    ('bus', 6),
-    ('car', 7),
-    ('cat', 8),
-    ('chair', 9),
-    ('cow', 10),
-    ('diningtable', 11),
-    ('dog', 12),
-    ('horse', 13),
-    ('motorbike', 14),
-    ('person', 15),
-    ('pottedplant', 16),
-    ('sheep', 17),
-    ('sofa', 18),
-    ('train', 19),
-    ('tvmonitor', 20),
-    ('ignored', 255),
-])
+class VocLabel(Enum):
+    background = 0
+    aeroplane = 1
+    bicycle = 2
+    bird = 3
+    boat = 4
+    bottle = 5
+    bus = 6
+    car = 7
+    cat = 8
+    chair = 9
+    cow = 10
+    diningtable = 11
+    dog = 12
+    horse = 13
+    motorbike = 14
+    person = 15
+    pottedplant = 16
+    sheep = 17
+    sofa = 18
+    train = 19
+    tvmonitor = 20
+    ignored = 255
 
-VocPose = Enum('VocPose', [
-    'Unspecified',
-    'Left',
-    'Right',
-    'Frontal',
-    'Rear',
-])
+class VocPose(Enum):
+    Unspecified = auto()
+    Left = auto()
+    Right = auto()
+    Frontal = auto()
+    Rear = auto()
 
-VocBodyPart = Enum('VocBodyPart', [
-    'head',
-    'hand',
-    'foot',
-])
+class VocBodyPart(Enum):
+    head = auto()
+    hand = auto()
+    foot = auto()
 
-VocAction = Enum('VocAction', [
-    'other',
-    'jumping',
-    'phoning',
-    'playinginstrument',
-    'reading',
-    'ridingbike',
-    'ridinghorse',
-    'running',
-    'takingphoto',
-    'usingcomputer',
-    'walking',
-])
+class VocAction(Enum):
+    other = auto()
+    jumping = auto()
+    phoning = auto()
+    playinginstrument = auto()
+    reading = auto()
+    ridingbike = auto()
+    ridinghorse = auto()
+    running = auto()
+    takingphoto = auto()
+    usingcomputer = auto()
+    walking = auto()
 
 def generate_colormap(length=256):
     def get_bit(number, index):

--- a/datumaro/util/command_targets.py
+++ b/datumaro/util/command_targets.py
@@ -1,17 +1,21 @@
 
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import argparse
-from enum import Enum
+from enum import Enum, auto
 
 from datumaro.components.project import Project
 from datumaro.util.image import load_image
 
 
-TargetKinds = Enum('TargetKinds',
-    ['project', 'source', 'external_dataset', 'inference', 'image'])
+class TargetKinds(Enum):
+    project = auto()
+    source = auto()
+    external_dataset = auto()
+    inference = auto()
+    image = auto()
 
 def is_project_name(value, project):
     return value == project.config.project_name

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -1,18 +1,20 @@
 
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 # pylint: disable=unused-import
 
-from enum import Enum
+from enum import Enum, auto
 from io import BytesIO
 from typing import Any, Callable, Iterator, Iterable, Optional, Tuple, Union
 import numpy as np
 import os
 import os.path as osp
 
-_IMAGE_BACKENDS = Enum('_IMAGE_BACKENDS', ['cv2', 'PIL'])
+class _IMAGE_BACKENDS(Enum):
+    cv2 = auto()
+    PIL = auto()
 _IMAGE_BACKEND = None
 _image_loading_errors = (FileNotFoundError, )
 try:


### PR DESCRIPTION
### Summary
The class style has advantages in terms of IDE support. In particular, with Visual Studio Code, when the functional style is used:

* The enumeration type is considered to be a variable rather than a class.
* Autocomplete doesn't work for enum members.
* "Go to definition" doesn't work for enum members (and indeed, with the functional style they don't really have proper definitions).

Using the class style solves these problems. I would also argue that the class style is slightly more readable due to not as much punctuation (although I can't deny that the repetition of `= auto()` is quite ugly).

The class style removes the need to repeat the enum name twice (in fact, there were a few cases in the codebase in which the two names didn't match).

I converted most of the enums automatically by using the following script:

```python
#!/usr/bin/env python3

import regex
import sys

from pathlib import Path

RE_ENUM = regex.compile(
   r'''
   ^(?<Indent>[ \t]*) (?<EnumName>\w+) \s* = \s* Enum \s* \( \s* (?: '.+?' | ".+?") \s* ,
       \s* \[ \s* (?: '(?<MemberName>.+?)' | "(?<MemberName>.+?)" )
       ( \s* , \s* (?: '(?<MemberName>.+?)' | "(?<MemberName>.+?)" ) )* (?: \s* , )?
       \s* \] \s* \) [ \t]*\n
   ''',
   regex.VERBOSE | regex.MULTILINE)

def main():
    for path in sys.argv[1:]:
        path = Path(path)

        contents = path.read_text()

        def replace(match):
            indent = match.group('Indent')
            enum_name = match.group('EnumName')
            member_names = match.captures('MemberName')
            replacement = f'{indent}class {enum_name}(Enum):\n' \
                + ''.join(f'{indent}    {name} = auto()\n' for name in member_names)
            print(f'{match.group()!r} -> {replacement!r}')
            return replacement

        contents = RE_ENUM.sub(replace, contents)

        path.write_text(contents)

main()
```

The rest of them I converted manually.

The only enum that I kept in the functional style is `MotLabel`, which has members that are not valid Python identifiers (and probably shouldn't be an enum at all).

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
N/A (although I should note that I used `flake8 --select=F821` to make sure all modules import `auto` if needed).

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)~~ N/A - no user-visible changes
- ~~[ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
