### PR TITLE
Utilize source extractor length in Dataset if available

### DIFF
--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -466,7 +466,15 @@ class DatasetStorage(IDataset):
 
     def __len__(self) -> int:
         if self._length is None:
-            self.init_cache()
+            if self._is_unchanged_wrapper and \
+                    is_method_redefined('__len__', Extractor, self._source):
+                # Allow to use optimized versions of __len__() if the source
+                # has them. The default implementation just iterates over
+                # the items, so using it won't give any benefits comparing
+                # to initializing the cache.
+                self._length = len(self._source)
+            else:
+                self.init_cache()
         return self._length
 
     def categories(self) -> CategoriesInfo:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1048,6 +1048,33 @@ class DatasetTest(TestCase):
         self.assertEqual(iter_called, 2)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_use_extractor_len_when_simple_wrapper(self):
+        class TestExtractor(Extractor):
+            def __iter__(self):
+                yield from [ DatasetItem(1), ]
+
+            def __len__(self):
+                return 42
+
+        dataset = Dataset(TestExtractor())
+
+        self.assertEqual(42, len(dataset))
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_cant_use_extractor_len_when_not_simple_wrapper(self):
+        class TestExtractor(Extractor):
+            def __iter__(self):
+                yield from [ DatasetItem(1), ]
+
+            def __len__(self):
+                return 42
+
+        dataset = Dataset(TestExtractor())
+        dataset.transform('reindex')
+
+        self.assertEqual(1, len(dataset))
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_raises_when_repeated_items_in_source(self):
         dataset = Dataset.from_iterable([DatasetItem(0), DatasetItem(0)])
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This patch allows to use optimized versions of `__len__` provided by the source extractors in the `Dataset`. Without this change, Dataset would always initialize cache, which is performance pessimization.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
