### PR TITLE
Add tests for dataset importing without images

### DIFF
--- a/datumaro/plugins/kitti_format/importer.py
+++ b/datumaro/plugins/kitti_format/importer.py
@@ -24,16 +24,16 @@ class KittiImporter(Importer):
             raise Exception("Failed to find 'kitti' dataset at '%s'" % path)
 
         # TODO: should be removed when proper label merging is implemented
-        conflicting_types = {KittiTask.segmentation, KittiTask.detection}
+        conflicting_types = {'kitti_segmentation','kitti_detection'}
         ann_types = set(t for s in subsets.values() for t in s) \
             & conflicting_types
         if 1 <= len(ann_types):
-            selected_ann_type = sorted(ann_types, key=lambda x: x.name)[0]
+            selected_ann_type = sorted(ann_types)[0]
         if 1 < len(ann_types):
             log.warning("Not implemented: "
                 "Found potentially conflicting source types with labels: %s. "
                 "Only one type will be used: %s" \
-                % (", ".join(t.name for t in ann_types), selected_ann_type.name))
+                % (", ".join(ann_types), selected_ann_type))
 
         sources = []
         for ann_files in subsets.values():

--- a/tests/test_datumaro_format.py
+++ b/tests/test_datumaro_format.py
@@ -104,6 +104,13 @@ class DatumaroConverterTest(TestCase):
                 partial(DatumaroConverter.convert, save_images=True), test_dir)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_and_load_with_no_save_images(self):
+        with TestDir() as test_dir:
+            self._test_save_and_load(self.test_dataset,
+                partial(DatumaroConverter.convert, save_images=True), test_dir,
+                compare=None, require_images=False)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         with TestDir() as test_dir:
             DatumaroConverter.convert(self.test_dataset, save_dir=test_dir)

--- a/tests/test_icdar_format.py
+++ b/tests/test_icdar_format.py
@@ -139,10 +139,12 @@ class IcdarConverterTest(TestCase):
                 ]),
         ])
 
-        with TestDir() as test_dir:
-            self._test_save_and_load(expected_dataset,
-                partial(IcdarWordRecognitionConverter.convert, save_images=True),
-                test_dir, 'icdar_word_recognition')
+        for save_images in (True, False):
+            with self.subTest(save_images=save_images), TestDir() as test_dir:
+                self._test_save_and_load(expected_dataset,
+                    partial(IcdarWordRecognitionConverter.convert,
+                        save_images=save_images),
+                    test_dir, 'icdar_word_recognition')
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_bboxes(self):
@@ -166,10 +168,12 @@ class IcdarConverterTest(TestCase):
                 ]),
         ])
 
-        with TestDir() as test_dir:
-            self._test_save_and_load(expected_dataset,
-                partial(IcdarTextLocalizationConverter.convert, save_images=True),
-                test_dir, 'icdar_text_localization')
+        for save_images in (True, False):
+            with self.subTest(save_images=save_images), TestDir() as test_dir:
+                self._test_save_and_load(expected_dataset,
+                    partial(IcdarTextLocalizationConverter.convert,
+                        save_images=save_images),
+                    test_dir, 'icdar_text_localization')
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_masks(self):
@@ -200,10 +204,12 @@ class IcdarConverterTest(TestCase):
                 ]),
         ])
 
-        with TestDir() as test_dir:
-            self._test_save_and_load(expected_dataset,
-                partial(IcdarTextSegmentationConverter.convert, save_images=True),
-                test_dir, 'icdar_text_segmentation')
+        for save_images in (True, False):
+            with self.subTest(save_images=save_images), TestDir() as test_dir:
+                self._test_save_and_load(expected_dataset,
+                    partial(IcdarTextSegmentationConverter.convert,
+                        save_images=save_images),
+                    test_dir, 'icdar_text_segmentation')
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_with_no_subsets(self):

--- a/tests/test_icdar_format.py
+++ b/tests/test_icdar_format.py
@@ -139,12 +139,24 @@ class IcdarConverterTest(TestCase):
                 ]),
         ])
 
