### PR TITLE
Add detection support for 4 more formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The following formats can now be detected unambiguously:
   `ade20k2017`, `ade20k2020`, `cvat`, `datumaro`, `icdar_text_localization`,
   `icdar_text_segmentation`, `icdar_word_recognition`, `kitti_raw`, `label_me`,
-  `mot_seq`, `yolo`
+  `lfw`, `mot_seq`, `open_images`, `vgg_face2`, `widerface`, `yolo`
   (<https://github.com/openvinotoolkit/datumaro/pull/531>,
-  <https://github.com/openvinotoolkit/datumaro/pull/536>)
+  <https://github.com/openvinotoolkit/datumaro/pull/536>,
+  <https://github.com/openvinotoolkit/datumaro/pull/550>)
 
 ### Deprecated
 - Using `Image`, `ByteImage` from `datumaro.util.image` - these classes

--- a/datumaro/components/format_detection.py
+++ b/datumaro/components/format_detection.py
@@ -121,14 +121,14 @@ class FormatDetectionContext:
             f"a requirement ({req_type}) can't be placed directly within " \
             "a 'require_any' block"
 
-    def fail(self, requirement: str) -> NoReturn:
+    def fail(self, requirement_desc: str) -> NoReturn:
         """
-        Places a requirement that is never met. `requirement` must contain
+        Places a requirement that is never met. `requirement_desc` must contain
         a human-readable description of the requirement.
         """
         self._start_requirement("fail")
 
-        raise FormatRequirementsUnmet((requirement,))
+        raise FormatRequirementsUnmet((requirement_desc,))
 
     def require_file(self, pattern: str) -> str:
         """

--- a/datumaro/components/format_detection.py
+++ b/datumaro/components/format_detection.py
@@ -118,7 +118,7 @@ class FormatDetectionContext:
 
     def _start_requirement(self) -> None:
         assert not self._alternatives_context, \
-            "checks can't be done directly within `alternatives` blocks"
+            "checks can't be done directly within 'alternatives' blocks"
 
     def fail(self, requirement: str) -> NoReturn:
         """
@@ -239,8 +239,8 @@ class FormatDetectionContext:
             # If no alternatives succeeded, and none failed, then there were
             # no alternatives at all.
             assert self._alternatives_context.failed_alternatives, \
-                "an `alternatives` block must contain " \
-                "at least one `alternative` block"
+                "an 'alternatives' block must contain " \
+                "at least one 'alternative' block"
 
             raise FormatRequirementsUnmet(
                 self._alternatives_context.failed_alternatives)
@@ -258,8 +258,8 @@ class FormatDetectionContext:
         """
 
         assert self._alternatives_context, \
-            "An `alternative` block must be directly within " \
-            "an `alternatives` block"
+            "An 'alternative' block must be directly within " \
+            "an 'alternatives' block"
 
         saved_alternatives_context = self._alternatives_context
         self._alternatives_context = None

--- a/datumaro/components/format_detection.py
+++ b/datumaro/components/format_detection.py
@@ -116,16 +116,17 @@ class FormatDetectionContext:
 
         return True
 
-    def _start_requirement(self) -> None:
+    def _start_requirement(self, req_type: str) -> None:
         assert not self._alternatives_context, \
-            "checks can't be done directly within 'alternatives' blocks"
+            f"a requirement ({req_type}) can't be placed directly within " \
+            "an 'alternatives' block"
 
     def fail(self, requirement: str) -> NoReturn:
         """
         Places a requirement that is never met. `requirement` must contain
         a human-readable description of the requirement.
         """
-        self._start_requirement()
+        self._start_requirement("fail")
 
         raise FormatRequirementsUnmet((requirement,))
 
@@ -142,7 +143,7 @@ class FormatDetectionContext:
         unspecified which one of them is returned.
         """
 
-        self._start_requirement()
+        self._start_requirement("require_file")
 
         requirement_desc = \
             f"dataset must contain a file matching pattern \"{pattern}\""
@@ -185,7 +186,7 @@ class FormatDetectionContext:
         requirement.
         """
 
-        self._start_requirement()
+        self._start_requirement("probe_text_file")
 
         requirement_desc_full = f"{path}: {requirement_desc}"
 
@@ -224,7 +225,7 @@ class FormatDetectionContext:
         `with context.alternatives()` block.
         """
 
-        self._start_requirement()
+        self._start_requirement("alternatives")
 
         self._alternatives_context = self._AlternativesContext()
 

--- a/datumaro/plugins/lfw_format.py
+++ b/datumaro/plugins/lfw_format.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -11,6 +11,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
+from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.util.image import find_images
 
 
@@ -172,6 +173,11 @@ class LfwExtractor(SourceExtractor):
         return image, item_id
 
 class LfwImporter(Importer):
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> None:
+        context.require_file(
+            f'*/{LfwPath.ANNOTATION_DIR}/{LfwPath.PAIRS_FILE}')
+
     @classmethod
     def find_sources(cls, path):
         base, ext = osp.splitext(LfwPath.PAIRS_FILE)

--- a/datumaro/plugins/open_images_format.py
+++ b/datumaro/plugins/open_images_format.py
@@ -563,7 +563,7 @@ class OpenImagesImporter(Importer):
 
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        with context.alternatives():
+        with context.require_any():
             for pattern in cls.POSSIBLE_ANNOTATION_PATTERNS:
                 with context.alternative():
                     context.require_file(

--- a/datumaro/plugins/open_images_format.py
+++ b/datumaro/plugins/open_images_format.py
@@ -28,6 +28,7 @@ from datumaro.components.errors import (
     DatasetError, RepeatedItemError, UndefinedLabel,
 )
 from datumaro.components.extractor import DatasetItem, Extractor, Importer
+from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.media import Image
 from datumaro.components.validator import Severity
 from datumaro.util.annotation_util import find_instances
@@ -552,15 +553,25 @@ class OpenImagesExtractor(Extractor):
         return resized.astype(bool)
 
 class OpenImagesImporter(Importer):
+    POSSIBLE_ANNOTATION_PATTERNS = (
+        OpenImagesPath.FULL_IMAGE_DESCRIPTION_FILE_NAME,
+        *OpenImagesPath.SUBSET_IMAGE_DESCRIPTION_FILE_PATTERNS,
+        '*' + OpenImagesPath.LABEL_DESCRIPTION_FILE_SUFFIX,
+        '*' + OpenImagesPath.BBOX_DESCRIPTION_FILE_SUFFIX,
+        '*' + OpenImagesPath.MASK_DESCRIPTION_FILE_SUFFIX,
+    )
+
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> None:
+        with context.alternatives():
+            for pattern in cls.POSSIBLE_ANNOTATION_PATTERNS:
+                with context.alternative():
+                    context.require_file(
+                        f'{OpenImagesPath.ANNOTATIONS_DIR}/{pattern}')
+
     @classmethod
     def find_sources(cls, path):
-        for pattern in [
-            OpenImagesPath.FULL_IMAGE_DESCRIPTION_FILE_NAME,
-            *OpenImagesPath.SUBSET_IMAGE_DESCRIPTION_FILE_PATTERNS,
-            '*' + OpenImagesPath.LABEL_DESCRIPTION_FILE_SUFFIX,
-            '*' + OpenImagesPath.BBOX_DESCRIPTION_FILE_SUFFIX,
-            '*' + OpenImagesPath.MASK_DESCRIPTION_FILE_SUFFIX,
-        ]:
+        for pattern in cls.POSSIBLE_ANNOTATION_PATTERNS:
             if glob.glob(osp.join(glob.escape(path),
                     OpenImagesPath.ANNOTATIONS_DIR, pattern)):
                 return [{'url': path, 'format': OpenImagesExtractor.NAME}]

--- a/datumaro/plugins/vgg_face2_format.py
+++ b/datumaro/plugins/vgg_face2_format.py
@@ -161,7 +161,7 @@ class VggFace2Extractor(Extractor):
 class VggFace2Importer(Importer):
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        with context.alternatives():
+        with context.require_any():
             for prefix in (
                 VggFace2Path.BBOXES_FILE, VggFace2Path.LANDMARKS_FILE
             ):

--- a/datumaro/plugins/vgg_face2_format.py
+++ b/datumaro/plugins/vgg_face2_format.py
@@ -11,6 +11,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Extractor, Importer
+from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.util.image import find_images
 
 
@@ -158,6 +159,16 @@ class VggFace2Extractor(Extractor):
         return items
 
 class VggFace2Importer(Importer):
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> None:
+        with context.alternatives():
+            for prefix in (
+                VggFace2Path.BBOXES_FILE, VggFace2Path.LANDMARKS_FILE
+            ):
+                with context.alternative():
+                    context.require_file(
+                        f'{VggFace2Path.ANNOTATION_DIR}/{prefix}*.csv')
+
     @classmethod
     def find_sources(cls, path):
         if osp.isdir(path):

--- a/datumaro/plugins/widerface_format.py
+++ b/datumaro/plugins/widerface_format.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -11,6 +11,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Importer, SourceExtractor
+from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.util import str_to_bool
 
 
@@ -138,6 +139,10 @@ class WiderFaceExtractor(SourceExtractor):
         return items
 
 class WiderFaceImporter(Importer):
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> None:
+        context.require_file(f'{WiderFacePath.ANNOTATIONS_DIR}/*.txt')
+
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(path, '.txt', 'wider_face',

--- a/tests/test_format_detection.py
+++ b/tests/test_format_detection.py
@@ -132,12 +132,12 @@ class FormatDetectionTest(TestCase):
             ('abcde',))
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_alternatives_success(self):
+    def test_require_any_success(self):
         alternatives_executed = set()
 
         def detect(context):
             nonlocal alternatives_executed
-            with context.alternatives():
+            with context.require_any():
                 with context.alternative():
                     alternatives_executed.add(1)
                     context.fail('bad alternative 1')
@@ -154,9 +154,9 @@ class FormatDetectionTest(TestCase):
         self.assertEqual(alternatives_executed, {1, 2, 3})
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_alternatives_failure(self):
+    def test_require_any_failure(self):
         def detect(context):
-            with context.alternatives():
+            with context.require_any():
                 with context.alternative():
                     context.fail('bad alternative 1')
                 with context.alternative():

--- a/tests/test_format_detection.py
+++ b/tests/test_format_detection.py
@@ -1,0 +1,169 @@
+from unittest import TestCase
+import os.path as osp
+
+from datumaro.components.format_detection import (
+    FormatDetectionConfidence, FormatRequirementsUnmet, apply_format_detector,
+)
+from datumaro.util.test_utils import TestDir
+
+from tests.requirements import Requirements, mark_requirement
+
+
+class FormatDetectionTest(TestCase):
+    def setUp(self) -> None:
+        test_dir_context = TestDir()
+        self._dataset_root = test_dir_context.__enter__()
+        self.addCleanup(test_dir_context.__exit__, None, None, None)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_empty_detector(self):
+        result = apply_format_detector(self._dataset_root, lambda c: None)
+        self.assertEqual(result, FormatDetectionConfidence.MEDIUM)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_custom_confidence(self):
+        result = apply_format_detector(self._dataset_root,
+            lambda c: FormatDetectionConfidence.LOW)
+        self.assertEqual(result, FormatDetectionConfidence.LOW)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_root_path(self):
+        provided_root: str
+        def detect(context):
+            nonlocal provided_root
+            provided_root = context.root_path
+
+        apply_format_detector(self._dataset_root, detect)
+        self.assertEqual(provided_root, self._dataset_root)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_fail(self):
+        def detect(context):
+            context.fail('abcde')
+
+        with self.assertRaises(FormatRequirementsUnmet) as result:
+            apply_format_detector(self._dataset_root, detect)
+
+        self.assertEqual(result.exception.failed_alternatives, ('abcde',))
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_require_file_success(self):
+        with open(osp.join(self._dataset_root, 'foobar.txt'), 'w'):
+            pass
+
+        selected_file: str
+        def detect(context):
+            nonlocal selected_file
+            selected_file = context.require_file('**/[fg]oo*.t?t')
+
+        result = apply_format_detector(self._dataset_root, detect)
+
+        self.assertEqual(result, FormatDetectionConfidence.MEDIUM)
+        self.assertEqual(selected_file, 'foobar.txt')
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_require_file_failure(self):
+        with open(osp.join(self._dataset_root, 'foobar.txt'), 'w'):
+            pass
+
+        def detect(context):
+            context.require_file('*/*')
+
+        with self.assertRaises(FormatRequirementsUnmet) as result:
+            apply_format_detector(self._dataset_root, detect)
+
+        self.assertEqual(len(result.exception.failed_alternatives), 1)
+        self.assertIn('*/*', result.exception.failed_alternatives[0])
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_probe_text_file_success(self):
+        with open(osp.join(self._dataset_root, 'foobar.txt'), 'w') as f:
+            print('123', file=f)
+
+        def detect(context):
+            with context.probe_text_file('foobar.txt', 'abcde') as f:
+                if next(f) != '123\n':
+                    raise Exception
+
+        result = apply_format_detector(self._dataset_root, detect)
+
+        self.assertEqual(result, FormatDetectionConfidence.MEDIUM)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_probe_text_file_failure_bad_file(self):
+        def detect(context):
+            with context.probe_text_file('foobar.txt', 'abcde'):
+                pass
+
+        with self.assertRaises(FormatRequirementsUnmet) as result:
+            apply_format_detector(self._dataset_root, detect)
+
+        self.assertEqual(result.exception.failed_alternatives,
+            ('foobar.txt: abcde',))
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_probe_text_file_failure_exception(self):
+        with open(osp.join(self._dataset_root, 'foobar.txt'), 'w'):
+            pass
+
+        def detect(context):
+            with context.probe_text_file('foobar.txt', 'abcde'):
+                raise Exception
+
+        with self.assertRaises(FormatRequirementsUnmet) as result:
+            apply_format_detector(self._dataset_root, detect)
+
+        self.assertEqual(result.exception.failed_alternatives,
+            ('foobar.txt: abcde',))
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_probe_text_file_nested_req(self):
+        with open(osp.join(self._dataset_root, 'foobar.txt'), 'w'):
+            pass
+
+        def detect(context):
+            with context.probe_text_file('foobar.txt', 'abcde'):
+                context.fail('abcde')
+
+        with self.assertRaises(FormatRequirementsUnmet) as result:
+            apply_format_detector(self._dataset_root, detect)
+
+        self.assertEqual(result.exception.failed_alternatives,
+            ('abcde',))
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_alternatives_success(self):
+        alternatives_executed = set()
+
+        def detect(context):
+            nonlocal alternatives_executed
+            with context.alternatives():
+                with context.alternative():
+                    alternatives_executed.add(1)
+                    context.fail('bad alternative 1')
+                with context.alternative():
+                    alternatives_executed.add(2)
+                    # good alternative 2
+                with context.alternative():
+                    alternatives_executed.add(3)
+                    context.fail('bad alternative 3')
+
+        result = apply_format_detector(self._dataset_root, detect)
+
+        self.assertEqual(result, FormatDetectionConfidence.MEDIUM)
+        self.assertEqual(alternatives_executed, {1, 2, 3})
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_alternatives_failure(self):
+        def detect(context):
+            with context.alternatives():
+                with context.alternative():
+                    context.fail('bad alternative 1')
+                with context.alternative():
+                    context.fail('bad alternative 2')
+
+        with self.assertRaises(FormatRequirementsUnmet) as result:
+            apply_format_detector(self._dataset_root, detect)
+
+        self.assertEqual(result.exception.failed_alternatives,
+            ('bad alternative 1', 'bad alternative 2'))

--- a/tests/test_lfw_format.py
+++ b/tests/test_lfw_format.py
@@ -207,7 +207,7 @@ class LfwImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(LfwImporter.NAME, detected_formats)
+        self.assertEqual([LfwImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import(self):

--- a/tests/test_open_images_format.py
+++ b/tests/test_open_images_format.py
@@ -320,6 +320,6 @@ class OpenImagesImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_274)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR_V6)
-        self.assertIn(OpenImagesImporter.NAME, detected_formats)
+        self.assertEqual([OpenImagesImporter.NAME], detected_formats)
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR_V5)
-        self.assertIn(OpenImagesImporter.NAME, detected_formats)
+        self.assertEqual([OpenImagesImporter.NAME], detected_formats)

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -214,7 +214,7 @@ class WiderFaceImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(WiderFaceImporter.NAME, detected_formats)
+        self.assertEqual([WiderFaceImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import(self):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
The formats in question are `lfw`, `open_images`, `vgg_face2` and `widerface`. As supporting infrastructure, add alternative requirement support.

Also, add low-level format detection tests, which I should really have done earlier.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
