### PR TITLE
ByteImage: try to guess the image extension if one is not given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/573>)
 - Image resizing transform
   (<https://github.com/openvinotoolkit/datumaro/pull/581>)
+- Extension autodetection in `ByteImage`
+  (<https://github.com/openvinotoolkit/datumaro/pull/595>)
 
 ### Changed
 - The following formats can now be detected unambiguously:

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -121,6 +121,12 @@ class Image(MediaElement):
             save_image(path, self.data)
 
 class ByteImage(Image):
+    _FORMAT_MAGICS = (
+        (b'\x89PNG\r\n\x1a\n', '.png'),
+        (b'\xff\xd8\xff', '.jpg'),
+        (b'BM', '.bmp'),
+    )
+
     def __init__(self,
             data: Union[bytes, Callable[[str], bytes], None] = None,
             *,
@@ -147,7 +153,17 @@ class ByteImage(Image):
             ext = ext.lower()
             if not ext.startswith('.'):
                 ext = '.' + ext
+        elif path is None and isinstance(data, bytes):
+            ext = self._guess_ext(data)
         self._ext = ext
+
+    @classmethod
+    def _guess_ext(cls, data: bytes) -> Optional[str]:
+        return next(
+            (ext for magic, ext in cls._FORMAT_MAGICS
+                if data.startswith(magic)),
+            None,
+        )
 
     def get_bytes(self):
         if callable(self._bytes_data):

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -137,6 +137,21 @@ class BytesImageTest(TestCase):
                         self.assertEqual(img.ext, args.get('ext', '.png'))
                     # pylint: enable=pointless-statement
 
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_ext_detection(self):
+        image_data = np.zeros((3, 4))
+
+        for ext in ('.bmp', '.jpg', '.png'):
+            with self.subTest(ext=ext):
+                image = ByteImage(data=encode_image(image_data, ext))
+                self.assertEqual(image.ext, ext)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_ext_detection_failure(self):
+        image_bytes = b'\xff' * 10 # invalid image
+        image = ByteImage(data=image_bytes)
+        self.assertEqual(image.ext, '')
+
 class ImageMetaTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_loading(self):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
This lets us avoid needless re-encoding when a `ByteImage` is saved as the format it already is in.

Unfortunately, neither OpenCV nor PIL seem to offer functionality to detect the format without loading the image, so we have to implement it ourselves. I only added support for a handful of most common formats, which should cover a majority of cases.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
