### PR TITLE
Reformat the diagram of datum subcommands

### DIFF
--- a/site/content/en/docs/user-manual/command-reference/_index.md
+++ b/site/content/en/docs/user-manual/command-reference/_index.md
@@ -11,41 +11,41 @@ weight: 6
 %%{init { 'theme':'neutral' }}%%
 flowchart LR
   d(("#0009; datum #0009;")):::mainclass
-  s(source):::nofillclass
   m(model):::nofillclass
   p(project):::nofillclass
+  s(source):::nofillclass
 
-  d===s
-    s===id1[add]:::hideclass
-    s===id2[remove]:::hideclass
-    s===id3[info]:::hideclass
   d===m
-    m===id4[add]:::hideclass
-    m===id5[remove]:::hideclass
-    m===id6[run]:::hideclass
-    m===id7[info]:::hideclass
+    m===m_add[add]:::hideclass
+    m===m_info[info]:::hideclass
+    m===m_remove[remove]:::hideclass
+    m===m_run[run]:::hideclass
   d===p
-    p===migrate:::hideclass
-    p===info:::hideclass
-  d====str1[create]:::filloneclass
-  d====str1[download]:::filloneclass
-  d====str2[import]:::filloneclass
-  d====str3[export]:::filloneclass
-  d====str4[add]:::filloneclass
-  d====str5[remove]:::filloneclass
-  d====str6[info]:::filloneclass
-  d====str7[transform]:::filltwoclass
-  d====str8[filter]:::filltwoclass
-  d====str9[diff]:::fillthreeclass
-  d====str10[merge]:::fillthreeclass
-  d====str11[patch]:::fillthreeclass
-  d====str12[validate]:::fillthreeclass
-  d====str13[explain]:::fillthreeclass
-  d====str14[stats]:::fillthreeclass
-  d====str15[commit]:::fillfourclass
-  d====str16[checkout]:::fillfourclass
-  d====str17[status]:::fillfourclass
-  d====str18[log]:::fillfourclass
+    p===p_info[info]:::hideclass
+    p===p_migrate[migrate]:::hideclass
+  d===s
+    s===s_add[add]:::hideclass
+    s===s_info[info]:::hideclass
+    s===s_remove[remove]:::hideclass
+  d====_add[add]:::filloneclass
+  d====_create[create]:::filloneclass
+  d====_download[download]:::filloneclass
+  d====_export[export]:::filloneclass
+  d====_import[import]:::filloneclass
+  d====_info[info]:::filloneclass
+  d====_remove[remove]:::filloneclass
+  d====_filter[filter]:::filltwoclass
+  d====_transform[transform]:::filltwoclass
+  d====_diff[diff]:::fillthreeclass
+  d====_explain[explain]:::fillthreeclass
+  d====_merge[merge]:::fillthreeclass
+  d====_patch[patch]:::fillthreeclass
+  d====_stats[stats]:::fillthreeclass
+  d====_validate[validate]:::fillthreeclass
+  d====_checkout[checkout]:::fillfourclass
+  d====_commit[commit]:::fillfourclass
+  d====_log[log]:::fillfourclass
+  d====_status[status]:::fillfourclass
 
   classDef nofillclass fill-opacity:0;
   classDef hideclass fill-opacity:0,stroke-opacity:0;


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
* Use meaningful identifiers for nodes so that we don't need to renumber them when adding new commands in the middle. (This also fixes duplicate IDs for the `create` and `download` commands, which I accidentally caused in a28b32db6).

* Order commands within a group and contexts alphabetically, to make the diagram easier to navigate.

The reason there's an underscore in front of each node ID corresponding to a command not in a context is that Mermaid refuses to render a graph if a node has "filter" as the ID. Don't know what's up with that.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [x] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
