### PR TITLE
Import without hashing

### DIFF
--- a/datumaro/cli/contexts/project/__init__.py
+++ b/datumaro/cli/contexts/project/__init__.py
@@ -597,17 +597,18 @@ def info_command(args):
     for source_name, source in rev.sources.items():
         print("  '%s':" % source_name)
         print("    format:", source.format)
-        print("    url:", source.url)
-        print("    location:",
-            osp.join(project.source_data_dir(source_name), source.path))
+        print("    url:", osp.abspath(source.url) if source.url else '')
+        print("    location:", osp.abspath(osp.join(
+            project.source_data_dir(source_name), source.path)))
         print("    options:", source.options)
-        print("    hash:", source.hash)
 
         print("    stages:")
         for stage in rev.build_targets[source_name].stages:
             print("      '%s':" % stage.name)
             print("        type:", stage.type)
             print("        hash:", stage.hash)
+            print("        cached:",
+                project.is_obj_cached(stage.hash) if stage.hash else 'n/a')
             if stage.kind:
                 print("        kind:", stage.kind)
             if stage.params:

--- a/datumaro/cli/contexts/project/__init__.py
+++ b/datumaro/cli/contexts/project/__init__.py
@@ -316,19 +316,24 @@ def filter_command(args):
     else:
         targets = [args.target]
 
+    build_tree = project.working_tree.clone()
+    for target in targets:
+        build_tree.build_targets.add_filter_stage(target,
+            expr=filter_expr, params=filter_args)
+
     if args.apply:
         log.info("Filtering...")
 
         if args.dst_dir:
-            dataset = project.working_tree.make_dataset(args.target)
-            dataset.filter(filter_expr, **filter_args)
+            dataset = project.working_tree.make_dataset(
+                build_tree.make_pipeline(args.target))
             dataset.save(dst_dir, save_images=True)
 
             log.info("Results have been saved to '%s'" % dst_dir)
         else:
             for target in targets:
-                dataset = project.working_tree.make_dataset(target)
-                dataset.filter(filter_expr, **filter_args)
+                dataset = project.working_tree.make_dataset(
+                    build_tree.make_pipeline(target))
 
                 # Source might be missing in the working dir, so we specify
                 # the output directory.
@@ -340,9 +345,7 @@ def filter_command(args):
             log.info("Finished")
 
     if args.stage:
-        for target in targets:
-            project.working_tree.build_targets.add_filter_stage(target,
-                expr=filter_expr, params=filter_args)
+        project.working_tree.config.update(build_tree.config)
         project.working_tree.save()
 
     return 0
@@ -460,19 +463,24 @@ def transform_command(args):
     else:
         targets = [args.target]
 
+    build_tree = project.working_tree.clone()
+    for target in targets:
+        build_tree.build_targets.add_transform_stage(target,
+            args.transform, params=extra_args)
+
     if args.apply:
         log.info("Transforming...")
 
         if args.dst_dir:
-            dataset = project.working_tree.make_dataset(args.target)
-            dataset.transform(args.transform, **extra_args)
+            dataset = project.working_tree.make_dataset(
+                build_tree.make_pipeline(args.target))
             dataset.save(dst_dir, save_images=True)
 
             log.info("Results have been saved to '%s'" % dst_dir)
         else:
             for target in targets:
-                dataset = project.working_tree.make_dataset(target)
-                dataset.transform(args.transform, **extra_args)
+                dataset = project.working_tree.make_dataset(
+                    build_tree.make_pipeline(target))
 
                 # Source might be missing in the working dir, so we specify
                 # the output directory
@@ -484,9 +492,7 @@ def transform_command(args):
             log.info("Finished")
 
     if args.stage:
-        for target in targets:
-            project.working_tree.build_targets.add_transform_stage(target,
-                args.transform, params=extra_args)
+        project.working_tree.config.update(build_tree.config)
         project.working_tree.save()
 
     return 0

--- a/datumaro/cli/contexts/project/__init__.py
+++ b/datumaro/cli/contexts/project/__init__.py
@@ -341,11 +341,8 @@ def filter_command(args):
 
     if args.stage:
         for target in targets:
-            had_hash = bool(project.working_tree.build_targets[target].head.hash)
             project.working_tree.build_targets.add_filter_stage(target,
                 expr=filter_expr, params=filter_args)
-            if had_hash:
-                project.refresh_source_hash(target)
         project.working_tree.save()
 
     return 0
