### PR TITLE
Make it easier to access a plugin's name

### DIFF
--- a/datumaro/components/cli_plugin.py
+++ b/datumaro/components/cli_plugin.py
@@ -29,11 +29,14 @@ def remove_plugin_type(s):
         s = s.replace('_' + t, '')
     return s
 
+class _PluginNameDescriptor:
+    def __get__(self, obj, objtype=None):
+        if not objtype:
+            objtype = type(obj)
+        return remove_plugin_type(to_snake_case(objtype.__name__))
+
 class CliPlugin:
-    @staticmethod
-    def _get_name(cls):
-        return getattr(cls, 'NAME',
-            remove_plugin_type(to_snake_case(cls.__name__)))
+    NAME = _PluginNameDescriptor()
 
     @staticmethod
     def _get_doc(cls):
@@ -46,7 +49,7 @@ class CliPlugin:
     @classmethod
     def build_cmdline_parser(cls, **kwargs):
         args = {
-            'prog': cls._get_name(cls),
+            'prog': cls.NAME,
             'description': cls._get_doc(cls),
             'formatter_class': MultilineFormatter,
         }

--- a/datumaro/components/environment.py
+++ b/datumaro/components/environment.py
@@ -10,7 +10,7 @@ import inspect
 import logging as log
 import os.path as osp
 
-from datumaro.components.cli_plugin import CliPlugin, plugin_types
+from datumaro.components.cli_plugin import plugin_types
 from datumaro.util.os_util import import_foreign_module, split_path
 
 
@@ -47,9 +47,8 @@ class PluginRegistry(Registry):
         for v in values:
             if self.filter and not self.filter(v):
                 continue
-            name = CliPlugin._get_name(v)
 
-            self.register(name, v)
+            self.register(v.NAME, v)
 
 class Environment:
     _builtin_plugins = None

--- a/datumaro/plugins/ade20k2017_format.py
+++ b/datumaro/plugins/ade20k2017_format.py
@@ -145,5 +145,7 @@ class Ade20k2017Importer(Importer):
         for i in range(5):
             for i in glob.iglob(osp.join(path, *('*' * i))):
                     if osp.splitext(i)[1].lower() in IMAGE_EXTENSIONS:
-                        return [{'url': path, 'format': 'ade20k2017'}]
+                        return [{
+                            'url': path, 'format': Ade20k2017Extractor.NAME,
+                        }]
         return []

--- a/datumaro/plugins/ade20k2020_format.py
+++ b/datumaro/plugins/ade20k2020_format.py
@@ -179,5 +179,7 @@ class Ade20k2020Importer(Importer):
         for i in range(5):
             for i in glob.iglob(osp.join(path, *('*' * i))):
                     if osp.splitext(i)[1].lower() in IMAGE_EXTENSIONS:
-                        return [{'url': path, 'format': 'ade20k2020'}]
+                        return [{
+                            'url': path, 'format': Ade20k2020Extractor.NAME,
+                        }]
         return []

--- a/datumaro/plugins/coco_format/importer.py
+++ b/datumaro/plugins/coco_format/importer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -7,6 +7,11 @@ import logging as log
 import os.path as osp
 
 from datumaro.components.extractor import DEFAULT_SUBSET_NAME, Importer
+from datumaro.plugins.coco_format.extractor import (
+    CocoCaptionsExtractor, CocoImageInfoExtractor, CocoInstancesExtractor,
+    CocoLabelsExtractor, CocoPanopticExtractor, CocoPersonKeypointsExtractor,
+    CocoStuffExtractor,
+)
 from datumaro.util.log_utils import logging_disabled
 
 from .format import CocoTask
@@ -14,13 +19,13 @@ from .format import CocoTask
 
 class CocoImporter(Importer):
     _TASKS = {
-        CocoTask.instances: 'coco_instances',
-        CocoTask.person_keypoints: 'coco_person_keypoints',
-        CocoTask.captions: 'coco_captions',
-        CocoTask.labels: 'coco_labels',
-        CocoTask.image_info: 'coco_image_info',
-        CocoTask.panoptic: 'coco_panoptic',
-        CocoTask.stuff: 'coco_stuff',
+        CocoTask.instances: CocoInstancesExtractor,
+        CocoTask.person_keypoints: CocoPersonKeypointsExtractor,
+        CocoTask.captions: CocoCaptionsExtractor,
+        CocoTask.labels: CocoLabelsExtractor,
+        CocoTask.image_info: CocoImageInfoExtractor,
+        CocoTask.panoptic: CocoPanopticExtractor,
+        CocoTask.stuff: CocoStuffExtractor,
     }
 
     @classmethod
@@ -69,7 +74,7 @@ class CocoImporter(Importer):
 
                 sources.append({
                     'url': ann_file,
-                    'format': self._TASKS[ann_type],
+                    'format': self._TASKS[ann_type].NAME,
                     'options': dict(extra_params),
                 })
 
@@ -102,7 +107,7 @@ class CocoImporter(Importer):
             if ann_type not in cls._TASKS:
                 log.warning("File '%s' was skipped, could't match this file "
                     "with any of these tasks: %s" %
-                    (subset_path, ','.join(e for e in cls._TASKS.values()))
+                    (subset_path, ','.join(e.NAME for e in cls._TASKS.values()))
                 )
                 continue
 

