### PR TITLE
Open Images: remove unneeded annotations when saving in-place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD
 
 ### Fixed
-- Patching of datasets in Datumaro, CVAT, COCO and CIFAR formats (<https://github.com/openvinotoolkit/datumaro/pull/365>, <https://github.com/openvinotoolkit/datumaro/pull/347>, <https://github.com/openvinotoolkit/datumaro/pull/346>)
+- Patching of datasets in Datumaro, CVAT, COCO, CIFAR and Open Images formats
+  (<https://github.com/openvinotoolkit/datumaro/pull/365>,
+  <https://github.com/openvinotoolkit/datumaro/pull/347>,
+  <https://github.com/openvinotoolkit/datumaro/pull/346>,
+  <https://github.com/openvinotoolkit/datumaro/pull/363>)
+  <https://github.com/openvinotoolkit/datumaro/pull/346>,
+  <https://github.com/openvinotoolkit/datumaro/pull/363>)
 - Unsafe unpickling in CIFAR import (<https://github.com/openvinotoolkit/datumaro/pull/362>)
 
 ### Security

--- a/datumaro/plugins/open_images_format.py
+++ b/datumaro/plugins/open_images_format.py
@@ -17,6 +17,7 @@ import types
 from attr import attrs
 
 from datumaro.components.converter import Converter
+from datumaro.components.dataset import ItemStatus
 from datumaro.components.errors import (
     DatasetError, RepeatedItemError, UndefinedLabel,
 )
@@ -447,6 +448,19 @@ class OpenImagesConverter(Converter):
         annotation_writer = _AnnotationWriter(save_dir)
         converter._save(annotation_writer)
         annotation_writer.remove_unwritten()
+
+        images_dir = osp.join(save_dir, OpenImagesPath.IMAGES_DIR)
+        for (item_id, subset), status in patch.updated_items.items():
+            if status != ItemStatus.removed:
+                continue
+
+            item = DatasetItem(item_id, subset=subset)
+
+            image_path = osp.join(images_dir,
+                converter._make_image_filename(item, subdir=subset))
+
+            if osp.isfile(image_path):
+                os.unlink(image_path)
 
     def _save(self, annotation_writer):
         self._save_categories(annotation_writer)

--- a/tests/test_open_images_format.py
+++ b/tests/test_open_images_format.py
@@ -114,32 +114,40 @@ class OpenImagesFormatTest(TestCase):
     @mark_requirement(Requirements.DATUM_274)
     def test_inplace_save_writes_only_updated_data(self):
         dataset = Dataset.from_iterable([
-            DatasetItem('a', subset='s', image=np.ones((2, 1, 3)),
+            DatasetItem('a', subset='modified', image=np.ones((2, 1, 3)),
                 annotations=[
                     Label(0, attributes={'score': 1}),
                     Bbox(0, 0, 1, 2, label=0),
                 ]),
-            DatasetItem('b', subset='t', image=np.ones((3, 2, 3)),
-                annotations=[Label(1, attributes={'score': 1})]),
-        ], categories=['/m/0', '/m/1', '/m/2'])
+            DatasetItem('b', subset='modified', image=np.ones((2, 1, 3)),
+                annotations=[
+                    Label(1, attributes={'score': 1}),
+                ]),
+            DatasetItem('c', subset='removed', image=np.ones((3, 2, 3)),
+                annotations=[Label(2, attributes={'score': 1})]),
+            DatasetItem('d', subset='unmodified', image=np.ones((4, 3, 3)),
+                annotations=[Label(3, attributes={'score': 1})]),
+        ], categories=['/m/0', '/m/1', '/m/2', '/m/3'])
 
         with TestDir() as path:
             dataset.export(path, 'open_images', save_images=True)
 
-            dataset.put(DatasetItem('c', subset='u', image=np.ones((3, 2, 3)),
+            dataset.put(DatasetItem('e', subset='new', image=np.ones((5, 4, 3)),
                 annotations=[Label(1, attributes={'score': 1})]))
-            dataset.remove('b', subset='t')
-            del dataset.get('a', subset='s').annotations[1]
+            dataset.remove('c', subset='removed')
+            del dataset.get('a', subset='modified').annotations[1]
             dataset.save(save_images=True)
 
             self.assertEqual(
                 {
                     'bbox_labels_600_hierarchy.json',
                     'class-descriptions.csv',
-                    's-annotations-human-imagelabels.csv',
-                    's-images-with-rotation.csv',
-                    'u-annotations-human-imagelabels.csv',
-                    'u-images-with-rotation.csv',
+                    'modified-annotations-human-imagelabels.csv',
+                    'modified-images-with-rotation.csv',
+                    'new-annotations-human-imagelabels.csv',
+                    'new-images-with-rotation.csv',
+                    'unmodified-annotations-human-imagelabels.csv',
+                    'unmodified-images-with-rotation.csv',
                 },
                 set(os.listdir(osp.join(path, 'annotations'))),
             )

--- a/tests/test_open_images_format.py
+++ b/tests/test_open_images_format.py
@@ -151,6 +151,16 @@ class OpenImagesFormatTest(TestCase):
                 },
                 set(os.listdir(osp.join(path, 'annotations'))),
             )
+
+            expected_images = {f'{id}.jpg' for id in ['a', 'b', 'd', 'e']}
+
+            actual_images = {file_name
+                for _, _, file_names in os.walk(osp.join(path, 'images'))
+                for file_name in file_names
+            }
+
+            self.assertEqual(actual_images, expected_images)
+
             dataset_reloaded = Dataset.import_from(path, 'open_images')
             compare_datasets(self, dataset, dataset_reloaded, require_images=True)
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This makes patching work correctly when a subset or annotation type is removed. As a side effect, I also factored out the functionality for lazily creating CSV files into a separate class.

Related to #348.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
N/A

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