@@ -488,11 +485,8 @@ def transform_command(args):
 
     if args.stage:
         for target in targets:
-            had_hash = bool(project.working_tree.build_targets[target].head.hash)
             project.working_tree.build_targets.add_transform_stage(target,
                 args.transform, params=extra_args)
-            if had_hash:
-                project.refresh_source_hash(target)
         project.working_tree.save()
 
     return 0

--- a/datumaro/cli/contexts/source.py
+++ b/datumaro/cli/contexts/source.py
@@ -68,10 +68,6 @@ def build_add_parser(parser_ctor=argparse.ArgumentParser):
             "a path to subset, subtask, or a specific file in URL.")
     parser.add_argument('--no-check', action='store_true',
         help="Don't try to read the source after importing")
-    parser.add_argument('--no-cache', action='store_true',
-        help="Don't put a copy into the project cache")
-    parser.add_argument('--no-hash', action='store_true',
-        help="Don't compute source hash. Implies '--no-cache'.")
     parser.add_argument('-p', '--project', dest='project_dir', default='.',
         help="Directory of the project to operate on (default: current dir)")
     parser.add_argument('extra_args', nargs=argparse.REMAINDER,
@@ -130,7 +126,7 @@ def add_command(args):
             'source', sep='-', default='1')
 
     project.import_source(name, url=args.url, format=args.format,
-        options=extra_args, no_cache=args.no_cache, no_hash=args.no_hash,
+        options=extra_args, no_cache=True, no_hash=True,
         rpath=args.path)
     on_error_do(project.remove_source, name, ignore_errors=True,
         kwargs={'force': True, 'keep_data': False})

--- a/datumaro/cli/contexts/source.py
+++ b/datumaro/cli/contexts/source.py
@@ -126,8 +126,7 @@ def add_command(args):
             'source', sep='-', default='1')
 
     project.import_source(name, url=args.url, format=args.format,
-        options=extra_args, no_cache=True, no_hash=True,
-        rpath=args.path)
+        options=extra_args, no_cache=True, no_hash=True, rpath=args.path)
     on_error_do(project.remove_source, name, ignore_errors=True,
         kwargs={'force': True, 'keep_data': False})
 

--- a/datumaro/cli/contexts/source.py
+++ b/datumaro/cli/contexts/source.py
@@ -70,6 +70,8 @@ def build_add_parser(parser_ctor=argparse.ArgumentParser):
         help="Don't try to read the source after importing")
     parser.add_argument('--no-cache', action='store_true',
         help="Don't put a copy into the project cache")
+    parser.add_argument('--no-hash', action='store_true',
+        help="Don't compute source hash. Implies '--no-cache'.")
     parser.add_argument('-p', '--project', dest='project_dir', default='.',
         help="Directory of the project to operate on (default: current dir)")
     parser.add_argument('extra_args', nargs=argparse.REMAINDER,
@@ -128,7 +130,8 @@ def add_command(args):
             'source', sep='-', default='1')
 
     project.import_source(name, url=args.url, format=args.format,
-        options=extra_args, no_cache=args.no_cache, rpath=args.path)
+        options=extra_args, no_cache=args.no_cache, no_hash=args.no_hash,
+        rpath=args.path)
     on_error_do(project.remove_source, name, ignore_errors=True,
         kwargs={'force': True, 'keep_data': False})
 

--- a/datumaro/components/config.py
+++ b/datumaro/components/config.py
@@ -207,16 +207,16 @@ class Config:
 
             schema_entry = self._schema[key]
             schema_entry_instance = schema_entry()
-            if not isinstance(value, type(schema_entry_instance)):
-                if isinstance(value, dict) and \
-                        isinstance(schema_entry_instance, Config):
-                    schema_entry_instance.update(value)
-                    value = schema_entry_instance
-                else:
-                    raise ValueError("Can not set key '%s' - schema mismatch:"
-                        "unexpected value type %s, expected %s" % \
-                        (key, type(value), type(schema_entry_instance))
-                    )
+
+            if isinstance(value, (dict, Config)) and \
+                    isinstance(schema_entry_instance, Config):
+                schema_entry_instance.update(value)
+                value = schema_entry_instance
+            elif not isinstance(value, type(schema_entry_instance)):
+                raise ValueError("Can not set key '%s' - schema mismatch:"
+                    "unexpected value type %s, expected %s" % \
+                    (key, type(value), type(schema_entry_instance))
+                )
 
         self._config[key] = value
         return value
