### PR TITLE
voc_format: don't create XML files with no objects on export

### DIFF
--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -358,13 +358,11 @@ class VocConverter(Converter):
                 if len(attrs_elem):
                     obj_elem.append(attrs_elem)
 
-        if self._tasks & {VocTask.detection, VocTask.person_layout,
-                            VocTask.action_classification}:
-            ann_path = osp.join(self._ann_dir, item.id + '.xml')
-            os.makedirs(osp.dirname(ann_path), exist_ok=True)
-            with open(ann_path, 'w', encoding='utf-8') as f:
-                f.write(ET.tostring(root_elem,
-                    encoding='unicode', pretty_print=True))
+        ann_path = osp.join(self._ann_dir, item.id + '.xml')
+        os.makedirs(osp.dirname(ann_path), exist_ok=True)
+        with open(ann_path, 'w', encoding='utf-8') as f:
+            f.write(ET.tostring(root_elem,
+                encoding='unicode', pretty_print=True))
 
         return objects_with_parts, objects_with_actions
 

--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -265,6 +265,21 @@ class VocConverter(Converter):
                 self.save_segm_lists(subset_name, segm_list)
 
     def _write_xml_objects(self, item, image_filename, bboxes, has_masks):
+        objects_with_parts = []
+        objects_with_actions = defaultdict(dict)
+
+        main_bboxes = []
+        layout_bboxes = []
+        for bbox in bboxes:
+            label = self.get_label(bbox.label)
+            if self._is_part(label):
+                layout_bboxes.append(bbox)
+            elif self._is_label(label):
+                main_bboxes.append(bbox)
+
+        if not main_bboxes:
+            return objects_with_parts, objects_with_actions
+
         root_elem = ET.Element('annotation')
         if '_' in item.id:
             folder = item.id[ : item.id.find('_')]
@@ -286,18 +301,6 @@ class VocConverter(Converter):
             ET.SubElement(size_elem, 'depth').text = ''
 
         ET.SubElement(root_elem, 'segmented').text = str(int(has_masks))
-
-        objects_with_parts = []
-        objects_with_actions = defaultdict(dict)
-
-        main_bboxes = []
-        layout_bboxes = []
-        for bbox in bboxes:
-            label = self.get_label(bbox.label)
-            if self._is_part(label):
-                layout_bboxes.append(bbox)
-            elif self._is_label(label):
-                main_bboxes.append(bbox)
 
         for new_obj_id, obj in enumerate(main_bboxes):
             attr = obj.attributes


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

The original VOC datasets (at least the 2007 and 2012 versions that I have checked) do not contain XML files with no defined objects. Where an image is not annotated with objects, the corresponding XML file is simply omitted.

This change makes the Datumaro VOC converter consistent with that convention by avoiding dumping the XML files when there are no objects associated with a dataset item.

Beside consistency, the other benefit of this is that written datasets can be disambiguated from the LabelMe format by the format detection machinery. The VOC and LabelMe formats seem to only differ by how annotations are represented inside the `object` element, so if there are no objects, the resulting XML file is ambiguous. By avoiding writing such XML files, we
avoid the ambiguity.

Fixes #658.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
