### PR TITLE
Add API documentation versioning

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           pip install gitpython packaging toml Sphinx==4.2.0 sphinx-rtd-theme==1.0.0
           pip install -r requirements.txt
-          pip install git+https://github.com/pytorch-ignite/sphinxcontrib-versioning.git
+          pip install git+https://github.com/pytorch-ignite/sphinxcontrib-versioning.git@a1a1a94ca80a0233f0df3eaf9876812484901e76
           sphinx-versioning -l site\source\conf.py build -r develop -w develop site\source site\static\api
           python site/build_docs.py
 

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -35,7 +35,7 @@ jobs:
           pip install gitpython packaging toml Sphinx==4.2.0 sphinx-rtd-theme==1.0.0
           pip install -r requirements.txt
           pip install git+https://github.com/pytorch-ignite/sphinxcontrib-versioning.git@a1a1a94ca80a0233f0df3eaf9876812484901e76
-          sphinx-versioning -l site\source\conf.py build -r develop -w develop site\source site\static\api
+          sphinx-versioning -l site/source/conf.py build -r develop -w develop site/source site/static/api
           python site/build_docs.py
 
       - name: Deploy

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -34,7 +34,8 @@ jobs:
         run: |
           pip install gitpython packaging toml Sphinx==4.2.0 sphinx-rtd-theme==1.0.0
           pip install -r requirements.txt
-          sphinx-build -a -n site/source site/static/api
+          pip install git+https://github.com/pytorch-ignite/sphinxcontrib-versioning.git
+          sphinx-versioning -l site\source\conf.py build -r develop -w develop site\source site\static\api
           python site/build_docs.py
 
       - name: Deploy

--- a/site/README.md
+++ b/site/README.md
@@ -27,10 +27,10 @@ display on the sidebar), the description and the tags:
 
 ### Start site localy
 
-To start the site locally, you need a recent [extended version hugo](https://github.com/gohugoio/hugo/releases)
+To start the site locally, you need a recent [extended version hugo](https://github.com/gohugoio/hugo/releases)
 (recommend version 0.75.0 or later).
 Open the most recent release and scroll down until you find
-a list of Extended versions. [Read more](https://gohugo.io/getting-started/installing/#quick-install)
+a list of Extended versions. [Read more](https://gohugo.io/getting-started/installing/#quick-install)
 
 Add a path to "hugo" in the "Path" environment variable.
 
@@ -39,7 +39,7 @@ using a git command:
 
     git clone --branch <branchname> <remote-repo-url>
 
-If you want to build and/or serve your site locally,
+If you want to build and/or serve your site locally,
 you also need to get local copies of the theme’s own submodules:
 
     git submodule update --init --recursive
@@ -51,8 +51,8 @@ API documentation is generated using `Sphinx` with a theme
 The `Read the Docs` theme is added as a submodule.
 Install Sphinx ([learn more](https://www.sphinx-doc.org/en/master/index.html)).
 
-    pip install -U Sphinx
-    pip install sphinx-rtd-theme==1.0.0
+    pip install Sphinx==4.2.0 sphinx-rtd-theme==1.0.0
+    pip install git+https://github.com/pytorch-ignite/sphinxcontrib-versioning.git@a1a1a94ca80a0233f0df3eaf9876812484901e76
 
 Documentation is generated automatically from `rst` files and comments
 contained in the source code, files located in `site/source/api` using
@@ -61,9 +61,15 @@ Comments in the source code should be in the format [reST](https://www.sphinx-do
 [Google](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings) or
 [Numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#).
 
+For generation only latest version
+
     sphinx-build -a -n site/source site/static/api
 
-Sphinx generates documentation in html format in `site/static/api`.
+For generation documentation with versioning
+
+    sphinx-versioning -l site\source\conf.py build -r develop -w develop site\source site\static\api
+
+Sphinx generates documentation in the html format to the `site/static/api`.
 After generating the documentation API,
 you can [generate a site with documentation](#site-generation).
 
@@ -98,11 +104,13 @@ In `rst` files you can used a few directives:
 
 After the directive you can specify the members that should be displayed.
 
+###### Features
+
 If can used `|n` and `|s` in the source code comments they will
 be replaced by `\n` and space accordingly.
 
-Members starting with `_` do not have comments are not displayed,
-except for the list of `include_members_list` located in `conf.py`.
+Members starting with `_` are not displayed,
+except for the list of `include_members_list` located in `site/source/conf.py`.
 
 #### Site generation
 
@@ -111,7 +119,7 @@ To build and preview your site locally, use:
     cd <your local directory>/datumaro/site/
     hugo server
 
-By default, your site will be available at <http://localhost:1313/docs/>.
+By default, your site will be available at <http://localhost:1313/docs/>.
 
 Instead of a "hugo server" command, you can use the "hugo" command
 that generates the site into a "public" folder.

--- a/site/source/_static/custom.css
+++ b/site/source/_static/custom.css
@@ -27,9 +27,9 @@ SPDX-License-Identifier: MIT
 }
 
 .rst-versions .rst-current-version {
-  background-color: #30638e !important;
+  background-color: #30638e;
 }
 
 .rst-versions {
-  background: #21425e !important;
+  background: #21425e;
 }

--- a/site/source/_static/custom.css
+++ b/site/source/_static/custom.css
@@ -25,3 +25,11 @@ SPDX-License-Identifier: MIT
 .wy-dropdown-menu > dd > a:hover {
   color: #30638e;
 }
+
+.rst-versions .rst-current-version {
+  background-color: #30638e !important;
+}
+
+.rst-versions {
+  background: #21425e !important;
+}

--- a/site/source/conf.py
+++ b/site/source/conf.py
@@ -35,7 +35,6 @@ extensions = [
     'sphinx.ext.napoleon', # Support for NumPy and Google style docstrings
     'sphinx.ext.autodoc',  # Core library for html generation from docstrings
     'sphinx.ext.viewcode', # Find the source files
-    'sphinx.ext.githubpages', # Creates .nojekyll file
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
This PR added API documentation versioning.
For versioning used [`sphinxcontrib-versioning fork`](https://github.com/pytorch-ignite/sphinxcontrib-versioning), because the main repository has not received updates for a long time.
After datumaro release `v0.2.2`, it is version will display on the version menu.

Preview: https://tosmanov.github.io/datumaro/api/
### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [x] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
