### PR TITLE
lazy_image: fix cache collisions leading to unrelated data being returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Deprecation warning in `open_images_format.py`
   (<https://github.com/openvinotoolkit/datumaro/pull/440>)
+- `lazy_image` returning unrelated data sometimes
+  (<https://github.com/openvinotoolkit/datumaro/issues/409>)
 
 ### Security
 - TBD

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -12,6 +12,7 @@ import os
 import os.path as osp
 import shlex
 import shutil
+import weakref
 
 import numpy as np
 
@@ -205,28 +206,28 @@ class lazy_image:
     def __init__(self, path, loader=None, cache=None):
         if loader is None:
             loader = load_image
-        self.path = path
-        self.loader = loader
+        self._path = path
+        self._loader = loader
 
         # Cache:
         # - False: do not cache
         # - None: use the global cache
         # - object: an object to be used as cache
         assert cache in {None, False} or isinstance(cache, object)
-        self.cache = cache
+        self._cache = cache
 
     def __call__(self):
         image = None
-        image_id = hash(self) # path is not necessary hashable or a file path
+        cache_key = weakref.ref(self)
 
-        cache = self._get_cache(self.cache)
+        cache = self._get_cache(self._cache)
         if cache is not None:
-            image = cache.get(image_id)
+            image = cache.get(cache_key)
 
         if image is None:
-            image = self.loader(self.path)
+            image = self._loader(self._path)
             if cache is not None:
-                cache.push(image_id, image)
+                cache.push(cache_key, image)
         return image
 
     @staticmethod
@@ -236,9 +237,6 @@ class lazy_image:
         elif cache == False:
             return None
         return cache
-
-    def __hash__(self):
-        return hash((id(self), self.path, self.loader))
 
 class Image:
     def __init__(self, data: Union[None, Callable, np.ndarray] = None,


### PR DESCRIPTION
### Summary
Currently, the key used to look up the cached image is based on a hash of a tuple containing `id(self)`, `path`, and `loader`. This means there are two situations in which a `lazy_image` can look up the wrong data:

* If there previously existed another `lazy_image` object whose `self` and `loader` had the same object IDs as the current `lazy_image`'s `self` and `loader`. This is possible, because deleted objects' IDs can be reused.

* If a hash collision occurs between the current `lazy_image`'s tuple and some other's.

Fix it by using a weak reference to `self` as the key instead. Different weak references will only compare equal if they point to the same object.

This will only work correctly if the loader and path of a `lazy_image` are not modified after creation. I don't think there are any use cases for modifying them (and there are no instances of that happening in the codebase), so it shouldn't be an issue. To reduce the temptation of client code to modify these fields, mark them as private.

Modifying the `cache` field should not cause issues, but just in case, make it private as well.

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

Fixes #409 (probably; I never managed to reliably reproduce it)

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