--- a/datumaro/plugins/image_dir_format.py
+++ b/datumaro/plugins/image_dir_format.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -16,7 +16,7 @@ class ImageDirImporter(Importer):
     def find_sources(cls, path):
         if not osp.isdir(path):
             return []
-        return [{ 'url': path, 'format': 'image_dir' }]
+        return [{ 'url': path, 'format': ImageDirExtractor.NAME }]
 
 class ImageDirExtractor(SourceExtractor):
     def __init__(self, url, subset=None, max_depth=None, exts=None):

--- a/datumaro/plugins/imagenet_format.py
+++ b/datumaro/plugins/imagenet_format.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -60,7 +60,7 @@ class ImagenetImporter(Importer):
     def find_sources(cls, path):
         if not osp.isdir(path):
             return []
-        return [{ 'url': path, 'format': 'imagenet' }]
+        return [{ 'url': path, 'format': ImagenetExtractor.NAME }]
 
 
 class ImagenetConverter(Converter):

--- a/datumaro/plugins/labelme_format.py
+++ b/datumaro/plugins/labelme_format.py
@@ -273,8 +273,6 @@ class LabelMeExtractor(Extractor):
 
 
 class LabelMeImporter(Importer):
-    EXTRACTOR = 'label_me'
-
     @classmethod
     def find_sources(cls, path):
         subsets = []
@@ -283,7 +281,9 @@ class LabelMeImporter(Importer):
 
         try:
             next(iglob(osp.join(path, '**', '*.xml'), recursive=True))
-            subsets.append({'url': osp.normpath(path), 'format': cls.EXTRACTOR})
+            subsets.append({
+                'url': osp.normpath(path), 'format': LabelMeExtractor.NAME,
+            })
         except StopIteration:
             pass
         return subsets

--- a/datumaro/plugins/market1501_format.py
+++ b/datumaro/plugins/market1501_format.py
@@ -100,7 +100,7 @@ class Market1501Importer(Importer):
     def find_sources(cls, path):
         if not osp.isdir(path):
             return []
-        return [{ 'url': path, 'format': 'market1501' }]
+        return [{ 'url': path, 'format': Market1501Extractor.NAME }]
 
 class Market1501Converter(Converter):
     DEFAULT_IMAGE_EXT = Market1501Path.IMAGE_EXT

--- a/datumaro/plugins/mots_format.py
+++ b/datumaro/plugins/mots_format.py
@@ -36,7 +36,7 @@ class MotsPngExtractor(SourceExtractor):
     @staticmethod
     def detect_dataset(path):
         if osp.isdir(osp.join(path, MotsPath.MASKS_DIR)):
-            return [{'url': path, 'format': 'mots_png'}]
+            return [{'url': path, 'format': MotsPngExtractor.NAME}]
         return []
 
     def __init__(self, path, subset=None):

--- a/datumaro/plugins/open_images_format.py
+++ b/datumaro/plugins/open_images_format.py
@@ -562,7 +562,7 @@ class OpenImagesImporter(Importer):
         ]:
             if glob.glob(osp.join(glob.escape(path),
                     OpenImagesPath.ANNOTATIONS_DIR, pattern)):
-                return [{'url': path, 'format': 'open_images'}]
+                return [{'url': path, 'format': OpenImagesExtractor.NAME}]
 
         return []
 

--- a/datumaro/plugins/transforms.py
+++ b/datumaro/plugins/transforms.py
@@ -226,7 +226,7 @@ class MasksToPolygons(ItemTransform, CliPlugin):
                     log.debug("[%s]: item %s: "
                         "Mask conversion to polygons resulted in too "
                         "small polygons, which were discarded" % \
-                        (self._get_name(__class__), item.id))
+                        (self.NAME, item.id))
                 annotations.extend(polygons)
             else:
                 annotations.append(ann)

--- a/datumaro/plugins/vgg_face2_format.py
+++ b/datumaro/plugins/vgg_face2_format.py
@@ -163,12 +163,16 @@ class VggFace2Importer(Importer):
         if osp.isdir(path):
             annotation_dir = osp.join(path, VggFace2Path.ANNOTATION_DIR)
             if osp.isdir(annotation_dir):
-                return [{'url': annotation_dir, 'format': 'vgg_face2'}]
+                return [{
+                    'url': annotation_dir, 'format': VggFace2Extractor.NAME,
+                }]
         elif osp.isfile(path):
             if (osp.basename(path).startswith(VggFace2Path.LANDMARKS_FILE) or \
                         osp.basename(path).startswith(VggFace2Path.BBOXES_FILE)) and \
                     path.endswith('.csv'):
-                return [{'url': path, 'format': 'vgg_face2'}]
+                return [{
+                    'url': path, 'format': VggFace2Extractor.NAME,
+                }]
         return []
 
 class VggFace2Converter(Converter):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
`CliPlugin._get_name` is a cumbersome and seemingly private API for something that should be easily accessible. For classes that override their plugin name you can already access it by `cls.NAME`; make that available for all classes
by defining a class attribute in `CliPlugin`.

Use this feature to unhardcode the extractor plugin names in importer implementations. This way, the link between importers and extractors is made more explicit.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
