### PR TITLE
Reduce duplication of dependency information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Tensorflow AVX check is made optional in API and is disabled by default (<https://github.com/openvinotoolkit/datumaro/pull/305>)
 - Extensions for images in ImageNet_txt are now mandatory (<https://github.com/openvinotoolkit/datumaro/pull/302>)
+- Several dependencies now have lower bounds (<https://github.com/openvinotoolkit/datumaro/pull/308>)
 
 ### Deprecated
 -

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,0 +1,21 @@
+attrs>=19.3.0
+defusedxml>=0.6.0
+GitPython>=3.0.8
+lxml>=4.4.1
+matplotlib>=3.3.1
+numpy>=1.17.3
+Pillow>=6.1.0
+
+# Avoid 2.0.2 Linux binary distribution because of
+# a conflict in numpy versions with TensorFlow:
+# - TF is compiled with numpy 1.19 ABI
+# - pycocotools is compiled with numpy 1.20 ABI
+# Using a previous version allows to force package rebuilding.
+#
+# https://github.com/openvinotoolkit/datumaro/issues/253
+pycocotools>=2.0.0,!=2.0.2; platform_system != "Windows"
+
+pycocotools-windows; platform_system == "Windows"
+PyYAML>=5.3.1
+scikit-image>=0.15.0
+tensorboardX>=1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,5 @@
-attrs>=19.3.0
 Cython>=0.27.3 # include before pycocotools
-defusedxml>=0.6.0
-GitPython>=3.0.8
-lxml>=4.4.1
-matplotlib>=3.3.1
+-r requirements-core.txt --no-binary=pycocotools # https://github.com/openvinotoolkit/datumaro/issues/253
 opencv-python-headless>=4.1.0.25
-Pillow>=6.1.0
-pycocotools>=2.0.0 --no-binary=pycocotools # https://github.com/openvinotoolkit/datumaro/issues/253
-PyYAML>=5.3.1
-scikit-image>=0.15.0
-tensorboardX>=1.8
 pandas>=1.1.5
 pytest>=5.3.5

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -34,29 +34,9 @@ def find_version(project_dir=None):
     return version
 
 def get_requirements():
-    requirements = [
-        'attrs>=19.3.0',
-        'defusedxml',
-        'GitPython',
-        'lxml',
-        'matplotlib',
-        'numpy>=1.17.3',
-        'Pillow',
+    with open('requirements-core.txt') as fh:
+        requirements = [fh.read()]
 
-        # Avoid 2.0.2 Linux binary distribution because of
-        # a conflict in numpy versions with TensorFlow:
-        # - TF is compiled with numpy 1.19 ABI
-        # - pycocotools is compiled with numpy 1.20 ABI
-        # Using a previous version allows to force package rebuilding.
-        #
-        # https://github.com/openvinotoolkit/datumaro/issues/253
-        'pycocotools!=2.0.2; platform_system != "Windows"',
-        'pycocotools-windows; platform_system == "Windows"',
-
-        'PyYAML',
-        'scikit-image',
-        'tensorboardX',
-    ]
     if strtobool(os.getenv('DATUMARO_HEADLESS', '0').lower()):
         requirements.append('opencv-python-headless')
     else:


### PR DESCRIPTION
### Summary

Currently, all runtime dependencies are listed in both `requirements.txt` and `setup.py`, except that they sometimes have differing version constraints. This is confusing and increases the amount of work a maintainer needs to do when updating the dependency list.

Fix it by moving all runtime dependencies to a separate file (`requirements-core.txt`) and referencing that file from both `setup.py` and `requirements.txt`. Combine all version constraints from both original files.

Unfortunately, some things still need to be duplicated:

* The OpenCV dependency varies depending on environment variables, and that logic can't be replicated with a requirements file. So OpenCV has to be listed separately in `setup.py` and `requirements.txt`.

* Cython is a build dependency, not a runtime dependency, so it shouldn't go into `requirements-core.txt`. It would technically be possible to move it to a separate requirements file and reference from there, but it's just one dependency, so it doesn't seem worth it.

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
Try to run `pip install -r requirements.txt`. (The installation through `pip install .` is covered by CI.)

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- ~~[ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly~~ No update should be needed
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
