### PR TITLE
Move image classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/534>)
 
 ### Deprecated
-- TBD
+- Using `Image`, `ByteImage` from `datumaro.util.image` - these classes
+  are moved to `datumaro.components.media`
+  (<https://github.com/openvinotoolkit/datumaro/pull/538>)
 
 ### Removed
 - TBD

--- a/datumaro/components/converter.py
+++ b/datumaro/components/converter.py
@@ -12,7 +12,7 @@ import shutil
 from datumaro.components.cli_plugin import CliPlugin
 from datumaro.components.dataset import DatasetPatch
 from datumaro.components.extractor import DatasetItem
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.os_util import rmtree
 from datumaro.util.scope import on_error_do, scoped
 

--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -21,7 +21,7 @@ from datumaro.components.format_detection import (
 )
 from datumaro.util import is_method_redefined
 from datumaro.util.attrs_util import default_if_none, not_empty
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 
 # Re-export some names from .annotation for backwards compatibility.
 import datumaro.components.annotation # isort:skip

--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -19,9 +19,9 @@ from datumaro.components.errors import DatasetNotFoundError
 from datumaro.components.format_detection import (
     FormatDetectionConfidence, FormatDetectionContext,
 )
+from datumaro.components.media import Image
 from datumaro.util import is_method_redefined
 from datumaro.util.attrs_util import default_if_none, not_empty
-from datumaro.components.media import Image
 
 # Re-export some names from .annotation for backwards compatibility.
 import datumaro.components.annotation # isort:skip

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -1,0 +1,188 @@
+# Copyright (C) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+from attr import attrs
+
+from typing import Callable, Optional, Tuple, Union
+import os
+import os.path as osp
+import shutil
+
+import numpy as np
+
+from datumaro.util.image import lazy_image, _image_loading_errors, save_image, decode_image
+
+@attrs(auto_attribs=True)
+class MediaElement:
+    path: str
+    "Path to the media file"
+
+class Image(MediaElement):
+    def __init__(self,
+            data: Union[np.ndarray, Callable[[str], np.ndarray], None] = None,
+            *,
+            path: Optional[str] = None,
+            size: Optional[Tuple[int, int]] = None):
+        assert size is None or len(size) == 2, size
+        if size is not None:
+            assert len(size) == 2 and 0 < size[0] and 0 < size[1], size
+            size = tuple(map(int, size))
+        self._size = size # (H, W)
+        if not self._size and isinstance(data, np.ndarray):
+            self._size = data.shape[:2]
+
+        assert path is None or isinstance(path, str), path
+        if path is None:
+            path = ''
+        elif path:
+            path = osp.abspath(path).replace('\\', '/')
+        self._path = path
+
+        if not isinstance(data, np.ndarray):
+            assert path or callable(data), "Image can not be empty"
+            assert data is None or callable(data)
+            if path and osp.isfile(path) or data:
+                data = lazy_image(path, loader=data)
+        self._data = data
+
+    @property
+    def path(self) -> str:
+        "Path to the media file"
+        return self._path
+
+    @property
+    def ext(self) -> str:
+        "Image file extension"
+        return osp.splitext(osp.basename(self.path))[1]
+
+    @property
+    def data(self) -> np.ndarray:
+        "Image data in BGR HWC [0; 255] (float) format"
+
+        if callable(self._data):
+            data = self._data()
+        else:
+            data = self._data
+
+        if self._size is None and data is not None:
+            self._size =  tuple(map(int, data.shape[:2]))
+        return data
+
+    @property
+    def has_data(self) -> bool:
+        return self._data is not None
+
+    @property
+    def has_size(self) -> bool:
+        return self._size is not None or isinstance(self._data, np.ndarray)
+
+    @property
+    def size(self) -> Optional[Tuple[int, int]]:
+        "Returns (H, W)"
+
+        if self._size is None:
+            try:
+                data = self.data
+            except _image_loading_errors:
+                return None
+            if data is not None:
+                self._size = tuple(map(int, data.shape[:2]))
+        return self._size
+
+    def __eq__(self, other):
+        if isinstance(other, np.ndarray):
+            return self.has_data and np.array_equal(self.data, other)
+
+        if not isinstance(other, __class__):
+            return False
+        return \
+            (np.array_equal(self.size, other.size)) and \
+            (self.has_data == other.has_data) and \
+            (self.has_data and np.array_equal(self.data, other.data) or \
+                not self.has_data)
+
+    def save(self, path):
+        cur_path = osp.abspath(self.path)
+        path = osp.abspath(path)
+
+        cur_ext = self.ext.lower()
+        new_ext = osp.splitext(osp.basename(path))[1].lower()
+
+        os.makedirs(osp.dirname(path), exist_ok=True)
+        if cur_ext == new_ext and osp.isfile(cur_path):
+            if cur_path != path:
+                shutil.copyfile(cur_path, path)
+        else:
+            save_image(path, self.data)
+
+class ByteImage(Image):
+    def __init__(self,
+            data: Union[bytes, Callable[[str], bytes], None] = None,
+            *,
+            path: Optional[str] = None,
+            ext: Optional[str] = None,
+            decoder: Optional[Callable[[bytes], np.ndarray]] = None,
+            size: Optional[Tuple[int, int]] = None):
+        if not isinstance(data, bytes):
+            assert path or callable(data), "Image can not be empty"
+            assert data is None or callable(data)
+            if path and osp.isfile(path) or data:
+                data = lazy_image(path, loader=data)
+
+        if decoder is None:
+            decoder = decode_image
+        assert callable(decoder)
+
+        super().__init__(path=path, size=size,
+            data=lambda _: decoder(self.get_bytes()))
+        if data is None:
+            # We don't expect decoder to produce images from nothing,
+            # otherwise using this class makes no sense. We undefine
+            # data to avoid using default image loader for loading binaries
+            # from the path, when no data is provided.
+            self._data = None
+
+        self._bytes_data = data
+        if ext:
+            ext = ext.lower()
+            if not ext.startswith('.'):
+                ext = '.' + ext
+        self._ext = ext
+
+    def get_bytes(self):
+        if callable(self._bytes_data):
+            return self._bytes_data()
+        return self._bytes_data
+
+    @property
+    def ext(self):
+        if self._ext:
+            return self._ext
+        return super().ext
+
+    def __eq__(self, other):
+        if not isinstance(other, __class__):
+            return super().__eq__(other)
+        return \
+            (np.array_equal(self.size, other.size)) and \
+            (self.has_data == other.has_data) and \
+            (self.has_data and self.get_bytes() == other.get_bytes() or \
+                not self.has_data)
+
+    def save(self, path):
+        cur_path = osp.abspath(self.path)
+        path = osp.abspath(path)
+
+        cur_ext = self.ext.lower()
+        new_ext = osp.splitext(osp.basename(path))[1].lower()
+
+        os.makedirs(osp.dirname(path), exist_ok=True)
+        if cur_ext == new_ext and osp.isfile(cur_path):
+            if cur_path != path:
+                shutil.copyfile(cur_path, path)
+        elif cur_ext == new_ext:
+            with open(path, 'wb') as f:
+                f.write(self.get_bytes())
+        else:
+            save_image(path, self.data)

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -25,11 +25,12 @@ class MediaElement:
 
     @property
     def ext(self) -> str:
-        """Image file extension"""
+        """Media file extension"""
         return osp.splitext(osp.basename(self.path))[1]
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, __class__):
+        # We need to compare exactly with this type
+        if type(other) is not __class__: # pylint: disable=unidiomatic-typecheck
             return False
         return self._path == other._path
 
