### PR TITLE
Add a pre-commit hook for developers

### DIFF
--- a/dev/pre-commit.py
+++ b/dev/pre-commit.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""
+This script is intended to be used as a pre-commit hook by contributors to this project.
+It runs a subset of CI checks that is sufficiently fast to not be annoying when run
+for every commit.
+
+To install, make sure isort and black are installed on your system, then run:
+
+$ ln -sv ../../dev/pre-commit.py ./.git/hooks/pre-commit
+"""
+
+import sys
+import tempfile
+from subprocess import call, check_call, check_output
+
+
+def main():
+    success = True
+
+    def try_call(args, **kwargs):
+        nonlocal success
+
+        if call(args, **kwargs) != 0:
+            success = False
+
+    try_call(["git", "diff-index", "--check", "--cached", "HEAD"])
+
+    diff_index_output = check_output(
+        ["git", "diff-index", "-z", "--name-only", "--diff-filter=AM", "--cached", "HEAD"]
+    )
+
+    changed_files = []
+    if diff_index_output:
+        changed_files = diff_index_output.decode("utf-8").rstrip("\0").split("\0")
+
+    changed_python_files = [f for f in changed_files if f.endswith(".py")]
+
+    if changed_python_files:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            check_call(["git", "checkout-index", "-a", f"--prefix={temp_dir}/"])
+
+            try_call(["isort", "--check", "--", *changed_python_files], cwd=temp_dir)
+            try_call(["black", "--check", "--", *changed_python_files], cwd=temp_dir)
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/pre-commit.py
+++ b/dev/pre-commit.py
@@ -16,7 +16,7 @@ $ ln -sv ../../dev/pre-commit.py ./.git/hooks/pre-commit
 
 import sys
 import tempfile
-from subprocess import call, check_call, check_output
+from subprocess import call, check_call, check_output  # nosec B404
 
 
 def main():
@@ -25,12 +25,12 @@ def main():
     def try_call(args, **kwargs):
         nonlocal success
 
-        if call(args, **kwargs) != 0:
+        if call(args, **kwargs) != 0:  # nosec B603
             success = False
 
     try_call(["git", "diff-index", "--check", "--cached", "HEAD"])
 
-    diff_index_output = check_output(
+    diff_index_output = check_output(  # nosec B603, B607
         ["git", "diff-index", "-z", "--name-only", "--diff-filter=AM", "--cached", "HEAD"]
     )
 
@@ -42,7 +42,7 @@ def main():
 
     if changed_python_files:
         with tempfile.TemporaryDirectory() as temp_dir:
-            check_call(["git", "checkout-index", "-a", f"--prefix={temp_dir}/"])
+            check_call(["git", "checkout-index", "-a", f"--prefix={temp_dir}/"])  # nosec B603, B607
 
             try_call(["isort", "--check", "--", *changed_python_files], cwd=temp_dir)
             try_call(["black", "--check", "--", *changed_python_files], cwd=temp_dir)

--- a/site/content/en/docs/contributing.md
+++ b/site/content/en/docs/contributing.md
@@ -71,6 +71,9 @@ The project uses Black for code formatting and isort for sorting import statemen
 You can find corresponding configurations in `pyproject.toml` in the repository root.
 No trailing whitespaces, at most 100 characters per line.
 
+Datumaro includes a Git pre-commit hook, `dev/pre-commit.py` that can help you
+follow the style requirements. See the comment at the top of that file for more information.
+
 ## Environment
 
 The recommended editor is VS Code with the Python language plugin.


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
It will help to remind people to format their code before committing.

This also establishes `dev` as a directory for developer-oriented scripts.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
