### PR TITLE
Save box attributes when downloading the TFDS version of VOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/634>)
 - Added image path equality checks in simple merge, when applicable
   (<https://github.com/openvinotoolkit/datumaro/pull/634>)
+- Supported saving box attributes when downloading the TFDS version of VOC
+  (<https://github.com/openvinotoolkit/datumaro/pull/668>)
 
 ### Deprecated
 - TBD

--- a/datumaro/components/extractor_tfds.py
+++ b/datumaro/components/extractor_tfds.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace as namespace
 from typing import (
     Any, Callable, Dict, Iterator, Mapping, Optional, Sequence, Tuple, Union,
 )
@@ -39,56 +40,90 @@ class TfdsDatasetMetadata:
 @frozen
 class _TfdsAdapter:
     category_transformers: Sequence[
-        Callable[['tfds.core.DatasetBuilder', CategoriesInfo], None]]
-    data_transformers: Sequence[Callable[[Any, DatasetItem], None]]
+        Callable[[tfds.core.DatasetBuilder, CategoriesInfo, namespace], None]]
+    data_transformers: Sequence[Callable[[Any, DatasetItem, namespace], None]]
     id_generator: Callable[[Any], str] = field(default=None, kw_only=True)
 
     metadata: TfdsDatasetMetadata
 
     def transform_categories(self,
         tfds_builder: tfds.core.DatasetBuilder, categories: CategoriesInfo,
+        state: namespace,
     ) -> None:
         for t in self.category_transformers:
-            t(tfds_builder, categories)
+            t(tfds_builder, categories, state)
 
-    def transform_data(self, tfds_example: Any, item: DatasetItem) -> None:
+    def transform_data(
+        self, tfds_example: Any, item: DatasetItem, state: namespace,
+    ) -> None:
         for t in self.data_transformers:
-            t(tfds_example, item)
+            t(tfds_example, item, state)
+
+_FeaturePath = Union[str, Tuple[str, ...]]
+
+def _resolve_feature_path(
+    feature_path: _FeaturePath, root: tfds.features.FeaturesDict,
+) -> tfds.features.FeatureConnector:
+    if isinstance(feature_path, str):
+        return root[feature_path]
+
+    feature_connector = root
+
+    for segment in feature_path:
+        assert isinstance(feature_connector, (
+            tfds.features.FeaturesDict, tfds.features.Sequence,
+        ))
+
+        if isinstance(feature_connector, tfds.features.Sequence):
+            assert segment == 'feature'
+            feature_connector = feature_connector.feature
+        else:
+            feature_connector = feature_connector[segment]
+
+    return feature_connector
 
 @frozen
 class _SetLabelCategoriesFromClassLabelFeature:
-    feature_path: Union[str, Tuple[str, ...]]
+    feature_path: _FeaturePath
 
     def __call__(self,
         tfds_builder: tfds.core.DatasetBuilder, categories: CategoriesInfo,
+        state: namespace,
     ) -> None:
         assert AnnotationType.label not in categories
-        if isinstance(self.feature_path, str):
-            feature_connector = tfds_builder.info.features[self.feature_path]
-        else:
-            feature_connector = tfds_builder.info.features
 
-            for segment in self.feature_path:
-                assert isinstance(feature_connector, (
-                    tfds.features.FeaturesDict, tfds.features.Sequence,
-                ))
-
-                if isinstance(feature_connector, tfds.features.Sequence):
-                    assert segment == 'feature'
-                    feature_connector = feature_connector.feature
-                else:
-                    feature_connector = feature_connector[segment]
+        feature_connector = _resolve_feature_path(
+            self.feature_path, tfds_builder.info.features)
 
         assert isinstance(feature_connector, tfds.features.ClassLabel)
         categories[AnnotationType.label] = LabelCategories.from_iterable(
             feature_connector.names)
+
+
+@frozen
+class _SaveFeatureClassList:
+    feature_path: _FeaturePath
+    state_key: str
+
+    def __call__(self,
+        tfds_builder: tfds.core.DatasetBuilder, categories: CategoriesInfo,
+        state: namespace,
+    ) -> None:
+        feature_connector = _resolve_feature_path(
+            self.feature_path, tfds_builder.info.features)
+
+        assert isinstance(feature_connector, tfds.features.ClassLabel)
+        setattr(state, self.state_key, feature_connector.names)
+
 
 @frozen
 class _SetImageFromImageFeature:
     feature_name: str
     filename_feature_name: Optional[str] = field(default=None)
 
-    def __call__(self, tfds_example: Any, item: DatasetItem) -> None:
+    def __call__(
+        self, tfds_example: Any, item: DatasetItem, state: namespace,
+    ) -> None:
         if self.filename_feature_name:
             filename = tfds_example[self.filename_feature_name].numpy() \
                 .decode('UTF-8')
@@ -102,20 +137,38 @@ class _SetImageFromImageFeature:
 class _AddLabelFromClassLabelFeature:
     feature_name: str
 
-    def __call__(self, tfds_example: Any, item: DatasetItem) -> None:
+    def __call__(
+        self, tfds_example: Any, item: DatasetItem, state: namespace,
+    ) -> None:
         item.annotations.append(
             Label(tfds_example[self.feature_name].numpy()),
         )
+
+@frozen
+class _AttributeMemberMapping:
+    member_name: str
+    attribute_name: str = field()
+    value_converter: Optional[Callable[[Any, namespace], Any]] = None
+
+    @attribute_name.default
+    def _attribute_name_default(self):
+        return self.member_name
 
 @frozen
 class _AddObjectsFromFeature:
     feature_name: str
     bbox_member: str
     label_member: Optional[str] = field(default=None, kw_only=True)
-    attribute_members: Optional[Tuple[str, ...]] = field(
-        default=(), kw_only=True)
+    attribute_members: Tuple[_AttributeMemberMapping, ...] = field(
+        default=(), kw_only=True,
+        converter=lambda values: tuple(
+            value if isinstance(value, _AttributeMemberMapping)
+                else _AttributeMemberMapping(value)
+            for value in values))
 
-    def __call__(self, tfds_example: Any, item: DatasetItem) -> None:
+    def __call__(
+        self, tfds_example: Any, item: DatasetItem, state: namespace,
+    ) -> None:
         tfds_objects = tfds_example[self.feature_name]
         tfds_bboxes = tfds_objects[self.bbox_member]
         num_objects = tfds_bboxes.shape[0]
@@ -125,8 +178,8 @@ class _AddObjectsFromFeature:
             tfds_labels = tfds_objects[self.label_member]
             assert tfds_labels.shape[0] == num_objects
 
-        for attribute_member in self.attribute_members:
-            assert tfds_objects[attribute_member].shape[0] == num_objects
+        for am_mapping in self.attribute_members:
+            assert tfds_objects[am_mapping.member_name].shape[0] == num_objects
 
         for i in range(num_objects):
             norm_ymin, norm_xmin, norm_ymax, norm_xmax = tfds_bboxes[i].numpy()
@@ -141,9 +194,13 @@ class _AddObjectsFromFeature:
             if tfds_labels is not None:
                 new_bbox.label = tfds_labels[i].numpy()
 
-            for attribute_member in self.attribute_members:
-                new_bbox.attributes[attribute_member] = \
-                    tfds_objects[attribute_member][i].numpy()
+            for am_mapping in self.attribute_members:
+                attr_value = tfds_objects[am_mapping.member_name][i].numpy()
+
+                if am_mapping.value_converter:
+                    attr_value = am_mapping.value_converter(attr_value, state)
+
+                new_bbox.attributes[am_mapping.attribute_name] = attr_value
 
             item.annotations.append(new_bbox)
 
@@ -153,7 +210,9 @@ class _SetAttributeFromFeature:
     feature_name: str
     attribute_name: str
 
-    def __call__(self, tfds_example: Any, item: DatasetItem) -> None:
+    def __call__(
+        self, tfds_example: Any, item: DatasetItem, state: namespace,
+    ) -> None:
         item.attributes[self.attribute_name] = \
             tfds_example[self.feature_name].numpy()
 
@@ -217,12 +276,22 @@ _IMAGENET_ADAPTER = _TfdsAdapter(
 )
 
 _VOC_ADAPTER = _TfdsAdapter(
-    category_transformers=[_SetLabelCategoriesFromClassLabelFeature(
-        ('objects', 'feature', 'label'))],
+    category_transformers=[
+        _SetLabelCategoriesFromClassLabelFeature(
+            ('objects', 'feature', 'label')),
+        _SaveFeatureClassList(('objects', 'feature', 'pose'), 'pose_names'),
+    ],
     data_transformers=[
         _SetImageFromImageFeature('image',
             filename_feature_name='image/filename'),
-        _AddObjectsFromFeature('objects', 'bbox', label_member='label')
+        _AddObjectsFromFeature('objects', 'bbox', label_member='label',
+            attribute_members=(
+                _AttributeMemberMapping('is_difficult', 'difficult'),
+                _AttributeMemberMapping('is_truncated', 'truncated'),
+                _AttributeMemberMapping('pose',
+                    value_converter=lambda idx, state: state.pose_names[idx]),
+            ),
+        ),
     ],
     id_generator=_GenerateIdFromFilenameFeature('image/filename'),
     metadata=TfdsDatasetMetadata(default_converter_name='voc'),
@@ -257,7 +326,8 @@ class _TfdsSplitExtractor(IExtractor):
                 item_id = str(example_index)
 
             dm_item = DatasetItem(id=item_id, subset=self._tfds_split_info.name)
-            self._parent._adapter.transform_data(tfds_example, dm_item)
+            self._parent._adapter.transform_data(
+                tfds_example, dm_item, self._parent._state)
 
             yield dm_item
 
@@ -290,7 +360,9 @@ class _TfdsExtractor(IExtractor):
         tfds_ds_info = tfds_builder.info
 
         self._categories = {}
-        self._adapter.transform_categories(tfds_builder, self._categories)
+        self._state = namespace()
+        self._adapter.transform_categories(
+            tfds_builder, self._categories, self._state)
 
         tfds_decoders = {}
         for tfds_feature_name, tfds_fc in tfds_ds_info.features.items():

--- a/datumaro/plugins/market1501_format.py
+++ b/datumaro/plugins/market1501_format.py
@@ -1,14 +1,14 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
-from distutils.util import strtobool
 import os
 import os.path as osp
 import re
 
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Extractor, Importer
+from datumaro.util import str_to_bool
 from datumaro.util.image import find_images
 
 
@@ -112,7 +112,7 @@ class Market1501Converter(Converter):
         dirname = Market1501Path.BBOX_DIR + item.subset
         query = item.attributes.get('query')
         if query is not None and isinstance(query, str):
-            query = strtobool(query)
+            query = str_to_bool(query)
         if query:
             dirname = Market1501Path.QUERY_DIR
         return dirname

--- a/datumaro/util/__init__.py
+++ b/datumaro/util/__init__.py
@@ -6,13 +6,13 @@ from functools import wraps
 from inspect import isclass
 from itertools import islice
 from typing import Any, Iterable, Optional, Tuple, Union
-import distutils.util
 
+import attrs
 import orjson
 
 NOTSET = object()
 
-str_to_bool = distutils.util.strtobool
+str_to_bool = attrs.converters.to_bool
 
 def find(iterable, pred=lambda x: True, default=None):
     return next((x for x in iterable if pred(x)), default)

--- a/tests/test_extractor_tfds.py
+++ b/tests/test_extractor_tfds.py
@@ -177,11 +177,16 @@ class TfdsExtractorTest(TestCase):
             'objects': {
                 'bbox': [[0.1, 0.2, 0.3, 0.4]],
                 'label': [5],
+                'is_difficult': [True],
+                'is_truncated': [False],
+                'pose': [0],
             }
         }
 
         with mock_tfds_data(example=tfds_example):
             tfds_info = tfds.builder('voc/2012').info
+
+            pose_names = tfds_info.features['objects'].feature['pose'].names
 
             expected_dataset = Dataset.from_iterable([
                 DatasetItem(
@@ -189,7 +194,10 @@ class TfdsExtractorTest(TestCase):
                     subset='train',
                     image=np.ones((20, 10)),
                     annotations=[
-                        Bbox(2, 2, 2, 4, label=5),
+                        Bbox(2, 2, 2, 4, label=5, attributes={
+                            'difficult': True, 'truncated': False,
+                            'pose': pose_names[0],
+                        }),
                     ],
                 ),
             ], categories=tfds_info.features['objects'].feature['label'].names)

--- a/tests/test_extractor_tfds.py
+++ b/tests/test_extractor_tfds.py
@@ -196,7 +196,7 @@ class TfdsExtractorTest(TestCase):
                     annotations=[
                         Bbox(2, 2, 2, 4, label=5, attributes={
                             'difficult': True, 'truncated': False,
-                            'pose': pose_names[0],
+                            'pose': pose_names[0].title(),
                         }),
                     ],
                 ),


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
The main nuisance with this is that Datumaro represents the pose as a string, while TFDS represents it as an index, and to convert the latter into the former, we need access to the list of poses.

To implement this, allow adapters access to a persistent state object that can be used to store and retrieve arbitrary data during conversion. We can then save the list of names during category creation and retrieve it when we convert box annotations.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
