### PR TITLE
Remove the __attrs_init__ workarounds

### DIFF
--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -360,7 +360,7 @@ class PolyLine(_Shape):
         return 0
 
 
-@attrs
+@attrs(init=False)
 class Cuboid3d(Annotation):
     _type = AnnotationType.cuboid_3d
     _points = attrib(type=list, default=None)
@@ -376,8 +376,6 @@ class Cuboid3d(Annotation):
             points = [round(p, _COORDINATE_ROUNDING_DIGITS) for p in points]
         self._points = points
 
-    # will be overridden by attrs, then will be overridden again by us
-    # attrs' method will be renamed to __attrs_init__
     def __init__(self, position, rotation=None, scale=None, **kwargs):
         assert len(position) == 3, position
         if not rotation:
@@ -386,7 +384,6 @@ class Cuboid3d(Annotation):
             scale = [1] * 3
         kwargs.pop('points', None)
         self.__attrs_init__(points=[*position, *rotation, *scale], **kwargs)
-    __actual_init__ = __init__ # save pointer
 
     @property
     def position(self):
@@ -421,9 +418,6 @@ class Cuboid3d(Annotation):
         self.scale[:] = \
             [round(p, _COORDINATE_ROUNDING_DIGITS) for p in value]
 
-assert not hasattr(Cuboid3d, '__attrs_init__') # hopefully, it will be supported
-setattr(Cuboid3d, '__attrs_init__', Cuboid3d.__init__)
-setattr(Cuboid3d, '__init__', Cuboid3d.__actual_init__)
 
 @attrs
 class Polygon(_Shape):
@@ -442,16 +436,13 @@ class Polygon(_Shape):
         area = mask_utils.area(rle)[0]
         return area
 
-@attrs
+@attrs(init=False)
 class Bbox(_Shape):
     _type = AnnotationType.bbox
 
-    # will be overridden by attrs, then will be overridden again by us
-    # attrs' method will be renamed to __attrs_init__
     def __init__(self, x, y, w, h, *args, **kwargs):
         kwargs.pop('points', None) # comes from wrap()
         self.__attrs_init__([x, y, x + w, y + h], *args, **kwargs)
-    __actual_init__ = __init__ # save pointer
 
     @property
     def x(self):
@@ -493,9 +484,6 @@ class Bbox(_Shape):
         d.update(kwargs)
         return attr.evolve(item, **d)
 
-assert not hasattr(Bbox, '__attrs_init__') # hopefully, it will be supported
-setattr(Bbox, '__attrs_init__', Bbox.__init__)
-setattr(Bbox, '__init__', Bbox.__actual_init__)
 
 @attrs
 class PointsCategories(Categories):

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,4 +1,4 @@
-attrs>=19.3.0
+attrs>=21.1.0
 defusedxml>=0.6.0
 GitPython>=3.0.8
 lxml>=4.4.1


### PR DESCRIPTION

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
attrs now supports this functionality natively, so bump the dependency version and replace the workarounds with the native approach.

Resolves #310.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] ~~I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)~~ I guess the dependency version change is user-visible, but is it notable enough to warrant a changelog entry?
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
