### PR TITLE
[WIP] Make coordinate rounding optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/680>)
 - Open Images: allowed to store annotations file in root path as well
   (<https://github.com/openvinotoolkit/datumaro/pull/680>)
+- Disabled automatic annotation coordinate rounding on dataset import
+  due to high impact on performance. Annotation comparisons still use rounding
+  (<https://github.com/openvinotoolkit/datumaro/pull/702>)
 
 ### Deprecated
 - `--save-images` is replaced with `--save-media` in CLI and converter API
@@ -41,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - \[API\] `image`, `point_cloud` and `related_images` of `DatasetItem` are
   replaced with `media` and `media_as(type)` members and c-tor parameters
   (<https://github.com/openvinotoolkit/datumaro/pull/539>)
+- Automatic annotation coordinate rounding to 2 digits on dataset export
+  will be disabled in future releases due to high impact on performance.
+  Corresponding formats have a new export parameter to control rounding.
+  (<https://github.com/openvinotoolkit/datumaro/pull/702>)
 
 ### Removed
 - TBD

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -577,7 +577,7 @@ class Cuboid3d(Annotation):
 
     @position.setter
     def position(self, value):
-        self.position[:] = value
+        self._points[0:3] = value
 
     @property
     def rotation(self):
@@ -586,7 +586,7 @@ class Cuboid3d(Annotation):
 
     @rotation.setter
     def rotation(self, value):
-        self.rotation[:] = value
+        self._points[3:6] = value
 
     @property
     def scale(self):
@@ -595,7 +595,7 @@ class Cuboid3d(Annotation):
 
     @scale.setter
     def scale(self, value):
-        self.scale[:] = value
+        self._points[6:9] = value
 
 
 @attrs(slots=True, order=False)

--- a/datumaro/plugins/coco_format/converter.py
+++ b/datumaro/plugins/coco_format/converter.py
@@ -7,12 +7,23 @@ import os
 import os.path as osp
 from enum import Enum, auto
 from itertools import chain, groupby
+from typing import List, overload
 
+import numpy as np
 import pycocotools.mask as mask_utils
 
+import datumaro.components.annotation as ann_module
 import datumaro.util.annotation_util as anno_tools
 import datumaro.util.mask_tools as mask_tools
-from datumaro.components.annotation import COORDINATE_ROUNDING_DIGITS, AnnotationType, Points
+from datumaro.components.annotation import (
+    AnnotationType,
+    Bbox,
+    Caption,
+    Label,
+    Mask,
+    Points,
+    Polygon,
+)
 from datumaro.components.converter import Converter
 from datumaro.components.dataset import ItemStatus
 from datumaro.components.errors import MediaTypeError
@@ -22,6 +33,21 @@ from datumaro.util import cast, dump_json_file, find, str_to_bool
 from datumaro.util.image import save_image
 
 from .format import CocoPath, CocoTask
+
+
+def _round(v: float, digits: int) -> float:
+    ...
+
+
+@overload
+def _round(v: List[float], digits: int) -> List[float]:
+    ...
+
+
+def _round(v, digits):
+    if digits:
+        return np.around(v, digits)
+    return v
 
 
 class SegmentationMode(Enum):
@@ -87,7 +113,7 @@ class _TaskConverter:
                 ann["id"] = next_id
                 next_id += 1
 
-        dump_json_file(path, self._data)
+        dump_json_file(path, self._data, allow_numpy=True)
 
     @property
     def annotations(self):
@@ -105,7 +131,7 @@ class _TaskConverter:
 
     @staticmethod
     def _convert_attributes(ann):
-        return {k: v for k, v in ann.attributes.items() if k not in {"is_crowd", "score"}}
+        return {k: v for k, v in ann.attributes.items() if k not in ["is_crowd", "score"]}
 
 
 class _ImageInfoConverter(_TaskConverter):
@@ -125,7 +151,7 @@ class _CaptionsConverter(_TaskConverter):
 
     def save_annotations(self, item):
         for ann_idx, ann in enumerate(item.annotations):
-            if ann.type != AnnotationType.caption:
+            if not isinstance(ann, Caption):
                 continue
 
             elem = {
@@ -198,9 +224,9 @@ class _InstancesConverter(_TaskConverter):
         return instances
 
     def find_instance_parts(self, group, img_width, img_height):
-        boxes = [a for a in group if a.type == AnnotationType.bbox]
-        polygons = [a for a in group if a.type == AnnotationType.polygon]
-        masks = [a for a in group if a.type == AnnotationType.mask]
+        boxes = [a for a in group if isinstance(a, Bbox)]
+        polygons = [a for a in group if isinstance(a, Polygon)]
+        masks = [a for a in group if isinstance(a, Mask)]
 
         anns = boxes + polygons + masks
         leader = anno_tools.find_group_leader(anns)
@@ -244,11 +270,7 @@ class _InstancesConverter(_TaskConverter):
 
     @staticmethod
     def find_instance_anns(annotations):
-        return [
-            a
-            for a in annotations
-            if a.type in {AnnotationType.bbox, AnnotationType.polygon, AnnotationType.mask}
-        ]
+        return [a for a in annotations if isinstance(a, (Bbox, Polygon, Mask))]
 
     @classmethod
     def find_instances(cls, annotations):
@@ -281,11 +303,11 @@ class _InstancesConverter(_TaskConverter):
         is_crowd = mask is not None
         if is_crowd:
             segmentation = {
-                "counts": list(int(c) for c in mask["counts"]),
-                "size": list(int(c) for c in mask["size"]),
+                "counts": np.asarray(mask["counts"], dtype=int),
+                "size": [int(mask["size"][0]), int(mask["size"][1])],
             }
         else:
-            segmentation = [list(map(float, p)) for p in polygons]
+            segmentation = [_round(v, self._context._round_digits) for v in polygons]
 
         area = 0
         if segmentation:
@@ -313,8 +335,8 @@ class _InstancesConverter(_TaskConverter):
             "image_id": self._get_image_id(item),
             "category_id": cast(ann.label, int, -1) + 1,
             "segmentation": segmentation,
-            "area": float(area),
-            "bbox": [round(float(n), COORDINATE_ROUNDING_DIGITS) for n in bbox],
+            "area": _round(area, self._context._round_digits),
+            "bbox": _round(bbox, self._context._round_digits),
             "iscrowd": int(is_crowd),
         }
         if "score" in ann.attributes:
@@ -358,13 +380,12 @@ class _KeypointsConverter(_InstancesConverter):
             self.categories.append(cat)
 
     def save_annotations(self, item):
-        point_annotations = [a for a in item.annotations if a.type == AnnotationType.points]
-        if not point_annotations:
+        if not any(isinstance(a, Points) for a in item.annotations):
             return
 
         # Create annotations for solitary keypoints annotations
         for points in self.find_solitary_points(item.annotations):
-            instance = [points, [], None, points.get_bbox()]
+            instance = [points, [], None, points.get_bbox(), points.get_area()]
             elem = super().convert_instance(instance, item)
             elem.update(self.convert_points_object(points))
             self.annotations.append(elem)
@@ -379,8 +400,7 @@ class _KeypointsConverter(_InstancesConverter):
 
         for g_id, group in groupby(annotations, lambda a: a.group):
             if not g_id or g_id and not cls.find_instance_anns(group):
-                group = [a for a in group if a.type == AnnotationType.points]
-                solitary_points.extend(group)
+                solitary_points += [a for a in group if isinstance(a, Points)]
 
         return solitary_points
 
@@ -434,7 +454,7 @@ class _LabelsConverter(_TaskConverter):
 
     def save_annotations(self, item):
         for ann in item.annotations:
-            if ann.type != AnnotationType.label:
+            if not isinstance(ann, Label):
                 continue
 
             elem = {
@@ -463,7 +483,7 @@ class _StuffConverter(_InstancesConverter):
 
 class _PanopticConverter(_TaskConverter):
     def write(self, path):
-        dump_json_file(path, self._data)
+        dump_json_file(path, self._data, allow_numpy=True)
 
     def save_categories(self, dataset):
         label_categories = dataset.categories().get(AnnotationType.label)
@@ -490,7 +510,7 @@ class _PanopticConverter(_TaskConverter):
         masks = []
         next_id = self._min_ann_id
         for ann in item.annotations:
-            if ann.type != AnnotationType.mask:
+            if not isinstance(ann, Mask):
                 continue
 
             if not ann.id:
@@ -500,8 +520,8 @@ class _PanopticConverter(_TaskConverter):
             segment_info = {}
             segment_info["id"] = ann.id
             segment_info["category_id"] = cast(ann.label, int, -1) + 1
-            segment_info["area"] = float(ann.get_area())
-            segment_info["bbox"] = [float(p) for p in ann.get_bbox()]
+            segment_info["area"] = _round(ann.get_area(), self._context._round_digits)
+            segment_info["bbox"] = _round(ann.get_bbox(), self._context._round_digits)
             segment_info["iscrowd"] = cast(ann.attributes.get("is_crowd"), int, 0)
             segments_info.append(segment_info)
             masks.append(ann)
@@ -592,6 +612,14 @@ class CocoConverter(Converter):
             help="Save all images into a single " "directory (default: %(default)s)",
         )
         parser.add_argument(
+            "--round-digits",
+            type=int,
+            default=0,
+            help="Round coordinates to this number of decimal digits. "
+            "Useful to make output files smaller. 0 means no rounding "
+            "(default: %(default)s",
+        )
+        parser.add_argument(
             "--tasks",
             type=cls._split_tasks_string,
             help="COCO task filter, comma-separated list of {%s} "
@@ -621,6 +649,7 @@ class CocoConverter(Converter):
         allow_attributes=True,
         reindex=False,
         merge_images=False,
+        round_digits=0,
         **kwargs,
     ):
         super().__init__(extractor, save_dir, **kwargs)
@@ -657,6 +686,10 @@ class CocoConverter(Converter):
         self._merge_images = merge_images
 
         self._image_ids = {}
+
+        if round_digits is None:
+            round_digits = ann_module.COORDINATE_ROUNDING_DIGITS
+        self._round_digits = round_digits
 
         self._patch = None
 
@@ -729,9 +762,11 @@ class CocoConverter(Converter):
                             task_conv.save_image_info(item, self._make_image_filename(item))
                             task_conv.save_annotations(item)
                         except Exception as e:
-                            self._report_annotation_error(e, item_id=(item.id, item.subset))
+                            self._ctx.error_policy.report_annotation_error(
+                                e, item_id=(item.id, item.subset)
+                            )
                 except Exception as e:
-                    self._report_item_error(e, item_id=(item.id, item.subset))
+                    self._ctx.error_policy.report_item_error(e, item_id=(item.id, item.subset))
 
             for task, task_conv in task_converters.items():
                 ann_file = osp.join(self._ann_dir, "%s_%s.json" % (task.name, subset_name))

--- a/datumaro/plugins/transforms.py
+++ b/datumaro/plugins/transforms.py
@@ -35,6 +35,7 @@ from datumaro.components.annotation import (
     Polygon,
     PolyLine,
     RleMask,
+    _Shape,
 )
 from datumaro.components.cli_plugin import CliPlugin
 from datumaro.components.errors import DatumaroError
@@ -47,7 +48,7 @@ from datumaro.components.extractor import (
 )
 from datumaro.components.media import Image
 from datumaro.util import NOTSET, around, filter_dict, parse_str_enum_value, take_by
-from datumaro.util.annotation_util import Shape, find_group_leader, find_instances
+from datumaro.util.annotation_util import find_group_leader, find_instances
 
 
 class CropCoveredSegments(ItemTransform, CliPlugin):
@@ -1202,7 +1203,7 @@ class RoundCoordinates(ItemTransform):
         updated_anns = []
         has_updates = False
         for ann in item.annotations:
-            if isinstance(ann, Shape):
+            if isinstance(ann, _Shape):
                 ann.points = around(ann.points, self._digits).tolist()
                 has_updates = True
             elif isinstance(ann, Cuboid3d):

--- a/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/plugins/voc_format/converter.py
@@ -234,7 +234,7 @@ class VocConverter(Converter):
 
                     self._export_annotations(item, image_filename=image_filename, lists=lists)
                 except Exception as e:
-                    self._report_item_error(e, item_id=(item.id, item.subset))
+                    self._ctx.error_policy.report_item_error(e, item_id=(item.id, item.subset))
 
             if self._tasks & {
                 VocTask.classification,

--- a/datumaro/plugins/yolo_format/converter.py
+++ b/datumaro/plugins/yolo_format/converter.py
@@ -110,7 +110,7 @@ class YoloConverter(Converter):
                     with open(annotation_path, "w", encoding="utf-8") as f:
                         f.write(yolo_annotation)
                 except Exception as e:
-                    self._report_item_error(e, item_id=(item.id, item.subset))
+                    self._ctx.error_policy.report_item_error(e, item_id=(item.id, item.subset))
 
             subset_list_name = f"{subset_name}.txt"
             subset_list_path = osp.join(save_dir, subset_list_name)

--- a/datumaro/util/__init__.py
+++ b/datumaro/util/__init__.py
@@ -5,9 +5,10 @@
 from functools import wraps
 from inspect import isclass
 from itertools import islice
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Iterable, List, Tuple, Union, overload
 
 import attrs
+import numpy as np
 import orjson
 
 NOTSET = object()
@@ -189,3 +190,24 @@ def dump_json_file(
                 append_newline=append_newline,
             )
         )
+
+
+@overload
+def around(v: float, digits: int) -> np.float_:
+    ...
+
+
+@overload
+def around(v: Iterable[float], digits: int) -> np.array:
+    ...
+
+
+def around(v: Union[float, Iterable[float]], digits: int) -> Union[np.float_, np.array]:
+    """
+    Rounds a number or an array to few decimal digits.
+    A negative value of digits means no rounding.
+    """
+
+    if digits < 0:
+        return v
+    return np.around(v, digits)

--- a/tests/requirements.py
+++ b/tests/requirements.py
@@ -39,6 +39,7 @@ class Requirements:
     DATUM_609 = "Allow not to prepend data/ prefix in YOLO export"
     DATUM_616 = "Import for BraTS dataset"
     DATUM_673 = "Pickling for Dataset and Annotations"
+    DATUM_702 = "Coordinate rounding"
 
     # GitHub issues (bugs)
     # https://github.com/openvinotoolkit/datumaro/issues

--- a/tests/test_cityscapes_format.py
+++ b/tests/test_cityscapes_format.py
@@ -184,7 +184,7 @@ class CityscapesImportTest(TestCase):
     @mark_requirement(Requirements.DATUM_267)
     def test_can_detect_cityscapes(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertEquals([CityscapesImporter.NAME], detected_formats)
+        self.assertEqual([CityscapesImporter.NAME], detected_formats)
 
 
 class TestExtractorBase(Extractor):

--- a/tests/test_extractor_tfds.py
+++ b/tests/test_extractor_tfds.py
@@ -18,6 +18,7 @@ if TFDS_EXTRACTOR_AVAILABLE:
     import tensorflow_datasets as tfds
 
 
+@skipIf(not TFDS_EXTRACTOR_AVAILABLE, reason="TFDS is not installed")
 class TfdsDatasetsTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_metadata(self):

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -492,7 +492,7 @@ class TestMultimerge(TestCase):
                                 ]
                             ),
                         ),
-                        Polygon([1, 0, 3, 2, 1, 2]),
+                        Polygon([0, 0, 0, 3, 3, 0]),
                         # an instance with keypoints
                         Bbox(4, 5, 2, 4, label=2, z_order=1, group=1),
                         Points([5, 6], label=0, group=1),
@@ -521,7 +521,7 @@ class TestMultimerge(TestCase):
                                 ]
                             ),
                         ),
