### PR TITLE
Remove usages of distutils from the library

### DIFF
--- a/datumaro/plugins/market1501_format.py
+++ b/datumaro/plugins/market1501_format.py
@@ -1,14 +1,14 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
-from distutils.util import strtobool
 import os
 import os.path as osp
 import re
 
 from datumaro.components.converter import Converter
 from datumaro.components.extractor import DatasetItem, Extractor, Importer
+from datumaro.util import str_to_bool
 from datumaro.util.image import find_images
 
 
@@ -112,7 +112,7 @@ class Market1501Converter(Converter):
         dirname = Market1501Path.BBOX_DIR + item.subset
         query = item.attributes.get('query')
         if query is not None and isinstance(query, str):
-            query = strtobool(query)
+            query = str_to_bool(query)
         if query:
             dirname = Market1501Path.QUERY_DIR
         return dirname

--- a/datumaro/util/__init__.py
+++ b/datumaro/util/__init__.py
@@ -6,13 +6,13 @@ from functools import wraps
 from inspect import isclass
 from itertools import islice
 from typing import Any, Iterable, Optional, Tuple, Union
-import distutils.util
 
+import attrs
 import orjson
 
 NOTSET = object()
 
-str_to_bool = distutils.util.strtobool
+str_to_bool = attrs.converters.to_bool
 
 def find(iterable, pred=lambda x: True, default=None):
     return next((x for x in iterable if pred(x)), default)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
`distutils` has been deprecated in Python 3.10. Fortunately, the only name we're using from there is `strtobool`, and conveniently, `attrs` has recently added a function with the same semantics and the same sets of true and false values. So just use that instead.

Note that `strtobool` is still used in `setup.py`, and we can't use `attrs` there. I'm hoping that setuptools will eventually provide a replacement.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
