### PR TITLE
Refactor COCO parsing

### DIFF
--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -205,7 +205,7 @@ class _CocoExtractor(SourceExtractor):
         mask = bgr2index(mask)
         return mask
 
-    @define(on_setattr=False)
+    @define
     class _lazy_merged_mask:
         segmentation: Any
         h: int

--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -1,13 +1,13 @@
-# Copyright (C) 2019-2021 Intel Corporation
+# Copyright (C) 2019-2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
-from collections import OrderedDict
+from typing import Any
 import json
 import logging as log
 import os.path as osp
 
-from pycocotools.coco import COCO
+from attrs import define
 import pycocotools.mask as mask_utils
 
 from datumaro.components.annotation import (
@@ -18,15 +18,20 @@ from datumaro.components.extractor import (
     DEFAULT_SUBSET_NAME, DatasetItem, SourceExtractor,
 )
 from datumaro.components.media import Image
+from datumaro.util import take_by
 from datumaro.util.image import lazy_image, load_image
 from datumaro.util.mask_tools import bgr2index
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
-from datumaro.util.os_util import suppress_output
 
 from .format import CocoPath, CocoTask
 
 
 class _CocoExtractor(SourceExtractor):
+    """
+    Parses COCO annotations written in the following format:
+    https://cocodataset.org/#format-data
+    """
+
     def __init__(self, path, task, *,
         merge_instance_polygons=False,
         subset=None,
@@ -54,145 +59,134 @@ class _CocoExtractor(SourceExtractor):
 
         self._merge_instance_polygons = merge_instance_polygons
 
+        json_data = self._load_json(path)
+        self._label_map = {} # coco_id -> dm_id
+        self._load_categories(json_data,
+            keep_original_ids=keep_original_category_ids,
+        )
+
         if self._task == CocoTask.panoptic:
             #panoptic is not added to pycocotools
-            panoptic_config = self._load_panoptic_config(path)
-            panoptic_images = osp.splitext(path)[0]
-
-            self._load_label_categories(
-                panoptic_config['categories'],
-                keep_original_ids=keep_original_category_ids,
-            )
-
-            self._items = list(self._load_panoptic_items(panoptic_config,
-                panoptic_images).values())
+            self._items = self._load_panoptic_items(json_data,
+                mask_dir=osp.splitext(path)[0])
         else:
-            loader = self._make_subset_loader(path)
-            self._load_categories(
-                loader,
-                keep_original_ids=keep_original_category_ids,
-            )
-            self._items = list(self._load_items(loader).values())
+            self._items = self._load_items(json_data)
 
-    @staticmethod
-    def _make_subset_loader(path):
-        # TODO: remove pycocotools dependency?
+    def __iter__(self):
+        yield from self._items.values()
 
-        # COCO API has an unclosed file problem, so we read json manually
-        coco_api = COCO()
-        with open(path, 'r', encoding='utf-8') as f:
-            dataset = json.load(f)
+    def _load_categories(self, json_data, *, keep_original_ids):
+        if has_meta_file(self._rootpath):
+            labels = parse_meta_file(self._rootpath).keys()
+            self._categories = {
+                AnnotationType.label: LabelCategories.from_iterable(labels)
+            }
+            # 0 is reserved for no class
+            self._label_map = { i + 1: i for i in range(len(labels)) }
+            return
 
-        coco_api.dataset = dataset
-
-        # suppress annoying messages about dataset reading from cocoapi
-        with suppress_output():
-            coco_api.createIndex()
-        return coco_api
-
-    def _load_categories(self, loader, *, keep_original_ids):
         self._categories = {}
 
         if self._task in [CocoTask.instances, CocoTask.labels,
-                CocoTask.person_keypoints, CocoTask.stuff]:
-            self._load_label_categories(
-                loader.loadCats(loader.getCatIds()),
+                CocoTask.person_keypoints, CocoTask.stuff,
+                CocoTask.panoptic]:
+            self._load_label_categories(json_data['categories'],
                 keep_original_ids=keep_original_ids,
             )
 
         if self._task == CocoTask.person_keypoints:
-            self._load_person_kp_categories(loader)
+            self._load_person_kp_categories(json_data['categories'])
 
-
-    def _load_label_categories(self, raw_cats, *, keep_original_ids):
-        if has_meta_file(self._rootpath):
-            labels = parse_meta_file(self._rootpath).keys()
-            self._categories =  { AnnotationType.label: LabelCategories.
-                from_iterable(labels) }
-            self._label_map = { (i + 1): label for i, label in enumerate(labels) }
-            return
-
+    def _load_label_categories(self, json_cat, *, keep_original_ids):
         categories = LabelCategories()
         label_map = {}
 
         if keep_original_ids:
-            for cat in sorted(raw_cats, key=lambda cat: cat['id']):
+            for cat in sorted(json_cat, key=lambda cat: cat['id']):
                 label_map[cat['id']] = cat['id']
 
                 while len(categories) < cat['id']:
-                    categories.add(name=f"class-{len(categories)}")
+                    categories.add(f"class-{len(categories)}")
 
-                categories.add(name=cat['name'], parent=cat.get('supercategory'))
+                categories.add(cat['name'], parent=cat.get('supercategory'))
         else:
-            for idx, cat in enumerate(raw_cats):
+            for idx, cat in enumerate(sorted(json_cat, key=lambda cat: cat['id'])):
                 label_map[cat['id']] = idx
-                categories.add(name=cat['name'], parent=cat.get('supercategory'))
+                categories.add(cat['name'], parent=cat.get('supercategory'))
 
         self._categories[AnnotationType.label] = categories
         self._label_map = label_map
 
-    def _load_person_kp_categories(self, loader):
-        catIds = loader.getCatIds()
-        cats = loader.loadCats(catIds)
-
+    def _load_person_kp_categories(self, json_cat):
         categories = PointsCategories()
-        for cat in cats:
+        for cat in json_cat:
             label_id = self._label_map[cat['id']]
-            categories.add(label_id=label_id,
+            categories.add(label_id,
                 labels=cat['keypoints'], joints=cat['skeleton']
             )
 
         self._categories[AnnotationType.points] = categories
 
     @staticmethod
-    def _load_panoptic_config(path):
-        with open(path, 'r', encoding='utf-8') as f:
-            return json.load(f)
+    def _load_json(path):
+        with open(path, 'rb') as f:
+            return json.loads(f.read())
 
-    def _load_items(self, loader):
-        items = OrderedDict()
+    def _load_items(self, json_data):
+        items = {}
 
-        for img_id in loader.getImgIds():
-            image_info = loader.loadImgs(img_id)[0]
-            image_path = osp.join(self._images_dir, image_info['file_name'])
-            image_size = (image_info.get('height'), image_info.get('width'))
-            if all(image_size):
-                image_size = (int(image_size[0]), int(image_size[1]))
+        img_infos = {}
+        for img_info in json_data['images']:
+            img_id = img_info['id']
+            img_infos[img_id] = img_info
+
+            if img_info.get('height') and img_info.get('width'):
+                image_size = (img_info['height'], img_info['width'])
             else:
                 image_size = None
-            image = Image(path=image_path, size=image_size)
-
-            anns = loader.getAnnIds(imgIds=img_id)
-            anns = loader.loadAnns(anns)
-            anns = sum((self._load_annotations(a, image_info) for a in anns), [])
 
             items[img_id] = DatasetItem(
-                id=osp.splitext(image_info['file_name'])[0],
-                subset=self._subset, image=image, annotations=anns,
+                id=osp.splitext(img_info['file_name'])[0],
+                subset=self._subset,
+                image=Image(
+                    path=osp.join(self._images_dir, img_info['file_name']),
+                    size=image_size),
+                annotations=[],
                 attributes={'id': img_id})
+
+        for ann in json_data['annotations']:
+            items[ann['image_id']].annotations += \
+                self._load_annotations(ann, img_infos[ann['image_id']])
 
         return items
 
-    def _load_panoptic_items(self, config, panoptic_images):
-        items = OrderedDict()
+    def _load_panoptic_items(self, json_data, mask_dir):
+        items = {}
 
-        imgs_info = {}
-        for img in config['images']:
-            imgs_info[img['id']] = img
+        img_infos = {}
+        for img_info in json_data['images']:
+            img_id = img_info['id']
+            img_infos[img_id] = img_info
 
-        for ann in config['annotations']:
-            img_id = int(ann['image_id'])
-            image_path = osp.join(self._images_dir, imgs_info[img_id]['file_name'])
-            image_size = (imgs_info[img_id].get('height'),
-                imgs_info[img_id].get('width'))
-            if all(image_size):
-                image_size = (int(image_size[0]), int(image_size[1]))
+            if img_info.get('height') and img_info.get('width'):
+                image_size = (img_info['height'], img_info['width'])
             else:
                 image_size = None
-            image = Image(path=image_path, size=image_size)
-            anns = []
 
-            mask_path = osp.join(panoptic_images, ann['file_name'])
+            items[img_id] = DatasetItem(
+                id=osp.splitext(img_info['file_name'])[0],
+                subset=self._subset,
+                image=Image(
+                    path=osp.join(self._images_dir, img_info['file_name']),
+                    size=image_size),
+                annotations=[],
+                attributes={'id': img_id})
+
+        for ann in json_data['annotations']:
+            # For the panoptic task, each annotation struct is a per-image
+            # annotation rather than a per-object annotation.
+            anns = items[ann['image_id']].annotations
+            mask_path = osp.join(mask_dir, ann['file_name'])
             mask = lazy_image(mask_path, loader=self._load_pan_mask)
             mask = CompiledMask(instance_mask=mask)
             for segm_info in ann['segments_info']:
@@ -203,10 +197,6 @@ class _CocoExtractor(SourceExtractor):
                     label=cat_id, id=segm_id,
                     group=segm_id, attributes=attributes))
 
-            items[img_id] = DatasetItem(
-                id=osp.splitext(imgs_info[img_id]['file_name'])[0],
-                subset=self._subset, image=image,
-                annotations=anns, attributes={'id': img_id})
         return items
 
     @staticmethod
@@ -215,47 +205,54 @@ class _CocoExtractor(SourceExtractor):
         mask = bgr2index(mask)
         return mask
 
+    @define(on_setattr=False)
+    class _lazy_merged_mask:
+        segmentation: Any
+        h: int
+        w: int
+
+        def __call__(self):
+            rles = mask_utils.frPyObjects(self.segmentation, self.h, self.w)
+            return mask_utils.merge(rles)
+
     def _get_label_id(self, ann):
-        cat_id = ann.get('category_id')
-        if cat_id in [0, None]:
+        if not ann['category_id']:
             return None
-        return self._label_map[cat_id]
+        return self._label_map[ann['category_id']]
 
     def _load_annotations(self, ann, image_info=None):
         parsed_annotations = []
 
-        ann_id = ann.get('id')
+        ann_id = ann['id']
 
-        attributes = {}
-        if 'attributes' in ann:
-            try:
-                attributes.update(ann['attributes'])
-            except Exception as e:
-                log.debug("item #%s: failed to read annotation attributes: %s",
-                    image_info['id'], e)
+        attributes = ann.get('attributes', {})
         if 'score' in ann:
             attributes['score'] = ann['score']
 
         group = ann_id # make sure all tasks' annotations are merged
 
-        if self._task in [CocoTask.instances, CocoTask.person_keypoints,
-            CocoTask.stuff]:
-            x, y, w, h = ann['bbox']
+        if self._task is CocoTask.instances or \
+                self._task is CocoTask.person_keypoints or \
+                self._task is CocoTask.stuff:
             label_id = self._get_label_id(ann)
 
-            is_crowd = bool(ann['iscrowd'])
-            attributes['is_crowd'] = is_crowd
+            attributes['is_crowd'] = bool(ann['iscrowd'])
 
             if self._task is CocoTask.person_keypoints:
                 keypoints = ann['keypoints']
-                points = [p for i, p in enumerate(keypoints) if i % 3 != 2]
-                visibility = keypoints[2::3]
+                points = []
+                visibility = []
+                for x, y, v in take_by(keypoints, 3):
+                    points.append(x)
+                    points.append(y)
+                    visibility.append(v)
+
                 parsed_annotations.append(
                     Points(points, visibility, label=label_id,
                         id=ann_id, attributes=attributes, group=group)
                 )
 
-            segmentation = ann.get('segmentation')
+            segmentation = ann['segmentation']
             if segmentation and segmentation != [[]]:
                 rle = None
 
@@ -269,18 +266,16 @@ class _CocoExtractor(SourceExtractor):
                             ))
                     else:
                         # merge all parts into a single mask RLE