-                        Polygon([0, 2, 2, 0, 2, 1]),
+                        Polygon([0, 0, 0, 2.5, 2.5, 0]),
                         # an instance with keypoints
                         Bbox(4, 4, 2, 5, label=2, z_order=1, group=2),
                         Points([5.5, 6.5], label=0, group=2),
@@ -551,7 +551,7 @@ class TestMultimerge(TestCase):
                                 ]
                             ),
                         ),
-                        Polygon([3, 1, 2, 2, 0, 1]),
+                        Polygon([0, 0, 0, 2, 2, 0]),
                         # an instance with keypoints, one is missing
                         Bbox(3, 6, 2, 3, label=2, z_order=4, group=3),
                         Points([4.5, 5.5], label=0, group=3),
@@ -583,7 +583,7 @@ class TestMultimerge(TestCase):
                                 ]
                             ),
                         ),
-                        Polygon([1, 0, 3, 2, 1, 2]),
+                        Polygon([0, 0, 0, 2.5, 2.5, 0]),
                         # an instance with keypoints
                         Bbox(4, 5, 2, 4, label=2, z_order=4, group=1),
                         Points([5, 6], label=0, group=1),


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Currently, Datumaro rounds spatial annotation coordinates to 2 decimal digits. There are few reasons for this:
- typically we don't need higher precision even for large images
- storing long decimal tails in annotation files increases file size and hinders visual editing for no reason
- fixed and short decimal range allows to compare annotations directly, without extra manual rounding, because numbers are already rounded and typical floating point problems are mitigated

However, while these reasons make sense, there are also a huge drawback: performance. For instance, in COCO 2017 parsing it takes about extra 30s (~50%) just to round numbers, while annotations may not be even needed (eg. to report dataset size or annotation count). For exporting this dataset back it takes even more time.

This PR changes the strategy on this and:
- Removes mandatory rounding from annotation class constructors
- Adds the `RoundCoordinates` transform (mostly, for internal use)
- Deprecates automatic rounding on export in COCO, CVAT, VOC, YOLO, LabelMe, MOT, Supervisely, Kitti formats. In future it should be disabled
- Adds the `round-digits` export parameter to control rounding in formats, that export coordinates (COCO, Datumaro, CVAT, Supervisely, LabeMe etc.)

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
