### PR TITLE
Fix a deprecation warning in open_images_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD
 
 ### Fixed
-- TBD
+- Deprecation warning in `open_images_format.py`
+  (<https://github.com/openvinotoolkit/datumaro/pull/440>)
 
 ### Security
 - TBD

--- a/datumaro/plugins/open_images_format.py
+++ b/datumaro/plugins/open_images_format.py
@@ -484,7 +484,7 @@ class OpenImagesExtractor(Extractor):
         raw = load_image(path, dtype=np.uint8)
         resized = cv2.resize(raw, (size[1], size[0]),
             interpolation=cv2.INTER_NEAREST)
-        return resized.astype(np.bool)
+        return resized.astype(bool)
 
 class OpenImagesImporter(Importer):
     @classmethod


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
`np.bool` was deprecated in NumPy 1.20 in favor of plain `bool`.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
