### PR TITLE
Fix checkout call without args

### DIFF
--- a/datumaro/cli/commands/checkout.py
+++ b/datumaro/cli/commands/checkout.py
@@ -20,8 +20,11 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         |n
         1 - Restores a revision and all the sources in the working directory.|n
         2, 3 - Restores only specified sources from the specified revision.|n
-        |s|sThe current revision is used, when not set.|n
-        |s|s"--" is optionally used to separate source names and revisions.|n
+        |n
+        The current revision is used, when not set. When no revision
+        and no sources is specified, restores the
+        current revision (like the 1-st form).
+        "--" is optionally used to separate source names and revisions.|n
         |n
         Examples:|n
         - Restore the previous revision:|n

--- a/datumaro/components/project.py
+++ b/datumaro/components/project.py
@@ -913,7 +913,7 @@ class GitWrapper:
         with suppress(Exception):
             self.close()
 
-    def checkout(self, ref: str = None, dst_dir=None, clean=False, force=False):
+    def checkout(self, ref: str, dst_dir=None, clean=False, force=False):
         # If user wants to navigate to a head, we need to supply its object
         # insted of just a string. Otherwise, we'll get a detached head.
         try:
@@ -2206,10 +2206,17 @@ class Project:
             sources: Union[None, str, Iterable[str]] = None, *,
             force: bool = False):
         """
-        Copies tree and objects from cache to working tree.
+        Copies tree and objects from the cache to the working tree.
 
-        Sets HEAD to the specified revision, unless targets specified.
-        When sources specified, only copies objects from cache to working tree.
+        Sets HEAD to the specified revision, unless sources specified.
+        When sources specified, only copies objects from the cache to
+        the working tree. When no revision and no sources is specified,
+        restores the sources from the current revision.
+
+        By default, uses the current (HEAD) revision.
+
+        Options:
+        - force (bool) - ignore unsaved changes. By default, an error is raised
         """
 
         if self.readonly:
@@ -2222,8 +2229,10 @@ class Project:
         else:
             sources = set(sources)
 
+        rev = rev or 'HEAD'
+
         if sources:
-            rev_tree = self.get_rev(rev or 'HEAD')
+            rev_tree = self.get_rev(rev)
 
             # Check targets
             for s in sources:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Fixed errors on `datum checkout` calls without args

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
