### PR TITLE
Allow double quotes for ICDAR Word Recognition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved Cityscapes export performance (<https://github.com/openvinotoolkit/datumaro/pull/367>)
 - Incorrect format of `*_labelIds.png` in Cityscapes export (<https://github.com/openvinotoolkit/datumaro/issues/325>, <https://github.com/openvinotoolkit/datumaro/issues/342>)
 - Item id in ImageNet format (<https://github.com/openvinotoolkit/datumaro/pull/371>)
+- Fix double quotes for ICDAR Word Recognition (<https://github.com/openvinotoolkit/datumaro/pull/375>)
 
 ### Security
 - TBD

--- a/datumaro/plugins/icdar_format/extractor.py
+++ b/datumaro/plugins/icdar_format/extractor.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 from glob import iglob
-import os.path as osp
 import logging as log
+import os.path as osp
 
 import numpy as np
 
@@ -54,7 +54,7 @@ class _IcdarExtractor(SourceExtractor):
     def _load_recognition_items(self):
         items = {}
 
-        with open(self._path, encoding='utf_8') as f:
+        with open(self._path, encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
                 objects = line.split(', ')

--- a/datumaro/plugins/icdar_format/extractor.py
+++ b/datumaro/plugins/icdar_format/extractor.py
@@ -4,6 +4,7 @@
 
 from glob import iglob
 import os.path as osp
+import logging as log
 
 import numpy as np
 
@@ -53,22 +54,18 @@ class _IcdarExtractor(SourceExtractor):
     def _load_recognition_items(self):
         items = {}
 
-        with open(self._path, encoding='utf-8') as f:
+        with open(self._path, encoding='utf_8') as f:
             for line in f:
                 line = line.strip()
                 objects = line.split(', ')
                 if len(objects) == 2:
                     image = objects[0]
-                    objects = objects[1].split('\"')
-                    if 1 < len(objects):
-                        if len(objects) % 2:
-                            captions = [objects[2 * i + 1]
-                                for i in range(int(len(objects) / 2))]
-                        else:
-                            raise Exception("Line %s: unexpected number "
-                                "of quotes in filename" % line)
-                    else:
-                        captions = objects[0].split()
+                    captions = []
+                    for caption in objects[1:]:
+                        if caption[0] != '\"' or caption[-1] != '\"':
+                            log.warning('Captions must be inside double quotes, \
+                                %s for %s skipped' % (caption, item_id))
+                        captions.append(caption.replace('\\', '')[1:-1])
                 else:
                     image = objects[0][:-1]
                     captions = []

--- a/datumaro/plugins/icdar_format/extractor.py
+++ b/datumaro/plugins/icdar_format/extractor.py
@@ -63,8 +63,8 @@ class _IcdarExtractor(SourceExtractor):
                     captions = []
                     for caption in objects[1:]:
                         if caption[0] != '\"' or caption[-1] != '\"':
-                            log.warning('Captions must be inside double quotes, \
-                                %s for %s skipped' % (caption, item_id))
+                            log.warning("Line %s: unexpected number "
+                                "of quotes" % line)
                         else:
                             captions.append(caption.replace('\\', '')[1:-1])
                 else:

--- a/datumaro/plugins/icdar_format/extractor.py
+++ b/datumaro/plugins/icdar_format/extractor.py
@@ -65,7 +65,8 @@ class _IcdarExtractor(SourceExtractor):
                         if caption[0] != '\"' or caption[-1] != '\"':
                             log.warning('Captions must be inside double quotes, \
                                 %s for %s skipped' % (caption, item_id))
-                        captions.append(caption.replace('\\', '')[1:-1])
+                        else:
+                            captions.append(caption.replace('\\', '')[1:-1])
                 else:
                     image = objects[0][:-1]
                     captions = []

--- a/tests/test_icdar_format.py
+++ b/tests/test_icdar_format.py
@@ -255,3 +255,16 @@ class IcdarConverterTest(TestCase):
                 self._test_save_and_load(expected,
                     partial(converter.convert, save_images=True),
                     test_dir, importer, require_images=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_and_load_captions_with_quotes(self):
+        expected_dataset = Dataset.from_iterable([
+            DatasetItem(id='1', image=np.ones((5, 5, 3)),
+                annotations=[Caption('caption\"')]
+            )
+        ])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(expected_dataset,
+                partial(IcdarWordRecognitionConverter.convert, save_images=True),
+                test_dir, 'icdar_word_recognition')


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Fixed #374.

### How to test
Load ICDAR Word Recognition dataset with double quotes in the captions.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
