### PR TITLE
Fix line matching in multimerge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using `Image`, `ByteImage` from `datumaro.util.image` - these classes
   are moved to `datumaro.components.media`
   (<https://github.com/openvinotoolkit/datumaro/pull/538>)
+- Using `smooth_line` from `datumaro.util.annotation_util` - the function
+  is renamed to `approximate_line` and has updated interface
+  (<https://github.com/openvinotoolkit/datumaro/pull/592>)
 
 ### Removed
 - Equality comparison support between `datumaro.components.media.Image`
@@ -58,6 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/564>)
 - Empty lines in VOC subset lists are not ignored
   (<https://github.com/openvinotoolkit/datumaro/pull/587>)
+- Fails in multimerge when lines are not approximated and when there are no
+  label categories (<https://github.com/openvinotoolkit/datumaro/pull/592>)
 
 ### Security
 - TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,14 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/563>)
 - Allowed export options in the `datum merge` command
   (<https://github.com/openvinotoolkit/datumaro/pull/545>)
+- `smooth_line` from `datumaro.util.annotation_util` - the function
+  is renamed to `approximate_line` and has updated interface
+  (<https://github.com/openvinotoolkit/datumaro/pull/592>)
 
 ### Deprecated
 - Using `Image`, `ByteImage` from `datumaro.util.image` - these classes
   are moved to `datumaro.components.media`
   (<https://github.com/openvinotoolkit/datumaro/pull/538>)
-- Using `smooth_line` from `datumaro.util.annotation_util` - the function
-  is renamed to `approximate_line` and has updated interface
-  (<https://github.com/openvinotoolkit/datumaro/pull/592>)
 
 ### Removed
 - Equality comparison support between `datumaro.components.media.Image`

--- a/datumaro/components/operations.py
+++ b/datumaro/components/operations.py
@@ -779,10 +779,9 @@ class LineMatcher(_ShapeMatcher):
             return 1
 
         def _approx(line, segments):
-            if len(line) // 2 == segments + 1:
-                return np.reshape(line, (-1, 2))
-            else:
-                return approximate_line(line, segments=segments)
+            if len(line) // 2 != segments + 1:
+                line = approximate_line(line, segments=segments)
+            return np.reshape(line, (-1, 2))
         segments = max(len(a.points) // 2, len(b.points) // 2, 5) - 1
 
         a = _approx(a.points, segments)

--- a/datumaro/components/operations.py
+++ b/datumaro/components/operations.py
@@ -784,7 +784,7 @@ class LineMatcher(_ShapeMatcher):
                 return np.reshape(line, (-1, 2))
             else:
                 return approximate_line(line, segments=segments)
-        segments = max(max(len(a.points) // 2, len(b.points) // 2), 5) - 1
+        segments = max(len(a.points) // 2, len(b.points) // 2, 5) - 1
 
         a = _approx(a.points, segments)
         b = _approx(b.points, segments)

--- a/datumaro/components/operations.py
+++ b/datumaro/components/operations.py
@@ -401,8 +401,7 @@ class IntersectMerge(MergingStrategy):
 
         label_cat = self._merge_label_categories(sources)
         if label_cat is None:
-            return dst_categories
-
+            label_cat = LabelCategories()
         dst_categories[AnnotationType.label] = label_cat
 
         points_cat = self._merge_point_categories(sources, label_cat)

--- a/datumaro/util/annotation_util.py
+++ b/datumaro/util/annotation_util.py
@@ -209,13 +209,13 @@ def approximate_line(points: Sequence[float], segments: int) -> np.ndarray:
     distributed uniformly across the resulting line.
 
     Args:
-      points (ndarray): an array of line point coordinates.
-        The shape is [points * 2] (flat), the layout is [x0, y0, x1, y1, ...].
+      points (Sequence): an array of line point coordinates.
+        The size is [points * 2], the layout is [x0, y0, x1, y1, ...].
       segments (int): the required numebr of segments in the resulting line.
 
     Returns:
       new_points (ndarray): an array of new line point coordinates.
-        The shape is [segments, 2], the layout is [[x0, y0], [x1, y1], ...].
+        The size is [(segments + 1) * 2], the layout is [x0, y0, x1, y1, ...].
     """
 
     assert 2 <= len(points) // 2 and len(points) % 2 == 0
@@ -250,7 +250,7 @@ def approximate_line(points: Sequence[float], segments: int) -> np.ndarray:
 
         new_points[new_segment] = prev_p * (1 - r) + next_p * r
 
-    return new_points
+    return np.reshape(new_points, (-1, ))
 
 def make_label_id_mapping(
         src_labels: LabelCategories, dst_labels: LabelCategories,

--- a/datumaro/util/annotation_util.py
+++ b/datumaro/util/annotation_util.py
@@ -178,11 +178,18 @@ def OKS(a, b, sigma=None, bbox=None, scale=None):
     dists = np.linalg.norm(p1 - p2, axis=1)
     return np.sum(np.exp(-(dists ** 2) / (2 * scale * (2 * sigma) ** 2)))
 
-def smooth_line(points, segments):
-    assert 2 <= len(points) // 2 and len(points) % 2 == 0
+def approximate_line(points: np.ndarray, segments: int) -> np.ndarray:
+    """
+    Approximates a 2d line to the required number of segments. Points are
+    distributed uniformly across the resulting line.
 
-    if len(points) // 2 == segments:
-        return points
+    Returns:
+      new_points (ndarray): a flat array of new line point coordinates.
+        The shape is [segments, 2], the layout is [[x0, y0], [x1, y1], ...].
+    """
+
+    assert 2 <= len(points) // 2 and len(points) % 2 == 0
+    assert 0 < segments
 
     points = list(points)
     if len(points) == 2:
@@ -213,7 +220,7 @@ def smooth_line(points, segments):
 
         new_points[new_segment] = prev_p * (1 - r) + next_p * r
 
-    return new_points, step
+    return new_points
 
 def make_label_id_mapping(
         src_labels: LabelCategories, dst_labels: LabelCategories,
@@ -225,14 +232,14 @@ def make_label_id_mapping(
             Dict[int, str]
         ]:
     """
-    Maps label ids from source to destination. Fallback is used for missing
+    Maps label ids from source to destination. Fallback id is used for missing
     labels.
 
     Returns:
-      function to map labels: src id -> dst id
-        dict: src id -> dst id
-        dict: src id -> src label
-        dict: dst id -> dst label
+      map_id (callable): src id -> dst id
+      id_mapping (dict): src id -> dst id
+      src_labels (dict): src id -> src label
+      dst_labels (dict): dst id -> dst label
     """
 
     source_labels = { id: label.name

--- a/datumaro/util/annotation_util.py
+++ b/datumaro/util/annotation_util.py
@@ -205,8 +205,8 @@ def OKS(a, b, sigma=None, bbox=None, scale=None):
 
 def approximate_line(points: Sequence[float], segments: int) -> np.ndarray:
     """
-    Approximates a 2d line to the required number of segments. Points are
-    distributed uniformly across the resulting line.
+    Approximates a 2d line to the required number of segments. The new points
+    are distributed uniformly across the input line.
 
     Args:
       points (Sequence): an array of line point coordinates.

--- a/datumaro/util/annotation_util.py
+++ b/datumaro/util/annotation_util.py
@@ -16,16 +16,6 @@ from datumaro.components.annotation import (
 from datumaro.util.mask_tools import mask_to_rle
 
 
-def __getattr__(name: str):
-    if name == 'smooth_line':
-        import warnings
-        warnings.warn(f"Using {name} from '{__package__}' is deprecated, "
-            "the function is renamed to 'approximate_line'", DeprecationWarning,
-            stacklevel=2)
-
-        return approximate_line
-    raise AttributeError
-
 def find_instances(instance_anns):
     instance_anns = sorted(instance_anns, key=lambda a: a.group)
     ann_groups = []

--- a/datumaro/util/annotation_util.py
+++ b/datumaro/util/annotation_util.py
@@ -13,6 +13,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.util.mask_tools import mask_to_rle
 
+
 def __getattr__(name: str):
     if name == 'smooth_line':
         import warnings

--- a/datumaro/util/annotation_util.py
+++ b/datumaro/util/annotation_util.py
@@ -13,6 +13,15 @@ from datumaro.components.annotation import (
 )
 from datumaro.util.mask_tools import mask_to_rle
 
+def __getattr__(name: str):
+    if name == 'smooth_line':
+        import warnings
+        warnings.warn(f"Using {name} from '{__package__}' is deprecated, "
+            "the function is renamed to 'approximate_line'", DeprecationWarning,
+            stacklevel=2)
+
+        return approximate_line
+    raise AttributeError
 
 def find_instances(instance_anns):
     instance_anns = sorted(instance_anns, key=lambda a: a.group)

--- a/datumaro/util/annotation_util.py
+++ b/datumaro/util/annotation_util.py
@@ -193,8 +193,13 @@ def approximate_line(points: np.ndarray, segments: int) -> np.ndarray:
     Approximates a 2d line to the required number of segments. Points are
     distributed uniformly across the resulting line.
 
+    Args:
+      points (ndarray): an array of line point coordinates.
+        The shape is [points * 2] (flat), the layout is [x0, y0, x1, y1, ...].
+      segments (int): the required numebr of segments in the resulting line.
+
     Returns:
-      new_points (ndarray): a flat array of new line point coordinates.
+      new_points (ndarray): an array of new line point coordinates.
         The shape is [segments, 2], the layout is [[x0, y0], [x1, y1], ...].
     """
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -388,6 +388,32 @@ class TestMultimerge(TestCase):
                 key=lambda e: len(e.sources))
         )
 
+    @mark_requirement(Requirements.DATUM_BUG_219)
+    def test_can_match_lines_when_line_not_approximated(self):
+        source0 = Dataset.from_iterable([
+            DatasetItem(1, annotations=[
+                PolyLine([1, 1, 2, 1, 3, 5, 5, 5, 8, 3]),
+            ]),
+        ])
+
+        source1 = Dataset.from_iterable([
+            DatasetItem(1, annotations=[
+                PolyLine([1, 1, 8, 3]),
+            ]),
+        ])
+
+        expected = Dataset.from_iterable([
+            DatasetItem(1, annotations=[
+                PolyLine([1, 1, 2, 1, 3, 5, 5, 5, 8, 3]),
+            ]),
+        ], categories=[])
+
+        merger = IntersectMerge(conf={'quorum': 1, 'pairwise_dist': 0.1})
+        merged = merger([source0, source1])
+
+        compare_datasets(self, expected, merged, ignored_attrs={'score'})
+        self.assertEqual(0, len(merger.errors))
+
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_attributes(self):
         source0 = Dataset.from_iterable([


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Closes #219 

- Renamed `smooth_line` to `approximate_line`, added deprecation notice
- Added more descriptions and type annotations
- The function now always returns only a single array
- Updated implementation of the line comparison algorithm
- Fixed the problem when multimerge failed because of missing label categories
- Fixed area computation in case of self-intersections

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
