### PR TITLE
Add navbar-version-selector.html for documentation website

### DIFF
--- a/site/layouts/partials/navbar-version-selector.html
+++ b/site/layouts/partials/navbar-version-selector.html
@@ -1,0 +1,11 @@
+{{ $page_rel := .Page.RelPermalink | safeURL }}
+{{ $page_rel_trim := strings.TrimLeft "/" $page_rel | safeURL }}
+<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  {{ .Site.Params.version_menu }}
+</a>
+<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+  {{ range .Site.Params.versions }}
+    {{ $ver := .version }}
+      <a class="dropdown-item" href="{{ .url }}{{ if eq $ver "develop" }}{{ $page_rel_trim }}{{ else }}{{ $page_rel }}{{ end }}">{{ $ver }}</a>
+  {{ end }}
+</div>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
This PR added `navbar-version-selector.html` to ensure that when you change the version, the current page in a different version opens and not the root of the site
### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [x] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
