### PR TITLE
Add an upper bound on the Pillow dependency to work around a regression in 8.3

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -4,7 +4,7 @@ GitPython>=3.0.8
 lxml>=4.4.1
 matplotlib>=3.3.1
 numpy>=1.17.3
-Pillow>=6.1.0
+Pillow>=6.1.0,<8.3 # upper bound due to https://github.com/python-pillow/Pillow/issues/5571
 
 # Avoid 2.0.2 Linux binary distribution because of
 # a conflict in numpy versions with TensorFlow:


### PR DESCRIPTION


<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

See python-pillow/Pillow#5571.

This will hopefully be resolved on Pillow's side soon, at which point we'll be able to revert this. But for now we need this workaround to fix CI.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
