### PR TITLE
Add more dataset format detectors

### DIFF
--- a/datumaro/components/format_detection.py
+++ b/datumaro/components/format_detection.py
@@ -126,22 +126,22 @@ class FormatDetectionContext:
         unspecified which one of them is returned.
         """
 
-        requirement_str = \
+        requirement_desc = \
             f"dataset must contain a file matching pattern \"{pattern}\""
 
         if not self._is_path_within_root(pattern):
-            self.fail(requirement_str)
+            self.fail(requirement_desc)
 
         pattern_abs = osp.join(glob.escape(self._root_path), pattern)
         for path in glob.iglob(pattern_abs, recursive=True):
             if osp.isfile(path):
                 return osp.relpath(path, self._root_path)
 
-        self.fail(requirement_str)
+        self.fail(requirement_desc)
 
     @contextlib.contextmanager
     def probe_text_file(
-        self, path: str, requirement_str: str,
+        self, path: str, requirement_desc: str,
     ) -> Iterator[TextIO]:
         """
         Returns a context manager that can be used to place a requirement on
@@ -163,14 +163,14 @@ class FormatDetectionContext:
         requirement being unmet, that exception is reraised and the new
         requirement is abandoned.
 
-        `requirement_str` must be a human-readable statement describing the
+        `requirement_desc` must be a human-readable statement describing the
         requirement.
         """
 
-        requirement_str_full = f"{path}: {requirement_str}"
+        requirement_desc_full = f"{path}: {requirement_desc}"
 
         if not self._is_path_within_root(path):
-            self.fail(requirement_str_full)
+            self.fail(requirement_desc_full)
 
         try:
             with open(osp.join(self._root_path, path), encoding='utf-8') as f:
@@ -178,7 +178,7 @@ class FormatDetectionContext:
         except FormatRequirementsUnmet:
             raise
         except Exception:
-            self.fail(requirement_str_full)
+            self.fail(requirement_desc_full)
 
 
 FormatDetector = Callable[

--- a/datumaro/components/format_detection.py
+++ b/datumaro/components/format_detection.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 from enum import IntEnum
-from typing import Callable, Optional, Sequence
+from typing import Callable, Iterator, Optional, Sequence, TextIO
+import contextlib
 import glob
 import os.path as osp
 
@@ -84,6 +85,27 @@ class FormatDetectionContext:
         """
         return self._root_path
 
