### PR TITLE
download: add an option to save a single subset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/680>)
 - Maximum recursion `--depth` parameter for `detect-dataset` CLI command
   (<https://github.com/openvinotoolkit/datumaro/pull/680>)
+- An option to save a single subset in the `download` command
+  (<https://github.com/openvinotoolkit/datumaro/pull/697>)
 
 ### Changed
 - `env.detect_dataset()` now returns a list of detected formats at all recursion levels

--- a/datumaro/cli/commands/download.py
+++ b/datumaro/cli/commands/download.py
@@ -68,6 +68,7 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
     parser.add_argument(
         "--overwrite", action="store_true", help="Overwrite existing files in the save directory"
     )
+    parser.add_argument("-s", "--subset", help="Save only the specified subset")
     parser.add_argument(
         "extra_args",
         nargs=argparse.REMAINDER,
@@ -132,6 +133,12 @@ def download_command(args):
 
     log.info("Downloading the dataset")
     extractor = extractor_factory()
+
+    if args.subset:
+        try:
+            extractor = extractor.subsets()[args.subset]
+        except KeyError:
+            raise CliException("Subset '%s' is not present in the dataset" % args.subset)
 
     log.info("Exporting the dataset")
     converter.convert(extractor, dst_dir, default_image_ext=".png", **extra_args)

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -314,7 +314,7 @@ def run_datum(test, *args, expected_code=0):
 
 
 @contextlib.contextmanager
-def mock_tfds_data(example=None):
+def mock_tfds_data(example=None, subsets=("train",)):
     import tensorflow as tf
     import tensorflow_datasets as tfds
 
@@ -341,8 +341,9 @@ def mock_tfds_data(example=None):
                 tfds.core.SplitDict(
                     [
                         tfds.core.SplitInfo(
-                            name="train", shard_lengths=[NUM_EXAMPLES], num_bytes=1234
-                        ),
+                            name=subset_name, shard_lengths=[NUM_EXAMPLES], num_bytes=1234
+                        )
+                        for subset_name in subsets
                     ],
                     dataset_name=self.name,
                 ),

--- a/site/content/en/docs/user-manual/command-reference/download.md
+++ b/site/content/en/docs/user-manual/command-reference/download.md
@@ -25,8 +25,8 @@ To use a proxy for downloading, configure it with the conventional
 Usage:
 
 ``` bash
-datum download [-h] -i DATASET_ID [-f OUTPUT_FORMAT] [-o DST_DIR] [--overwrite]
-  [-- EXTRA_EXPORT_ARGS]
+datum download [-h] -i DATASET_ID [-f OUTPUT_FORMAT] [-o DST_DIR]
+               [--overwrite] [-s SUBSET] [-- EXTRA_EXPORT_ARGS]
 ```
 
 Parameters:
@@ -39,6 +39,9 @@ Parameters:
   in the current directory is used.
 - `--overwrite` - Allows overwriting existing files in the output directory,
   when it is not empty.
+- `--subset` (string) - Which subset of the dataset to save. By default, all
+  subsets are saved. Note that due to limitations of TFDS, all subsets are
+  downloaded even if this option is specified.
 - `-- <extra export args>` - Additional arguments for the format writer
   (use `-- -h` for help). Must be specified after the main command arguments.
 

--- a/tests/cli/test_download.py
+++ b/tests/cli/test_download.py
@@ -14,7 +14,7 @@ from ..requirements import Requirements, mark_requirement
 class DownloadTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_download(self):
-        with TestDir() as test_dir, mock_tfds_data():
+        with TestDir() as test_dir, mock_tfds_data(subsets=("train", "val")):
             expected_dataset = Dataset(AVAILABLE_TFDS_DATASETS["mnist"].make_extractor())
 
             run(self, "download", "-i", "tfds:mnist", "-o", test_dir, "--", "--save-media")
@@ -79,4 +79,48 @@ class DownloadTest(TestCase):
                 "--overwrite",
                 "--",
                 "--save-media",
+            )
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_download_subset(self):
+        with TestDir() as test_dir, mock_tfds_data(subsets=("train", "val")):
+            expected_dataset = Dataset(
+                AVAILABLE_TFDS_DATASETS["mnist"].make_extractor().get_subset("train")
+            )
+
+            run(
+                self,
+                "download",
+                "-i",
+                "tfds:mnist",
+                "-f",
+                "datumaro",
+                "-o",
+                test_dir,
+                "-s",
+                "train",
+                "--",
+                "--save-media",
+            )
+
+            actual_dataset = Dataset.load(test_dir)
+            compare_datasets(self, expected_dataset, actual_dataset, require_media=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_download_invalid_subset(self):
+        with TestDir() as test_dir, mock_tfds_data(subsets=("train", "val")):
+            run(
+                self,
+                "download",
+                "-i",
+                "tfds:mnist",
+                "-f",
+                "datumaro",
+                "-o",
+                test_dir,
+                "-s",
+                "test",
+                "--",
+                "--save-media",
+                expected_code=1,
             )

--- a/tests/cli/test_download.py
+++ b/tests/cli/test_download.py
@@ -17,7 +17,14 @@ class DownloadTest(TestCase):
         with TestDir() as test_dir, mock_tfds_data(subsets=("train", "val")):
             expected_dataset = Dataset(AVAILABLE_TFDS_DATASETS["mnist"].make_extractor())
 
-            run(self, "download", "-i", "tfds:mnist", "-o", test_dir, "--", "--save-media")
+            run(
+                self,
+                "download",
+                "--dataset-id=tfds:mnist",
+                f"--output-dir={test_dir}",
+                "--",
+                "--save-media",
+            )
 
             actual_dataset = Dataset.import_from(test_dir, "mnist")
             compare_datasets(self, expected_dataset, actual_dataset, require_media=True)
@@ -30,12 +37,9 @@ class DownloadTest(TestCase):
             run(
                 self,
                 "download",
-                "-i",
-                "tfds:mnist",
-                "-f",
-                "datumaro",
-                "-o",
-                test_dir,
+                "--dataset-id=tfds:mnist",
+                "--output-format=datumaro",
+                f"--output-dir={test_dir}",
                 "--",
                 "--save-media",
             )
@@ -52,12 +56,9 @@ class DownloadTest(TestCase):
             run(
                 self,
                 "download",
-                "-i",
-                "tfds:mnist",
-                "-f",
-                "datumaro",
-                "-o",
-                test_dir,
+                "--dataset-id=tfds:mnist",
+                "--output-format=datumaro",
+                f"--output-dir={test_dir}",
                 expected_code=1,
             )
 
@@ -70,12 +71,9 @@ class DownloadTest(TestCase):
             run(
                 self,
                 "download",
-                "-i",
-                "tfds:mnist",
-                "-f",
-                "datumaro",
-                "-o",
-                test_dir,
+                "--dataset-id=tfds:mnist",
+                "--output-format=datumaro",
+                f"--output-dir={test_dir}",
                 "--overwrite",
                 "--",
                 "--save-media",
@@ -91,14 +89,10 @@ class DownloadTest(TestCase):
             run(
                 self,
                 "download",
-                "-i",
-                "tfds:mnist",
-                "-f",
-                "datumaro",
-                "-o",
-                test_dir,
-                "-s",
-                "train",
+                "--dataset-id=tfds:mnist",
+                "--output-format=datumaro",
+                f"--output-dir={test_dir}",
+                "--subset=train",
                 "--",
                 "--save-media",
             )
@@ -112,15 +106,9 @@ class DownloadTest(TestCase):
             run(
                 self,
                 "download",
-                "-i",
-                "tfds:mnist",
-                "-f",
-                "datumaro",
-                "-o",
-                test_dir,
-                "-s",
-                "test",
-                "--",
-                "--save-media",
+                "--dataset-id=tfds:mnist",
+                "--output-format=datumaro",
+                f"--output-dir={test_dir}",
+                "--subset=test",
                 expected_code=1,
             )


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
This option is similar to the `--subset` option in the `validate` command. It was requested by the DL Workbench team.

Note that it only affects saving. TFDS will still download all subsets, even if only one is requested.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [x] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