@@ -100,7 +101,7 @@ class Image(MediaElement):
             return self.has_data and np.array_equal(self.data, other)
 
         if not isinstance(other, __class__):
-            return super().__eq__(other)
+            return False
         return \
             (np.array_equal(self.size, other.size)) and \
             (self.has_data == other.has_data) and \
@@ -160,15 +161,6 @@ class ByteImage(Image):
         if self._ext:
             return self._ext
         return super().ext
-
-    def __eq__(self, other):
-        if not isinstance(other, __class__):
-            return super().__eq__(other)
-        return \
-            (np.array_equal(self.size, other.size)) and \
-            (self.has_data == other.has_data) and \
-            (self.has_data and self.get_bytes() == other.get_bytes() or \
-                not self.has_data)
 
     def save(self, path):
         cur_path = osp.abspath(self.path)

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -7,7 +7,6 @@ import os
 import os.path as osp
 import shutil
 
-from attr import attrs
 import numpy as np
 
 from datumaro.util.image import (
@@ -21,12 +20,12 @@ class MediaElement:
 
     @property
     def path(self) -> str:
-        "Path to the media file"
+        """Path to the media file"""
         return self._path
 
     @property
     def ext(self) -> str:
-        "Image file extension"
+        """Image file extension"""
         return osp.splitext(osp.basename(self.path))[1]
 
     def __eq__(self, other: object) -> bool:
@@ -64,7 +63,7 @@ class Image(MediaElement):
 
     @property
     def data(self) -> np.ndarray:
-        "Image data in BGR HWC [0; 255] (float) format"
+        """Image data in BGR HWC [0; 255] (float) format"""
 
         if callable(self._data):
             data = self._data()
@@ -85,7 +84,7 @@ class Image(MediaElement):
 
     @property
     def size(self) -> Optional[Tuple[int, int]]:
-        "Returns (H, W)"
+        """Returns (H, W)"""
 
         if self._size is None:
             try:

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -124,7 +124,6 @@ class ByteImage(Image):
             *,
             path: Optional[str] = None,
             ext: Optional[str] = None,
-            decoder: Optional[Callable[[bytes], np.ndarray]] = None,
             size: Optional[Tuple[int, int]] = None):
         if not isinstance(data, bytes):
             assert path or callable(data), "Image can not be empty"
@@ -132,12 +131,8 @@ class ByteImage(Image):
             if path and osp.isfile(path) or data:
                 data = lazy_image(path, loader=data)
 
-        if decoder is None:
-            decoder = decode_image
-        assert callable(decoder)
-
         super().__init__(path=path, size=size,
-            data=lambda _: decoder(self.get_bytes()))
+            data=lambda _: decode_image(self.get_bytes()))
         if data is None:
             # We don't expect decoder to produce images from nothing,
             # otherwise using this class makes no sense. We undefine

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -15,10 +15,24 @@ from datumaro.util.image import (
 )
 
 
-@attrs(auto_attribs=True)
 class MediaElement:
