### PR TITLE
Dataset caching fixes

### DIFF
--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -686,6 +686,9 @@ class Extractor(IExtractor):
         if self._subsets is None:
             self._init_cache()
         if name in self._subsets:
+            if len(self._subsets) == 1:
+                return self
+
             return self.select(lambda item: item.subset == name)
         else:
             raise Exception("Unknown subset '%s', available subsets: %s" % \

--- a/datumaro/plugins/coco_format/importer.py
+++ b/datumaro/plugins/coco_format/importer.py
@@ -73,8 +73,12 @@ class CocoImporter(Importer):
 
     @classmethod
     def find_sources(cls, path):
-        if path.endswith('.json') and osp.isfile(path):
-            subset_paths = [path]
+        if osp.isfile(path):
+            if len(cls._TASKS) == 1:
+                return {'': { next(iter(cls._TASKS)): path }}
+
+            if path.endswith('.json'):
+                subset_paths = [path]
         else:
             subset_paths = glob(osp.join(path, '**', '*_*.json'),
                 recursive=True)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Fixed importing of arbitrary named annotation files in COCO subformats
- Fixed application of transforms when `Dataset.subsets` are called (related #350)
- Optimized `Extractor.get_subset` in the simple case

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