-                        img_h = image_info['height']
-                        img_w = image_info['width']
-                        rles = mask_utils.frPyObjects(segmentation, img_h, img_w)
-                        rle = mask_utils.merge(rles)
+                        rle = self._lazy_merged_mask(segmentation,
+                            image_info['height'], image_info['width'])
                 elif isinstance(segmentation['counts'], list):
                     # uncompressed RLE
                     img_h = image_info['height']
                     img_w = image_info['width']
                     mask_h, mask_w = segmentation['size']
                     if img_h == mask_h and img_w == mask_w:
-                        rle = mask_utils.frPyObjects(
-                            [segmentation], mask_h, mask_w)[0]
+                        rle = self._lazy_merged_mask(
+                            [segmentation], mask_h, mask_w)
                     else:
                         log.warning("item #%s: mask #%s "
                             "does not match image size: %s vs. %s. "
@@ -292,11 +287,12 @@ class _CocoExtractor(SourceExtractor):
                     # compressed RLE
                     rle = segmentation
 
-                if rle is not None:
+                if rle:
                     parsed_annotations.append(RleMask(rle=rle, label=label_id,
                         id=ann_id, attributes=attributes, group=group
                     ))
             else:
+                x, y, w, h = ann['bbox']
                 parsed_annotations.append(
                     Bbox(x, y, w, h, label=label_id,
                         id=ann_id, attributes=attributes, group=group)

--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -66,7 +66,6 @@ class _CocoExtractor(SourceExtractor):
         )
 
         if self._task == CocoTask.panoptic:
-            #panoptic is not added to pycocotools
             self._items = self._load_panoptic_items(json_data,
                 mask_dir=osp.splitext(path)[0])
         else:

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,4 +1,4 @@
-attrs>=21.1.0
+attrs>=21.3.0
 defusedxml>=0.7.0
 lxml>=4.4.1
 matplotlib>=3.3.1

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setuptools.setup(
     install_requires=CORE_REQUIREMENTS,
     extras_require={
         'tf': ['tensorflow'],
-        'tfds': ['tensorflow-datasets!=4.5.0'], # 4.5.0 fails on Windows, https://github.com/tensorflow/datasets/issues/3709
+        'tfds': ['tensorflow-datasets!=4.5.0,!=4.5.1'], # 4.5.0 fails on Windows, https://github.com/tensorflow/datasets/issues/3709
         'tf-gpu': ['tensorflow-gpu'],
         'default': DEFAULT_REQUIREMENTS,
     },


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Experiments have shown that COCO import is quite slow:
```
from datumaro.components.dataset import Dataset

dataset = Dataset.import_from('coco/', 'coco_instances') # train + val 2014
dataset.init_cache()
```
Works ~57s on my machine. This patch does some refactoring to make loading faster.

- Dont use pycocotools for parsing (no benefits at all except format logic encapsulation) (dropping gives ~6s / 10% speedup)
- Allow lazy rle and make masks lazy

Parsing can be further improved by using more performant json library (`orjson` gives ~3s speedup), it can be done in another PR separately.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
