### PR TITLE
Enable the Pylint undefined-variable checker

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -86,6 +86,7 @@ enable=
     E0301, # non-iterator-returned
     E0302, # unexpected-special-method-signature
     E0601, # used-before-assignment
+    E0602, # undefined-variable
     E0603, # undefined-all-variable
     E0604, # invalid-all-object
     E0701, # bad-except-order

--- a/datumaro/cli/commands/merge.py
+++ b/datumaro/cli/commands/merge.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 import argparse
 import json
 import logging as log
+import os
 import os.path as osp
 
 from datumaro.components.errors import MergeError, QualityError

--- a/datumaro/plugins/accuracy_checker_plugin/details/representation.py
+++ b/datumaro/plugins/accuracy_checker_plugin/details/representation.py
@@ -34,7 +34,7 @@ def import_prediction(pred):
     elif isinstance(pred, (ac.DetectionPrediction, ac.ActionDetectionPrediction)):
         return (dm.Bbox(x0, y0, x1 - x0, y1 - y0, int(label_id),
                 attributes={'score': float(score)})
-            for label, score, x0, y0, x1, y1 in zip(pred.labels, pred.scores,
+            for label_id, score, x0, y0, x1, y1 in zip(pred.labels, pred.scores,
                 pred.x_mins, pred.y_mins, pred.x_maxs, pred.y_maxs)
         )
     elif isinstance(pred, ac.DepthEstimationPrediction):

--- a/datumaro/util/annotation_util.py
+++ b/datumaro/util/annotation_util.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -58,7 +58,7 @@ def nms(segments, iou_thresh=0.5):
     """
 
     indices = np.argsort([b.attributes['score'] for b in segments])
-    ious = np.array([[iou(a, b) for b in segments] for a in segments])
+    ious = np.array([[segment_iou(a, b) for b in segments] for a in segments])
 
     predictions = []
     while len(indices) != 0:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

Undefined variables are a serious problem, and easy to check for, so do that and fix all existing occurrences.

~~WRT the `error_rollback` changes: there was no error there, but Pylint would complain, because it didn't know where the `on_error` variable was coming from. Defining `on_error` explicitly is the workaround for that. While it's less elegant, it makes the code more transparent, both for human users and static analyzers (such as Pylint itself, or VS Code's syntax checker). Also, IMO, the benefits of the checker far outweigh the drawback of having to implement this workaround.~~


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