@@ -256,14 +256,14 @@ class DictConfig(Config):
     def set(self, key, value):
         if self._default is not None:
             schema_entry_instance = self._default(value)
-            if not isinstance(value, type(schema_entry_instance)):
-                if isinstance(value, dict) and \
-                        isinstance(schema_entry_instance, Config):
-                    value = schema_entry_instance
-                else:
-                   raise ValueError("Can not set key '%s' - schema mismatch:"
-                        "unexpected value type %s, expected %s" % \
-                        (key, type(value), type(schema_entry_instance))
-                    )
+
+            if isinstance(value, (dict, Config)) and \
+                    isinstance(schema_entry_instance, Config):
+                value = schema_entry_instance
+            elif not isinstance(value, type(schema_entry_instance)):
+                raise ValueError("Can not set key '%s' - schema mismatch:"
+                    "unexpected value type %s, expected %s" % \
+                    (key, type(value), type(schema_entry_instance))
+                )
 
         return super().set(key, value)

--- a/datumaro/components/project.py
+++ b/datumaro/components/project.py
@@ -1937,6 +1937,8 @@ class Project:
             dvcfile=dvcfile, no_cache=no_cache)
 
         build_target.head.hash = obj_hash
+        if not build_target.has_stages:
+            self.working_tree.sources[source].hash = obj_hash
 
         return obj_hash
 
@@ -2294,9 +2296,9 @@ class Project:
 
             if osp.isdir(self.source_data_dir(t_name)):
                 old_hash = wd_target.head.hash
-                new_hash = self.refresh_source_hash(t_name)
+                new_hash = self.compute_source_hash(t_name, no_cache=True)
 
-                if old_hash != new_hash:
+                if old_hash and old_hash != new_hash:
                     changed_targets[t_name] = DiffStatus.foreign_modified
 
         for t_name in set(head.build_targets) | set(wd.build_targets):

