### PR TITLE
Support of score attribute in KITTI detetion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/532>)
 - Support for Accuracy Checker dataset meta files in formats
   (<https://github.com/openvinotoolkit/datumaro/pull/553>)
-- More information about detection to KITTI documentation
+- Support of `score` attribute in KITTI detetion
   (<https://github.com/openvinotoolkit/datumaro/pull/571>)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/532>)
 - Support for Accuracy Checker dataset meta files in formats
   (<https://github.com/openvinotoolkit/datumaro/pull/553>)
+- More information about detection to KITTI documentation
+  (<https://github.com/openvinotoolkit/datumaro/pull/571>)
 
 ### Changed
 - The following formats can now be detected unambiguously:

--- a/datumaro/plugins/kitti_format/converter.py
+++ b/datumaro/plugins/kitti_format/converter.py
@@ -133,7 +133,7 @@ class KittiConverter(Converter):
                     os.makedirs(osp.dirname(labels_file), exist_ok=True)
                     with open(labels_file, 'w', encoding='utf-8') as f:
                         for bbox in bboxes:
-                            label_line = [-1] * 15
+                            label_line = [-1] * 16
                             label_line[0] = self.get_label(bbox.label)
                             label_line[1] = cast(bbox.attributes.get('truncated'),
                                 float, KittiPath.DEFAULT_TRUNCATED)
@@ -141,6 +141,9 @@ class KittiConverter(Converter):
                                 int, KittiPath.DEFAULT_OCCLUDED)
                             x, y, h, w = bbox.get_bbox()
                             label_line[4:8] = x, y, x + h, y + w
+
+                            label_line[15] = cast(bbox.attributes.get('score'),
+                                float, KittiPath.DEFAULT_SCORE)
 
                             label_line = ' '.join(str(v) for v in label_line)
                             f.write('%s\n' % label_line)

--- a/datumaro/plugins/kitti_format/extractor.py
+++ b/datumaro/plugins/kitti_format/extractor.py
@@ -91,7 +91,7 @@ class _KittiExtractor(SourceExtractor):
 
                 for line_idx, line in enumerate(lines):
                     line = line.split()
-                    assert len(line) == 15
+                    assert len(line) == 15 or len(line) == 16
 
                     x1, y1 = float(line[4]), float(line[5])
                     x2, y2 = float(line[6]), float(line[7])
@@ -99,6 +99,9 @@ class _KittiExtractor(SourceExtractor):
                     attributes = {}
                     attributes['truncated'] = float(line[1]) != 0
                     attributes['occluded']  = int(line[2]) != 0
+
+                    if len(line) == 16:
+                        attributes['score'] = float(line[15])
 
                     label_id = self.categories()[
                         AnnotationType.label].find(line[0])[0]

--- a/datumaro/plugins/kitti_format/format.py
+++ b/datumaro/plugins/kitti_format/format.py
@@ -67,6 +67,7 @@ class KittiPath:
 
     DEFAULT_TRUNCATED = 0.0 # 0% truncated
     DEFAULT_OCCLUDED = 0    # fully visible
+    DEFAULT_SCORE = 1.0
 
 
 def make_kitti_categories(label_map=None):

--- a/site/content/en/docs/formats/kitti.md
+++ b/site/content/en/docs/formats/kitti.md
@@ -43,6 +43,28 @@ datum import --format kitti <path/to/dataset>
 It is possible to specify project name and project directory. Run
 `datum create --help` for more information.
 
+KITTI detection dataset directory should have the following structure:
+
+<!--lint disable fenced-code-flag-->
+```
+└─ Dataset/
+    ├── label_colors.txt # optional, color map for non-original segmentation labels
+    ├── testing/
+    │   └── image_2/
+    │       ├── <name_1>.<img_ext>
+    │       ├── <name_2>.<img_ext>
+    │       └── ...
+    └── training/
+        ├── image_2/ # left color camera images
+        │   ├── <name_1>.<img_ext>
+        │   ├── <name_2>.<img_ext>
+        │   └── ...
+        └─── label_2/ # left color camera label files
+            ├── <name_1>.txt
+            ├── <name_2>.txt
+            └── ...
+```
+
 KITTI segmentation dataset directory should have the following structure:
 
 <!--lint disable fenced-code-flag-->

--- a/site/content/en/docs/formats/kitti.md
+++ b/site/content/en/docs/formats/kitti.md
@@ -26,6 +26,7 @@ Supported annotation attributes:
   the object does not correspond to the full extent of the object
 - `occluded` (boolean) - indicates that a significant portion of the object
   within the bounding box is occluded by another object
+- `score` (float) - indicates confidence in detection
 
 ## Import KITTI dataset
 

--- a/site/content/en/docs/formats/kitti.md
+++ b/site/content/en/docs/formats/kitti.md
@@ -48,7 +48,6 @@ KITTI detection dataset directory should have the following structure:
 <!--lint disable fenced-code-flag-->
 ```
 └─ Dataset/
-    ├── label_colors.txt # optional, color map for non-original segmentation labels
     ├── testing/
     │   └── image_2/
     │       ├── <name_1>.<img_ext>

--- a/tests/test_kitti_format.py
+++ b/tests/test_kitti_format.py
@@ -183,14 +183,17 @@ class KittiConverterTest(TestCase):
             DatasetItem(id='1_2', subset='test',
                 image=np.ones((10, 10, 3)), annotations=[
                 Bbox(0, 1, 2, 2, label=0, id=0,
-                    attributes={'truncated': False, 'occluded': False}),
+                    attributes={'truncated': False, 'occluded': False,
+                        'score': 1.0}),
             ]),
             DatasetItem(id='1_3', subset='test',
                 image=np.ones((10, 10, 3)), annotations=[
                 Bbox(0, 0, 2, 2, label=1, id=0,
-                    attributes={'truncated': True, 'occluded': False}),
+                    attributes={'truncated': True, 'occluded': False,
+                        'score': 1.0}),
                 Bbox(6, 2, 3, 4, label=1, id=1,
-                    attributes={'truncated': False, 'occluded': True}),
+                    attributes={'truncated': False, 'occluded': True,
+                        'score': 1.0}),
             ]),
         ], categories=['label_0', 'label_1'])
 
@@ -462,7 +465,8 @@ class KittiConverterTest(TestCase):
             DatasetItem(id='b', subset='val', image=np.ones((5, 5, 3)),
                 annotations=[
                     Bbox(0, 0, 3, 3, label=0, attributes={
-                        'truncated': True, 'occluded': False
+                        'truncated': True, 'occluded': False,
+                        'score': 0.9
                     })
                 ])
         ], categories=['label_0'])
@@ -517,3 +521,28 @@ class KittiConverterTest(TestCase):
                 partial(KittiConverter.convert, tasks=KittiTask.segmentation,
                     label_map=source_label_map), test_dir,
                     target_dataset=expected_dataset)
+
+    @mark_requirement(Requirements.DATUM_280)
+    def test_can_save_detection_with_score_attribute(self):
+        source_dataset = Dataset.from_iterable([
+            DatasetItem(id='1_2', subset='test',
+                image=np.ones((10, 10, 3)), annotations=[
+                Bbox(0, 1, 2, 2, label=0, id=0,
+                    attributes={'truncated': False, 'occluded': False,
+                        'score': 0.78}),
+            ]),
+            DatasetItem(id='1_3', subset='test',
+                image=np.ones((10, 10, 3)), annotations=[
+                Bbox(0, 0, 2, 2, label=1, id=0,
+                    attributes={'truncated': True, 'occluded': False,
+                        'score': 0.8}),
+                Bbox(6, 2, 3, 4, label=1, id=1,
+                    attributes={'truncated': False, 'occluded': True,
+                        'score': 0.67}),
+            ]),
+        ], categories=['label_0', 'label_1'])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(source_dataset,
+                partial(KittiConverter.convert,
+                save_images=True, tasks=KittiTask.detection), test_dir)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [x] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
