### PR TITLE
Fix an invalid call to pycocotools.mask.iou

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/440>)
 - `lazy_image` returning unrelated data sometimes
   (<https://github.com/openvinotoolkit/datumaro/issues/409>)
+- Invalid call to `pycocotools.mask.iou`
+  (<https://github.com/openvinotoolkit/datumaro/pull/450>)
 
 ### Security
 - TBD

--- a/datumaro/util/mask_tools.py
+++ b/datumaro/util/mask_tools.py
@@ -230,7 +230,7 @@ def crop_covered_segments(segments, width, height,
         rles_top = []
         for j in range(i + 1, len(input_rles)):
             rle_top = input_rles[j]
-            iou = sum(mask_utils.iou(rle_bottom, rle_top, [0, 0]))[0]
+            iou = sum(mask_utils.iou(rle_bottom, rle_top, [0]))[0]
 
             if iou <= iou_threshold:
                 continue


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
The `pyiscrowd` parameter is supposed to have the same length as `gt`, which in this case is 1, not 2. This mistake used to be harmless, but an assert for this was added in the upstream repository (see ppwwyyxx/cocoapi@4f034008), so if a new release of pycocotools comes out, the current version will start crashing.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
