### PR TITLE
Added missed pytest marking.

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -161,18 +161,21 @@ class TestMemberRedefined(TestCase):
         def method(self):
             pass
 
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_no_changes_in_derived_class(self):
         class Derived(self.Base):
             pass
 
         self.assertFalse(is_method_redefined('method', self.Base, Derived))
 
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_no_changes_in_derived_instance(self):
         class Derived(self.Base):
             pass
 
         self.assertFalse(is_method_redefined('method', self.Base, Derived()))
 
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_changes_in_derived_class(self):
         class Derived(self.Base):
             def method(self):
@@ -180,6 +183,7 @@ class TestMemberRedefined(TestCase):
 
         self.assertTrue(is_method_redefined('method', self.Base, Derived))
 
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_changes_in_derived_instance(self):
         class Derived(self.Base):
             def method(self):
@@ -187,6 +191,7 @@ class TestMemberRedefined(TestCase):
 
         self.assertTrue(is_method_redefined('method', self.Base, Derived()))
 
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_changes_in_patched_instance(self):
         obj = self.Base()
         with mock.patch.object(obj, 'method'):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
This PR adds missed tests marking in tests/test_util.py file.
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