-        for save_images in (True, False):
-            with self.subTest(save_images=save_images), TestDir() as test_dir:
-                self._test_save_and_load(expected_dataset,
-                    partial(IcdarWordRecognitionConverter.convert,
-                        save_images=save_images),
-                    test_dir, 'icdar_word_recognition')
+        with TestDir() as test_dir:
+            self._test_save_and_load(expected_dataset,
+                partial(IcdarWordRecognitionConverter.convert, save_images=True),
+                test_dir, 'icdar_word_recognition')
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_and_load_captions_with_no_save_images(self):
+        expected_dataset = Dataset.from_iterable([
+            DatasetItem(id='a/b/1', subset='train',
+                image=np.ones((10, 15, 3)), annotations=[
+                    Caption('caption 0'),
+                ])
+        ])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(expected_dataset,
+                partial(IcdarWordRecognitionConverter.convert, save_images=False),
+                test_dir, 'icdar_word_recognition')
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_bboxes(self):
@@ -168,12 +180,27 @@ class IcdarConverterTest(TestCase):
                 ]),
         ])
 
-        for save_images in (True, False):
-            with self.subTest(save_images=save_images), TestDir() as test_dir:
-                self._test_save_and_load(expected_dataset,
-                    partial(IcdarTextLocalizationConverter.convert,
-                        save_images=save_images),
-                    test_dir, 'icdar_text_localization')
+        with TestDir() as test_dir:
+            self._test_save_and_load(expected_dataset,
+                partial(IcdarTextLocalizationConverter.convert, save_images=True),
+                test_dir, 'icdar_text_localization')
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_and_load_bboxes_with_no_save_images(self):
+        expected_dataset = Dataset.from_iterable([
+            DatasetItem(id=3, subset='train',
+                image=np.ones((10, 15, 3)), annotations=[
+                    Polygon([2, 2, 8, 3, 7, 10, 2, 9],
+                        attributes={'text': 'word_2'}),
+                    Bbox(0, 2, 5, 9, attributes={'text': 'word_3'}),
+                ]),
+        ])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(expected_dataset,
+                partial(IcdarTextLocalizationConverter.convert, save_images=False),
+                test_dir, 'icdar_text_localization')
+
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_masks(self):
@@ -204,12 +231,31 @@ class IcdarConverterTest(TestCase):
                 ]),
         ])
 
-        for save_images in (True, False):
-            with self.subTest(save_images=save_images), TestDir() as test_dir:
-                self._test_save_and_load(expected_dataset,
-                    partial(IcdarTextSegmentationConverter.convert,
-                        save_images=save_images),
-                    test_dir, 'icdar_text_segmentation')
+        with TestDir() as test_dir:
+            self._test_save_and_load(expected_dataset,
+                partial(IcdarTextSegmentationConverter.convert,
+                    save_images=True),
+                test_dir, 'icdar_text_segmentation')
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_and_load_masks_with_no_save_images(self):
+        expected_dataset = Dataset.from_iterable([
+            DatasetItem(id='a/b/1', subset='train',
+                image=np.ones((10, 15, 3)), annotations=[
+                    Mask(image=np.array([[0, 0, 0, 1, 1]]), group=1,
+                        attributes={ 'index': 1, 'color': '82 174 214', 'text': 'j',
+                            'center': '0 3' }),
+                    Mask(image=np.array([[0, 1, 1, 0, 0]]), group=1,
+                        attributes={ 'index': 0, 'color': '108 225 132', 'text': 'F',
+                            'center': '0 1' }),
+                ]),
+        ])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(expected_dataset,
+                partial(IcdarTextSegmentationConverter.convert,
+                    save_images=False),
+                test_dir, 'icdar_text_segmentation')
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_with_no_subsets(self):

--- a/tests/test_imagenet_txt_format.py
+++ b/tests/test_imagenet_txt_format.py
@@ -32,15 +32,30 @@ class ImagenetTxtFormatTest(TestCase):
                 'label_' + str(label) for label in range(4)),
         })
 
-        for save_images in (True, False):
-            with self.subTest(save_images=save_images), TestDir() as test_dir:
-                ImagenetTxtConverter.convert(source_dataset, test_dir,
-                    save_images=save_images)
+        with TestDir() as test_dir:
+            ImagenetTxtConverter.convert(source_dataset, test_dir,
+                save_images=True)
 
-                parsed_dataset = Dataset.import_from(test_dir, 'imagenet_txt')
+            parsed_dataset = Dataset.import_from(test_dir, 'imagenet_txt')
 
