### PR TITLE
format_detection: add a dedicated function to report unsupported detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for downloading the ImageNetV2 and COCO datasets
   (<https://github.com/openvinotoolkit/datumaro/pull/653>,
    <https://github.com/openvinotoolkit/datumaro/pull/659>)
+- A way for formats to signal that they don't support detection
+  (<https://github.com/openvinotoolkit/datumaro/pull/665>)
 
 ### Changed
 - Allowed direct file paths in `datum import`. Such sources are imported like

--- a/datumaro/plugins/coco_format/importer.py
+++ b/datumaro/plugins/coco_format/importer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 Intel Corporation
+# Copyright (C) 2019-2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -48,7 +48,7 @@ class CocoImporter(Importer):
         # to use autodetection with the COCO dataset), disable autodetection
         # for the single-task formats.
         if len(cls._TASKS) == 1:
-            context.fail('this format cannot be autodetected')
+            context.raise_unsupported()
 
         with context.require_any():
             for task in cls._TASKS.keys():

--- a/datumaro/plugins/voc_format/importer.py
+++ b/datumaro/plugins/voc_format/importer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2021 Intel Corporation
+# Copyright (C) 2019-2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -26,7 +26,7 @@ class VocImporter(Importer):
         # possible to use autodetection with the VOC datasets), disable
         # autodetection for the single-task formats.
         if len(cls._TASKS) == 1:
-            context.fail('this format cannot be autodetected')
+            context.raise_unsupported()
 
         with context.require_any():
             task_dirs = {task_dir for _, task_dir in cls._TASKS.values()}

--- a/site/content/en/docs/user-manual/command-reference/detect-format.md
+++ b/site/content/en/docs/user-manual/command-reference/detect-format.md
@@ -36,6 +36,9 @@ The format of the machine-readable report is as follows:
 
 The `<reason-code>` can be one of:
 
+- `"detection_unsupported"`: the corresponding format does not support
+  detection.
+
 - `"insufficient_confidence"`: the dataset matched the corresponding format,
   but it matched at least one other format better.
 


### PR DESCRIPTION


<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Currently, instances where detection for a format is unsupported are reported via `context.fail`. However, `context.fail` is intended primarily for situations where the dataset fails some requirement, and using it for this leads to unnatural-looking messages:

    The following requirement was not met:
      this format cannot be autodetected

Fix this by adding a dedicated rejection reason for this case and a new method, `context.raise_unsupported` to abort detection for this reason.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [x] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