+    def _is_path_within_root(self, path: str) -> bool:
+        """
+        Checks that `path` is a relative path and does not attempt to leave
+        the dataset root by using `..` segments.
+
+        Requirement-placing methods that use this to verify their arguments
+        should raise a FormatRequirementsUnmet rather than a "hard" error like
+        AssertionError if False is returned. The reason is that the path passed
+        by the detector might not have been hardcoded, and instead might have
+        been acquired from another file in the dataset. In that case, an invalid
+        pattern signifies a problem with the dataset, not with the detector.
+        """
+        if osp.isabs(path) or osp.splitdrive(path)[0]:
+            return False
+
+        path = osp.normpath(path)
+        if path.startswith('..' + osp.sep):
+            return False
+
+        return True
+
     def fail(self, requirement: str) -> NoReturn:
         """
         Places a requirement that is never met. `requirement` must contain
@@ -107,15 +129,7 @@ class FormatDetectionContext:
         requirement_str = \
             f"dataset must contain a file matching pattern \"{pattern}\""
 
-        # These pattern checks raise a FormatRequirementsUnmet rather than an
-        # AssertionError, because the detector might have gotten the pattern
-        # from another file in the dataset. In that case, an invalid pattern
-        # signifies a problem with the dataset, rather than with the detector.
-        if osp.isabs(pattern) or osp.splitdrive(pattern)[0]:
-            self.fail(requirement_str)
-
-        pattern = osp.normpath(pattern)
-        if pattern.startswith('..' + osp.sep):
+        if not self._is_path_within_root(pattern):
             self.fail(requirement_str)
 
         pattern_abs = osp.join(glob.escape(self._root_path), pattern)
@@ -124,6 +138,48 @@ class FormatDetectionContext:
                 return osp.relpath(path, self._root_path)
 
         self.fail(requirement_str)
+
+    @contextlib.contextmanager
+    def probe_text_file(
+        self, path: str, requirement_str: str,
+    ) -> Iterator[TextIO]:
+        """
+        Returns a context manager that can be used to place a requirement on
+        the contents of the file referred to by `path`. To do so, you must
+        enter and exit this context manager (typically, by using the `with`
+        statement). On entering, the file is opened for reading in text mode and
+        the resulting file object is returned. On exiting, the file object is
+        closed.
+
+        The requirement that is placed by doing this is considered met if all
+        of the following are true:
+
+        * `path` is a relative path that refers to a file within the dataset
+          root.
+        * The file is opened successfully.
+        * The context is exited without an exception.
+
+        If the context is exited with an exception that was produced by another
+        requirement being unmet, that exception is reraised and the new
+        requirement is abandoned.
+
+        `requirement_str` must be a human-readable statement describing the
+        requirement.
+        """
+
+        requirement_str_full = f"{path}: {requirement_str}"
+
+        if not self._is_path_within_root(path):
+            self.fail(requirement_str_full)
+
+        try:
+            with open(osp.join(self._root_path, path), encoding='utf-8') as f:
+                yield f
+        except FormatRequirementsUnmet:
+            raise
+        except Exception:
+            self.fail(requirement_str_full)
+
 
 FormatDetector = Callable[
     [FormatDetectionContext],

--- a/datumaro/plugins/ade20k2017_format.py
+++ b/datumaro/plugins/ade20k2017_format.py
@@ -14,6 +14,7 @@ from datumaro.components.annotation import (
     AnnotationType, CompiledMask, LabelCategories, Mask,
 )
 from datumaro.components.extractor import DatasetItem, Extractor, Importer
+from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.util.image import (
     IMAGE_EXTENSIONS, find_images, lazy_image, load_image,
 )
@@ -140,6 +141,10 @@ class Ade20k2017Extractor(Extractor):
         return instance_mask
 
 class Ade20k2017Importer(Importer):
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> None:
+        context.require_file('*/**/*_atr.txt')
+
     @classmethod
     def find_sources(cls, path):
         for i in range(5):

--- a/datumaro/plugins/ade20k2020_format.py
+++ b/datumaro/plugins/ade20k2020_format.py
@@ -180,7 +180,7 @@ class Ade20k2020Importer(Importer):
         annot_path = context.require_file('*/**/*.json')
 
         with context.probe_text_file(
-            annot_path, "must be an ADE20K JSON annotation file",
+            annot_path, "must be a JSON object with an \"annotation\" key",
         ) as f:
             contents = json.load(f)
             if not isinstance(contents, dict):

--- a/datumaro/plugins/ade20k2020_format.py
+++ b/datumaro/plugins/ade20k2020_format.py
@@ -15,6 +15,7 @@ from datumaro.components.annotation import (
     AnnotationType, CompiledMask, LabelCategories, Mask, Polygon,
 )
 from datumaro.components.extractor import DatasetItem, Extractor, Importer
+from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.util.image import (
     IMAGE_EXTENSIONS, find_images, lazy_image, load_image,
 )
@@ -174,6 +175,19 @@ class Ade20k2020Extractor(Extractor):
         return mask
 
 class Ade20k2020Importer(Importer):
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> None:
+        annot_path = context.require_file('*/**/*.json')
+
+        with context.probe_text_file(
+            annot_path, "must be an ADE20K JSON annotation file",
+        ) as f:
+            contents = json.load(f)
+            if not isinstance(contents, dict):
+                raise Exception
+            if 'annotation' not in contents:
+                raise Exception
+
     @classmethod
     def find_sources(cls, path):
         for i in range(5):

--- a/datumaro/plugins/cvat_format/extractor.py
+++ b/datumaro/plugins/cvat_format/extractor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -11,6 +11,7 @@ from datumaro.components.annotation import (
     AnnotationType, Bbox, Label, LabelCategories, Points, Polygon, PolyLine,
 )
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
+from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.media import Image
 
 from .format import CvatPath
@@ -315,6 +316,17 @@ class CvatExtractor(SourceExtractor):
         return parsed
 
 class CvatImporter(Importer):
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> None:
+        annot_file = context.require_file('*.xml')
+
+        with context.probe_text_file(
+            annot_file, "must be a CVAT annotation file",
+        ) as f:
+            _, root_elem = next(ElementTree.iterparse(f, events=('start',)))
+            if root_elem.tag != 'annotations':
+                raise Exception
+
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(path, '.xml', 'cvat')

--- a/datumaro/plugins/cvat_format/extractor.py
+++ b/datumaro/plugins/cvat_format/extractor.py
@@ -321,7 +321,7 @@ class CvatImporter(Importer):
         annot_file = context.require_file('*.xml')
 
         with context.probe_text_file(
-            annot_file, "must be a CVAT annotation file",
+            annot_file, "must be an XML file with an \"annotations\" root element",
         ) as f:
             _, root_elem = next(ElementTree.iterparse(f, events=('start',)))
             if root_elem.tag != 'annotations':

--- a/datumaro/plugins/datumaro_format/extractor.py
+++ b/datumaro/plugins/datumaro_format/extractor.py
@@ -196,7 +196,8 @@ class DatumaroImporter(Importer):
         annot_file = context.require_file('annotations/*.json')
 
         with context.probe_text_file(
-            annot_file, "must be a Datumaro annotation file",
+            annot_file, "must be a JSON object with \"categories\" "
+                "and \"items\" keys",
         ) as f:
             contents = json.load(f)
             if not {'categories', 'items'} <= contents.keys():

--- a/datumaro/plugins/datumaro_format/extractor.py
+++ b/datumaro/plugins/datumaro_format/extractor.py
@@ -10,6 +10,7 @@ from datumaro.components.annotation import (
     MaskCategories, Points, PointsCategories, Polygon, PolyLine, RleMask,
 )
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
+from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.media import Image
 
 from .format import DatumaroPath
@@ -190,6 +191,17 @@ class DatumaroExtractor(SourceExtractor):
         return loaded
 
 class DatumaroImporter(Importer):
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> None:
+        annot_file = context.require_file('annotations/*.json')
+
+        with context.probe_text_file(
+            annot_file, "must be a Datumaro annotation file",
+        ) as f:
+            contents = json.load(f)
+            if not {'categories', 'items'} <= contents.keys():
+                raise Exception
+
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(path, '.json', 'datumaro',

--- a/datumaro/plugins/labelme_format.py
+++ b/datumaro/plugins/labelme_format.py
@@ -17,6 +17,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Extractor, Importer
+from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.media import Image
 from datumaro.util import cast, escape, unescape
 from datumaro.util.image import save_image
@@ -274,6 +275,34 @@ class LabelMeExtractor(Extractor):
 
 
 class LabelMeImporter(Importer):
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> None:
+        annot_file = context.require_file('**/*.xml')
+
+        with context.probe_text_file(
+            annot_file, "must be a LabelMe annotation file",
+        ) as f:
+            elem_parents = []
+
+            for event, elem in ElementTree.iterparse(f, events=('start', 'end')):
+                if event == 'start':
+                    if elem_parents == [] and elem.tag != 'annotation':
+                        raise Exception
+
+                    if elem_parents == ['annotation', 'object'] \
+                            and elem.tag in {'polygon', 'segm'}:
+                        return
+
+                    elem_parents.append(elem.tag)
+                elif event == 'end':
+                    elem_parents.pop()
+
+                    if elem_parents == ['annotation'] and elem.tag == 'object':
+                        # If we got here, then we found an object with no
+                        # polygon and no mask, so it's probably the wrong
+                        # format.
+                        raise Exception
+
     @classmethod
     def find_sources(cls, path):
         subsets = []

--- a/datumaro/plugins/mot_format.py
+++ b/datumaro/plugins/mot_format.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -16,6 +16,7 @@ import os.path as osp
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
+from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.media import Image
 from datumaro.util import cast
 from datumaro.util.image import find_images
@@ -199,6 +200,10 @@ class MotSeqExtractor(SourceExtractor):
         assert set(seq_info) == {'name', 'imdir', 'framerate', 'seqlength', 'imwidth', 'imheight', 'imext'}, seq_info
 
 class MotSeqImporter(Importer):
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> None:
+        context.require_file('gt/gt.txt')
+
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(path, '.txt', 'mot_seq',

--- a/datumaro/plugins/yolo_format/extractor.py
+++ b/datumaro/plugins/yolo_format/extractor.py
@@ -10,6 +10,7 @@ from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.extractor import (
     DatasetItem, Extractor, Importer, SourceExtractor,
 )
+from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.media import Image
 from datumaro.util.image import (
     DEFAULT_IMAGE_META_FILE_NAME, load_image_meta_file,
@@ -192,6 +193,10 @@ class YoloExtractor(SourceExtractor):
         return self._subsets[name]
 
 class YoloImporter(Importer):
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> None:
+        context.require_file('obj.data')
+
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(path, '.data', 'yolo')

--- a/tests/cli/test_revpath.py
+++ b/tests/cli/test_revpath.py
@@ -1,13 +1,8 @@
 from unittest.case import TestCase
 import os.path as osp
 
-from datumaro.cli.util.project import (
-    WrongRevpathError, parse_full_revpath, split_local_revpath,
-)
+from datumaro.cli.util.project import parse_full_revpath, split_local_revpath
 from datumaro.components.dataset import DEFAULT_FORMAT, Dataset, IDataset
-from datumaro.components.errors import (
-    MultipleFormatsMatchError, ProjectNotFoundError, UnknownTargetError,
-)
 from datumaro.components.extractor import DatasetItem
 from datumaro.components.project import Project
 from datumaro.util.scope import scope_add, scoped
@@ -95,12 +90,11 @@ class TestRevpath(TestCase):
             self.assertEqual(None, project)
 
         with self.subTest("dataset (in context)"):
-            with self.assertRaises(WrongRevpathError) as cm:
-                parse_full_revpath(dataset_url, proj)
-            self.assertEqual(
-                {UnknownTargetError, MultipleFormatsMatchError},
-                set(type(e) for e in cm.exception.problems)
-            )
+            dataset, project = parse_full_revpath(dataset_url, proj)
+            if project:
+                scope_add(project)
+            self.assertTrue(isinstance(dataset, IDataset))
+            self.assertEqual(None, project)
 
         with self.subTest("dataset format (in context)"):
             dataset, project = parse_full_revpath(
@@ -111,12 +105,11 @@ class TestRevpath(TestCase):
             self.assertEqual(None, project)
 
         with self.subTest("dataset (no context)"):
-            with self.assertRaises(WrongRevpathError) as cm:
-                parse_full_revpath(dataset_url)
-            self.assertEqual(
-                {ProjectNotFoundError, MultipleFormatsMatchError},
-                set(type(e) for e in cm.exception.problems)
-            )
+            dataset, project = parse_full_revpath(dataset_url)
+            if project:
+                scope_add(project)
+            self.assertTrue(isinstance(dataset, IDataset))
+            self.assertEqual(None, project)
 
         with self.subTest("dataset format (no context)"):
             dataset, project = parse_full_revpath(f"{dataset_url}:datumaro")

--- a/tests/test_ade20k2017_format.py
+++ b/tests/test_ade20k2017_format.py
@@ -21,7 +21,7 @@ class Ade20k2017ImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_399)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(Ade20k2017Importer.NAME, detected_formats)
+        self.assertEqual([Ade20k2017Importer.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_399)
     def test_can_import(self):

--- a/tests/test_ade20k2020_format.py
+++ b/tests/test_ade20k2020_format.py
@@ -23,7 +23,7 @@ class Ade20k2020ImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_399)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(Ade20k2020Importer.NAME, detected_formats)
+        self.assertEqual([Ade20k2020Importer.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_399)
     def test_can_import(self):

--- a/tests/test_cvat_format.py
+++ b/tests/test_cvat_format.py
@@ -30,12 +30,12 @@ class CvatImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_image(self):
         detected_formats = Environment().detect_dataset(DUMMY_IMAGE_DATASET_DIR)
-        self.assertIn(CvatImporter.NAME, detected_formats)
+        self.assertEqual([CvatImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_video(self):
         detected_formats = Environment().detect_dataset(DUMMY_VIDEO_DATASET_DIR)
-        self.assertIn(CvatImporter.NAME, detected_formats)
+        self.assertEqual([CvatImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_load_image(self):

--- a/tests/test_datumaro_format.py
+++ b/tests/test_datumaro_format.py
@@ -117,7 +117,7 @@ class DatumaroConverterTest(TestCase):
             DatumaroConverter.convert(self.test_dataset, save_dir=test_dir)
 
             detected_formats = Environment().detect_dataset(test_dir)
-            self.assertIn(DatumaroImporter.NAME, detected_formats)
+            self.assertEqual([DatumaroImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_relative_paths(self):

--- a/tests/test_icdar_format.py
+++ b/tests/test_icdar_format.py
@@ -30,7 +30,7 @@ class IcdarImporterTest(TestCase):
     def test_can_detect_word_recognition(self):
         detected_formats = Environment().detect_dataset(
             osp.join(DUMMY_DATASET_DIR, 'word_recognition'))
-        self.assertIn(IcdarWordRecognitionImporter.NAME, detected_formats)
+        self.assertEqual([IcdarWordRecognitionImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_text_localization(self):
@@ -42,7 +42,7 @@ class IcdarImporterTest(TestCase):
     def test_can_detect_text_segmentation(self):
         detected_formats = Environment().detect_dataset(
             osp.join(DUMMY_DATASET_DIR, 'text_segmentation'))
-        self.assertIn(IcdarTextSegmentationImporter.NAME, detected_formats)
+        self.assertEqual([IcdarTextSegmentationImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import_captions(self):

--- a/tests/test_kitti_raw_format.py
+++ b/tests/test_kitti_raw_format.py
@@ -25,7 +25,7 @@ class KittiRawImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(KittiRawImporter.NAME, detected_formats)
+        self.assertEqual([KittiRawImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_load(self):

--- a/tests/test_labelme_format.py
+++ b/tests/test_labelme_format.py
@@ -186,7 +186,7 @@ class LabelMeImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(LabelMeImporter.NAME, detected_formats)
+        self.assertEqual([LabelMeImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import(self):

--- a/tests/test_mot_format.py
+++ b/tests/test_mot_format.py
@@ -163,7 +163,7 @@ class MotImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(MotSeqImporter.NAME, detected_formats)
+        self.assertEqual([MotSeqImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import(self):

--- a/tests/test_yolo_format.py
+++ b/tests/test_yolo_format.py
@@ -185,7 +185,7 @@ class YoloImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(YoloImporter.NAME, detected_formats)
+        self.assertEqual([YoloImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import(self):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

Add detectors for a few more dataset formats:

* `ade20k2017`
* `ade20k2020`
* `cvat`
* `datumaro`
* `icdar_text_segmentation`
* `icdar_word_recognition`
* `kitti_raw`
* `label_me`
* `mot_seq`
* `yolo`

To support them, add a mechanism for placing requirements on file contents.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
