### PR TITLE
Fix the GitHub pages workflow

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -30,9 +30,15 @@ jobs:
         run: |
           npm ci
 
-      - name: Build docs
+      # The pip upgrade must be in a separate step, because otherwise bash will
+      # remember where the system-installed pip was, and will use it in any following
+      # commands instead of the newly-installed pip.
+      - name: Upgrade pip
         run: |
           pip install --upgrade pip
+
+      - name: Build docs
+        run: |
           pip install gitpython packaging toml Sphinx==4.2.0 sphinx-rtd-theme==1.0.0 sphinx-copybutton==0.4.0 \
             tensorflow openvino-dev sphinxcontrib-mermaid
           pip install -r requirements.txt


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
This workflow uses Ubuntu 20.04, which has pip 20.0.2 installed by default. However, the latest version of the `openvino` wheel uses the `manylinux_2_27_x86_64` platform tag, which was not supported until pip 20.3. pip 20.0.2 also doesn't have the new resolver enabled by default, so it's not smart enough to try an older version of `openvino-dev`. Therefore, this pip cannot install `openvino` and therefore `openvino-dev`.

This can be solved by upgrading pip, and there _is_ a pip upgrade command in the workflow. However, it has no effect, because the upgrade installs the new version as `/usr/local/bin/pip`, while bash remembers that pip was at `/usr/bin/pip` and keeps using that version.

Fix it by separating the pip upgrade into a separate step. It looks nicer this way in the build log, anyway.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
