### PR TITLE
Add class restriction on unpickling in CIFAR import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Patching of datasets in COCO and CIFAR formats (<https://github.com/openvinotoolkit/datumaro/pull/347>, <https://github.com/openvinotoolkit/datumaro/pull/346>)
+- Unsafe unpickling in CIFAR import (<https://github.com/openvinotoolkit/datumaro/pull/362>)
 
 ### Security
 - TBD

--- a/datumaro/plugins/cifar_format.py
+++ b/datumaro/plugins/cifar_format.py
@@ -5,7 +5,7 @@
 from collections import OrderedDict
 import os
 import os.path as osp
-import pickle
+import pickle  # nosec - disable B403:import_pickle check, TODO: issue #327
 
 import numpy as np
 import numpy.core.multiarray
@@ -17,6 +17,7 @@ from datumaro.components.extractor import (
     SourceExtractor,
 )
 from datumaro.util import cast
+
 
 class RestrictedUnpickler(pickle.Unpickler):
     def find_class(self, module, name):

--- a/datumaro/plugins/cifar_format.py
+++ b/datumaro/plugins/cifar_format.py
@@ -3,11 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 from collections import OrderedDict
+import io
 import os
 import os.path as osp
-import pickle  # nosec - disable B403:import_pickle check, TODO: issue #327
+import pickle
 
 import numpy as np
+import numpy.core.multiarray
 
 from datumaro.components.converter import Converter
 from datumaro.components.dataset import ItemStatus
@@ -17,6 +19,25 @@ from datumaro.components.extractor import (
 )
 from datumaro.util import cast
 
+class RestrictedUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module == "numpy.core.multiarray" and \
+                name in PickleLoader.safe_numpy:
+            return getattr(numpy.core.multiarray, name)
+        elif module == 'numpy' and name in PickleLoader.safe_numpy:
+            return getattr(numpy, name)
+        raise pickle.UnpicklingError("Global '%s.%s' is forbidden"
+            % (module, name))
+
+class PickleLoader():
+    safe_numpy = {
+        'dtype',
+        'ndarray',
+        '_reconstruct',
+    }
+
+    def restricted_load(s):
+        return RestrictedUnpickler(s, encoding='latin1').load()
 
 class CifarPath:
     META_10_FILE = 'batches.meta'
@@ -59,7 +80,7 @@ class CifarExtractor(SourceExtractor):
             # fine_label_names: ['apple', 'aquarium_fish', 'baby', ...]
             # coarse_label_names: ['aquatic_mammals', 'fish', 'flowers', ...]
             with open(meta_file, 'rb') as labels_file:
-                data = pickle.load(labels_file) # nosec - disable B301:pickle check
+                data = PickleLoader.restricted_load(labels_file)
             labels = data.get('label_names')
             if labels != None:
                 for label in labels:
@@ -88,7 +109,7 @@ class CifarExtractor(SourceExtractor):
         #            'coarse_labels': list
 
         with open(path, 'rb') as anno_file:
-            annotation_dict = pickle.load(anno_file, encoding='latin1') # nosec - disable B301:pickle check
+            annotation_dict = PickleLoader.restricted_load(anno_file)
 
         labels = annotation_dict.get('labels', [])
         coarse_labels = annotation_dict.get('coarse_labels', [])

--- a/datumaro/plugins/cifar_format.py
+++ b/datumaro/plugins/cifar_format.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 from collections import OrderedDict
-import io
 import os
 import os.path as osp
 import pickle

--- a/datumaro/plugins/cifar_format.py
+++ b/datumaro/plugins/cifar_format.py
@@ -5,7 +5,7 @@
 from collections import OrderedDict
 import os
 import os.path as osp
-import pickle  # nosec - disable B403:import_pickle check, TODO: issue #327
+import pickle  # nosec - disable B403:import_pickle check - fixed
 
 import numpy as np
 import numpy.core.multiarray

--- a/tests/test_cifar_format.py
+++ b/tests/test_cifar_format.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 import os
 import os.path as osp
+import pickle
 
 import numpy as np
 
@@ -195,6 +196,15 @@ class CifarFormatTest(TestCase):
 
             compare_datasets(self, source_dataset, parsed_dataset,
                 require_images=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_catch_pickle_exception(self):
+        with TestDir() as test_dir:
+            anno_file = osp.join(test_dir, 'test')
+            with open(anno_file,'wb') as file:
+                pickle.dump(enumerate([1, 2, 3]), file)
+            with self.assertRaisesRegex(pickle.UnpicklingError, "Global"):
+                Dataset.import_from(test_dir, 'cifar')
 
 
 DUMMY_10_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets',

--- a/tests/test_cifar_format.py
+++ b/tests/test_cifar_format.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 import os
 import os.path as osp
-import pickle
+import pickle  # nosec - disable B403:import_pickle check, TODO: issue #327
 
 import numpy as np
 

--- a/tests/test_cifar_format.py
+++ b/tests/test_cifar_format.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 import os
 import os.path as osp
-import pickle  # nosec - disable B403:import_pickle check, TODO: issue #327
+import pickle  # nosec - disable B403:import_pickle check
 
 import numpy as np
 
@@ -201,7 +201,7 @@ class CifarFormatTest(TestCase):
     def test_can_catch_pickle_exception(self):
         with TestDir() as test_dir:
             anno_file = osp.join(test_dir, 'test')
-            with open(anno_file,'wb') as file:
+            with open(anno_file, 'wb') as file:
                 pickle.dump(enumerate([1, 2, 3]), file)
             with self.assertRaisesRegex(pickle.UnpicklingError, "Global"):
                 Dataset.import_from(test_dir, 'cifar')


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Added class restriction on unpickling in CIFAR import

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
Unit test, manually on original CIFAR-10/100

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
