### PR TITLE
Allow to add image without  path

### DIFF
--- a/datumaro/plugins/open_images_format.py
+++ b/datumaro/plugins/open_images_format.py
@@ -269,7 +269,7 @@ class OpenImagesExtractor(Extractor):
                     if _RE_INVALID_PATH_COMPONENT.fullmatch(subset):
                         raise UnsupportedSubsetNameError(item_id=image_id, subset=subset)
 
-                    image_path = image_paths_by_id.get(image_id)
+                    image_path = image_paths_by_id.get(image_id, image_id)
 
                     image = None
                     if image_path is not None:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary and Motivation
Open Images requires you to know the size of the image.
Current format implementation does not add `Image` to `Item` if the image has no path.
It is not possible to load a dataset without images, but with meta information about them.
This small fix adds a dummy path to the image.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
