### PR TITLE
Remove the `Image`<->`np.ndarray` equality comparison support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/538>)
 
 ### Removed
-- TBD
+- Equality comparison support between `datumaro.components.media.Image`
+  and `numpy.ndarray`
+  (<https://github.com/openvinotoolkit/datumaro/pull/568>)
 
 ### Fixed
 - Bug #560: import issue with MOT dataset when using seqinfo.ini file

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -97,9 +97,6 @@ class Image(MediaElement):
         return self._size
 
     def __eq__(self, other):
-        if isinstance(other, np.ndarray):
-            return self.has_data and np.array_equal(self.data, other)
-
         if not isinstance(other, __class__):
             return False
         return \

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -91,11 +91,9 @@ class ImageTest(TestCase):
             ]:
                 with self.subTest(**args):
                     img = Image(**args)
-                    # pylint: disable=pointless-statement
                     self.assertTrue(img.has_data)
-                    self.assertEqual(img, image)
+                    np.testing.assert_array_equal(img.data, image)
                     self.assertEqual(img.size, tuple(image.shape[:2]))
-                    # pylint: enable=pointless-statement
 
 class BytesImageTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
@@ -130,7 +128,7 @@ class BytesImageTest(TestCase):
                     # pylint: disable=pointless-statement
                     self.assertEqual('data' in args, img.has_data)
                     if img.has_data:
-                        self.assertEqual(img, image)
+                        np.testing.assert_array_equal(img.data, image)
                         self.assertEqual(img.get_bytes(), image_bytes)
                     img.size
                     if 'size' in args:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This support has some questionable semantics:

* It's not symmetric (`Image` can be equal to `ndarray`, but not the other way around).

* It doesn't behave the same as `ndarray` comparison (which returns an `ndarray` rather than `bool`), so it's not quite transitive either (if `image == array1` and `image == array2` are true, then `array1 == array2` is not true (but an array of `True`s).

Moreover, it's seemingly only used in two tests, and those tests can easily use `np.testing.assert_array_equal` instead, which has the added benefit of printing detailed mismatch information.

Inspired by the discussion in #521.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
