### PR TITLE
Fix reading, writing anno file and saving name of the subset for test subset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calling `ProjectDataset.transform()` with a string argument (<https://github.com/openvinotoolkit/datumaro/issues/402>)
 - Attributes casting for CVAT format (<https://github.com/openvinotoolkit/datumaro/pull/403>)
 - Loading of custom project plugins (<https://github.com/openvinotoolkit/datumaro/issues/404>)
+- Reading, writing anno file and saving name of the subset for test subset(<https://github.com/openvinotoolkit/datumaro/pull/447>)
 
 ### Security
 - Fixed unsafe unpickling in CIFAR import (<https://github.com/openvinotoolkit/datumaro/pull/362>)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calling `ProjectDataset.transform()` with a string argument (<https://github.com/openvinotoolkit/datumaro/issues/402>)
 - Attributes casting for CVAT format (<https://github.com/openvinotoolkit/datumaro/pull/403>)
 - Loading of custom project plugins (<https://github.com/openvinotoolkit/datumaro/issues/404>)
-- Reading, writing anno file and saving name of the subset for test subset(<https://github.com/openvinotoolkit/datumaro/pull/447>)
+- Reading, writing anno file and saving name of the subset for test subset 
+  (<https://github.com/openvinotoolkit/datumaro/pull/447>)
 
 ### Security
 - Fixed unsafe unpickling in CIFAR import (<https://github.com/openvinotoolkit/datumaro/pull/362>)

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -34,8 +34,7 @@ class WiderFaceExtractor(SourceExtractor):
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]
-            if re.fullmatch(r'wider_face_\S+_bbx_gt', subset) or \
-                    re.fullmatch(r'wider_face_\S+_filelist', subset):
+            if re.fullmatch(r'wider_face_\S+', subset):
                 subset = subset.split('_')[2]
         super().__init__(subset=subset)
 

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -34,7 +34,8 @@ class WiderFaceExtractor(SourceExtractor):
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]
-            if re.fullmatch(r'wider_face_\S+_bbx_gt', subset):
+            if re.fullmatch(r'wider_face_\S+_bbx_gt', subset) or \
+                    re.fullmatch(r'wider_face_\S+_filelist', subset):
                 subset = subset.split('_')[2]
         super().__init__(subset=subset)
 
@@ -102,6 +103,8 @@ class WiderFaceExtractor(SourceExtractor):
             try:
                 bbox_count = int(lines[line_idx + 1]) # can be the next image
             except ValueError:
+                continue
+            except IndexError:
                 continue
 
             bbox_lines = lines[line_idx + 2 : line_idx + bbox_count + 2]
@@ -176,7 +179,8 @@ class WiderFaceConverter(Converter):
 
                 bboxes = [a for a in item.annotations
                     if a.type == AnnotationType.bbox]
-                wider_annotation += '%s\n' % len(bboxes)
+                if len(bboxes) > 0:
+                    wider_annotation += '%s\n' % len(bboxes)
                 for bbox in bboxes:
                     wider_bb = ' '.join('%s' % p for p in bbox.get_bbox())
                     wider_annotation += '%s ' % wider_bb

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -34,7 +34,7 @@ class WiderFaceExtractor(SourceExtractor):
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]
-            if re.fullmatch(r'wider_face_\S+(_bbx_gt)|(_filelist)', subset):
+            if re.fullmatch(r'wider_face_\S+((_bbx_gt)|(_filelist))', subset):
                 subset = subset.split('_')[2]
         super().__init__(subset=subset)
 

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -101,10 +101,10 @@ class WiderFaceExtractor(SourceExtractor):
                 image=image_path, annotations=annotations)
 
             try:
-                bbox_count = int(lines[line_idx + 1]) # can be the next image
-            except ValueError:
+                bbox_count = int(lines[line_idx + 1])
+            except ValueError: # can be the next image
                 continue
-            except IndexError:
+            except IndexError: # the file can only contain names of images
                 continue
 
             bbox_lines = lines[line_idx + 2 : line_idx + bbox_count + 2]
@@ -179,7 +179,7 @@ class WiderFaceConverter(Converter):
 
                 bboxes = [a for a in item.annotations
                     if a.type == AnnotationType.bbox]
-                if len(bboxes) > 0:
+                if 0 < len(bboxes):
                     wider_annotation += '%s\n' % len(bboxes)
                 for bbox in bboxes:
                     wider_bb = ' '.join('%s' % p for p in bbox.get_bbox())

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -34,7 +34,7 @@ class WiderFaceExtractor(SourceExtractor):
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]
-            if re.fullmatch(r'wider_face_\S+', subset):
+            if re.fullmatch(r'wider_face_\S+(_bbx_gt)|(_filelist)', subset):
                 subset = subset.split('_')[2]
         super().__init__(subset=subset)
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Fixed saving the name of the test subset
- Changed: If there are no bounding boxes, only the image name is written to the file (previously, zero was written)

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
manually on the widerface dataset

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