-                compare_datasets(self, source_dataset, parsed_dataset,
-                    require_images=save_images)
+            compare_datasets(self, source_dataset, parsed_dataset,
+                require_images=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_and_load_with_no_save_images(self):
+        source_dataset = Dataset.from_iterable([
+            DatasetItem(id='1', subset='train',
+                annotations=[Label(0)]
+            ),
+        ], categories=['label_0'])
+
+        with TestDir() as test_dir:
+            ImagenetTxtConverter.convert(source_dataset, test_dir,
+                save_images=False)
+
+            parsed_dataset = Dataset.import_from(test_dir, 'imagenet_txt')
+
+            compare_datasets(self, source_dataset, parsed_dataset)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_with_multiple_labels(self):

--- a/tests/test_imagenet_txt_format.py
+++ b/tests/test_imagenet_txt_format.py
@@ -32,14 +32,15 @@ class ImagenetTxtFormatTest(TestCase):
                 'label_' + str(label) for label in range(4)),
         })
 
-        with TestDir() as test_dir:
-            ImagenetTxtConverter.convert(source_dataset, test_dir,
-                save_images=True)
+        for save_images in (True, False):
+            with self.subTest(save_images=save_images), TestDir() as test_dir:
+                ImagenetTxtConverter.convert(source_dataset, test_dir,
+                    save_images=save_images)
 
-            parsed_dataset = Dataset.import_from(test_dir, 'imagenet_txt')
+                parsed_dataset = Dataset.import_from(test_dir, 'imagenet_txt')
 
-            compare_datasets(self, source_dataset, parsed_dataset,
-                require_images=True)
+                compare_datasets(self, source_dataset, parsed_dataset,
+                    require_images=save_images)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_with_multiple_labels(self):

--- a/tests/test_kitti_format.py
+++ b/tests/test_kitti_format.py
@@ -439,7 +439,7 @@ class KittiConverterTest(TestCase):
                 KittiPath.IMAGES_DIR, 'q/1.JPEG')))
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_can_save_and_load_without_image_saving_segmentation(self):
+    def test_can_save_and_load_with_no_save_images_segmentation(self):
         class TestExtractor(TestExtractorBase):
             def __iter__(self):
                 return iter([
@@ -459,7 +459,7 @@ class KittiConverterTest(TestCase):
                     label_map='kitti'), test_dir)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_can_save_and_load_without_image_saving_detection(self):
+    def test_can_save_and_load_with_no_save_images_detection(self):
         class TestExtractor(TestExtractorBase):
             def __iter__(self):
                 return iter([

--- a/tests/test_kitti_format.py
+++ b/tests/test_kitti_format.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 import os.path as osp
 
 import numpy as np
-from numpy.lib.function_base import extract
 
 from datumaro.components.annotation import (
     AnnotationType, Bbox, LabelCategories, Mask,
@@ -478,4 +477,3 @@ class KittiConverterTest(TestCase):
             self._test_save_and_load(TestExtractor(),
                 partial(KittiConverter.convert, tasks=KittiTask.detection,
                     save_images=False), test_dir)
-

--- a/tests/test_lfw_format.py
+++ b/tests/test_lfw_format.py
@@ -45,14 +45,42 @@ class LfwFormatTest(TestCase):
             ),
         ], categories=['name0', 'name1'])
 
-        for save_images in (True, False):
-            with self.subTest(save_images=save_images), TestDir() as test_dir:
-                LfwConverter.convert(source_dataset, test_dir,
-                    save_images=save_images)
-                parsed_dataset = Dataset.import_from(test_dir, 'lfw')
+        with TestDir() as test_dir:
+            LfwConverter.convert(source_dataset, test_dir,
+                save_images=True)
+            parsed_dataset = Dataset.import_from(test_dir, 'lfw')
 
-                compare_datasets(self, source_dataset, parsed_dataset,
-                    require_images=save_images)
+            compare_datasets(self, source_dataset, parsed_dataset,
+                require_images=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_and_load_with_no_save_images(self):
+        source_dataset = Dataset.from_iterable([
+            DatasetItem(id='name0_0001', subset='test',
+                image=np.ones((2, 5, 3)),
+                annotations=[Label(0, attributes={
+                    'positive_pairs': ['name0/name0_0002']
+                })]
+            ),
+            DatasetItem(id='name0_0002', subset='test',
+                image=np.ones((2, 5, 3)),
+                annotations=[Label(0, attributes={
+                    'positive_pairs': ['name0/name0_0001'],
+                    'negative_pairs': ['name1/name1_0001']
+                })]
+            ),
+            DatasetItem(id='name1_0001', subset='test',
+                image=np.ones((2, 5, 3)),
+                annotations=[Label(1, attributes={})]
+            ),
+        ], categories=['name0', 'name1'])
+
+        with TestDir() as test_dir:
+            LfwConverter.convert(source_dataset, test_dir,
+                save_images=False)
+            parsed_dataset = Dataset.import_from(test_dir, 'lfw')
+
+            compare_datasets(self, source_dataset, parsed_dataset)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_with_landmarks(self):

--- a/tests/test_lfw_format.py
+++ b/tests/test_lfw_format.py
@@ -45,11 +45,16 @@ class LfwFormatTest(TestCase):
             ),
         ], categories=['name0', 'name1'])
 
