### PR TITLE
Open Images: implement bounding box support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased]
 ### Added
-- TBD
+- The Open Images format now supports bounding box annotations
+  (<https://github.com/openvinotoolkit/datumaro/pull/352>).
 
 ### Changed
 - TBD

--- a/datumaro/plugins/open_images_format.py
+++ b/datumaro/plugins/open_images_format.py
@@ -307,7 +307,7 @@ class OpenImagesExtractor(Extractor):
                             item_id=item.id, subset=item.subset,
                             label_name=label_name, severity=Severity.error)
 
-                    if item.has_image:
+                    if item.has_image and item.image.size is not None:
                         height, width = item.image.size
                     else:
                         log.warning(
@@ -484,7 +484,7 @@ class OpenImagesConverter(Converter):
                                         OpenImagesPath.BBOX_DESCRIPTION_FIELDS))
                                 bbox_description_writer.writeheader()
 
-                            if item.has_image:
+                            if item.has_image and item.image.size is not None:
                                 image_meta[item.id] = (height, width) = item.image.size
                             else:
                                 log.warning(

--- a/datumaro/plugins/open_images_format.py
+++ b/datumaro/plugins/open_images_format.py
@@ -12,7 +12,6 @@ import logging as log
 import os
 import os.path as osp
 import re
-import shlex
 import types
 
 from attr import attrs
@@ -28,6 +27,7 @@ from datumaro.components.extractor import (
 from datumaro.components.validator import Severity
 from datumaro.util.image import (
     DEFAULT_IMAGE_META_FILE_NAME, Image, find_images, load_image_meta_file,
+    save_image_meta_file,
 )
 from datumaro.util.os_util import split_path
 
@@ -512,6 +512,4 @@ class OpenImagesConverter(Converter):
                 self._save_dir, OpenImagesPath.ANNOTATIONS_DIR,
                 DEFAULT_IMAGE_META_FILE_NAME)
 
-            with open(image_meta_file_path, 'w') as image_meta_file:
-                for image_name, (height, width) in image_meta.items():
-                    print(shlex.quote(image_name), height, width, file=image_meta_file)
+            save_image_meta_file(image_meta, image_meta_file_path)

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -419,3 +419,15 @@ def load_image_meta_file(image_meta_path: str) -> ImageMeta:
             image_meta[image_name] = (int(h), int(w))
 
     return image_meta
+
+def save_image_meta_file(image_meta: ImageMeta, image_meta_path: str) -> None:
+    """
+    Saves image_meta to the path specified by image_meta_path in the format
+    defined in load_image_meta_file's documentation.
+    """
+
+    assert isinstance(image_meta_path, str)
+
+    with open(image_meta_path, 'w', encoding='utf-8') as f:
+        for image_name, (height, width) in image_meta.items():
+            print(shlex.quote(image_name), height, width, file=f)

--- a/docs/formats/open_images_user_manual.md
+++ b/docs/formats/open_images_user_manual.md
@@ -110,6 +110,36 @@ Open Images dataset directory should have the following structure:
 To use per-subset image description files instead of `image_ids_and_rotation.csv`,
 place them in the `annotations` subdirectory.
 
+### Speeding up bounding box loading
+
+To load bounding box annotations,
+Datumaro needs to know the sizes of the corresponding images.
+By default, it will determine these sizes by loading each image from disk,
+which will make the loading process slow.
+
+You can speed up this process
+by extracting the image size information in advance
+and recording it in an `images.meta` file.
+This file must be located in the `annotations` directory,
+and must contain one line per image, with the following structure:
+
+```
+<ID> <height> <width>
+```
+
+Where `<ID>` is the file name of the image without the extension,
+and `<height>` and `<width>` are the dimensions of that image.
+`<ID>` may be quoted with either single or double quotes.
+
+Here's one way to create the `images.meta` file using ImageMagick:
+
+```bash
+# run this from the dataset directory
+find images -name '*.jpg' -exec \
+    identify -format '"%[basename]" %[height] %[width]\n' {} + \
+    > annotations/images.meta
+```
+
 ## Export to other formats
 
 Datumaro can convert OID into any other format [Datumaro supports](../user_manual.md#supported-formats).

--- a/docs/formats/open_images_user_manual.md
+++ b/docs/formats/open_images_user_manual.md
@@ -15,7 +15,7 @@ on [its website](https://storage.googleapis.com/openimages/web/download.html).
 Datumaro supports versions 4, 5 and 6.
 
 Datumaro currently supports only the human-verified image-level label
-annotations from this dataset.
+annotations and bounding box annotations from this dataset.
 
 ## Load Open Images dataset
 
@@ -47,6 +47,9 @@ Annotations can be downloaded from the following URLs:
 - [train image labels](https://storage.googleapis.com/openimages/v6/oidv6-train-annotations-human-imagelabels.csv)
 - [validation image labels](https://storage.googleapis.com/openimages/v5/validation-annotations-human-imagelabels.csv)
 - [test image labels](https://storage.googleapis.com/openimages/v5/test-annotations-human-imagelabels.csv)
+- [train bounding boxes](https://storage.googleapis.com/openimages/v6/oidv6-train-annotations-bbox.csv)
+- [validation bounding boxes](https://storage.googleapis.com/openimages/v5/validation-annotations-bbox.csv)
+- [test bounding boxes](https://storage.googleapis.com/openimages/v5/test-annotations-bbox.csv)
 
 The annotations are optional.
 

--- a/docs/formats/open_images_user_manual.md
+++ b/docs/formats/open_images_user_manual.md
@@ -17,6 +17,24 @@ Datumaro supports versions 4, 5 and 6.
 Datumaro currently supports only the human-verified image-level label
 annotations and bounding box annotations from this dataset.
 
+One attribute is supported on the labels:
+
+- `score`: the confidence level from 0 to 1. A score of 0 indicates that
+  the image does not contain objects of the corresponding class.
+
+The following attributes are supported on the bounding boxes:
+
+- `score`: the confidence level from 0 to 1. In the original dataset
+  this is always equal to 1, but custom datasets may be created with
+  arbitrary values.
+- `occluded`: whether the object is occluded by another object.
+- `truncated`: whether the object extends beyond the boundary of the image.
+- `is_group_of`: whether the object represents a group of objects
+  of the same class.
+- `is_depiction`: whether the object is a depiction (such as a drawing)
+  rather than a real object.
+- `is_inside`: whether the object is seen from the inside.
+
 ## Load Open Images dataset
 
 The Open Images dataset is available for free download.

--- a/docs/formats/open_images_user_manual.md
+++ b/docs/formats/open_images_user_manual.md
@@ -19,21 +19,26 @@ annotations and bounding box annotations from this dataset.
 
 One attribute is supported on the labels:
 
-- `score`: the confidence level from 0 to 1. A score of 0 indicates that
+- `score` (read/write, float). The confidence level from 0 to 1.
+  A score of 0 indicates that
   the image does not contain objects of the corresponding class.
 
 The following attributes are supported on the bounding boxes:
 
-- `score`: the confidence level from 0 to 1. In the original dataset
-  this is always equal to 1, but custom datasets may be created with
-  arbitrary values.
-- `occluded`: whether the object is occluded by another object.
-- `truncated`: whether the object extends beyond the boundary of the image.
-- `is_group_of`: whether the object represents a group of objects
-  of the same class.
-- `is_depiction`: whether the object is a depiction (such as a drawing)
+- `score` (read/write, float). The confidence level from 0 to 1.
+  In the original dataset this is always equal to 1,
+  but custom datasets may be created with arbitrary values.
+- `occluded` (read/write, boolean).
+  Whether the object is occluded by another object.
+- `truncated` (read/write, boolean).
+  Whether the object extends beyond the boundary of the image.
+- `is_group_of` (read/write, boolean).
+  Whether the object represents a group of objects of the same class.
+- `is_depiction` (read/write, boolean).
+  Whether the object is a depiction (such as a drawing)
   rather than a real object.
-- `is_inside`: whether the object is seen from the inside.
+- `is_inside` (read/write, boolean).
+  Whether the object is seen from the inside.
 
 ## Load Open Images dataset
 

--- a/docs/formats/open_images_user_manual.md
+++ b/docs/formats/open_images_user_manual.md
@@ -19,13 +19,15 @@ annotations and bounding box annotations from this dataset.
 
 One attribute is supported on the labels:
 
-- `score` (read/write, float). The confidence level from 0 to 1.
+- `score` (read/write, float).
+  The confidence level from 0 to 1.
   A score of 0 indicates that
   the image does not contain objects of the corresponding class.
 
 The following attributes are supported on the bounding boxes:
 
-- `score` (read/write, float). The confidence level from 0 to 1.
+- `score` (read/write, float).
+  The confidence level from 0 to 1.
   In the original dataset this is always equal to 1,
   but custom datasets may be created with arbitrary values.
 - `occluded` (read/write, boolean).
@@ -115,17 +117,19 @@ Open Images dataset directory should have the following structure:
 To use per-subset image description files instead of `image_ids_and_rotation.csv`,
 place them in the `annotations` subdirectory.
 
-### Speeding up bounding box loading
+### Creating an image metadata file
 
 To load bounding box annotations,
 Datumaro needs to know the sizes of the corresponding images.
 By default, it will determine these sizes by loading each image from disk,
-which will make the loading process slow.
+which requires the images to be present and makes the loading process slow.
 
-You can speed up this process
-by extracting the image size information in advance
-and recording it in an `images.meta` file.
-This file must be located in the `annotations` directory,
+If you want to load the bounding box annotations on a machine where
+the images are not available,
+or just to speed up the dataset loading process,
+you can extract the image size information in advance
+and record it in an image metadata file.
+This file must be placed at `annotations/images.meta`,
 and must contain one line per image, with the following structure:
 
 ```
@@ -136,7 +140,11 @@ Where `<ID>` is the file name of the image without the extension,
 and `<height>` and `<width>` are the dimensions of that image.
 `<ID>` may be quoted with either single or double quotes.
 
-Here's one way to create the `images.meta` file using ImageMagick:
+The image metadata file, if present, will be used to determine the image
+sizes without loading the images themselves.
+
+Here's one way to create the `images.meta` file using ImageMagick,
+assuming that the images are present on the current machine:
 
 ```bash
 # run this from the dataset directory

--- a/tests/assets/open_images_dataset_v6/annotations/images.meta
+++ b/tests/assets/open_images_dataset_v6/annotations/images.meta
@@ -1,0 +1,3 @@
+b 2 8
+# c also has boxes, but we don't mention it here in order to test
+# that Datumaro correctly falls back to reading the image file

--- a/tests/assets/open_images_dataset_v6/annotations/oidv6-train-annotations-bbox.csv
+++ b/tests/assets/open_images_dataset_v6/annotations/oidv6-train-annotations-bbox.csv
@@ -1,2 +1,2 @@
 ImageID,Source,LabelName,Confidence,XMin,XMax,YMin,YMax,IsOccluded,IsTruncated,IsGroupOf,IsDepiction,IsInside
-c,xclick,/m/3,0.7,0.7,0.8,0,0.5,1,0,1,0,0
+b,xclick,/m/0,1,0.2,1,0.3,0.5,-1,-1,-1,-1,-1

--- a/tests/assets/open_images_dataset_v6/annotations/test-annotations-bbox.csv
+++ b/tests/assets/open_images_dataset_v6/annotations/test-annotations-bbox.csv
@@ -1,0 +1,3 @@
+ImageID,Source,LabelName,Confidence,XMin,XMax,YMin,YMax,IsOccluded,IsTruncated,IsGroupOf,IsDepiction,IsInside
+c,xclick,/m/1,1,0.2,1,0.3,0.5,-1,-1,-1,-1,-1
+c,xclick,/m/3,0.7,0.7,0.8,0,0.5,1,0,1,0,0

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from datumaro.util.image import (
     ByteImage, Image, encode_image, lazy_image, load_image,
-    load_image_meta_file, save_image,
+    load_image_meta_file, save_image, save_image_meta_file,
 )
 from datumaro.util.image_cache import ImageCache
 from datumaro.util.test_utils import TestDir
@@ -156,3 +156,18 @@ class ImageMetaTest(TestCase):
             meta_loaded = load_image_meta_file(meta_path)
 
         self.assertEqual(meta_loaded, meta_expected)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_saving(self):
+        meta_original = {
+            'a': (123, 456),
+            'b c': (10, 20),
+        }
+
+        with TestDir() as test_dir:
+            meta_path = osp.join(test_dir, 'images.meta')
+
+            save_image_meta_file(meta_original, meta_path)
+            meta_reloaded = load_image_meta_file(meta_path)
+
+        self.assertEqual(meta_reloaded, meta_original)

--- a/tests/test_open_images_format.py
+++ b/tests/test_open_images_format.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from datumaro.components.dataset import Dataset
 from datumaro.components.extractor import (
-    AnnotationType, DatasetItem, Label, LabelCategories,
+    AnnotationType, Bbox, DatasetItem, Label, LabelCategories,
 )
 from datumaro.plugins.open_images_format import (
     OpenImagesConverter, OpenImagesImporter,
@@ -29,7 +29,17 @@ class OpenImagesFormatTest(TestCase):
                     annotations=[Label(0, attributes={'score': 0.7})]
                 ),
                 DatasetItem(id='b', subset='train', image=np.zeros((8, 8, 3)),
-                    annotations=[Label(1), Label(2, attributes={'score': 0})]
+                    annotations=[
+                        Label(1),
+                        Label(2, attributes={'score': 0}),
+                        Bbox(label=0, x=4, y=3, w=2, h=3),
+                        Bbox(label=1, x=2, y=3, w=6, h=1, attributes={
+                            'score': 0.7,
+                            'occluded': True, 'truncated': False,
+                            'is_group_of': True, 'is_depiction': False,
+                            'is_inside': False,
+                        }),
+                    ]
                 ),
             ],
             categories={
@@ -45,10 +55,17 @@ class OpenImagesFormatTest(TestCase):
         expected_dataset.put(
             DatasetItem(id='b', subset='train', image=np.zeros((8, 8, 3)),
                 annotations=[
-                    # the converter assumes that labels without a score
+                    # the converter assumes that annotations without a score
                     # have a score of 100%
                     Label(1, attributes={'score': 1}),
                     Label(2, attributes={'score': 0}),
+                    Bbox(label=0, x=4, y=3, w=2, h=3, attributes={'score': 1}),
+                    Bbox(label=1, x=2, y=3, w=6, h=1, attributes={
+                        'score': 0.7,
+                        'occluded': True, 'truncated': False,
+                        'is_group_of': True, 'is_depiction': False,
+                        'is_inside': False,
+                    }),
                 ]
             ),
         )
@@ -111,6 +128,13 @@ class OpenImagesImporterTest(TestCase):
                     annotations=[
                         Label(label=1, attributes={'score': 1}),
                         Label(label=3, attributes={'score': 1}),
+                        Bbox(label=1, x=1, y=3, w=4, h=2, attributes={'score': 1}),
+                        Bbox(label=3, x=3.5, y=0, w=0.5, h=5, attributes={
+                            'score': 0.7,
+                            'occluded': True, 'truncated': False,
+                            'is_group_of': True, 'is_depiction': False,
+                            'is_inside': False,
+                        }),
                     ]),
                 DatasetItem(id='d', subset='validation', image=np.ones((1, 5, 3)),
                     annotations=[]),

--- a/tests/test_open_images_format.py
+++ b/tests/test_open_images_format.py
@@ -123,12 +123,14 @@ class OpenImagesImporterTest(TestCase):
                 DatasetItem(id='a', subset='train', image=np.zeros((8, 6, 3)),
                     annotations=[Label(label=0, attributes={'score': 1})]),
                 DatasetItem(id='b', subset='train', image=np.zeros((2, 8, 3)),
-                    annotations=[Label(label=0, attributes={'score': 0})]),
+                    annotations=[
+                        Label(label=0, attributes={'score': 0}),
+                        Bbox(label=0, x=1.6, y=0.6, w=6.4, h=0.4, attributes={'score': 1}),
+                    ]),
                 DatasetItem(id='c', subset='test', image=np.ones((10, 5, 3)),
                     annotations=[
                         Label(label=1, attributes={'score': 1}),
                         Label(label=3, attributes={'score': 1}),
-                        Bbox(label=1, x=1, y=3, w=4, h=2, attributes={'score': 1}),
                         Bbox(label=3, x=3.5, y=0, w=0.5, h=5, attributes={
                             'score': 0.7,
                             'occluded': True, 'truncated': False,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This continues the implementation of #274.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
You can download some of the bounding boxes for OID, create `images.meta` as described in the documentation and try to import the dataset.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [x] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
