### PR TITLE
Unblock install on Python 3.9+ on Windows

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -19,10 +19,6 @@ jobs:
       matrix:
         os: ['macos-10.15', 'ubuntu-20.04', 'windows-2016']
         python-version: ['3.6', '3.7', '3.8', '3.9']
-        exclude:
-        # pycocotools-windows doesn't have a wheel for Python 3.9
-        - os: windows-2016
-          python-version: 3.9
     name: build and test (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/484>)
 - Mapillary Vistas dataset format (Import-only)
   (<https://github.com/openvinotoolkit/datumaro/pull/537>)
+- Datumaro can now be installed on Windows on Python 3.9
+  (<https://github.com/openvinotoolkit/datumaro/pull/547>)
 
 ### Changed
 - File `people.txt` became optional in LFW

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -8,9 +8,9 @@ Pillow>=6.1.0
 ruamel.yaml>=0.17.0
 typing_extensions>=3.7.4.3
 
-pycocotools>=2.0.2; platform_system != "Windows"
+pycocotools>=2.0.2; platform_system != "Windows" or python_version >= '3.9'
 
-pycocotools-windows; platform_system == "Windows"
+pycocotools-windows; platform_system == "Windows" and python_version < '3.9'
 PyYAML>=5.3.1
 
 # 2.3 has an unlisted dependency on PyTorch, which we don't need


### PR DESCRIPTION

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Use the original `pycocotools` PyPI package, since `pycocotools-windows` does not have wheels for Python 3.9+. `pycocotools` doesn't have wheels either, but at least it's buildable from source.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
