### PR TITLE
Make TF availability check optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated YOLO format user manual (<https://github.com/openvinotoolkit/datumaro/pull/295>)
 
 ### Changed
--
+- Tensorflow AVX check is made optional in API and is disabled by default (<https://github.com/openvinotoolkit/datumaro/pull/305>)
 
 ### Deprecated
 -

--- a/datumaro/util/tf_util.py
+++ b/datumaro/util/tf_util.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 
+enable_tf_check = False
+
 def check_import():
     # Workaround for checking import availability:
     # Official TF builds include AVX instructions. Once we try to import,
@@ -32,7 +34,7 @@ def check_import():
 
         raise ImportError(message)
 
-def import_tf(check=True):
+def import_tf(check=None):
     import sys
 
     not_found = object()
@@ -45,6 +47,9 @@ def import_tf(check=True):
     # Reduce output noise, https://stackoverflow.com/questions/38073432/how-to-suppress-verbose-tensorflow-logging
     import os
     os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+
+    if check is None:
+        check = enable_tf_check
 
     if check:
         try:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Related #269, #146 

- TF availability (avx check) check is made optional in the API and disabled by default
- CLI startup time reduced significantly

This PR disables the most performance-hurting part of CLI startup process. The main reason for this TF availability check
is producing a reasonable error message on TF import failure. As TF is a plugin for Datumaro, it should not affect _all_
users, but those users, who don't need it won't suffer from very long loading time anymore.

For CVAT the provided functionality remains the same, the check is still available via API, but it needs to be enabled.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
