### PR TITLE
Fix import of module aliases in API

### DIFF
--- a/datumaro/__init__.py
+++ b/datumaro/__init__.py
@@ -5,7 +5,6 @@
 from . import errors as errors
 from . import ops as ops
 from . import project as project
-
 from .components.annotation import (
     NO_GROUP, Annotation, AnnotationType, Bbox, BinaryMaskImage, Caption,
     Categories, Colormap, CompiledMask, CompiledMaskImage, Cuboid3d,

--- a/datumaro/__init__.py
+++ b/datumaro/__init__.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-import datumaro.components.errors as errors
-import datumaro.components.operations as ops
-import datumaro.components.project as project
+from . import errors as errors
+from . import ops as ops
+from . import project as project
 
 from .components.annotation import (
     NO_GROUP, Annotation, AnnotationType, Bbox, BinaryMaskImage, Caption,

--- a/datumaro/errors.py
+++ b/datumaro/errors.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+# This module is a usability proxy for components.errors
+
+from .components.errors import *

--- a/datumaro/ops.py
+++ b/datumaro/ops.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+# This module is a usability proxy for components.operations
+
+from .components.operations import *

--- a/datumaro/project.py
+++ b/datumaro/project.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+# pylint: disable=unused-import
+
+# This module is a usability proxy for components.project
+
+from .components.project import (
+    BuildStageType, DiffStatus, IgnoreMode, ObjectId, Pipeline, Project,
+    ProjectBuilder, ProjectBuildTargets, ProjectSourceDataset, Revision, Tree,
+)

--- a/site/source/api/datumaro.rst
+++ b/site/source/api/datumaro.rst
@@ -35,7 +35,7 @@ Once you can use the components:
 
 * :mod:`dm.errors <datumaro.components.errors>`
 
-* :mod:`dm.operations <datumaro.components.operations>`
+* :mod:`dm.ops <datumaro.components.operations>`
 
 * :mod:`dm.project <datumaro.components.project>`
 

--- a/tests/requirements.py
+++ b/tests/requirements.py
@@ -18,6 +18,7 @@ class Requirements:
     # Exact requirements
     DATUM_GENERAL_REQ = "Datumaro general requirement"
     DATUM_TELEMETRY = "Datumaro telemetry requirement"
+    DATUM_API = "Datumaro API"
 
     # GitHub issues (not bugs)
     # https://github.com/openvinotoolkit/datumaro/issues

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+from .requirements import Requirements, mark_requirement
+
+
+class ApiTest:
+    @mark_requirement(Requirements.DATUM_API)
+    def test_can_import_core(self):
+        import datumaro as dm
+
+        assert hasattr(dm, 'Dataset')
+
+    @mark_requirement(Requirements.DATUM_API)
+    def test_can_reach_module_alias_symbols_from_base(self):
+        import datumaro as dm
+
+        assert hasattr(dm.ops, 'ExactMerge')
+        assert hasattr(dm.project, 'Project')
+        assert hasattr(dm.errors, 'DatumaroError')
+
+    @mark_requirement(Requirements.DATUM_API)
+    def test_can_import_from_module_aliases(self):
+        # pylint: disable=unused-import
+        from datumaro.errors import DatumaroError
+        from datumaro.ops import ExactMerge
+        from datumaro.project import Project


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Fixes the problems with importing of symbols from module aliases in API using `from x import y`.

- Added proxy modules for module aliases in API
- Added API tests

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