-    path: str
-    "Path to the media file"
+    def __init__(self, path: str) -> None:
+        self._path = path
+
+    @property
+    def path(self) -> str:
+        "Path to the media file"
+        return self._path
+
+    @property
+    def ext(self) -> str:
+        "Image file extension"
+        return osp.splitext(osp.basename(self.path))[1]
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, __class__):
+            return False
+        return self._path == other._path
 
 class Image(MediaElement):
     def __init__(self,
@@ -47,16 +61,6 @@ class Image(MediaElement):
             if path and osp.isfile(path) or data:
                 data = lazy_image(path, loader=data)
         self._data = data
-
-    @property
-    def path(self) -> str:
-        "Path to the media file"
-        return self._path
-
-    @property
-    def ext(self) -> str:
-        "Image file extension"
-        return osp.splitext(osp.basename(self.path))[1]
 
     @property
     def data(self) -> np.ndarray:
@@ -97,7 +101,7 @@ class Image(MediaElement):
             return self.has_data and np.array_equal(self.data, other)
 
         if not isinstance(other, __class__):
-            return False
+            return super().__eq__(other)
         return \
             (np.array_equal(self.size, other.size)) and \
             (self.has_data == other.has_data) and \

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -2,16 +2,18 @@
 #
 # SPDX-License-Identifier: MIT
 
-from attr import attrs
-
 from typing import Callable, Optional, Tuple, Union
 import os
 import os.path as osp
 import shutil
 
+from attr import attrs
 import numpy as np
 
-from datumaro.util.image import lazy_image, _image_loading_errors, save_image, decode_image
+from datumaro.util.image import (
+    _image_loading_errors, decode_image, lazy_image, save_image,
+)
+
 
 @attrs(auto_attribs=True)
 class MediaElement:

--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -17,7 +17,8 @@ from datumaro.components.annotation import (
 from datumaro.components.extractor import (
     DEFAULT_SUBSET_NAME, DatasetItem, SourceExtractor,
 )
-from datumaro.util.image import Image, lazy_image, load_image
+from datumaro.components.media import Image
+from datumaro.util.image import lazy_image, load_image
 from datumaro.util.mask_tools import bgr2index
 from datumaro.util.os_util import suppress_output
 

--- a/datumaro/plugins/cvat_format/extractor.py
+++ b/datumaro/plugins/cvat_format/extractor.py
@@ -11,7 +11,7 @@ from datumaro.components.annotation import (
     AnnotationType, Bbox, Label, LabelCategories, Points, Polygon, PolyLine,
 )
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 
 from .format import CvatPath
 

--- a/datumaro/plugins/datumaro_format/extractor.py
+++ b/datumaro/plugins/datumaro_format/extractor.py
@@ -10,7 +10,7 @@ from datumaro.components.annotation import (
     MaskCategories, Points, PointsCategories, Polygon, PolyLine, RleMask,
 )
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 
 from .format import DatumaroPath
 

--- a/datumaro/plugins/image_zip_format.py
+++ b/datumaro/plugins/image_zip_format.py
@@ -10,8 +10,10 @@ import os.path as osp
 
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
+from datumaro.components.media import ByteImage
+
 from datumaro.util import parse_str_enum_value
-from datumaro.util.image import IMAGE_EXTENSIONS, ByteImage, encode_image
+from datumaro.util.image import IMAGE_EXTENSIONS, encode_image
 
 
 class Compression(Enum):

--- a/datumaro/plugins/image_zip_format.py
+++ b/datumaro/plugins/image_zip_format.py
@@ -11,7 +11,6 @@ import os.path as osp
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
 from datumaro.components.media import ByteImage
-
 from datumaro.util import parse_str_enum_value
 from datumaro.util.image import IMAGE_EXTENSIONS, encode_image
 

--- a/datumaro/plugins/labelme_format.py
+++ b/datumaro/plugins/labelme_format.py
@@ -18,7 +18,8 @@ from datumaro.components.annotation import (
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Extractor, Importer
 from datumaro.util import cast, escape, unescape
-from datumaro.util.image import Image, save_image
+from datumaro.components.media import Image
+from datumaro.util.image import save_image
 from datumaro.util.mask_tools import find_mask_bbox, load_mask
 from datumaro.util.os_util import split_path
 

--- a/datumaro/plugins/labelme_format.py
+++ b/datumaro/plugins/labelme_format.py
@@ -17,8 +17,8 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Extractor, Importer
-from datumaro.util import cast, escape, unescape
 from datumaro.components.media import Image
+from datumaro.util import cast, escape, unescape
 from datumaro.util.image import save_image
 from datumaro.util.mask_tools import find_mask_bbox, load_mask
 from datumaro.util.os_util import split_path

--- a/datumaro/plugins/mot_format.py
+++ b/datumaro/plugins/mot_format.py
@@ -17,7 +17,8 @@ from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
 from datumaro.util import cast
-from datumaro.util.image import Image, find_images
+from datumaro.components.media import Image
+from datumaro.util.image import find_images
 
 MotLabel = Enum('MotLabel', [
     ('pedestrian', 1),

--- a/datumaro/plugins/mot_format.py
+++ b/datumaro/plugins/mot_format.py
@@ -16,8 +16,8 @@ import os.path as osp
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
-from datumaro.util import cast
 from datumaro.components.media import Image
+from datumaro.util import cast
 from datumaro.util.image import find_images
 
 MotLabel = Enum('MotLabel', [

--- a/datumaro/plugins/open_images_format.py
+++ b/datumaro/plugins/open_images_format.py
@@ -28,9 +28,9 @@ from datumaro.components.errors import (
     DatasetError, RepeatedItemError, UndefinedLabel,
 )
 from datumaro.components.extractor import DatasetItem, Extractor, Importer
+from datumaro.components.media import Image
 from datumaro.components.validator import Severity
 from datumaro.util.annotation_util import find_instances
-from datumaro.components.media import Image
 from datumaro.util.image import (
     DEFAULT_IMAGE_META_FILE_NAME, find_images, lazy_image, load_image,
     load_image_meta_file, save_image, save_image_meta_file,

--- a/datumaro/plugins/open_images_format.py
+++ b/datumaro/plugins/open_images_format.py
@@ -30,8 +30,9 @@ from datumaro.components.errors import (
 from datumaro.components.extractor import DatasetItem, Extractor, Importer
 from datumaro.components.validator import Severity
 from datumaro.util.annotation_util import find_instances
+from datumaro.components.media import Image
 from datumaro.util.image import (
-    DEFAULT_IMAGE_META_FILE_NAME, Image, find_images, lazy_image, load_image,
+    DEFAULT_IMAGE_META_FILE_NAME, find_images, lazy_image, load_image,
     load_image_meta_file, save_image, save_image_meta_file,
 )
 from datumaro.util.os_util import make_file_name, split_path

--- a/datumaro/plugins/tf_detection_api_format/converter.py
+++ b/datumaro/plugins/tf_detection_api_format/converter.py
@@ -15,7 +15,8 @@ from datumaro.components.converter import Converter
 from datumaro.util.annotation_util import (
     find_group_leader, find_instances, max_bbox,
 )
-from datumaro.util.image import ByteImage, encode_image
+from datumaro.components.media import ByteImage
+from datumaro.util.image import encode_image
 from datumaro.util.mask_tools import merge_masks
 from datumaro.util.tf_util import import_tf as _import_tf
 

--- a/datumaro/plugins/tf_detection_api_format/converter.py
+++ b/datumaro/plugins/tf_detection_api_format/converter.py
@@ -12,10 +12,10 @@ import string
 
 from datumaro.components.annotation import AnnotationType, LabelCategories
 from datumaro.components.converter import Converter
+from datumaro.components.media import ByteImage
 from datumaro.util.annotation_util import (
     find_group_leader, find_instances, max_bbox,
 )
-from datumaro.components.media import ByteImage
 from datumaro.util.image import encode_image
 from datumaro.util.mask_tools import merge_masks
 from datumaro.util.tf_util import import_tf as _import_tf

--- a/datumaro/plugins/tf_detection_api_format/extractor.py
+++ b/datumaro/plugins/tf_detection_api_format/extractor.py
@@ -11,8 +11,8 @@ import numpy as np
 from datumaro.components.annotation import (
     AnnotationType, Bbox, LabelCategories, Mask,
 )
-from datumaro.components.media import ByteImage
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
+from datumaro.components.media import ByteImage
 from datumaro.util.image import decode_image, lazy_image
 from datumaro.util.tf_util import import_tf as _import_tf
 

--- a/datumaro/plugins/tf_detection_api_format/extractor.py
+++ b/datumaro/plugins/tf_detection_api_format/extractor.py
@@ -11,8 +11,9 @@ import numpy as np
 from datumaro.components.annotation import (
     AnnotationType, Bbox, LabelCategories, Mask,
 )
+from datumaro.components.media import ByteImage
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
-from datumaro.util.image import ByteImage, decode_image, lazy_image
+from datumaro.util.image import decode_image, lazy_image
 from datumaro.util.tf_util import import_tf as _import_tf
 
 from .format import DetectionApiPath

--- a/datumaro/plugins/voc_format/extractor.py
+++ b/datumaro/plugins/voc_format/extractor.py
@@ -12,7 +12,8 @@ from datumaro.components.annotation import (
     AnnotationType, Bbox, CompiledMask, Label, Mask,
 )
 from datumaro.components.extractor import DatasetItem, SourceExtractor
-from datumaro.util.image import Image, find_images
+from datumaro.components.media import Image
+from datumaro.util.image import find_images
 from datumaro.util.mask_tools import invert_colormap, lazy_mask
 
 from .format import (

--- a/datumaro/plugins/yolo_format/extractor.py
+++ b/datumaro/plugins/yolo_format/extractor.py
@@ -10,8 +10,9 @@ from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.extractor import (
     DatasetItem, Extractor, Importer, SourceExtractor,
 )
+from datumaro.components.media import Image
 from datumaro.util.image import (
-    DEFAULT_IMAGE_META_FILE_NAME, Image, load_image_meta_file,
+    DEFAULT_IMAGE_META_FILE_NAME, load_image_meta_file,
 )
 from datumaro.util.os_util import split_path
 

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -32,10 +32,11 @@ except ModuleNotFoundError:
     _IMAGE_BACKEND = _IMAGE_BACKENDS.PIL
     _image_loading_errors = (*_image_loading_errors, PIL.UnidentifiedImageError)
 
+import warnings
+
 from datumaro.util.image_cache import ImageCache
 from datumaro.util.os_util import walk
 
-import warnings
 
 def __getattr__(name: str):
     if name in {'Image', 'ByteImage'}:

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -14,6 +14,7 @@ import weakref
 import numpy as np
 
 try:
+    # Introduced in 1.20
     from numpy.typing import DTypeLike
 except ImportError:
     DTypeLike = Any

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -4,15 +4,19 @@
 
 from enum import Enum, auto
 from io import BytesIO
-from typing import Callable, Dict, Iterable, Iterator, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, Tuple, Union
 import importlib
 import os
 import os.path as osp
 import shlex
 import weakref
 
-from numpy.typing import DTypeLike
 import numpy as np
+
+try:
+    from numpy.typing import DTypeLike
+except ImportError:
+    DTypeLike = Any
 
 
 class _IMAGE_BACKENDS(Enum):

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -239,7 +239,7 @@ class lazy_image:
 
     @staticmethod
     def _get_cache(cache):
-        if cache is None:
+        if cache is None or cache is True:
             cache = ImageCache.get_instance()
         elif cache is False:
             return None

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -5,17 +5,17 @@
 from enum import Enum, auto
 from io import BytesIO
 from typing import (
-    Any, Callable, Dict, Iterable, Iterator, Optional, Tuple, Union,
+    Any, Callable, Dict, Iterable, Iterator, Tuple, Union,
 )
 import importlib
 import os
 import os.path as osp
 import shlex
-import shutil
 import weakref
 
 import numpy as np
 
+from numpy.typing import DTypeLike
 
 class _IMAGE_BACKENDS(Enum):
     cv2 = auto()
@@ -30,11 +30,11 @@ except ModuleNotFoundError:
     _IMAGE_BACKEND = _IMAGE_BACKENDS.PIL
     _image_loading_errors = (*_image_loading_errors, PIL.UnidentifiedImageError)
 
-from datumaro.util.image_cache import ImageCache as _ImageCache
+from datumaro.util.image_cache import ImageCache
 from datumaro.util.os_util import walk
 
 
-def load_image(path, dtype=np.float32):
+def load_image(path: str, dtype: DTypeLike = np.float32):
     """
     Reads an image in the HWC Grayscale/BGR(A) float [0; 255] format.
     """
@@ -62,7 +62,8 @@ def load_image(path, dtype=np.float32):
         assert image.shape[2] in {3, 4}
     return image
 
-def save_image(path, image, create_dir=False, dtype=np.uint8, **kwargs):
+def save_image(path: str, image: np.ndarray, create_dir: bool = False,
+        dtype: DTypeLike = np.uint8, **kwargs) -> None:
     # NOTE: Check destination path for existence
     # OpenCV silently fails if target directory does not exist
     dst_dir = osp.dirname(path)
@@ -107,7 +108,8 @@ def save_image(path, image, create_dir=False, dtype=np.uint8, **kwargs):
     else:
         raise NotImplementedError()
 
-def encode_image(image, ext, dtype=np.uint8, **kwargs):
+def encode_image(image: np.ndarray, ext: str, dtype: DTypeLike = np.uint8,
+        **kwargs) -> bytes:
     if not kwargs:
         kwargs = {}
 
@@ -150,7 +152,8 @@ def encode_image(image, ext, dtype=np.uint8, **kwargs):
     else:
         raise NotImplementedError()
 
-def decode_image(image_bytes, dtype=np.float32):
+def decode_image(image_bytes: bytes,
+        dtype: DTypeLike = np.float32) -> np.ndarray:
     if _IMAGE_BACKEND == _IMAGE_BACKENDS.cv2:
         import cv2
         image = np.frombuffer(image_bytes, dtype=np.uint8)
@@ -170,7 +173,8 @@ def decode_image(image_bytes, dtype=np.float32):
         assert image.shape[2] in {3, 4}
     return image
 
-IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.jpe', '.jp2',
+IMAGE_EXTENSIONS = {
+    '.jpg', '.jpeg', '.jpe', '.jp2',
     '.png', '.bmp', '.dib', '.tif', '.tiff', '.tga', '.webp', '.pfm',
     '.sr', '.ras', '.exr', '.hdr', '.pic',
     '.pbm', '.pgm', '.ppm', '.pxm', '.pnm',
@@ -201,13 +205,14 @@ def find_images(dirpath: str, exts: Union[str, Iterable[str]] = None,
 
             yield osp.join(d, filename)
 
-def is_image(path: str):
+def is_image(path: str) -> bool:
     trunk, ext = osp.splitext(osp.basename(path))
     return trunk and ext.lower() in IMAGE_EXTENSIONS and \
         osp.isfile(path)
 
 class lazy_image:
-    def __init__(self, path, loader=None, cache=None):
+    def __init__(self, path: str, loader: Callable[[str], np.ndarray] = None,
+            cache: Union[None, bool, ImageCache] = None):
         if loader is None:
             loader = load_image
         self._path = path
@@ -217,10 +222,10 @@ class lazy_image:
         # - False: do not cache
         # - None: use the global cache
         # - object: an object to be used as cache
-        assert cache in {None, False} or isinstance(cache, object)
+        assert cache is None or isinstance(cache, (object, bool))
         self._cache = cache
 
-    def __call__(self):
+    def __call__(self) -> np.ndarray:
         image = None
         cache_key = weakref.ref(self)
 
@@ -237,164 +242,12 @@ class lazy_image:
     @staticmethod
     def _get_cache(cache):
         if cache is None:
-            cache = _ImageCache.get_instance()
-        elif cache == False:
+            cache = ImageCache.get_instance()
+        elif cache is False:
             return None
         return cache
 
-class Image:
-    def __init__(self, data: Union[None, Callable, np.ndarray] = None,
-            path: Optional[str] = None, loader: Optional[Callable] = None,
-            size: Optional[Tuple[int, int]] = None, cache: Any = None):
-        assert size is None or len(size) == 2, size
-        if size is not None:
-            assert len(size) == 2 and 0 < size[0] and 0 < size[1], size
-            size = tuple(map(int, size))
-        self._size = size # (H, W)
-
-        assert path is None or isinstance(path, str), path
-        if path is None:
-            path = ''
-        elif path:
-            path = osp.abspath(path).replace('\\', '/')
-        self._path = path
-
-        assert data is not None or path or loader, "Image can not be empty"
-        if data is not None:
-            assert callable(data) or isinstance(data, np.ndarray), type(data)
-        if data is None and (path or loader):
-            if osp.isfile(path) or loader:
-                data = lazy_image(path, loader=loader, cache=cache)
-        self._data = data
-
-        if not self._size and isinstance(data, np.ndarray):
-            self._size = data.shape[:2]
-
-    @property
-    def path(self) -> str:
-        return self._path
-
-    @property
-    def ext(self) -> str:
-        return osp.splitext(osp.basename(self.path))[1]
-
-    @property
-    def data(self) -> np.ndarray:
-        if callable(self._data):
-            data = self._data()
-        else:
-            data = self._data
-
-        if self._size is None and data is not None:
-            self._size =  tuple(map(int, data.shape[:2]))
-        return data
-
-    @property
-    def has_data(self) -> bool:
-        return self._data is not None
-
-    @property
-    def has_size(self) -> bool:
-        return self._size is not None or isinstance(self._data, np.ndarray)
-
-    @property
-    def size(self) -> Optional[Tuple[int, int]]:
-        "Returns (H, W)"
-
-        if self._size is None:
-            try:
-                data = self.data
-            except _image_loading_errors:
-                return None
-            if data is not None:
-                self._size = tuple(map(int, data.shape[:2]))
-        return self._size
-
-    def __eq__(self, other):
-        if isinstance(other, np.ndarray):
-            return self.has_data and np.array_equal(self.data, other)
-
-        if not isinstance(other, __class__):
-            return False
-        return \
-            (np.array_equal(self.size, other.size)) and \
-            (self.has_data == other.has_data) and \
-            (self.has_data and np.array_equal(self.data, other.data) or \
-                not self.has_data)
-
-    def save(self, path):
-        cur_path = osp.abspath(self.path)
-        path = osp.abspath(path)
-
-        cur_ext = self.ext.lower()
-        new_ext = osp.splitext(osp.basename(path))[1].lower()
-
-        os.makedirs(osp.dirname(path), exist_ok=True)
-        if cur_ext == new_ext and osp.isfile(cur_path):
-            if cur_path != path:
-                shutil.copyfile(cur_path, path)
-        else:
-            save_image(path, self.data)
-
-class ByteImage(Image):
-    def __init__(self, data=None, path=None, ext=None, cache=None, size=None):
-        loader = None
-        if data is not None:
-            if callable(data) and not isinstance(data, lazy_image):
-                data = lazy_image(path, loader=data, cache=cache)
-            loader = lambda _: decode_image(self.get_bytes())
-
-        super().__init__(path=path, size=size, loader=loader, cache=cache)
-        if data is None and loader is None:
-            # unset defaults for regular images
-            # to avoid random file reading to bytes
-            self._data = None
-
-        self._bytes_data = data
-        if ext:
-            ext = ext.lower()
-            if not ext.startswith('.'):
-                ext = '.' + ext
-        self._ext = ext
-
-    def get_bytes(self):
-        if callable(self._bytes_data):
-            return self._bytes_data()
-        return self._bytes_data
-
-    @property
-    def ext(self):
-        if self._ext:
-            return self._ext
-        return super().ext
-
-    def __eq__(self, other):
-        if not isinstance(other, __class__):
-            return super().__eq__(other)
-        return \
-            (np.array_equal(self.size, other.size)) and \
-            (self.has_data == other.has_data) and \
-            (self.has_data and self.get_bytes() == other.get_bytes() or \
-                not self.has_data)
-
-    def save(self, path):
-        cur_path = osp.abspath(self.path)
-        path = osp.abspath(path)
-
-        cur_ext = self.ext.lower()
-        new_ext = osp.splitext(osp.basename(path))[1].lower()
-
-        os.makedirs(osp.dirname(path), exist_ok=True)
-        if cur_ext == new_ext and osp.isfile(cur_path):
-            if cur_path != path:
-                shutil.copyfile(cur_path, path)
-        elif cur_ext == new_ext:
-            with open(path, 'wb') as f:
-                f.write(self.get_bytes())
-        else:
-            save_image(path, self.data)
-
-ImageMeta = Dict[str, Tuple[int, int]]
+ImageMeta = Dict[str, Tuple[int, int]] # filename, height, width
 
 DEFAULT_IMAGE_META_FILE_NAME = 'images.meta'
 

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -4,18 +4,16 @@
 
 from enum import Enum, auto
 from io import BytesIO
-from typing import (
-    Any, Callable, Dict, Iterable, Iterator, Tuple, Union,
-)
+from typing import Any, Callable, Dict, Iterable, Iterator, Tuple, Union
 import importlib
 import os
 import os.path as osp
 import shlex
 import weakref
 
+from numpy.typing import DTypeLike
 import numpy as np
 
-from numpy.typing import DTypeLike
 
 class _IMAGE_BACKENDS(Enum):
     cv2 = auto()

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -4,7 +4,7 @@
 
 from enum import Enum, auto
 from io import BytesIO
-from typing import Any, Callable, Dict, Iterable, Iterator, Tuple, Union
+from typing import Callable, Dict, Iterable, Iterator, Tuple, Union
 import importlib
 import os
 import os.path as osp

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -35,6 +35,17 @@ except ModuleNotFoundError:
 from datumaro.util.image_cache import ImageCache
 from datumaro.util.os_util import walk
 
+import warnings
+
+def __getattr__(name: str):
+    if name in {'Image', 'ByteImage'}:
+        warnings.warn(f"Using {name} from 'util.image' is deprecated, "
+            "the class is moved to 'components.media'", DeprecationWarning,
+            stacklevel=2)
+
+        import datumaro.components.media as media_module
+        return getattr(media_module, name)
+    raise AttributeError
 
 def load_image(path: str, dtype: DTypeLike = np.float32):
     """

--- a/datumaro/util/image.py
+++ b/datumaro/util/image.py
@@ -47,7 +47,7 @@ def __getattr__(name: str):
 
         import datumaro.components.media as media_module
         return getattr(media_module, name)
-    raise AttributeError
+    raise AttributeError(f"module {__name__} has no attribute {name}")
 
 def load_image(path: str, dtype: DTypeLike = np.float32):
     """

--- a/tests/cli/test_diff.py
+++ b/tests/cli/test_diff.py
@@ -12,7 +12,7 @@ from datumaro.components.annotation import (
 from datumaro.components.extractor import DatasetItem
 from datumaro.components.operations import DistanceComparator
 from datumaro.components.project import Dataset
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir
 from datumaro.util.test_utils import run_datum as run
 

--- a/tests/cli/test_diff.py
+++ b/tests/cli/test_diff.py
@@ -10,9 +10,9 @@ from datumaro.components.annotation import (
     Points, PointsCategories, Polygon, PolyLine,
 )
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.components.operations import DistanceComparator
 from datumaro.components.project import Dataset
-from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir
 from datumaro.util.test_utils import run_datum as run
 

--- a/tests/test_camvid_format.py
+++ b/tests/test_camvid_format.py
@@ -12,8 +12,8 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem, Extractor
-from datumaro.plugins.camvid_format import CamvidConverter, CamvidImporter
 from datumaro.components.media import Image
+from datumaro.plugins.camvid_format import CamvidConverter, CamvidImporter
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_camvid_format.py
+++ b/tests/test_camvid_format.py
@@ -13,7 +13,7 @@ from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem, Extractor
 from datumaro.plugins.camvid_format import CamvidConverter, CamvidImporter
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_cifar_format.py
+++ b/tests/test_cifar_format.py
@@ -10,7 +10,7 @@ from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.cifar_format import CifarConverter, CifarImporter
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_cifar_format.py
+++ b/tests/test_cifar_format.py
@@ -9,8 +9,8 @@ from datumaro.components.annotation import Label
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
-from datumaro.plugins.cifar_format import CifarConverter, CifarImporter
 from datumaro.components.media import Image
+from datumaro.plugins.cifar_format import CifarConverter, CifarImporter
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_cityscapes_format.py
+++ b/tests/test_cityscapes_format.py
@@ -12,10 +12,10 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem, Extractor
+from datumaro.components.media import Image
 from datumaro.plugins.cityscapes_format import (
     CityscapesConverter, CityscapesImporter,
 )
-from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     IGNORE_ALL, TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_cityscapes_format.py
+++ b/tests/test_cityscapes_format.py
@@ -15,7 +15,7 @@ from datumaro.components.extractor import DatasetItem, Extractor
 from datumaro.plugins.cityscapes_format import (
     CityscapesConverter, CityscapesImporter,
 )
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     IGNORE_ALL, TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_coco_format.py
+++ b/tests/test_coco_format.py
@@ -23,7 +23,7 @@ from datumaro.plugins.coco_format.importer import (
     CocoInstancesImporter, CocoLabelsImporter, CocoPanopticImporter,
     CocoPersonKeypointsImporter, CocoStuffImporter,
 )
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_coco_format.py
+++ b/tests/test_coco_format.py
@@ -13,6 +13,7 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.plugins.coco_format.converter import (
     CocoCaptionsConverter, CocoConverter, CocoImageInfoConverter,
     CocoInstancesConverter, CocoLabelsConverter, CocoPanopticConverter,
@@ -23,7 +24,6 @@ from datumaro.plugins.coco_format.importer import (
     CocoInstancesImporter, CocoLabelsImporter, CocoPanopticImporter,
     CocoPersonKeypointsImporter, CocoStuffImporter,
 )
-from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_cvat_format.py
+++ b/tests/test_cvat_format.py
@@ -13,7 +13,7 @@ from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.cvat_format.converter import CvatConverter
 from datumaro.plugins.cvat_format.extractor import CvatImporter
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_cvat_format.py
+++ b/tests/test_cvat_format.py
@@ -11,9 +11,9 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.plugins.cvat_format.converter import CvatConverter
 from datumaro.plugins.cvat_format.extractor import CvatImporter
-from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -24,7 +24,7 @@ from datumaro.components.extractor import (
     DEFAULT_SUBSET_NAME, DatasetItem, Extractor, ItemTransform, Transform,
 )
 from datumaro.components.launcher import Launcher
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_datumaro_format.py
+++ b/tests/test_datumaro_format.py
@@ -11,10 +11,10 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.components.project import Dataset
 from datumaro.plugins.datumaro_format.converter import DatumaroConverter
 from datumaro.plugins.datumaro_format.extractor import DatumaroImporter
-from datumaro.components.media import Image
 from datumaro.util.mask_tools import generate_colormap
 from datumaro.util.test_utils import (
     Dimensions, TestDir, compare_datasets_strict, test_save_and_load,

--- a/tests/test_datumaro_format.py
+++ b/tests/test_datumaro_format.py
@@ -14,7 +14,7 @@ from datumaro.components.extractor import DatasetItem
 from datumaro.components.project import Dataset
 from datumaro.plugins.datumaro_format.converter import DatumaroConverter
 from datumaro.plugins.datumaro_format.extractor import DatumaroImporter
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.mask_tools import generate_colormap
 from datumaro.util.test_utils import (
     Dimensions, TestDir, compare_datasets_strict, test_save_and_load,

--- a/tests/test_icdar_format.py
+++ b/tests/test_icdar_format.py
@@ -7,6 +7,7 @@ import numpy as np
 from datumaro.components.annotation import Bbox, Caption, Mask, Polygon
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.components.project import Dataset
 from datumaro.plugins.icdar_format.converter import (
     IcdarTextLocalizationConverter, IcdarTextSegmentationConverter,
@@ -16,7 +17,6 @@ from datumaro.plugins.icdar_format.extractor import (
     IcdarTextLocalizationImporter, IcdarTextSegmentationImporter,
     IcdarWordRecognitionImporter,
 )
-from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_icdar_format.py
+++ b/tests/test_icdar_format.py
@@ -16,7 +16,7 @@ from datumaro.plugins.icdar_format.extractor import (
     IcdarTextLocalizationImporter, IcdarTextSegmentationImporter,
     IcdarWordRecognitionImporter,
 )
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_image_dir_format.py
+++ b/tests/test_image_dir_format.py
@@ -7,7 +7,8 @@ import numpy as np
 from datumaro.components.extractor import DatasetItem
 from datumaro.components.project import Dataset
 from datumaro.plugins.image_dir_format import ImageDirConverter
-from datumaro.util.image import Image, save_image
+from datumaro.components.media import Image
+from datumaro.util.image import save_image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_image_dir_format.py
+++ b/tests/test_image_dir_format.py
@@ -5,9 +5,9 @@ import os.path as osp
 import numpy as np
 
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.components.project import Dataset
 from datumaro.plugins.image_dir_format import ImageDirConverter
-from datumaro.components.media import Image
 from datumaro.util.image import save_image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,

--- a/tests/test_image_zip_format.py
+++ b/tests/test_image_zip_format.py
@@ -6,7 +6,7 @@ import numpy as np
 from datumaro.components.extractor import DatasetItem
 from datumaro.components.project import Dataset
 from datumaro.plugins.image_zip_format import ImageZipConverter, ImageZipPath
-from datumaro.util.image import Image, save_image
+from datumaro.components.media import Image, save_image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_image_zip_format.py
+++ b/tests/test_image_zip_format.py
@@ -4,9 +4,9 @@ import os.path as osp
 import numpy as np
 
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image, save_image
 from datumaro.components.project import Dataset
 from datumaro.plugins.image_zip_format import ImageZipConverter, ImageZipPath
-from datumaro.components.media import Image, save_image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_imagenet_format.py
+++ b/tests/test_imagenet_format.py
@@ -9,8 +9,8 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
-from datumaro.plugins.imagenet_format import ImagenetConverter, ImagenetImporter
 from datumaro.components.media import Image
+from datumaro.plugins.imagenet_format import ImagenetConverter, ImagenetImporter
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_imagenet_format.py
+++ b/tests/test_imagenet_format.py
@@ -10,7 +10,7 @@ from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.imagenet_format import ImagenetConverter, ImagenetImporter
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_imagenet_txt_format.py
+++ b/tests/test_imagenet_txt_format.py
@@ -9,10 +9,10 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.plugins.imagenet_txt_format import (
     ImagenetTxtConverter, ImagenetTxtImporter,
 )
-from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_imagenet_txt_format.py
+++ b/tests/test_imagenet_txt_format.py
@@ -12,7 +12,7 @@ from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.imagenet_txt_format import (
     ImagenetTxtConverter, ImagenetTxtImporter,
 )
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -22,7 +22,7 @@ class ImageCacheTest(TestCase):
             image_path = osp.join(test_dir, 'image.jpg')
             save_image(image_path, image)
 
-            caching_loader = lazy_image(image_path, cache=None)
+            caching_loader = lazy_image(image_path, cache=True)
             self.assertTrue(caching_loader() is caching_loader())
 
             non_caching_loader = lazy_image(image_path, cache=False)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from datumaro.components.media import ByteImage, Image
 from datumaro.util.image import (
-    encode_image, lazy_image, load_image,
-    load_image_meta_file, save_image, save_image_meta_file,
+    encode_image, lazy_image, load_image, load_image_meta_file, save_image,
+    save_image_meta_file,
 )
 from datumaro.util.image_cache import ImageCache
 from datumaro.util.test_utils import TestDir

--- a/tests/test_kitti_format.py
+++ b/tests/test_kitti_format.py
@@ -11,6 +11,7 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem, Extractor
+from datumaro.components.media import Image
 from datumaro.plugins.kitti_format.converter import KittiConverter
 from datumaro.plugins.kitti_format.format import (
     KittiLabelMap, KittiPath, KittiTask, make_kitti_categories, parse_label_map,
@@ -19,7 +20,6 @@ from datumaro.plugins.kitti_format.format import (
 from datumaro.plugins.kitti_format.importer import (
     KittiDetectionImporter, KittiImporter, KittiSegmentationImporter,
 )
-from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_kitti_format.py
+++ b/tests/test_kitti_format.py
@@ -19,7 +19,7 @@ from datumaro.plugins.kitti_format.format import (
 from datumaro.plugins.kitti_format.importer import (
     KittiDetectionImporter, KittiImporter, KittiSegmentationImporter,
 )
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_labelme_format.py
+++ b/tests/test_labelme_format.py
@@ -9,8 +9,8 @@ from datumaro.components.annotation import Bbox, Mask, Polygon
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
-from datumaro.plugins.labelme_format import LabelMeConverter, LabelMeImporter
 from datumaro.components.media import Image
+from datumaro.plugins.labelme_format import LabelMeConverter, LabelMeImporter
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_labelme_format.py
+++ b/tests/test_labelme_format.py
@@ -10,7 +10,7 @@ from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.labelme_format import LabelMeConverter, LabelMeImporter
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_lfw_format.py
+++ b/tests/test_lfw_format.py
@@ -9,8 +9,8 @@ from datumaro.components.annotation import Label, Points
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
-from datumaro.plugins.lfw_format import LfwConverter, LfwImporter
 from datumaro.components.media import Image
+from datumaro.plugins.lfw_format import LfwConverter, LfwImporter
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_lfw_format.py
+++ b/tests/test_lfw_format.py
@@ -10,7 +10,7 @@ from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.lfw_format import LfwConverter, LfwImporter
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_market1501_format.py
+++ b/tests/test_market1501_format.py
@@ -6,10 +6,10 @@ import numpy as np
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.plugins.market1501_format import (
     Market1501Converter, Market1501Importer,
 )
-from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_market1501_format.py
+++ b/tests/test_market1501_format.py
@@ -9,7 +9,7 @@ from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.market1501_format import (
     Market1501Converter, Market1501Importer,
 )
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_mnist_csv_format.py
+++ b/tests/test_mnist_csv_format.py
@@ -9,10 +9,10 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.plugins.mnist_csv_format import (
     MnistCsvConverter, MnistCsvImporter,
 )
-from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_mnist_csv_format.py
+++ b/tests/test_mnist_csv_format.py
@@ -12,7 +12,7 @@ from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.mnist_csv_format import (
     MnistCsvConverter, MnistCsvImporter,
 )
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_mnist_format.py
+++ b/tests/test_mnist_format.py
@@ -9,8 +9,8 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
-from datumaro.plugins.mnist_format import MnistConverter, MnistImporter
 from datumaro.components.media import Image
+from datumaro.plugins.mnist_format import MnistConverter, MnistImporter
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_mnist_format.py
+++ b/tests/test_mnist_format.py
@@ -10,7 +10,7 @@ from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.mnist_format import MnistConverter, MnistImporter
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_mot_format.py
+++ b/tests/test_mot_format.py
@@ -8,8 +8,8 @@ from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
-from datumaro.plugins.mot_format import MotSeqGtConverter, MotSeqImporter
 from datumaro.components.media import Image
+from datumaro.plugins.mot_format import MotSeqGtConverter, MotSeqImporter
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_mot_format.py
+++ b/tests/test_mot_format.py
@@ -9,7 +9,7 @@ from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.mot_format import MotSeqGtConverter, MotSeqImporter
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_mots_format.py
+++ b/tests/test_mots_format.py
@@ -8,8 +8,8 @@ from datumaro.components.annotation import Mask
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
-from datumaro.plugins.mots_format import MotsImporter, MotsPngConverter
 from datumaro.components.media import Image
+from datumaro.plugins.mots_format import MotsImporter, MotsPngConverter
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_mots_format.py
+++ b/tests/test_mots_format.py
@@ -9,7 +9,7 @@ from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.mots_format import MotsImporter, MotsPngConverter
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_open_images_format.py
+++ b/tests/test_open_images_format.py
@@ -18,7 +18,7 @@ from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.open_images_format import (
     OpenImagesConverter, OpenImagesImporter,
 )
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from tests.requirements import Requirements, mark_requirement

--- a/tests/test_open_images_format.py
+++ b/tests/test_open_images_format.py
@@ -15,10 +15,10 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.plugins.open_images_format import (
     OpenImagesConverter, OpenImagesImporter,
 )
-from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from tests.requirements import Requirements, mark_requirement

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -6,8 +6,8 @@ from datumaro.components.annotation import (
     AnnotationType, Label, LabelCategories,
 )
 from datumaro.components.extractor import DatasetItem
-from datumaro.components.project import Dataset
 from datumaro.components.media import Image
+from datumaro.components.project import Dataset
 
 try:
     import pandas as pd

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -7,7 +7,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.extractor import DatasetItem
 from datumaro.components.project import Dataset
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 
 try:
     import pandas as pd

--- a/tests/test_tfrecord_format.py
+++ b/tests/test_tfrecord_format.py
@@ -11,7 +11,8 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
-from datumaro.util.image import ByteImage, Image, encode_image
+from datumaro.components.media import ByteImage, Image
+from datumaro.util.image import encode_image
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,
 )

--- a/tests/test_vgg_face2_format.py
+++ b/tests/test_vgg_face2_format.py
@@ -9,10 +9,10 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.plugins.vgg_face2_format import (
     VggFace2Converter, VggFace2Importer,
 )
-from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_vgg_face2_format.py
+++ b/tests/test_vgg_face2_format.py
@@ -12,7 +12,7 @@ from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.vgg_face2_format import (
     VggFace2Converter, VggFace2Importer,
 )
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_voc_format.py
+++ b/tests/test_voc_format.py
@@ -12,6 +12,7 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem, Extractor
+from datumaro.components.media import Image
 from datumaro.plugins.voc_format.converter import (
     VocActionConverter, VocClassificationConverter, VocConverter,
     VocDetectionConverter, VocLayoutConverter, VocSegmentationConverter,
@@ -20,7 +21,6 @@ from datumaro.plugins.voc_format.importer import (
     VocActionImporter, VocClassificationImporter, VocDetectionImporter,
     VocImporter, VocLayoutImporter, VocSegmentationImporter,
 )
-from datumaro.components.media import Image
 from datumaro.util.mask_tools import load_mask
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,

--- a/tests/test_voc_format.py
+++ b/tests/test_voc_format.py
@@ -20,7 +20,7 @@ from datumaro.plugins.voc_format.importer import (
     VocActionImporter, VocClassificationImporter, VocDetectionImporter,
     VocImporter, VocLayoutImporter, VocSegmentationImporter,
 )
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.mask_tools import load_mask
 from datumaro.util.test_utils import (
     TestDir, compare_datasets, test_save_and_load,

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -8,10 +8,10 @@ from datumaro.components.annotation import Bbox, Label
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.plugins.widerface_format import (
     WiderFaceConverter, WiderFaceImporter,
 )
-from datumaro.components.media import Image
 from datumaro.util.test_utils import IGNORE_ALL, TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -11,7 +11,7 @@ from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.widerface_format import (
     WiderFaceConverter, WiderFaceImporter,
 )
-from datumaro.util.image import Image
+from datumaro.components.media import Image
 from datumaro.util.test_utils import IGNORE_ALL, TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement

--- a/tests/test_yolo_format.py
+++ b/tests/test_yolo_format.py
@@ -8,9 +8,9 @@ from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 from datumaro.plugins.yolo_format.converter import YoloConverter
 from datumaro.plugins.yolo_format.extractor import YoloImporter
-from datumaro.components.media import Image
 from datumaro.util.image import save_image
 from datumaro.util.test_utils import TestDir, compare_datasets
 

--- a/tests/test_yolo_format.py
+++ b/tests/test_yolo_format.py
@@ -10,7 +10,8 @@ from datumaro.components.environment import Environment
 from datumaro.components.extractor import DatasetItem
 from datumaro.plugins.yolo_format.converter import YoloConverter
 from datumaro.plugins.yolo_format.extractor import YoloImporter
-from datumaro.util.image import Image, save_image
+from datumaro.components.media import Image
+from datumaro.util.image import save_image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 from .requirements import Requirements, mark_requirement


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This PR moves `Image` and `ByteImage` classes to `components.media`, because these classes are parts of the domain model. `uitls` are more about auxiliary things, which can be replaced by other providers.

- `Image` and `ByteImage` are moved from `datumaro.util.image` to `datumaro.components.media`
- `Image.__init__`'s `loader` parameter merged into `data`, because it was not used and their semantics was overlapping.
  It seems that `loader` can be more clear, though.
- Image ctor's no more accept the `cache` parameter, because it was not used.
- `Image` ctor's parameters are now mostly kw-only
- Added some type annotations and docs
- Added deprecation warnings

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
