### PR TITLE
Use variable annotations instead of attrib(type=...)

### DIFF
--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -381,7 +381,7 @@ class PolyLine(_Shape):
 @attrs(init=False)
 class Cuboid3d(Annotation):
     _type = AnnotationType.cuboid_3d
-    _points = attrib(type=list, default=None)
+    _points: list = attrib(default=None)
     label = attrib(converter=attr.converters.optional(int),
         default=None, kw_only=True)
 
@@ -555,7 +555,7 @@ class Points(_Shape):
 
     _type = AnnotationType.points
 
-    visibility = attrib(type=list, default=None)
+    visibility: list = attrib(default=None)
     @visibility.validator
     def _visibility_validator(self, attribute, visibility):
         if visibility is None:

--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -31,19 +31,19 @@ DEFAULT_SUBSET_NAME = 'default'
 
 @attrs
 class DatasetItem:
-    id = attrib(converter=lambda x: str(x).replace('\\', '/'),
-        type=str, validator=not_empty)
+    id: str = attrib(converter=lambda x: str(x).replace('\\', '/'),
+        validator=not_empty)
     annotations = attrib(factory=list, validator=default_if_none(list))
-    subset = attrib(converter=lambda v: v or DEFAULT_SUBSET_NAME,
-        type=str, default=None)
+    subset: str = attrib(converter=lambda v: v or DEFAULT_SUBSET_NAME,
+        default=None)
 
     # TODO: introduce "media" field with type info. Replace image and pcd.
-    image = attrib(type=Optional[Image], default=None)
+    image: Optional[Image] = attrib(default=None)
     # TODO: introduce pcd type like Image
-    point_cloud = attrib(converter=lambda x: \
-            str(x).replace('\\', '/') if x else None,
-        type=Optional[str], default=None)
-    related_images = attrib(type=List[Image], default=None)
+    point_cloud: Optional[str] = attrib(
+        converter=lambda x: str(x).replace('\\', '/') if x else None,
+        default=None)
+    related_images: List[Image] = attrib(default=None)
 
     def __attrs_post_init__(self):
         if (self.has_image and self.has_point_cloud):

--- a/datumaro/components/operations.py
+++ b/datumaro/components/operations.py
@@ -644,7 +644,7 @@ class IntersectMerge(MergingStrategy):
 
 @attrs(kw_only=True)
 class AnnotationMatcher:
-    _context = attrib(type=IntersectMerge, default=None)
+    _context: Optional[IntersectMerge] = attrib(default=None)
 
     def match_annotations(self, sources):
         raise NotImplementedError()
@@ -753,7 +753,7 @@ class MaskMatcher(_ShapeMatcher):
 
 @attrs(kw_only=True)
 class PointsMatcher(_ShapeMatcher):
-    sigma = attrib(type=list, default=None)
+    sigma: Optional[list] = attrib(default=None)
     instance_map = attrib(converter=dict)
 
     def distance(self, a, b):
@@ -1357,7 +1357,7 @@ def match_classes(a: CategoriesInfo, b: CategoriesInfo):
 
 @attrs
 class ExactComparator:
-    match_images = attrib(kw_only=True, type=bool, default=False)
+    match_images: bool = attrib(kw_only=True, default=False)
     ignored_fields = attrib(kw_only=True,
         factory=set, validator=default_if_none(set))
     ignored_attrs = attrib(kw_only=True,
@@ -1365,8 +1365,8 @@ class ExactComparator:
     ignored_item_attrs = attrib(kw_only=True,
         factory=set, validator=default_if_none(set))
 
-    _test = attrib(init=False, type=TestCase)
-    errors = attrib(init=False, type=list)
+    _test: TestCase = attrib(init=False)
+    errors: list = attrib(init=False)
 
     def __attrs_post_init__(self):
         self._test = TestCase()


### PR DESCRIPTION
### Summary

The attrs documentation says that this approach is preferred for Python 3.6+, and the next-generation API (`attr.field`) doesn't include the `type` argument at all.

In the cases of `AnnotationMatcher._context` and `PointsMatcher.sigma`, change the type to `Optional`, since otherwise the default value won't match it.

Related to #310.

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
