### PR TITLE
Fix type annotations on some `__iter__` methods

### DIFF
--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -451,7 +451,7 @@ class DatasetStorage(IDataset):
             self._flush_changes = False
             self._updated_items = {}
 
-    def __iter__(self) -> Iterable[DatasetItem]:
+    def __iter__(self) -> Iterator[DatasetItem]:
         if self._is_unchanged_wrapper:
             yield from self._iter_init_cache()
         else:

--- a/datumaro/components/extractor.py
+++ b/datumaro/components/extractor.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from glob import iglob
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 import os
 import os.path as osp
 
@@ -92,7 +92,7 @@ class DatasetItem:
 CategoriesInfo = Dict[AnnotationType, Categories]
 
 class IExtractor:
-    def __iter__(self) -> Iterable[DatasetItem]:
+    def __iter__(self) -> Iterator[DatasetItem]:
         raise NotImplementedError()
 
     def __len__(self) -> int:

--- a/datumaro/components/project.py
+++ b/datumaro/components/project.py
@@ -5,8 +5,8 @@
 from contextlib import ExitStack, suppress
 from enum import Enum, auto
 from typing import (
-    Any, Dict, Generic, Iterable, List, NewType, Optional, Tuple, TypeVar,
-    Union,
+    Any, Dict, Generic, Iterable, Iterator, List, NewType, Optional, Tuple,
+    TypeVar, Union,
 )
 import json
 import logging as log
@@ -181,7 +181,7 @@ class CrudProxy(Generic[CrudEntry]):
             -> Union[None, T, CrudEntry]:
         return self._data.get(name, default)
 
-    def __iter__(self) -> Iterable[CrudEntry]:
+    def __iter__(self) -> Iterator[CrudEntry]:
         return iter(self._data.keys())
 
     def items(self) -> Iterable[Tuple[str, CrudEntry]]:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
`__iter__` is supposed to return an iterator, not an iterable (the object
with the `__iter__` method is the iterable).

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
