### PR TITLE
coco_format: add an option to preserve original category IDs when extracting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/238>)
 - `add`, `remove`, `commit`, `checkout`, `log`, `status`, `info` CLI commands
   (<https://github.com/openvinotoolkit/datumaro/pull/238>)
+- `Coco*Extractor` classes now have an option to preserve label IDs from the
+  original annotation file
+  (<https://github.com/openvinotoolkit/datumaro/pull/453>)
 
 ### Changed
 - A project can contain and manage multiple datasets instead of a single one.

--- a/datumaro/cli/contexts/source.py
+++ b/datumaro/cli/contexts/source.py
@@ -114,7 +114,7 @@ def add_command(args):
         arg_parser = env.extractors[fmt]
     else:
         raise CliException("Unknown format '%s'. A format can be added"
-            "by providing an Extractor and Importer plugins" % fmt)
+            " by providing an Extractor and Importer plugins" % fmt)
 
     extra_args = arg_parser.parse_cmdline(args.extra_args)
 

--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -28,7 +28,7 @@ class _CocoExtractor(SourceExtractor):
     def __init__(self, path, task, *,
         merge_instance_polygons=False,
         subset=None,
-        preserve_original_category_ids=False,
+        keep_original_category_ids=False,
     ):
         assert osp.isfile(path), path
 
@@ -57,7 +57,7 @@ class _CocoExtractor(SourceExtractor):
 
             self._load_label_categories(
                 panoptic_config['categories'],
-                preserve_original_ids=preserve_original_category_ids,
+                keep_original_ids=keep_original_category_ids,
             )
 
             self._items = list(self._load_panoptic_items(panoptic_config,
@@ -66,7 +66,7 @@ class _CocoExtractor(SourceExtractor):
             loader = self._make_subset_loader(path)
             self._load_categories(
                 loader,
-                preserve_original_ids=preserve_original_category_ids,
+                keep_original_ids=keep_original_category_ids,
             )
             self._items = list(self._load_items(loader).values())
 
@@ -86,25 +86,25 @@ class _CocoExtractor(SourceExtractor):
             coco_api.createIndex()
         return coco_api
 
-    def _load_categories(self, loader, *, preserve_original_ids):
+    def _load_categories(self, loader, *, keep_original_ids):
         self._categories = {}
 
         if self._task in [CocoTask.instances, CocoTask.labels,
                 CocoTask.person_keypoints, CocoTask.stuff]:
             self._load_label_categories(
                 loader.loadCats(loader.getCatIds()),
-                preserve_original_ids=preserve_original_ids,
+                keep_original_ids=keep_original_ids,
             )
 
         if self._task == CocoTask.person_keypoints:
             self._load_person_kp_categories(loader)
 
 
-    def _load_label_categories(self, raw_cats, *, preserve_original_ids):
+    def _load_label_categories(self, raw_cats, *, keep_original_ids):
         categories = LabelCategories()
         label_map = {}
 
-        if preserve_original_ids:
+        if keep_original_ids:
             for cat in sorted(raw_cats, key=lambda cat: cat['id']):
                 label_map[cat['id']] = cat['id']
 

--- a/datumaro/plugins/coco_format/importer.py
+++ b/datumaro/plugins/coco_format/importer.py
@@ -25,6 +25,15 @@ class CocoImporter(Importer):
     }
 
     @classmethod
+    def build_cmdline_parser(cls, **kwargs):
+        parser = super().build_cmdline_parser(**kwargs)
+        parser.add_argument('--keep-original-category-ids', action='store_true',
+            help="Add dummy label categories so that category indexes"
+                " correspond to the category IDs in the original annotation"
+                " file")
+        return parser
+
+    @classmethod
     def detect(cls, path):
         with logging_disabled(log.WARN):
             return len(cls.find_sources(path)) != 0

--- a/site/content/en/docs/formats/coco.md
+++ b/site/content/en/docs/formats/coco.md
@@ -72,6 +72,12 @@ datum add path -f coco <path/to/dataset>
 It is possible to specify project name and project directory, run
 `datum create --help` for more information.
 
+Extra options for adding a source in the COCO format:
+
+- `--keep-original-category-ids`: Add dummy label categories so that
+ category indexes in the imported data source correspond to the category IDs
+ in the original annotation file.
+
 A COCO dataset directory should have the following layout:
 
 <!--lint disable fenced-code-flag-->

--- a/tests/assets/coco_dataset/coco/annotations/instances_train.json
+++ b/tests/assets/coco_dataset/coco/annotations/instances_train.json
@@ -26,7 +26,7 @@
         "supercategory":""
       },
       {
-        "id":3,
+        "id":4,
         "name":"c",
         "supercategory":""
       }

--- a/tests/assets/coco_dataset/coco/annotations/instances_val.json
+++ b/tests/assets/coco_dataset/coco/annotations/instances_val.json
@@ -26,7 +26,7 @@
         "supercategory":""
       },
       {
-        "id":3,
+        "id":4,
         "name":"c",
         "supercategory":""
       }

--- a/tests/assets/coco_dataset/coco_instances/annotations/instances_train.json
+++ b/tests/assets/coco_dataset/coco_instances/annotations/instances_train.json
@@ -26,7 +26,7 @@
         "supercategory":""
       },
       {
-        "id":3,
+        "id":4,
         "name":"c",
         "supercategory":""
       }

