### PR TITLE
Fix inplace saving in YOLO, CamVid and Cityscapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD
 
 ### Fixed
-- Patching of datasets in Cityscapes, CamVid, Datumaro, CVAT, COCO and CIFAR formats (<https://github.com/openvinotoolkit/datumaro/pull/365>, <https://github.com/openvinotoolkit/datumaro/pull/347>, <https://github.com/openvinotoolkit/datumaro/pull/346>)
+- Patching of datasets in Cityscapes, CamVid, Datumaro, CVAT, COCO and CIFAR formats (<https://github.com/openvinotoolkit/datumaro/pull/367>, <https://github.com/openvinotoolkit/datumaro/pull/365>, <https://github.com/openvinotoolkit/datumaro/pull/347>, <https://github.com/openvinotoolkit/datumaro/pull/346>)
 - Unsafe unpickling in CIFAR import (<https://github.com/openvinotoolkit/datumaro/pull/362>)
+- Improved Cityscapes export performance (<https://github.com/openvinotoolkit/datumaro/pull/367>)
 
 ### Security
 - TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD
 
 ### Fixed
-- Patching of datasets in Cityscapes, CamVid, Datumaro, CVAT, COCO and CIFAR formats (<https://github.com/openvinotoolkit/datumaro/pull/367>, <https://github.com/openvinotoolkit/datumaro/pull/365>, <https://github.com/openvinotoolkit/datumaro/pull/347>, <https://github.com/openvinotoolkit/datumaro/pull/346>)
+- Patching of datasets in formats (<https://github.com/openvinotoolkit/datumaro/issues/348>)
 - Unsafe unpickling in CIFAR import (<https://github.com/openvinotoolkit/datumaro/pull/362>)
 - Improved Cityscapes export performance (<https://github.com/openvinotoolkit/datumaro/pull/367>)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Patching of datasets in formats (<https://github.com/openvinotoolkit/datumaro/issues/348>)
 - Unsafe unpickling in CIFAR import (<https://github.com/openvinotoolkit/datumaro/pull/362>)
 - Improved Cityscapes export performance (<https://github.com/openvinotoolkit/datumaro/pull/367>)
+- Incorrect format of `*_labelIds.png` in Cityscapes export (<https://github.com/openvinotoolkit/datumaro/issues/325>, <https://github.com/openvinotoolkit/datumaro/issues/342>)
 
 ### Security
 - TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD
 
 ### Fixed
-- Patching of datasets in Datumaro, CVAT, COCO and CIFAR formats (<https://github.com/openvinotoolkit/datumaro/pull/365>, <https://github.com/openvinotoolkit/datumaro/pull/347>, <https://github.com/openvinotoolkit/datumaro/pull/346>)
+- Patching of datasets in Cityscapes, CamVid, Datumaro, CVAT, COCO and CIFAR formats (<https://github.com/openvinotoolkit/datumaro/pull/365>, <https://github.com/openvinotoolkit/datumaro/pull/347>, <https://github.com/openvinotoolkit/datumaro/pull/346>)
 - Unsafe unpickling in CIFAR import (<https://github.com/openvinotoolkit/datumaro/pull/362>)
 
 ### Security

--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -761,7 +761,7 @@ class Dataset(IDataset):
 
     @property
     def is_bound(self) -> bool:
-        return self._source_path and self._format
+        return bool(self._source_path) and bool(self._format)
 
     def bind(self, path: str, format: str = None):
         self._source_path = path

--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -198,6 +198,9 @@ class DatasetPatch:
                 for s in self.data.subsets()}
         return self._updated_subsets
 
+    def __contains__(self, x: Union[DatasetItem, Tuple[str, str]]) -> bool:
+        return x in self.data
+
     def as_dataset(self, parent: IDataset) -> IDataset:
         return __class__.DatasetPatchWrapper(self, parent)
 

--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -131,7 +131,7 @@ class Label(Annotation):
 @attrs(eq=False)
 class MaskCategories(Categories):
     @classmethod
-    def generate(cls, size=256, include_background=True):
+    def generate(cls, size=255, include_background=True):
         """
         Generates a color map with the specified size.
 

--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -139,7 +139,7 @@ class MaskCategories(Categories):
             "0: (0, 0, 0)", which is typically used as a background color.
         """
         from datumaro.util.mask_tools import generate_colormap
-        colormap = generate_colormap(size)
+        colormap = generate_colormap(size + (not include_background))
         if not include_background:
             colormap.pop(0)
             colormap = { k - 1: v for k, v in colormap.items() }
@@ -248,12 +248,12 @@ class CompiledMask:
             instance_ids=None, instance_labels=None, dtype=None):
         from datumaro.util.mask_tools import make_index_mask
 
-        if instance_ids is not None:
+        if instance_ids:
             assert len(instance_ids) == len(instance_masks)
         else:
             instance_ids = [None] * len(instance_masks)
 
-        if instance_labels is not None:
+        if instance_labels:
             assert len(instance_labels) == len(instance_masks)
         else:
             instance_labels = [None] * len(instance_masks)

--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -131,9 +131,19 @@ class Label(Annotation):
 @attrs(eq=False)
 class MaskCategories(Categories):
     @classmethod
-    def make_default(cls, size=256):
+    def generate(cls, size=256, include_background=True):
+        """
+        Generates a color map with the specified size.
+
+        If include_background is True, the result will include the item
+            "0: (0, 0, 0)", which is typically used as a background color.
+        """
         from datumaro.util.mask_tools import generate_colormap
-        return cls(generate_colormap(size))
+        colormap = generate_colormap(size)
+        if not include_background:
+            colormap.pop(0)
+            colormap = { k - 1: v for k, v in colormap.items() }
+        return cls(colormap)
 
     colormap = attrib(factory=dict, validator=default_if_none(dict))
     _inverse_colormap = attrib(default=None,

--- a/datumaro/plugins/camvid_format.py
+++ b/datumaro/plugins/camvid_format.py
@@ -389,8 +389,7 @@ class CamvidConverter(Converter):
             else:
                 item = DatasetItem(item_id, subset=subset)
 
-            if not (status == ItemStatus.removed or \
-                    not item.has_image and not item.has_point_cloud):
+            if not (status == ItemStatus.removed or not item.has_image):
                 continue
 
             image_path = osp.join(save_dir,

--- a/datumaro/plugins/camvid_format.py
+++ b/datumaro/plugins/camvid_format.py
@@ -307,7 +307,7 @@ class CamvidConverter(Converter):
 
     def save_label_map(self):
         path = osp.join(self._save_dir, CamvidPath.LABELMAP_FILE)
-        labels = self._extractor.categories()[AnnotationType.label]._indices
+        labels = self._extractor.categories()[AnnotationType.label]
         if len(self._label_map) > len(labels):
             self._label_map.pop('background')
         write_label_map(path, self._label_map)

--- a/datumaro/plugins/camvid_format.py
+++ b/datumaro/plugins/camvid_format.py
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
@@ -12,6 +11,7 @@ import os.path as osp
 import numpy as np
 
 from datumaro.components.converter import Converter
+from datumaro.components.dataset import ItemStatus
 from datumaro.components.extractor import (
     AnnotationType, CompiledMask, DatasetItem, Importer, LabelCategories, Mask,
     MaskCategories, SourceExtractor,
@@ -118,7 +118,7 @@ def make_camvid_categories(label_map=None):
 
     categories = {}
     label_categories = LabelCategories()
-    for label, desc in label_map.items():
+    for label in label_map:
         label_categories.add(label)
     categories[AnnotationType.label] = label_categories
 
@@ -128,7 +128,7 @@ def make_camvid_categories(label_map=None):
     else: # only copy defined colors
         label_id = lambda label: label_categories.find(label)[0]
         colormap = { label_id(name): (desc[0], desc[1], desc[2])
-            for name, desc in label_map.items() }
+            for name, desc in label_map.items() if desc }
     mask_categories = MaskCategories(colormap)
     mask_categories.inverse_colormap # pylint: disable=pointless-statement
     categories[AnnotationType.mask] = mask_categories
@@ -288,10 +288,14 @@ class CamvidConverter(Converter):
         save_image(path, mask, create_dir=True)
 
     def save_segm_lists(self, subset_name, segm_list):
+        ann_file = osp.join(self._save_dir, subset_name + '.txt')
+
         if not segm_list:
+            if self._patch and subset_name in self._patch.updated_subsets:
+                if osp.isfile(ann_file):
+                    os.remove(ann_file)
             return
 
-        ann_file = osp.join(self._save_dir, subset_name + '.txt')
         with open(ann_file, 'w', encoding='utf-8') as f:
             for (image_path, mask_path) in segm_list.values():
                 image_path = '/' + image_path.replace('\\', '/')
@@ -370,3 +374,40 @@ class CamvidConverter(Converter):
         )
 
         return map_id
+
+    @classmethod
+    def patch(cls, dataset, patch, save_dir, **kwargs):
+        for subset in patch.updated_subsets:
+            conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
+            conv._patch = patch
+            conv.apply()
+
+        conv = cls(dataset, save_dir=save_dir, **kwargs)
+        for (item_id, subset), status in patch.updated_items.items():
+            if status != ItemStatus.removed:
+                item = patch.data.get(item_id, subset)
+            else:
+                item = DatasetItem(item_id, subset=subset)
+
+            if not (status == ItemStatus.removed or \
+                    not item.has_image and not item.has_point_cloud):
+                continue
+
+            image_path = osp.join(save_dir,
+                conv._make_image_filename(item, subdir=subset))
+            if osp.isfile(image_path):
+                os.unlink(image_path)
+
+            mask_path = osp.join(save_dir, subset + CamvidPath.SEGM_DIR,
+                item.id + CamvidPath.MASK_EXT)
+            if osp.isfile(mask_path):
+                os.remove(mask_path)
+
+        for subset in patch.updated_subsets:
+            ann_dir = osp.join(save_dir, subset + CamvidPath.SEGM_DIR)
+            if osp.isdir(ann_dir) and not os.listdir(ann_dir):
+                os.rmdir(ann_dir)
+
+            img_dir = osp.join(save_dir, subset)
+            if osp.isdir(img_dir) and not os.listdir(img_dir):
+                os.rmdir(img_dir)

--- a/datumaro/plugins/cityscapes_format.py
+++ b/datumaro/plugins/cityscapes_format.py
@@ -290,7 +290,7 @@ class CityscapesConverter(Converter):
                 cls_mask_path = osp.join(mask_dir,
                     mask_name + CityscapesPath.LABELIDS_IMAGE)
                 self.save_mask(cls_mask_path, compiled_mask.class_mask,
-                    apply_colormap=False, dtype=np.int32)
+                    apply_colormap=False, dtype=np.uint8)
 
                 inst_mask_path = osp.join(mask_dir,
                     mask_name + CityscapesPath.INSTANCES_IMAGE)

--- a/datumaro/plugins/yolo_format/converter.py
+++ b/datumaro/plugins/yolo_format/converter.py
@@ -1,5 +1,4 @@
-
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -93,9 +92,15 @@ class YoloConverter(Converter):
                     f.write(yolo_annotation)
 
             subset_list_name = '%s.txt' % subset_name
+            subset_list_path = osp.join(save_dir, subset_list_name)
+            if self._patch and subset_name in self._patch.updated_subsets and \
+                    not image_paths:
+                if osp.isfile(subset_list_path):
+                    os.remove(subset_list_path)
+                continue
+
             subset_lists[subset_name] = subset_list_name
-            with open(osp.join(save_dir, subset_list_name),
-                    'w', encoding='utf-8') as f:
+            with open(subset_list_path, 'w', encoding='utf-8') as f:
                 f.writelines('%s\n' % s for s in image_paths.values())
 
         with open(osp.join(save_dir, 'obj.data'), 'w', encoding='utf-8') as f:
@@ -110,10 +115,10 @@ class YoloConverter(Converter):
 
     @classmethod
     def patch(cls, dataset, patch, save_dir, **kwargs):
-        for subset in patch.updated_subsets:
-            cls.convert(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
-
         conv = cls(dataset, save_dir=save_dir, **kwargs)
+        conv._patch = patch
+        conv.apply()
+
         for (item_id, subset), status in patch.updated_items.items():
             if status != ItemStatus.removed:
                 item = patch.data.get(item_id, subset)
@@ -125,7 +130,12 @@ class YoloConverter(Converter):
 
             if subset == DEFAULT_SUBSET_NAME:
                 subset = YoloPath.DEFAULT_SUBSET_NAME
-            image_path = osp.join(save_dir, 'obj_%s_data' % subset,
-                conv._make_image_filename(item))
+            subset_dir = osp.join(save_dir, 'obj_%s_data' % subset)
+
+            image_path = osp.join(subset_dir, conv._make_image_filename(item))
             if osp.isfile(image_path):
-                os.unlink(image_path)
+                os.remove(image_path)
+
+            ann_path = osp.join(subset_dir, '%s.txt' % item.id)
+            if osp.isfile(ann_path):
+                os.remove(ann_path)

--- a/docs/formats/cityscapes_user_manual.md
+++ b/docs/formats/cityscapes_user_manual.md
@@ -15,6 +15,11 @@ Cityscapes format specification available [here](https://github.com/mcordts/city
 
 Cityscapes dataset format supports `Masks` (segmentations tasks) annotations.
 
+Supported annotation attributes:
+- `is_crowd` (boolean). Specifies if the annotation label can
+    distinquish between different instances.
+    If `False`, the annotation `id` field encodes the instance id.
+
 ## Load Cityscapes dataset
 
 The Cityscapes dataset is available for free [download](https://www.cityscapes-dataset.com/downloads/).
@@ -58,14 +63,14 @@ Cityscapes dataset directory should have the following structure:
 ```
 
 Annotated files description:
-1. *leftImg8bit.png - left images in 8-bit LDR format
-1. *color.png - class labels are encoded by its color
-1. *instanceIds.png - class and instance labels are encoded by an instance ID.
+1. `*_leftImg8bit.png` - left images in 8-bit LDR format
+1. `*_color.png` - class labels encoded by its color
+1. `*_labelIds.png` - class labels are encoded by its index
+1. `*_instanceIds.png` - class and instance labels encoded by an instance ID.
     The pixel values encode class and the individual instance: the integer part
     of a division by 1000 of each ID provides class ID, the remainder
     is the instance ID. If a certain annotation describes multiple instances,
     then the pixels have the regular ID of that class
-1. *labelIds.png - class labels are encoded by its ID
 
 To make sure that the selected dataset has been added to the project, you can
 run `datum info`, which will display the project and dataset information.
@@ -108,8 +113,6 @@ Extra options for export to cityscapes format:
 (by default `False`);
 - `--image-ext IMAGE_EXT` allow to specify image extension
 for exporting dataset (by default - keep original or use `.png`, if none).
-- `--apply-colormap APPLY_COLORMAP` allow to use colormap for class masks
-(`*color.png` files, by default `True`);
 - `--label_map` allow to define a custom colormap. Example
 
 ``` bash
@@ -159,15 +162,14 @@ categories = Cityscapes.make_cityscapes_categories(label_map)
 
 dataset = Dataset.from_iterable([
     DatasetItem(id=1,
-                image=np.ones((1, 5, 3)),
-                annotations=[
-                    Mask(image=np.array([[1, 0, 0, 1, 1]]), label=1, id=1,
-                        attributes={'is_crowd': False}),
-                    Mask(image=np.array([[0, 1, 1, 0, 0]]), label=2, id=2,
-                        attributes={'is_crowd': False}),
-                ]
-            ),
-    ], categories=categories)
+        image=np.ones((1, 5, 3)),
+        annotations=[
+            Mask(image=np.array([[1, 0, 0, 1, 1]]), label=1),
+            Mask(image=np.array([[0, 1, 1, 0, 0]]), label=2, id=2,
+                attributes={'is_crowd': False}),
+        ]
+    ),
+], categories=categories)
 
 dataset.export('./dataset', format='cityscapes')
 ```

--- a/tests/cli/test_diff.py
+++ b/tests/cli/test_diff.py
@@ -21,7 +21,7 @@ class DiffTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_compare_projects(self): # just a smoke test
         label_categories1 = LabelCategories.from_iterable(['x', 'a', 'b', 'y'])
-        mask_categories1 = MaskCategories.make_default(len(label_categories1))
+        mask_categories1 = MaskCategories.generate(len(label_categories1))
 
         point_categories1 = PointsCategories()
         for index, _ in enumerate(label_categories1.items):
@@ -69,7 +69,7 @@ class DiffTest(TestCase):
 
 
         label_categories2 = LabelCategories.from_iterable(['a', 'b', 'x', 'y'])
-        mask_categories2 = MaskCategories.make_default(len(label_categories2))
+        mask_categories2 = MaskCategories.generate(len(label_categories2))
 
         point_categories2 = PointsCategories()
         for index, _ in enumerate(label_categories2.items):

--- a/tests/test_camvid_format.py
+++ b/tests/test_camvid_format.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 import os
 import os.path as osp
 
-from numpy.core.records import array
 import numpy as np
 
 from datumaro.components.dataset import Dataset

--- a/tests/test_cityscapes_format.py
+++ b/tests/test_cityscapes_format.py
@@ -41,16 +41,17 @@ class CityscapesFormatTest(TestCase):
 class CityscapesImportTest(TestCase):
     @mark_requirement(Requirements.DATUM_267)
     def test_can_import(self):
+        # is_crowd marks labels allowing to specify instance id
         source_dataset = Dataset.from_iterable([
             DatasetItem(id='defaultcity/defaultcity_000001_000031',
                 subset='test',
                 image=np.ones((1, 5, 3)),
                 annotations=[
-                    Mask(image=np.array([[1, 1, 0, 0, 0]]), id=3, label=3,
+                    Mask(np.array([[1, 1, 0, 0, 0]]), label=3,
                         attributes={'is_crowd': True}),
-                    Mask(image=np.array([[0, 0, 1, 0, 0]]), id=1, label=27,
+                    Mask(np.array([[0, 0, 1, 0, 0]]), id=1, label=27,
                         attributes={'is_crowd': False}),
-                    Mask(image=np.array([[0, 0, 0, 1, 1]]), id=2, label=27,
+                    Mask(np.array([[0, 0, 0, 1, 1]]), id=2, label=27,
                         attributes={'is_crowd': False}),
                 ]
             ),
@@ -58,11 +59,11 @@ class CityscapesImportTest(TestCase):
                 subset='test',
                 image=np.ones((1, 5, 3)),
                 annotations=[
-                    Mask(image=np.array([[1, 1, 0, 0, 0]]), id=1, label=31,
+                    Mask(np.array([[1, 1, 0, 0, 0]]), id=1, label=31,
                         attributes={'is_crowd': False}),
-                    Mask(image=np.array([[0, 0, 1, 0, 0]]), id=12, label=12,
+                    Mask(np.array([[0, 0, 1, 0, 0]]), label=12,
                         attributes={'is_crowd': True}),
-                    Mask(image=np.array([[0, 0, 0, 1, 1]]), id=3, label=3,
+                    Mask(np.array([[0, 0, 0, 1, 1]]), label=3,
                         attributes={'is_crowd': True}),
                 ]
             ),
@@ -70,9 +71,9 @@ class CityscapesImportTest(TestCase):
                 subset='train',
                 image=np.ones((1, 5, 3)),
                 annotations=[
-                    Mask(image=np.array([[1, 1, 0, 1, 1]]), id=3, label=3,
+                    Mask(np.array([[1, 1, 0, 1, 1]]), label=3,
                         attributes={'is_crowd': True}),
-                    Mask(image=np.array([[0, 0, 1, 0, 0]]), id=1, label=24,
+                    Mask(np.array([[0, 0, 1, 0, 0]]), id=1, label=24,
                         attributes={'is_crowd': False}),
                 ]
             ),
@@ -80,9 +81,9 @@ class CityscapesImportTest(TestCase):
                 subset = 'val',
                 image=np.ones((1, 5, 3)),
                 annotations=[
-                    Mask(image=np.array([[1, 0, 0, 1, 1]]), id=3, label=3,
+                    Mask(np.array([[1, 0, 0, 1, 1]]), label=3,
                         attributes={'is_crowd': True}),
-                    Mask(image=np.array([[0, 1, 1, 0, 0]]), id=24, label=1,
+                    Mask(np.array([[0, 1, 1, 0, 0]]), id=24, label=1,
                         attributes={'is_crowd': False}),
                 ]
             ),
@@ -112,97 +113,68 @@ class CityscapesConverterTest(TestCase):
             target_dataset=target_dataset, importer_args=importer_args, **kwargs)
 
     @mark_requirement(Requirements.DATUM_267)
-    def test_can_save_cityscapes_segm(self):
+    def test_can_save_segm(self):
         class TestExtractor(TestExtractorBase):
             def __iter__(self):
                 return iter([
                     DatasetItem(id='defaultcity_1_2', subset='test',
-                        image=np.ones((1, 5, 3)), annotations=[
-                        Mask(image=np.array([[0, 0, 0, 1, 0]]), label=3, id=3,
-                            attributes={'is_crowd': True}),
-                        Mask(image=np.array([[0, 1, 1, 0, 0]]), label=24, id=1,
-                            attributes={'is_crowd': False}),
-                        Mask(image=np.array([[1, 0, 0, 0, 1]]), label=15, id=15,
-                            attributes={'is_crowd': True}),
-                    ]),
+                        image=np.ones((1, 5, 3)),
+                        annotations=[
+                            Mask(np.array([[0, 0, 0, 1, 0]]), label=3,
+                                attributes={'is_crowd': True}),
+                            Mask(np.array([[0, 1, 1, 0, 0]]), label=24, id=1,
+                                attributes={'is_crowd': False}),
+                            Mask(np.array([[1, 0, 0, 0, 1]]), label=15,
+                                attributes={'is_crowd': True}),
+                        ]
+                    ),
+
                     DatasetItem(id='defaultcity_3', subset='val',
-                        image=np.ones((1, 5, 3)), annotations=[
-                        Mask(image=np.array([[1, 1, 0, 1, 1]]), label=3, id=3,
-                            attributes={'is_crowd': True}),
-                        Mask(image=np.array([[0, 0, 1, 0, 0]]), label=5, id=5,
-                            attributes={'is_crowd': True}),
-                    ]),
-                ])
-        with TestDir() as test_dir:
-            self._test_save_and_load(TestExtractor(),
-                partial(CityscapesConverter.convert, label_map='cityscapes',
-                save_images=True), test_dir)
-
-    @mark_requirement(Requirements.DATUM_267)
-    def test_can_save_cityscapes_segm_unpainted(self):
-        class TestExtractor(TestExtractorBase):
-            def __iter__(self):
-                return iter([
-                    DatasetItem(id='defaultcity_1_2', subset='test',
-                        image=np.ones((1, 5, 3)), annotations=[
-                        Mask(image=np.array([[0, 0, 0, 1, 0]]), label=3, id=3,
-                            attributes={'is_crowd': True}),
-                        Mask(image=np.array([[0, 1, 1, 0, 0]]), label=24, id=1,
-                            attributes={'is_crowd': False}),
-                        Mask(image=np.array([[1, 0, 0, 0, 1]]), label=15, id=15,
-                            attributes={'is_crowd': True}),
-                    ]),
+                        image=np.ones((1, 5, 3)),
+                        annotations=[
+                            Mask(np.array([[1, 1, 0, 1, 1]]), label=3,
+                                attributes={'is_crowd': True}),
+                            Mask(np.array([[0, 0, 1, 0, 0]]), label=5,
+                                attributes={'is_crowd': True}),
+                        ]
+                    ),
                 ])
 
         with TestDir() as test_dir:
             self._test_save_and_load(TestExtractor(),
                 partial(CityscapesConverter.convert, label_map='cityscapes',
-                save_images=True, apply_colormap=False), test_dir)
+                    save_images=True), test_dir)
 
     @mark_requirement(Requirements.DATUM_267)
-    def test_can_save_cityscapes_dataset_with_no_subsets(self):
+    def test_can_save_with_no_subsets(self):
         class TestExtractor(TestExtractorBase):
             def __iter__(self):
                 return iter([
                     DatasetItem(id='defaultcity_1_2',
-                        image=np.ones((1, 5, 3)), annotations=[
-                        Mask(image=np.array([[1, 0, 0, 1, 0]]), label=0, id=0,
-                            attributes={'is_crowd': True}),
-                        Mask(image=np.array([[0, 1, 1, 0, 1]]), label=3, id=3,
-                            attributes={'is_crowd': True}),
-                    ]),
+                        image=np.ones((1, 5, 3)),
+                        annotations=[
+                            Mask(np.array([[1, 0, 0, 1, 0]]), label=0,
+                                attributes={'is_crowd': True}),
+                            Mask(np.array([[0, 1, 1, 0, 1]]), label=3,
+                                attributes={'is_crowd': True}),
+                        ]
+                    ),
 
                     DatasetItem(id='defaultcity_1_3',
-                        image=np.ones((1, 5, 3)), annotations=[
-                        Mask(image=np.array([[1, 1, 0, 1, 0]]), label=1, id=1,
-                            attributes={'is_crowd': True}),
-                        Mask(image=np.array([[0, 0, 1, 0, 1]]), label=2, id=2,
-                            attributes={'is_crowd': True}),
-                    ]),
+                        image=np.ones((1, 5, 3)),
+                        annotations=[
+                            Mask(np.array([[1, 1, 0, 1, 0]]), label=1,
+                                attributes={'is_crowd': True}),
+                            Mask(np.array([[0, 0, 1, 0, 1]]), label=2,
+                                attributes={'is_crowd': True}),
+                        ]
+                    ),
                 ])
 
         with TestDir() as test_dir:
             self._test_save_and_load(TestExtractor(),
                 partial(CityscapesConverter.convert, label_map='cityscapes',
-                save_images=True), test_dir)
-
-    @mark_requirement(Requirements.DATUM_267)
-    def test_can_save_cityscapes_dataset_without_frame_and_sequence(self):
-        class TestExtractor(TestExtractorBase):
-            def __iter__(self):
-                return iter([
-                    DatasetItem(id='justcity', subset='test',
-                        image=np.ones((1, 5, 3)), annotations=[
-                        Mask(image=np.array([[1, 0, 0, 1, 1]]), label=3, id=3,
-                            attributes={'is_crowd': True}),
-                        Mask(image=np.array([[0, 1, 1, 0, 0]]), label=24, id=1,
-                            attributes={'is_crowd': False}),
-                    ]),
-                ])
-        with TestDir() as test_dir:
-            self._test_save_and_load(TestExtractor(),
-                partial(CityscapesConverter.convert, label_map='cityscapes',
-                save_images=True), test_dir)
+                    save_images=True), test_dir)
 
     @mark_requirement(Requirements.DATUM_267)
     def test_can_save_dataset_with_cyrillic_and_spaces_in_filename(self):
@@ -210,37 +182,41 @@ class CityscapesConverterTest(TestCase):
             def __iter__(self):
                 return iter([
                     DatasetItem(id='кириллица с пробелом',
-                       image=np.ones((1, 5, 3)), annotations=[
-                         Mask(image=np.array([[1, 0, 0, 1, 1]]), label=3, id=3,
-                             attributes={'is_crowd': True}),
-                         Mask(image=np.array([[0, 1, 1, 0, 0]]), label=24, id=1,
-                             attributes={'is_crowd': False}),
-                    ]),
+                        image=np.ones((1, 5, 3)),
+                        annotations=[
+                            Mask(np.array([[1, 0, 0, 1, 1]]), label=3,
+                                attributes={'is_crowd': True}),
+                            Mask(np.array([[0, 1, 1, 0, 0]]), label=24, id=1,
+                                attributes={'is_crowd': False}),
+                        ]
+                    ),
                 ])
 
         with TestDir() as test_dir:
             self._test_save_and_load(TestExtractor(),
                 partial(CityscapesConverter.convert, label_map='cityscapes',
-                save_images=True), test_dir)
+                    save_images=True), test_dir)
 
     @mark_requirement(Requirements.DATUM_267)
-    def test_can_save_cityscapes_dataset_with_strange_id(self):
+    def test_can_save_with_relative_path_in_id(self):
         class TestExtractor(TestExtractorBase):
             def __iter__(self):
                 return iter([
                     DatasetItem(id='a/b/1', subset='test',
-                        image=np.ones((1, 5, 3)), annotations=[
-                        Mask(image=np.array([[1, 0, 0, 1, 1]]), label=3, id=3,
-                            attributes={'is_crowd': True}),
-                        Mask(image=np.array([[0, 1, 1, 0, 0]]), label=24, id=1,
-                            attributes={'is_crowd': False}),
-                    ]),
+                        image=np.ones((1, 5, 3)),
+                        annotations=[
+                            Mask(np.array([[1, 0, 0, 1, 1]]), label=3,
+                                attributes={'is_crowd': True}),
+                            Mask(np.array([[0, 1, 1, 0, 0]]), label=24, id=1,
+                                attributes={'is_crowd': False}),
+                        ]
+                    ),
                 ])
 
         with TestDir() as test_dir:
             self._test_save_and_load(TestExtractor(),
                 partial(CityscapesConverter.convert, label_map='cityscapes',
-                save_images=True), test_dir)
+                    save_images=True), test_dir)
 
     @mark_requirement(Requirements.DATUM_267)
     def test_can_save_with_no_masks(self):
@@ -259,55 +235,44 @@ class CityscapesConverterTest(TestCase):
 
     @mark_requirement(Requirements.DATUM_267)
     def test_dataset_with_source_labelmap_undefined(self):
-        class SrcExtractor(TestExtractorBase):
-            def __iter__(self):
-                yield DatasetItem(id=1, image=np.ones((1, 5, 3)), annotations=[
-                    Mask(image=np.array([[1, 0, 0, 1, 1]]), label=1, id=1,
-                        attributes={'is_crowd': False}),
-                    Mask(image=np.array([[0, 1, 1, 0, 0]]), label=2, id=2,
-                        attributes={'is_crowd': False}),
-                ])
-
-            def categories(self):
-                label_cat = LabelCategories()
-                label_cat.add('background')
-                label_cat.add('Label_1')
-                label_cat.add('label_2')
-                return {
-                    AnnotationType.label: label_cat,
-                }
+        source_dataset = Dataset.from_iterable([
+            DatasetItem(id=1, image=np.ones((1, 5, 3)), annotations=[
+                Mask(np.array([[1, 0, 0, 1, 1]]), label=0),
+                Mask(np.array([[0, 1, 1, 0, 0]]), label=1),
+            ]),
+        ], categories=['a', 'b'])
 
         class DstExtractor(TestExtractorBase):
             def __iter__(self):
                 yield DatasetItem(id=1, image=np.ones((1, 5, 3)), annotations=[
-                    Mask(image=np.array([[1, 0, 0, 1, 1]]),
+                    Mask(np.array([[1, 0, 0, 1, 1]]),
                         attributes={'is_crowd': False}, id=1,
-                        label=self._label('Label_1')),
-                    Mask(image=np.array([[0, 1, 1, 0, 0]]),
+                        label=self._label('a')),
+                    Mask(np.array([[0, 1, 1, 0, 0]]),
                         attributes={'is_crowd': False}, id=2,
-                        label=self._label('label_2')),
+                        label=self._label('b')),
                 ])
 
             def categories(self):
                 label_map = OrderedDict()
                 label_map['background'] = None
-                label_map['Label_1'] = None
-                label_map['label_2'] = None
+                label_map['a'] = None
+                label_map['b'] = None
                 return Cityscapes.make_cityscapes_categories(label_map)
 
         with TestDir() as test_dir:
-            self._test_save_and_load(SrcExtractor(),
+            self._test_save_and_load(source_dataset,
                 partial(CityscapesConverter.convert, label_map='source',
-                save_images=True), test_dir, target_dataset=DstExtractor())
+                    save_images=True), test_dir, target_dataset=DstExtractor())
 
     @mark_requirement(Requirements.DATUM_267)
     def test_dataset_with_source_labelmap_defined(self):
         class SrcExtractor(TestExtractorBase):
             def __iter__(self):
                 yield DatasetItem(id=1, image=np.ones((1, 5, 3)), annotations=[
-                    Mask(image=np.array([[1, 0, 0, 1, 1]]), label=1, id=1,
+                    Mask(np.array([[1, 0, 0, 1, 1]]), label=1, id=1,
                         attributes={'is_crowd': False}),
-                    Mask(image=np.array([[0, 1, 1, 0, 0]]), label=2, id=2,
+                    Mask(np.array([[0, 1, 1, 0, 0]]), label=2, id=2,
                         attributes={'is_crowd': False}),
                 ])
 
@@ -321,10 +286,10 @@ class CityscapesConverterTest(TestCase):
         class DstExtractor(TestExtractorBase):
             def __iter__(self):
                 yield DatasetItem(id=1, image=np.ones((1, 5, 3)), annotations=[
-                    Mask(image=np.array([[1, 0, 0, 1, 1]]),
+                    Mask(np.array([[1, 0, 0, 1, 1]]),
                         attributes={'is_crowd': False}, id=1,
                         label=self._label('label_1')),
-                    Mask(image=np.array([[0, 1, 1, 0, 0]]),
+                    Mask(np.array([[0, 1, 1, 0, 0]]),
                         attributes={'is_crowd': False}, id=2,
                         label=self._label('label_2')),
                 ])
@@ -346,18 +311,19 @@ class CityscapesConverterTest(TestCase):
         class TestExtractor(TestExtractorBase):
             def __iter__(self):
                 return iter([
-                    DatasetItem(id='q/1', image=Image(path='q/1.JPEG',
-                        data=np.zeros((4, 3, 3)))),
+                    DatasetItem(id='q',
+                        image=Image(path='q.JPEG', data=np.zeros((4, 3, 3)))
+                    ),
 
-                    DatasetItem(id='a/b/c/2', image=Image(
-                             path='a/b/c/2.bmp', data=np.ones((1, 5, 3))
-                         ), annotations=[
-                        Mask(image=np.array([[1, 0, 0, 1, 0]]), label=0, id=0,
-                            attributes={'is_crowd': True}),
-                        Mask(image=np.array([[0, 1, 1, 0, 1]]), label=1, id=1,
-                            attributes={'is_crowd': True}),
-                    ]),
-                ])
+                    DatasetItem(id='w',
+                        image=Image(path='w.bmp', data=np.ones((1, 5, 3))),
+                        annotations=[
+                            Mask(np.array([[1, 0, 0, 1, 0]]), label=0,
+                                attributes={'is_crowd': True}),
+                            Mask(np.array([[0, 1, 1, 0, 1]]), label=1,
+                                attributes={'is_crowd': True}),
+                        ]),
+                    ])
 
             def categories(self):
                 label_map = OrderedDict()
@@ -377,13 +343,13 @@ class CityscapesConverterTest(TestCase):
         expected = Dataset.from_iterable([
             DatasetItem(1, subset='a', image=np.ones((2, 1, 3)),
                 annotations=[
-                    Mask(np.ones((2, 1)), label=2)
+                    Mask(np.ones((2, 1)), label=2, id=1)
                 ]),
             DatasetItem(2, subset='a', image=np.ones((3, 2, 3))),
 
             DatasetItem(2, subset='b', image=np.ones((2, 2, 3)),
                 annotations=[
-                    Mask(np.ones((2, 2)), label=1)
+                    Mask(np.ones((2, 2)), label=1, id=1)
                 ]),
         ], categories=Cityscapes.make_cityscapes_categories(OrderedDict([
             ('a', src_mask_cat.colormap[0]),


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Related #348 

- Renamed `MaskCategories.make_default()` to `.generate()`, added an option to include background color
- Fixed dataset patching in YOLO
- Fixed dataset patching in CamVid
- Fixed dataset patching in Cityscapes
- Updated Cityscapes implementation and documentation. Fixed #325, fixed #342. 
- Fixed "background" class in Cityscapes colormaps
- Fixed `Dataset.is_bound` return value
- Added item presence check in `DatasetPatch`

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
