### PR TITLE
Sk/fix kitti

### DIFF
--- a/datumaro/plugins/kitti_format/converter.py
+++ b/datumaro/plugins/kitti_format/converter.py
@@ -115,7 +115,8 @@ class KittiConverter(Converter):
 
                     # TODO: optimize second merging
                     compiled_instance_mask = CompiledMask.from_instance_masks(masks,
-                        instance_labels=[(m.label << 8) + m.id for m in masks])
+                        instance_labels=[(self._label_id_mapping(m.label) << 8) \
+                            + m.id for m in masks])
                     inst_path = osp.join(subset_name,
                         KittiPath.INSTANCES_DIR, item.id + KittiPath.MASK_EXT)
                     self.save_mask(osp.join(self._save_dir, inst_path),

--- a/datumaro/plugins/kitti_format/extractor.py
+++ b/datumaro/plugins/kitti_format/extractor.py
@@ -7,7 +7,7 @@ import os.path as osp
 
 import numpy as np
 
-from datumaro.components.annotation import Bbox, Mask
+from datumaro.components.annotation import Bbox, Mask, LabelCategories
 from datumaro.components.extractor import (
     AnnotationType, DatasetItem, SourceExtractor,
 )
@@ -37,7 +37,16 @@ class _KittiExtractor(SourceExtractor):
         if self._task == KittiTask.segmentation:
             return self._load_categories_segmentation(path)
         elif self._task == KittiTask.detection:
-            return make_kitti_detection_categories()
+            return self._load_categories_detection(path)
+
+    def _load_categories_detection(self, path):
+        labels_list_path = osp.join(path, KittiPath.LABELS_LIST_FILE)
+        if osp.isfile(labels_list_path):
+            labels_cat = LabelCategories().from_iterable(
+                parse_label_map(labels_list_path).keys())
+            return {AnnotationType.label: labels_cat}
+        else:
+             return make_kitti_detection_categories()
 
     def _load_categories_segmentation(self, path):
         label_map = None

--- a/datumaro/plugins/kitti_format/format.py
+++ b/datumaro/plugins/kitti_format/format.py
@@ -75,6 +75,7 @@ class KittiPath:
     MASK_EXT = '.png'
 
     LABELMAP_FILE = 'label_colors.txt'
+    LABELS_LIST_FILE = 'labels.txt'
 
     DEFAULT_TRUNCATED = 0.0 # 0% truncated
     DEFAULT_OCCLUDED = 0    # fully visible
@@ -143,3 +144,8 @@ def write_label_map(path, label_map):
             else:
                 color_rgb = ''
             f.write('%s %s\n' % (color_rgb, label_name))
+
+def write_labels_list(path, labels):
+    with open(path, 'w', encoding='utf-8') as f:
+        for label in labels:
+            f.write('%s\n' % label)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
* Allowed to load not original KITTI labels for detection task
* Fixed labels `id` for exporting masks

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
