### PR TITLE
Migrate a few more modules to the next-generation attrs API

### DIFF
--- a/datumaro/components/extractor_tfds.py
+++ b/datumaro/components/extractor_tfds.py
@@ -11,7 +11,7 @@ import itertools
 import logging as log
 import os.path as osp
 
-from attr import attrib, attrs
+from attrs import field, frozen
 
 from datumaro.components.annotation import (
     AnnotationType, Bbox, Label, LabelCategories,
@@ -32,16 +32,16 @@ except ImportError:
 else:
     TFDS_EXTRACTOR_AVAILABLE = True
 
-@attrs(auto_attribs=True)
+@frozen
 class TfdsDatasetMetadata:
     default_converter_name: str
 
-@attrs(auto_attribs=True)
+@frozen
 class _TfdsAdapter:
     category_transformers: Sequence[
         Callable[['tfds.core.DatasetBuilder', CategoriesInfo], None]]
     data_transformers: Sequence[Callable[[Any, DatasetItem], None]]
-    id_generator: Callable[[Any], str] = attrib(default=None, kw_only=True)
+    id_generator: Callable[[Any], str] = field(default=None, kw_only=True)
 
     metadata: TfdsDatasetMetadata
 
@@ -55,7 +55,7 @@ class _TfdsAdapter:
         for t in self.data_transformers:
             t(tfds_example, item)
 
-@attrs(auto_attribs=True)
+@frozen
 class _SetLabelCategoriesFromClassLabelFeature:
     feature_path: Union[str, Tuple[str, ...]]
 
@@ -83,10 +83,10 @@ class _SetLabelCategoriesFromClassLabelFeature:
         categories[AnnotationType.label] = LabelCategories.from_iterable(
             feature_connector.names)
 
-@attrs(auto_attribs=True)
+@frozen
 class _SetImageFromImageFeature:
     feature_name: str
-    filename_feature_name: Optional[str] = attrib(default=None)
+    filename_feature_name: Optional[str] = field(default=None)
 
     def __call__(self, tfds_example: Any, item: DatasetItem) -> None:
         if self.filename_feature_name:
@@ -98,7 +98,7 @@ class _SetImageFromImageFeature:
         item.image = ByteImage(data=tfds_example[self.feature_name].numpy(),
             path=filename)
 
-@attrs(auto_attribs=True)
+@frozen
 class _AddLabelFromClassLabelFeature:
     feature_name: str
 
@@ -107,11 +107,11 @@ class _AddLabelFromClassLabelFeature:
             Label(tfds_example[self.feature_name].numpy()),
         )
 
-@attrs(auto_attribs=True)
+@frozen
 class _AddObjectsFromFeature:
     feature_name: str
     bbox_member: str
-    label_member: Optional[str] = attrib(default=None, kw_only=True)
+    label_member: Optional[str] = field(default=None, kw_only=True)
 
     def __call__(self, tfds_example: Any, item: DatasetItem) -> None:
         tfds_objects = tfds_example[self.feature_name]
@@ -134,14 +134,14 @@ class _AddObjectsFromFeature:
             if tfds_labels is not None:
                 item.annotations[-1].label = tfds_labels[i].numpy()
 
-@attrs(auto_attribs=True)
+@frozen
 class _GenerateIdFromTextFeature:
     feature_name: str
 
     def __call__(self, tfds_example: Any) -> str:
         return tfds_example[self.feature_name].numpy().decode('UTF-8')
 
-@attrs(auto_attribs=True)
+@frozen
 class _GenerateIdFromFilenameFeature:
     feature_name: str
 

--- a/datumaro/util/attrs_util.py
+++ b/datumaro/util/attrs_util.py
@@ -1,10 +1,10 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import inspect
 
-import attr
+import attrs
 
 
 def not_empty(inst, attribute, x):
@@ -16,7 +16,7 @@ def default_if_none(conv):
         if value is None:
             if callable(default):
                 value = default()
-            elif isinstance(default, attr.Factory):
+            elif isinstance(default, attrs.Factory):
                 value = default.factory()
             else:
                 value = default

--- a/datumaro/util/scope.py
+++ b/datumaro/util/scope.py
@@ -9,7 +9,7 @@ from functools import partial, wraps
 from typing import Any, Callable, ContextManager, Dict, Optional, Tuple, TypeVar
 import threading
 
-from attr import attrs
+from attrs import frozen
 
 from datumaro.util import optional_arg_decorator
 
@@ -22,8 +22,8 @@ class Scope:
 
     _thread_locals = threading.local()
 
-    @attrs(auto_attribs=True)
-    class ExitHandler:
+    @frozen
+    class _ExitHandler:
         callback: Callable[[], Any]
         ignore_errors: bool = True
 
@@ -34,8 +34,8 @@ class Scope:
                 if not self.ignore_errors:
                     raise
 
-    @attrs
-    class ErrorHandler(ExitHandler):
+    @frozen
+    class _ErrorHandler(_ExitHandler):
         def __exit__(self, exc_type, exc_value, exc_traceback):
             if exc_type:
                 return super().__exit__(exc_type=exc_type, exc_value=exc_value,
@@ -56,7 +56,7 @@ class Scope:
         will be ignored.
         """
 
-        self._register_callback(self.ErrorHandler,
+        self._register_callback(self._ErrorHandler,
             ignore_errors=ignore_errors,
             callback=callback, args=args, kwargs=kwargs)
 
@@ -67,7 +67,7 @@ class Scope:
         Registers a function to be called on scope exit.
         """
 
-        self._register_callback(self.ExitHandler,
+        self._register_callback(self._ExitHandler,
             ignore_errors=ignore_errors,
             callback=callback, args=args, kwargs=kwargs)
 

--- a/tests/requirements.py
+++ b/tests/requirements.py
@@ -1,10 +1,10 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import typing
 
-from attr import attrs
+from attrs import frozen
 import pytest
 
 
@@ -57,7 +57,7 @@ class SkipMessages:
     NOT_IMPLEMENTED = "NOT IMPLEMENTED"
 
 
-@attrs(auto_attribs=True)
+@frozen
 class _CombinedDecorator:
     decorators: typing.List[typing.Callable]
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Working towards #310. 

I made `Scope.ExitHandler` and `Scope.ErrorHandler` private, since they seem to be implementation details.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
