### PR TITLE
Redesign the implicit mode of error_rollback

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -369,7 +369,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=on_error
+generated-members=
 
 # List of decorators that produce context managers, such as
 # contextlib.contextmanager. Add to this list to register other decorators that

--- a/datumaro/cli/contexts/model.py
+++ b/datumaro/cli/contexts/model.py
@@ -9,7 +9,7 @@ import os.path as osp
 import shutil
 
 from datumaro.components.project import Environment
-from datumaro.util import error_rollback
+from datumaro.util import error_rollback, on_error_do
 
 from ..util import CliException, MultilineFormatter, add_subparser
 from ..util.project import (
@@ -46,7 +46,7 @@ def build_add_parser(parser_ctor=argparse.ArgumentParser):
 
     return parser
 
-@error_rollback('on_error', implicit=True)
+@error_rollback
 def add_command(args):
     project = load_project(args.project_dir)
 
@@ -73,7 +73,7 @@ def add_command(args):
         model_dir = osp.join(project.config.project_dir,
             project.local_model_dir(args.name))
         os.makedirs(model_dir, exist_ok=False)
-        on_error.do(shutil.rmtree, model_dir, ignore_errors=True)
+        on_error_do(shutil.rmtree, model_dir, ignore_errors=True)
 
         try:
             cli_plugin.copy_model(model_dir, model_args)

--- a/datumaro/cli/contexts/project/__init__.py
+++ b/datumaro/cli/contexts/project/__init__.py
@@ -21,7 +21,7 @@ from datumaro.components.operations import (
 from datumaro.components.project import PROJECT_DEFAULT_CONFIG as DEFAULT_CONFIG
 from datumaro.components.project import Environment, Project
 from datumaro.components.validator import TaskType
-from datumaro.util import error_rollback
+from datumaro.util import error_rollback, on_error_do
 
 from ...util import (
     CliException, MultilineFormatter, add_subparser, make_file_name,
@@ -527,7 +527,7 @@ def build_diff_parser(parser_ctor=argparse.ArgumentParser):
 
     return parser
 
-@error_rollback('on_error', implicit=True)
+@error_rollback
 def diff_command(args):
     first_project = load_project(args.project_dir)
     second_project = load_project(args.other_project_dir)
@@ -548,7 +548,7 @@ def diff_command(args):
     log.info("Saving diff to '%s'" % dst_dir)
 
     if not osp.exists(dst_dir):
-        on_error.do(shutil.rmtree, dst_dir, ignore_errors=True)
+        on_error_do(shutil.rmtree, dst_dir, ignore_errors=True)
 
     with DatasetDiffVisualizer(save_dir=dst_dir, comparator=comparator,
             output_format=args.visualizer) as visualizer:

--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -23,7 +23,7 @@ from datumaro.components.extractor import (
     DEFAULT_SUBSET_NAME, AnnotationType, CategoriesInfo, DatasetItem, Extractor,
     IExtractor, ItemTransform, LabelCategories, Transform,
 )
-from datumaro.util import error_rollback, is_member_redefined
+from datumaro.util import error_rollback, is_member_redefined, on_error_do
 from datumaro.util.log_utils import logging_disabled
 
 DEFAULT_FORMAT = 'datumaro'
@@ -770,7 +770,7 @@ class Dataset(IDataset):
     def flush_changes(self):
         self._data.flush_changes()
 
-    @error_rollback('on_error', implicit=True)
+    @error_rollback
     def export(self, save_dir: str, format, **kwargs):
         inplace = (save_dir == self._source_path and format == self._format)
 
@@ -781,7 +781,7 @@ class Dataset(IDataset):
 
         save_dir = osp.abspath(save_dir)
         if not osp.exists(save_dir):
-            on_error.do(shutil.rmtree, save_dir, ignore_errors=True)
+            on_error_do(shutil.rmtree, save_dir, ignore_errors=True)
             inplace = False
         os.makedirs(save_dir, exist_ok=True)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 import os
 import os.path as osp
 
-from datumaro.util import Rollback, error_rollback
+from datumaro.util import Rollback, error_rollback, on_error_do
 from datumaro.util.os_util import walk
 from datumaro.util.test_utils import TestDir
 
@@ -73,15 +73,15 @@ class TestRollback(TestCase):
         self.assertTrue(success)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_decorator_supports_implicit_arg(self):
+    def test_decorator_supports_implicit_form(self):
         success = False
         def cb():
             nonlocal success
             success = True
 
-        @error_rollback('on_error', implicit=True)
+        @error_rollback
         def foo():
-            on_error.do(cb)  # noqa: F821
+            on_error_do(cb)
             raise Exception('err')
 
         try:
@@ -119,7 +119,7 @@ class TestRollback(TestCase):
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_decorator_can_return_on_success_in_implicit_form(self):
-        @error_rollback('on_error', implicit=True)
+        @error_rollback
         def f():
             return 42
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Instead of adding a global `on_error` variable in the module of the calling function, use a thread-local variable in the `Rollback` class. This has the following advantages:

* Linters and IDEs no longer complain about undefined variables.
* The `Rollback.current` accessor is type-annotated, allowing IDEs to provide autocompletion for methods.
* Using a thread-local variable eliminates potential conflicts if Datumaro is used in multiple threads.
* The `implicit` parameter is no longer required, since we can default to implicit mode if the variable name is unspecified.

Inspired by the discussion in #373.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