--- a/tests/assets/coco_dataset/coco_instances/annotations/instances_val.json
+++ b/tests/assets/coco_dataset/coco_instances/annotations/instances_val.json
@@ -26,7 +26,7 @@
         "supercategory":""
       },
       {
-        "id":3,
+        "id":4,
         "name":"c",
         "supercategory":""
       }

--- a/tests/test_coco_format.py
+++ b/tests/test_coco_format.py
@@ -75,6 +75,26 @@ class CocoImporterTest(TestCase):
                 compare_datasets(self, expected, dataset, require_images=True)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_import_instances_with_original_cat_ids(self):
+        expected_dataset = Dataset.from_iterable([
+            DatasetItem(id='a', subset='train', image=np.ones((5, 10, 3)),
+                attributes={'id': 5},
+                annotations=[
+                    Bbox(2, 2, 3, 1, label=2,
+                        group=1, id=1, attributes={'is_crowd': False})
+                ]
+            ),
+        ], categories=['class-0', 'a', 'b', 'class-3', 'c'])
+
+        actual_dataset = Dataset.import_from(
+            osp.join(DUMMY_DATASET_DIR, 'coco_instances',
+                'annotations', 'instances_train.json'),
+            'coco_instances',
+            preserve_original_category_ids=True)
+        compare_datasets(self, expected_dataset, actual_dataset,
+            require_images=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import_captions(self):
         expected_dataset = Dataset.from_iterable([
             DatasetItem(id='a', subset='train', image=np.ones((5, 10, 3)),
@@ -197,6 +217,35 @@ class CocoImporterTest(TestCase):
                 compare_datasets(self, expected, dataset, require_images=True)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_import_keypoints_with_original_cat_ids(self):
+        expected_dataset = Dataset.from_iterable([
+            DatasetItem(id='a', subset='train', image=np.ones((5, 10, 3)),
+                attributes={'id': 5},
+                annotations=[
+                    Points([0, 0, 0, 2, 4, 1], [0, 1, 2], label=2,
+                        id=1, group=1, attributes={'is_crowd': False}),
+                    Bbox(2, 2, 3, 1, label=2,
+                        id=1, group=1, attributes={'is_crowd': False}),
+                ]),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                ['class-0', 'a', 'b']
+            ),
+            AnnotationType.points: PointsCategories.from_iterable(
+                [(i, None, [[0, 1], [1, 2]]) for i in range(1, 3)],
+            ),
+        })
+
+        actual_dataset = Dataset.import_from(
+            osp.join(DUMMY_DATASET_DIR, 'coco_person_keypoints',
+                'annotations', 'person_keypoints_train.json'),
+            'coco_person_keypoints',
+            preserve_original_category_ids=True)
+
+        compare_datasets(self, expected_dataset, actual_dataset,
+            require_images=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import_image_info(self):
         expected_dataset = Dataset.from_iterable([
             DatasetItem(id='a', subset='train', image=np.ones((5, 10, 3)),
@@ -260,6 +309,25 @@ class CocoImporterTest(TestCase):
             with self.subTest(path=path, format=format, subset=subset):
                 dataset = Dataset.import_from(path, format)
                 compare_datasets(self, expected, dataset, require_images=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_import_panoptic_with_original_cat_ids(self):
+        expected_dataset = Dataset.from_iterable([
+            DatasetItem(id='a', subset='train', image=np.ones((5, 10, 3)),
+                attributes={'id': 5},
+                annotations=[
+                    Mask(np.ones((5, 5)), label=1, id=460551,
+                        group=460551, attributes={'is_crowd': False}),
+                ]),
+        ], categories=['class-0', 'a', 'b'])
+
+        actual_dataset = Dataset.import_from(
+            osp.join(DUMMY_DATASET_DIR, 'coco_panoptic',
+                'annotations', 'panoptic_train.json'),
+            'coco_panoptic',
+            preserve_original_category_ids=True)
+        compare_datasets(self, expected_dataset, actual_dataset,
+            require_images=True)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import_stuff(self):

--- a/tests/test_coco_format.py
+++ b/tests/test_coco_format.py
@@ -90,7 +90,7 @@ class CocoImporterTest(TestCase):
             osp.join(DUMMY_DATASET_DIR, 'coco_instances',
                 'annotations', 'instances_train.json'),
             'coco_instances',
-            preserve_original_category_ids=True)
+            keep_original_category_ids=True)
         compare_datasets(self, expected_dataset, actual_dataset,
             require_images=True)
 
@@ -240,7 +240,7 @@ class CocoImporterTest(TestCase):
             osp.join(DUMMY_DATASET_DIR, 'coco_person_keypoints',
                 'annotations', 'person_keypoints_train.json'),
             'coco_person_keypoints',
-            preserve_original_category_ids=True)
+            keep_original_category_ids=True)
 
         compare_datasets(self, expected_dataset, actual_dataset,
             require_images=True)
@@ -325,7 +325,7 @@ class CocoImporterTest(TestCase):
             osp.join(DUMMY_DATASET_DIR, 'coco_panoptic',
                 'annotations', 'panoptic_train.json'),
             'coco_panoptic',
-            preserve_original_category_ids=True)
+            keep_original_category_ids=True)
         compare_datasets(self, expected_dataset, actual_dataset,
             require_images=True)
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
This is needed for potential integration into Accuracy Checker, since AC has this option as well.

As a side effect, refactor the loading of categories to remove duplication between the panoptic segmentation and other task types.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