--- a/datumaro/components/project.py
+++ b/datumaro/components/project.py
@@ -1972,7 +1972,7 @@ class Project:
     @scoped
     def import_source(self, name: str, url: Optional[str],
             format: str, options: Optional[Dict] = None, *,
-            no_cache: bool = False, no_hash: bool = False,
+            no_cache: bool = True, no_hash: bool = True,
             rpath: Optional[str] = None) -> Source:
         """
         Adds a new source (dataset) to the working directory of the project.

--- a/datumaro/util/os_util.py
+++ b/datumaro/util/os_util.py
@@ -23,9 +23,6 @@ try:
     # readonly files on Windows, which Git uses extensively
     # It double checks if a file cannot be removed because of readonly flag
     from git.util import rmfile, rmtree  # pylint: disable=unused-import
-    import git.util
-    git.util.HIDE_WINDOWS_KNOWN_ERRORS = False
-
 except ModuleNotFoundError:
     from os import remove as rmfile # pylint: disable=unused-import
     from shutil import rmtree as rmtree # pylint: disable=unused-import

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -9,6 +9,7 @@ import inspect
 import os
 import os.path as osp
 import tempfile
+import unittest
 
 from typing_extensions import Literal
 
@@ -17,7 +18,6 @@ from datumaro.components.dataset import Dataset, IDataset
 from datumaro.util import filter_dict, find
 from datumaro.util.os_util import rmfile, rmtree
 
-import unittest
 
 class Dimensions(Enum):
     dim_2d = auto()

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -17,6 +17,7 @@ from datumaro.components.dataset import Dataset, IDataset
 from datumaro.util import filter_dict, find
 from datumaro.util.os_util import rmfile, rmtree
 
+import unittest
 
 class Dimensions(Enum):
     dim_2d = auto()
@@ -35,7 +36,12 @@ class FileRemover:
 
     def __exit__(self, exc_type=None, exc_value=None, traceback=None):
         if self.is_dir:
-            rmtree(self.path)
+            try:
+                rmtree(self.path)
+            except unittest.SkipTest:
+                # Suppress skip test errors from git.util.rmtree
+                if not exc_type:
+                    raise
         else:
             rmfile(self.path)
 

--- a/site/content/en/docs/formats/cityscapes.md
+++ b/site/content/en/docs/formats/cityscapes.md
@@ -66,7 +66,7 @@ Annotated files description:
   then the pixels have the regular ID of that class
 
 To make sure that the selected dataset has been added to the project, you can
-run `datum info`, which will display the project and dataset information.
+run `datum project info`, which will display the project and dataset information.
 
 ## Export to other formats
 

--- a/site/content/en/docs/formats/cityscapes.md
+++ b/site/content/en/docs/formats/cityscapes.md
@@ -66,7 +66,7 @@ Annotated files description:
   then the pixels have the regular ID of that class
 
 To make sure that the selected dataset has been added to the project, you can
-run `datum project info`, which will display the project and dataset information.
+run `datum project info`, which will display the project information.
 
 ## Export to other formats
 

--- a/site/content/en/docs/formats/coco.md
+++ b/site/content/en/docs/formats/coco.md
@@ -134,7 +134,7 @@ datum add --format coco_stuff -r <relpath/to/stuff.json> <path/to/dataset>
 ```
 
 To make sure that the selected dataset has been added to the project, you can
-run `datum project info`, which will display the project and dataset information.
+run `datum project info`, which will display the project information.
 
 Notes:
 - COCO categories can have any integer ids, however, Datumaro will count

--- a/site/content/en/docs/formats/coco.md
+++ b/site/content/en/docs/formats/coco.md
@@ -134,7 +134,7 @@ datum add --format coco_stuff -r <relpath/to/stuff.json> <path/to/dataset>
 ```
 
 To make sure that the selected dataset has been added to the project, you can
-run `datum info`, which will display the project and dataset information.
+run `datum project info`, which will display the project and dataset information.
 
 Notes:
 - COCO categories can have any integer ids, however, Datumaro will count

--- a/site/content/en/docs/formats/kitti.md
+++ b/site/content/en/docs/formats/kitti.md
@@ -85,7 +85,7 @@ datum add --format kitti_detection <path/to/dataset>
 ```
 
 To make sure that the selected dataset has been added to the project, you can
-run `datum project info`, which will display the project and dataset information.
+run `datum project info`, which will display the project information.
 
 ## Export to other formats
 

--- a/site/content/en/docs/formats/kitti.md
+++ b/site/content/en/docs/formats/kitti.md
@@ -85,7 +85,7 @@ datum add --format kitti_detection <path/to/dataset>
 ```
 
 To make sure that the selected dataset has been added to the project, you can
-run `datum info`, which will display the project and dataset information.
+run `datum project info`, which will display the project and dataset information.
 
 ## Export to other formats
 

--- a/site/content/en/docs/formats/kitti_raw.md
+++ b/site/content/en/docs/formats/kitti_raw.md
@@ -76,7 +76,7 @@ datum add --format kitti_raw <path/to/dataset>
 ```
 
 To make sure that the selected dataset has been added to the project,
-you can run `datum info`, which will display the project and dataset
+you can run `datum project info`, which will display the project and dataset
 information.
 
 ## Export to other formats

--- a/site/content/en/docs/formats/pascal_voc.md
+++ b/site/content/en/docs/formats/pascal_voc.md
@@ -143,7 +143,7 @@ datum add -f voc_detection -r ImageSets/Main/train.txt <path/to/dataset>
 ```
 
 To make sure that the selected dataset has been added to the project, you
-can run `datum info`, which will display the project and dataset information.
+can run `datum project info`, which will display the project and dataset information.
 
 ## Export to other formats
 

--- a/site/content/en/docs/formats/pascal_voc.md
+++ b/site/content/en/docs/formats/pascal_voc.md
@@ -143,7 +143,7 @@ datum add -f voc_detection -r ImageSets/Main/train.txt <path/to/dataset>
 ```
 
 To make sure that the selected dataset has been added to the project, you
-can run `datum project info`, which will display the project and dataset information.
+can run `datum project info`, which will display the project information.
 
 ## Export to other formats
 

--- a/site/content/en/docs/formats/sly_pointcloud.md
+++ b/site/content/en/docs/formats/sly_pointcloud.md
@@ -71,7 +71,7 @@ datum add -f sly_pointcloud <path/to/dataset>
 ```
 
 To make sure that the selected dataset has been added to the project,
-you can run `datum info`, which will display the project and dataset
+you can run `datum project info`, which will display the project and dataset
 information.
 
 ## Export to other formats

--- a/site/content/en/docs/user-manual/command-reference/sources.md
+++ b/site/content/en/docs/user-manual/command-reference/sources.md
@@ -55,7 +55,6 @@ non-standard placement or names.
 When a dataset is imported, the following things are done:
 - URL is saved in the project config
 - data in copied into the project
-- data is cached inside the project (use `--no-cache` to disable)
 
 Each data source has a name assigned, which can be used in other commands. To
 set a specific name, use the `-n/--name` parameter.
@@ -66,7 +65,7 @@ is _not_ done automatically.
 Usage:
 
 ``` bash
-datum add [-h] [-n NAME] -f FORMAT [-r PATH] [--no-check] [--no-cache]
+datum add [-h] [-n NAME] -f FORMAT [-r PATH] [--no-check]
   [-p PROJECT_DIR] url [-- EXTRA_FORMAT_ARGS]
 ```
 
@@ -76,7 +75,6 @@ Parameters:
 - `-r, --path` (string) - A path relative to the source URL the data source.
   Useful to specify a path to a subset, subtask, or a specific file in URL.
 - `--no-check` - Don't try to read the source after importing
-- `--no-cache` - Don't put a copy into the project cache
 - `-n`, `--name` (string) - Name of the new source (default: generate
   automatically)
 - `-p, --project` (string) - Directory of the project to operate on

--- a/site/content/en/docs/user-manual/how_to_use_datumaro.md
+++ b/site/content/en/docs/user-manual/how_to_use_datumaro.md
@@ -234,7 +234,7 @@ datum add <...> -n source1
 ```
 
 The dataset will be copied to the working directory inside the project. It
-will be hashed and added to the project working tree.
+will be added to the project working tree.
 
 After the dataset is added, we want to transform it and filter out some
 irrelevant samples, so we run the following commands:
@@ -245,7 +245,7 @@ datum filter <...> source1
 ```
 
 The commands modify the data source inside the working directory, inplace.
-The operations done are recorded in the working tree, the results are hashed.
+The operations done are recorded in the working tree.
 
 Now, we want to make a new version of the dataset and make a snapshot in the
 project cache. So we `commit` the working tree:
@@ -259,7 +259,9 @@ datum commit <...>
 At this time, the data source is copied into the project cache and a new
 project revision is created. The dataset operation history is saved, so
 the dataset can be reproduced even if it is removed from the cache and the
-working directory.
+working directory. Note, however, that the original dataset hash was not
+computed, so Datumaro won't be able to compare dataset hash on re-downloading.
+If it is desired, consider making a `commit` with an unmodified data source.
 
 After this, we do some other modifications to the dataset and make a new
 commit. Note that the dataset is not cached, until a `commit` is done.
@@ -314,8 +316,8 @@ step-by-step:
   should be controlled manually.
 1. If the project is not read-only (3b), Datumaro will try to download
   the original dataset and reproduce the resulting dataset. The data hash
-  will be computed and hashes will be compared. On success, the data will be
-  put into the cache.
+  will be computed and hashes will be compared (if the data source had hash
+  computed on addition). On success, the data will be put into the cache.
 1. The downloaded dataset will be read and the remaining operations from the
   source history will be re-applied.
 1. The resulting dataset might be cached in some cases.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -942,6 +942,26 @@ class ProjectTest(TestCase):
         with self.subTest("make_dataset"), self.assertRaises(MissingObjectError):
             project.get_rev('HEAD').make_dataset()
 
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    @scoped
+    def test_can_import_without_hashing(self):
+        test_dir = scope_add(TestDir())
+        dataset_url = osp.join(test_dir, 'dataset')
+        dataset = Dataset.from_iterable([
+            DatasetItem('a'),
+            DatasetItem('b'),
+        ])
+        dataset.save(dataset_url)
+
+        proj_dir = osp.join(test_dir, 'proj')
+        project = scope_add(Project.init(proj_dir))
+        project.import_source('source1', url=dataset_url,
+            format=DEFAULT_FORMAT, no_hash=True)
+
+        self.assertEqual('', project.working_tree.sources['source1'].hash)
+        compare_dirs(self, dataset_url, project.source_data_dir('source1'))
+        compare_datasets(self, dataset, project.working_tree.make_dataset())
+
 class BackwardCompatibilityTests_v0_1(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @scoped


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Added `--no-hash` option in `Project.import_source()`. The option is enabled by default, so no hashing is performed until commit is requested.
- Allowed `Pipeline` arguments in `Tree.make_dataset()`
- Removed output hashing in modifying CLI operations (`datum filter`, `datum transform`)
- Added cache status info in `project info` output
- Fixed `Config` copying with recursive structures - `Config` instances do recursive copying
- Fixed `TestDir` behavior on Windows in case of errors - test errors are not shadowed by `SkipTest` errors from `git.utils.rmtree` anymore.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