-        with TestDir() as test_dir:
-            LfwConverter.convert(source_dataset, test_dir, save_images=True)
-            parsed_dataset = Dataset.import_from(test_dir, 'lfw')
+        save_images_options = {True, False}
+        for save_images in save_images_options:
+            with self.subTest(save_images=save_images):
+                with TestDir() as test_dir:
+                    LfwConverter.convert(source_dataset, test_dir,
+                        save_images=save_images)
+                    parsed_dataset = Dataset.import_from(test_dir, 'lfw')
 
-            compare_datasets(self, source_dataset, parsed_dataset)
+                    compare_datasets(self, source_dataset, parsed_dataset,
+                        require_images=save_images)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_with_landmarks(self):

--- a/tests/test_lfw_format.py
+++ b/tests/test_lfw_format.py
@@ -46,14 +46,13 @@ class LfwFormatTest(TestCase):
         ], categories=['name0', 'name1'])
 
         for save_images in (True, False):
-            with self.subTest(save_images=save_images):
-                with TestDir() as test_dir:
-                    LfwConverter.convert(source_dataset, test_dir,
-                        save_images=save_images)
-                    parsed_dataset = Dataset.import_from(test_dir, 'lfw')
+            with self.subTest(save_images=save_images), TestDir() as test_dir:
+                LfwConverter.convert(source_dataset, test_dir,
+                    save_images=save_images)
+                parsed_dataset = Dataset.import_from(test_dir, 'lfw')
 
-                    compare_datasets(self, source_dataset, parsed_dataset,
-                        require_images=save_images)
+                compare_datasets(self, source_dataset, parsed_dataset,
+                    require_images=save_images)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_with_landmarks(self):

--- a/tests/test_lfw_format.py
+++ b/tests/test_lfw_format.py
@@ -45,8 +45,7 @@ class LfwFormatTest(TestCase):
             ),
         ], categories=['name0', 'name1'])
 
-        save_images_options = {True, False}
-        for save_images in save_images_options:
+        for save_images in (True, False):
             with self.subTest(save_images=save_images):
                 with TestDir() as test_dir:
                     LfwConverter.convert(source_dataset, test_dir,

--- a/tests/test_mot_format.py
+++ b/tests/test_mot_format.py
@@ -103,6 +103,37 @@ class MotConverterTest(TestCase):
                 test_dir, target_dataset=target_dataset, require_images=True)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_and_load_with_no_save_images(self):
