### PR TITLE
Fix VOC extra parsing error for classification annotations

### DIFF
--- a/datumaro/plugins/voc_format/extractor.py
+++ b/datumaro/plugins/voc_format/extractor.py
@@ -164,10 +164,10 @@ class VocClassificationExtractor(_VocExtractor):
                         )
 
                     item, present = parts
-                    if present not in ["-1", "1"]:
+                    if present not in ["-1", "0", "1"]:
                         raise InvalidAnnotationError(
                             f"{osp.basename(ann_file)}:{i+1}: "
-                            f"unexpected class existence value '{present}', expected -1 or 1"
+                            f"unexpected class existence value '{present}', expected -1, 0 or 1"
                         )
 
                     if present == "1":

--- a/datumaro/plugins/voc_format/extractor.py
+++ b/datumaro/plugins/voc_format/extractor.py
@@ -165,6 +165,7 @@ class VocClassificationExtractor(_VocExtractor):
 
                     item, present = parts
                     if present not in ["-1", "0", "1"]:
+                        # Both -1 and 0 are used in the original VOC, they mean the same
                         raise InvalidAnnotationError(
                             f"{osp.basename(ann_file)}:{i+1}: "
                             f"unexpected class existence value '{present}', expected -1, 0 or 1"

--- a/tests/test_voc_format.py
+++ b/tests/test_voc_format.py
@@ -746,9 +746,16 @@ class VocExtractorTest(TestCase):
                 f.write("c 1\n")
 
             parsed = Dataset.import_from(test_dir, format="voc_classification")
-            parsed.init_cache()
 
-            self.assertEqual(len(parsed), 3)
+            expected = Dataset.from_iterable(
+                [
+                    DatasetItem("a", subset="test"),
+                    DatasetItem("b", subset="test"),
+                    DatasetItem("c", subset="test", annotations=[Label(VOC.VocLabel.cat.value)]),
+                ],
+                categories=VOC.make_voc_categories(),
+            )
+            compare_datasets(self, expected, parsed)
 
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
     def test_can_report_invalid_annotation_value_in_classification(self):

--- a/tests/test_voc_format.py
+++ b/tests/test_voc_format.py
@@ -730,6 +730,27 @@ class VocExtractorTest(TestCase):
                 Dataset.import_from(test_dir, format="voc_classification").init_cache()
 
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
+    def test_can_parse_classification_without_errors(self):
+        with TestDir() as test_dir:
+            subset_file = osp.join(test_dir, "ImageSets", "Main", "test.txt")
+            os.makedirs(osp.dirname(subset_file))
+            with open(subset_file, "w") as f:
+                f.write("a\n")
+                f.write("b\n")
+                f.write("c\n")
+
+            ann_file = osp.join(test_dir, "ImageSets", "Main", "cat_test.txt")
+            with open(ann_file, "w") as f:
+                f.write("a -1\n")
+                f.write("b 0\n")
+                f.write("c 1\n")
+
+            parsed = Dataset.import_from(test_dir, format="voc_classification")
+            parsed.init_cache()
+
+            self.assertEqual(len(parsed), 3)
+
+    @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
     def test_can_report_invalid_annotation_value_in_classification(self):
         with TestDir() as test_dir:
             subset_file = osp.join(test_dir, "ImageSets", "Main", "test.txt")


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

The original VOC parsing fails when "0" appears in a classification list file. It seems, in some cases this value was used along with "-1" to indicate a missing class on an image.

- Added "0" as a possible class presence value

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
