### PR TITLE
Allow direct matching of files without extension in _find_sources_recursive

### DIFF
--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -797,7 +797,7 @@ class Importer:
                 ext = '.' + ext
             ext = ext.lower()
 
-        if (ext and path.lower().endswith(ext) and osp.isfile(path)) or \
+        if (path.lower().endswith(ext) and osp.isfile(path)) or \
                 (not ext and dirname and osp.isdir(path) and \
                 os.sep + osp.normpath(dirname.lower()) + os.sep in \
                     osp.abspath(path.lower()) + os.sep):

--- a/tests/test_cifar_format.py
+++ b/tests/test_cifar_format.py
@@ -257,6 +257,11 @@ class CifarImporterTest(TestCase):
         self.assertTrue(CifarImporter.detect(DUMMY_10_DATASET_DIR))
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_detect_10_subset(self):
+        self.assertTrue(CifarImporter.detect(
+            osp.join(DUMMY_10_DATASET_DIR, 'data_batch_1')))
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import_100(self):
         # Unless simple dataset merge can't overlap labels and add parent
         # information, the datasets must contain all the possible labels.
@@ -301,3 +306,8 @@ class CifarImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_100(self):
         self.assertTrue(CifarImporter.detect(DUMMY_100_DATASET_DIR))
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_detect_100_subset(self):
+        self.assertTrue(CifarImporter.detect(
+            osp.join(DUMMY_100_DATASET_DIR, 'train')))


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Fixed the problem with CIFAR export and checking dataset in importer (annotation files haven't extensions)

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
