### PR TITLE
Enable pylint checkers that find invalid escape sequences

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -155,6 +155,8 @@ enable=
     W1305, # format-combined-specification
     W1306, # missing-format-attribute
     W1307, # invalid-format-index
+    W1401, # anomalous-backslash-in-string
+    W1402, # anomalous-unicode-escape-in-string
 
 
 [REPORTS]

--- a/datumaro/plugins/sampler/sampler.py
+++ b/datumaro/plugins/sampler/sampler.py
@@ -13,7 +13,7 @@ from .algorithm.algorithm import Algorithm, SamplingMethod
 
 
 class Sampler(Transform, CliPlugin):
-    """
+    r"""
     Sampler that analyzes model inference results on the dataset |n
     and picks the best sample for training.|n
     |n

--- a/datumaro/plugins/transforms.py
+++ b/datumaro/plugins/transforms.py
@@ -399,7 +399,7 @@ class IdFromImageName(ItemTransform, CliPlugin):
             return item
 
 class Rename(ItemTransform, CliPlugin):
-    """
+    r"""
     Renames items in the dataset. Supports regular expressions.
     The first character in the expression is a delimiter for
     the pattern and replacement parts. Replacement part can also
@@ -409,7 +409,7 @@ class Rename(ItemTransform, CliPlugin):
     - Replace 'pattern' with 'replacement':|n
     |s|srename -e '|pattern|replacement|'|n
     - Remove 'frame_' from item ids:|n
-    |s|srename -e '|frame_(\d+)|\\1|'
+    |s|srename -e '|frame_(\d+)|\1|'
     """
 
     @classmethod


### PR DESCRIPTION


<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

Invalid escape sequences are deprecated, so fix them and ensure they don't occur again.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
