### PR TITLE
Fix page 404 on documentation website

### DIFF
--- a/site/content/en/page_404.html
+++ b/site/content/en/page_404.html
@@ -1,0 +1,11 @@
++++
+Title = 404
++++
+
+  <main id="main">
+    <div class="text-center">
+      <h1>404</h1>
+      <p>Not found</p>
+      <p>Oops! This page doesn't exist. Try going back to <a href="/docs">documentation page</a>.</p>
+    </div>
+  </main>

--- a/site/layouts/404.html
+++ b/site/layouts/404.html
@@ -1,9 +1,1 @@
-{{ define "main"}}
-    <main id="main">
-      <div class="text-center">
-       <h1>404</h1>
-       <p>Not found</p>
-       <p>Oops! This page doesn't exist. Try going back to <a href="{{ "/docs" | relURL }}">documentation page</a>.</p>
-      </div>
-    </main>
-{{ end }}
+<meta http-equiv="refresh" content="0; URL=/datumaro/page_404">


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
This PR contains fix page 404.
The page was corrected by a redirect in the `404` template, the redirect leads to the created page `page_404` at the root of the site

Preview: 
https://tosmanov.github.io/datumaro/2134
https://tosmanov.github.io/datumaro/docs/usr_manual

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [x] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
