### PR TITLE
Factor out the images.meta loading code from YoloExtractor

### DIFF
--- a/datumaro/plugins/yolo_format/extractor.py
+++ b/datumaro/plugins/yolo_format/extractor.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -11,7 +11,9 @@ from datumaro.components.extractor import (
     AnnotationType, Bbox, DatasetItem, Extractor, Importer, LabelCategories,
     SourceExtractor,
 )
-from datumaro.util.image import Image
+from datumaro.util.image import (
+    DEFAULT_IMAGE_META_FILE_NAME, Image, load_image_meta_file,
+)
 from datumaro.util.os_util import split_path
 
 from .format import YoloPath
@@ -47,17 +49,12 @@ class YoloExtractor(SourceExtractor):
 
         assert image_info is None or isinstance(image_info, (str, dict))
         if image_info is None:
-            image_info = osp.join(rootpath, YoloPath.IMAGE_META_FILE)
+            image_info = osp.join(rootpath, DEFAULT_IMAGE_META_FILE_NAME)
             if not osp.isfile(image_info):
                 image_info = {}
         if isinstance(image_info, str):
-            if not osp.isfile(image_info):
-                raise Exception("Can't read image meta file '%s'" % image_info)
-            with open(image_info, encoding='utf-8') as f:
-                image_info = {}
-                for line in f:
-                    image_name, h, w = line.strip().rsplit(maxsplit=2)
-                    image_info[image_name] = (int(h), int(w))
+            image_info = load_image_meta_file(image_info)
+
         self._image_info = image_info
 
         with open(config_path, 'r', encoding='utf-8') as f:

--- a/datumaro/plugins/yolo_format/format.py
+++ b/datumaro/plugins/yolo_format/format.py
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -7,5 +7,3 @@
 class YoloPath:
     DEFAULT_SUBSET_NAME = 'train'
     SUBSET_NAMES = ['train', 'valid']
-
-    IMAGE_META_FILE = 'images.meta'

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -4,7 +4,9 @@
 
 from enum import Enum, auto
 from io import BytesIO
-from typing import Any, Callable, Iterable, Iterator, Optional, Tuple, Union
+from typing import (
+    Any, Callable, Dict, Iterable, Iterator, Optional, Tuple, Union,
+)
 import importlib
 import os
 import os.path as osp
@@ -380,3 +382,32 @@ class ByteImage(Image):
                 f.write(self.get_bytes())
         else:
             save_image(path, self.data)
+
+ImageMeta = Dict[str, Tuple[int, int]]
+
+DEFAULT_IMAGE_META_FILE_NAME = 'images.meta'
+
+def load_image_meta_file(image_meta_path: str) -> ImageMeta:
+    """
+    Loads image metadata from a file with the following format:
+
+        <image name 1> <height 1> <width 1>
+        <image name 2> <height 2> <width 2>
+        ...
+
+    This can be useful to support datasets in which image dimensions are
+    required to interpret annotations.
+    """
+    assert isinstance(image_meta_path, str)
+
+    if not osp.isfile(image_meta_path):
+        raise Exception("Can't read image meta file '%s'" % image_meta_path)
+
+    image_meta = {}
+
+    with open(image_meta_path, encoding='utf-8') as f:
+        for line in f:
+            image_name, h, w = line.strip().rsplit(maxsplit=2)
+            image_meta[image_name] = (int(h), int(w))
+
+    return image_meta

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -10,6 +10,7 @@ from typing import (
 import importlib
 import os
 import os.path as osp
+import shlex
 import shutil
 
 import numpy as np
@@ -395,6 +396,8 @@ def load_image_meta_file(image_meta_path: str) -> ImageMeta:
         <image name 2> <height 2> <width 2>
         ...
 
+    Shell-like comments and quoted fields are allowed.
+
     This can be useful to support datasets in which image dimensions are
     required to interpret annotations.
     """
@@ -407,7 +410,12 @@ def load_image_meta_file(image_meta_path: str) -> ImageMeta:
 
     with open(image_meta_path, encoding='utf-8') as f:
         for line in f:
-            image_name, h, w = line.strip().rsplit(maxsplit=2)
+            fields = shlex.split(line, comments=True)
+            if not fields:
+                continue
+
+            # ignore extra fields, so that the format can be extended later
+            image_name, h, w = fields[:3]
             image_meta[image_name] = (int(h), int(w))
 
     return image_meta

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -4,7 +4,8 @@ import os.path as osp
 import numpy as np
 
 from datumaro.util.image import (
-    ByteImage, Image, encode_image, lazy_image, load_image, save_image,
+    ByteImage, Image, encode_image, lazy_image, load_image,
+    load_image_meta_file, save_image,
 )
 from datumaro.util.image_cache import ImageCache
 from datumaro.util.test_utils import TestDir
@@ -130,3 +131,22 @@ class BytesImageTest(TestCase):
                     if 'ext' in args or 'path' in args:
                         self.assertEqual(img.ext, args.get('ext', '.png'))
                     # pylint: enable=pointless-statement
+
+class ImageMetaTest(TestCase):
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_loading(self):
+        meta_original = {
+            'a': (123, 456),
+            'b c': (10, 20),
+        }
+
+        with TestDir() as test_dir:
+            meta_path = osp.join(test_dir, 'images.meta')
+
+            with open(meta_path, 'w') as meta_file:
+                for name, (h, w) in meta_original.items():
+                    print(name, h, w, file=meta_file)
+
+            meta_reloaded = load_image_meta_file(meta_path)
+
+        self.assertEqual(meta_reloaded, meta_original)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -135,7 +135,14 @@ class BytesImageTest(TestCase):
 class ImageMetaTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_loading(self):
-        meta_original = {
+        meta_file_contents = r"""
+        # this is a comment
+
+        a 123 456
+        'b c' 10 20 # inline comment
+        """
+
+        meta_expected = {
             'a': (123, 456),
             'b c': (10, 20),
         }
@@ -144,9 +151,8 @@ class ImageMetaTest(TestCase):
             meta_path = osp.join(test_dir, 'images.meta')
 
             with open(meta_path, 'w') as meta_file:
-                for name, (h, w) in meta_original.items():
-                    print(name, h, w, file=meta_file)
+                meta_file.write(meta_file_contents)
 
-            meta_reloaded = load_image_meta_file(meta_path)
+            meta_loaded = load_image_meta_file(meta_path)
 
-        self.assertEqual(meta_reloaded, meta_original)
+        self.assertEqual(meta_loaded, meta_expected)


### PR DESCRIPTION


<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
It looks like the same thing will be needed for Open Images, so I'm
moving it to a common module.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