+        source_dataset = Dataset.from_iterable([
+            DatasetItem(id=1,
+                image=np.ones((16, 16, 3)),
+                annotations=[
+                    Bbox(0, 4, 4, 8, label=0, attributes={
+                        'occluded': True,
+                        'visibility': 0.0,
+                        'ignored': False,
+                    }),
+                ]
+            ),
+
+            DatasetItem(id=2,
+                image=np.ones((8, 8, 3)),
+                annotations=[
+                    Bbox(1, 2, 4, 2, label=1, attributes={
+                        'occluded': False,
+                        'visibility': 1.0,
+                        'ignored': False,
+                    }),
+                ]
+            ),
+        ], categories=['label_0', 'label_1'])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(source_dataset,
+                partial(MotSeqGtConverter.convert, save_images=False),
+                test_dir)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_image_with_arbitrary_extension(self):
         expected = Dataset.from_iterable([
             DatasetItem('1', image=Image(

--- a/tests/test_mots_format.py
+++ b/tests/test_mots_format.py
@@ -73,6 +73,22 @@ class MotsPngConverterTest(TestCase):
                 test_dir, target_dataset=target)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_and_load_with_no_save_images(self):
+        source_dataset = Dataset.from_iterable([
+            DatasetItem(id=1, subset='a', image=np.ones((5, 1)), annotations=[
+                Mask(np.array([[1, 1, 0, 0, 0]]), label=0,
+                    attributes={'track_id': 3}),
+                Mask(np.array([[0, 0, 1, 1, 1]]), label=1,
+                    attributes={'track_id': 3}),
+            ]),
+        ], categories=['label_0', 'label_1'])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(source_dataset,
+                partial(MotsPngConverter.convert, save_images=False),
+                test_dir)
+ 
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_dataset_with_cyrillic_and_spaces_in_filename(self):
         source = Dataset.from_iterable([
             DatasetItem(id='кириллица с пробелом', subset='a',

--- a/tests/test_mots_format.py
+++ b/tests/test_mots_format.py
@@ -87,7 +87,7 @@ class MotsPngConverterTest(TestCase):
             self._test_save_and_load(source_dataset,
                 partial(MotsPngConverter.convert, save_images=False),
                 test_dir)
- 
+
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_dataset_with_cyrillic_and_spaces_in_filename(self):
         source = Dataset.from_iterable([

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -63,11 +63,15 @@ class WiderFaceFormatTest(TestCase):
             DatasetItem(id='4', subset='val', image=np.ones((8, 8, 3))),
         ], categories=['face', 'label_0', 'label_1'])
 
-        with TestDir() as test_dir:
-            WiderFaceConverter.convert(source_dataset, test_dir, save_images=True)
-            parsed_dataset = Dataset.import_from(test_dir, 'wider_face')
+        for save_images in (True, False):
+            with self.subTest():
+                with TestDir() as test_dir:
+                    WiderFaceConverter.convert(source_dataset, test_dir,
+                        save_images=save_images)
+                    parsed_dataset = Dataset.import_from(test_dir, 'wider_face')
 
-            compare_datasets(self, source_dataset, parsed_dataset)
+                    compare_datasets(self, source_dataset, parsed_dataset,
+                        require_images=save_images)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_dataset_with_no_subsets(self):

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -64,14 +64,13 @@ class WiderFaceFormatTest(TestCase):
         ], categories=['face', 'label_0', 'label_1'])
 
         for save_images in (True, False):
-            with self.subTest():
-                with TestDir() as test_dir:
-                    WiderFaceConverter.convert(source_dataset, test_dir,
-                        save_images=save_images)
-                    parsed_dataset = Dataset.import_from(test_dir, 'wider_face')
+            with self.subTest(save_images=save_images), TestDir() as test_dir:
+                WiderFaceConverter.convert(source_dataset, test_dir,
+                    save_images=save_images)
+                parsed_dataset = Dataset.import_from(test_dir, 'wider_face')
 
-                    compare_datasets(self, source_dataset, parsed_dataset,
-                        require_images=save_images)
+                compare_datasets(self, source_dataset, parsed_dataset,
+                    require_images=save_images)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_dataset_with_no_subsets(self):

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -63,14 +63,35 @@ class WiderFaceFormatTest(TestCase):
             DatasetItem(id='4', subset='val', image=np.ones((8, 8, 3))),
         ], categories=['face', 'label_0', 'label_1'])
 
-        for save_images in (True, False):
-            with self.subTest(save_images=save_images), TestDir() as test_dir:
-                WiderFaceConverter.convert(source_dataset, test_dir,
-                    save_images=save_images)
-                parsed_dataset = Dataset.import_from(test_dir, 'wider_face')
+        with TestDir() as test_dir:
+            WiderFaceConverter.convert(source_dataset, test_dir,
+                save_images=True)
+            parsed_dataset = Dataset.import_from(test_dir, 'wider_face')
 
-                compare_datasets(self, source_dataset, parsed_dataset,
-                    require_images=save_images)
+            compare_datasets(self, source_dataset, parsed_dataset,
+                require_images=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_and_load_with_no_save_images(self):
+        source_dataset = Dataset.from_iterable([
+            DatasetItem(id='1', subset='train', image=np.ones((8, 8, 3)),
+                annotations=[
+                    Bbox(0, 2, 4, 2, label=1),
+                    Bbox(0, 1, 2, 3, label=0, attributes={
+                        'blur': '2', 'expression': '0', 'illumination': '0',
+                        'occluded': '0', 'pose': '2', 'invalid': '0'}),
+                    Label(1),
+                ]
+            )
+        ], categories=['face', 'label_0'])
+
+        with TestDir() as test_dir:
+            WiderFaceConverter.convert(source_dataset, test_dir,
+                save_images=False)
+            parsed_dataset = Dataset.import_from(test_dir, 'wider_face')
+
+            compare_datasets(self, source_dataset, parsed_dataset)
+
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_dataset_with_no_subsets(self):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Some formats does not have tests for importing dataset without images. So I added such tests.
And also fixed Kitti format.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
