### PR TITLE
Add Label, Points, Polygon, PolyLine, and Caption visualization features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Visualization Python API
   - Bbox
     (<https://github.com/openvinotoolkit/datumaro/pull/744>)
+  - Add Label, Points, Polygon, PolyLine, and Caption visualization features
+    (<https://github.com/openvinotoolkit/datumaro/pull/746>)
 
 ### Changed
 - N/A

--- a/datumaro/components/visualizer.py
+++ b/datumaro/components/visualizer.py
@@ -181,9 +181,13 @@ class Visualizer:
             x, y = 0.01, 0.99
         else:
             # Draw below the previously drawn label.
-            text = context[-1]
-            bbox = ax.transAxes.inverted().transform(text.get_tightbbox())
-            x, y = 0.01, bbox[0][1]
+            text: Text = context[-1]
+            # We can know the position of text bbox only if drawing it actually.
+            # https://stackoverflow.com/a/41271773/16880031
+            fig.canvas.draw()
+            bbox = text.get_window_extent()
+            bbox = ax.transAxes.inverted().transform_bbox(bbox)
+            x, y = 0.01, bbox.y0
 
         text = ax.text(x, y, label_text, ha="left", va="top", color=color, transform=ax.transAxes)
         context.append(text)

--- a/datumaro/components/visualizer.py
+++ b/datumaro/components/visualizer.py
@@ -2,17 +2,17 @@
 #
 # SPDX-License-Identifier: MIT
 
-from collections import defaultdict
 import math
 import warnings
+from collections import defaultdict
 from typing import Iterable, List, Optional, Tuple, Union
 
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
-from matplotlib.text import Text
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from matplotlib.text import Text
 
 from datumaro.components.annotation import (
     Annotation,
@@ -25,8 +25,8 @@ from datumaro.components.annotation import (
     LabelCategories,
     Mask,
     Points,
-    PolyLine,
     Polygon,
+    PolyLine,
     SuperResolutionAnnotation,
 )
 from datumaro.components.dataset import IDataset

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -30,7 +30,7 @@ class VisualizerTestBase:
         GridSizeTestCase((5, 1), (5, 1)),
     ]
 
-    def test_vis_one_sample(self, mocked: mock.MagicMock, check_z_order: bool = True):
+    def _test_vis_one_sample(self, mocked: mock.MagicMock, check_z_order: bool = True):
         visualizer = Visualizer(self.dataset)
 
         for item in self.items:
@@ -55,7 +55,7 @@ class VisualizerTestBase:
             with self.assertRaises(Exception):
                 visualizer.vis_one_sample(item.id, "unknown")
 
-    def test_vis_gallery(self, test_cases: GridSizeTestCase):
+    def _test_vis_gallery(self, test_cases: GridSizeTestCase):
         visualizer = Visualizer(self.dataset)
 
         # Too small nrows and ncols
@@ -108,11 +108,11 @@ class LabelVisualizerTest(TestCase, VisualizerTestBase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @mock.patch("datumaro.components.visualizer.Visualizer._draw_label")
     def test_vis_one_sample(self, mocked: mock.MagicMock):
-        super().test_vis_one_sample(mocked, check_z_order=False)
+        self._test_vis_one_sample(mocked, check_z_order=False)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_gallery(self):
-        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
 class PointsVisualizerTest(TestCase, VisualizerTestBase):
@@ -143,11 +143,11 @@ class PointsVisualizerTest(TestCase, VisualizerTestBase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @mock.patch("datumaro.components.visualizer.Visualizer._draw_points")
     def test_vis_one_sample(self, mocked: mock.MagicMock):
-        super().test_vis_one_sample(mocked, check_z_order=True)
+        self._test_vis_one_sample(mocked, check_z_order=True)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_gallery(self):
-        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
 class PolygonVisualizerTest(TestCase, VisualizerTestBase):
@@ -178,11 +178,11 @@ class PolygonVisualizerTest(TestCase, VisualizerTestBase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @mock.patch("datumaro.components.visualizer.Visualizer._draw_polygon")
     def test_vis_one_sample(self, mocked: mock.MagicMock):
-        super().test_vis_one_sample(mocked, check_z_order=True)
+        self._test_vis_one_sample(mocked, check_z_order=True)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_gallery(self):
-        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
 class PolyLineVisualizerTest(TestCase, VisualizerTestBase):
@@ -213,11 +213,11 @@ class PolyLineVisualizerTest(TestCase, VisualizerTestBase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @mock.patch("datumaro.components.visualizer.Visualizer._draw_polygon")
     def test_vis_one_sample(self, mocked: mock.MagicMock):
-        super().test_vis_one_sample(mocked, check_z_order=True)
+        self._test_vis_one_sample(mocked, check_z_order=True)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_gallery(self):
-        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
 class BboxVisualizerTest(TestCase, VisualizerTestBase):
@@ -251,11 +251,11 @@ class BboxVisualizerTest(TestCase, VisualizerTestBase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @mock.patch("datumaro.components.visualizer.Visualizer._draw_bbox")
     def test_vis_one_sample(self, mocked: mock.MagicMock):
-        super().test_vis_one_sample(mocked)
+        self._test_vis_one_sample(mocked)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_gallery(self):
-        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
 class CaptionVisualizerTest(TestCase, VisualizerTestBase):
@@ -283,8 +283,8 @@ class CaptionVisualizerTest(TestCase, VisualizerTestBase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @mock.patch("datumaro.components.visualizer.Visualizer._draw_caption")
     def test_vis_one_sample(self, mocked: mock.MagicMock):
-        super().test_vis_one_sample(mocked, check_z_order=False)
+        self._test_vis_one_sample(mocked, check_z_order=False)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_gallery(self):
-        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from unittest import TestCase, mock
 
 import numpy as np
@@ -12,7 +13,65 @@ from datumaro.components.visualizer import Visualizer
 from .requirements import Requirements, mark_requirement
 
 
-class BboxVisualizerTest(TestCase):
+@dataclass
+class GridSizeTestCase:
+    infer_grid_size: tuple
+    expected_grid_size: tuple
+
+
+class VisualizerTestBase:
+    def test_vis_one_sample(self, mocked: mock.MagicMock):
+        visualizer = Visualizer(self.dataset)
+
+        for item in self.items:
+            visualizer.vis_one_sample(item.id, self.subset)
+
+            # Check count
+            assert mocked.call_count == len(item.annotations)
+
+            # Check z-order
+            called_z_order = [call[0][0].z_order for call in mocked.call_args_list]
+            assert sorted(called_z_order) == called_z_order
+
+            mocked.reset_mock()
+
+        # Unknown id
+        with self.assertRaises(Exception):
+            visualizer.vis_one_sample("unknown", self.subset)
+
+        # Unknown subset
+        for item in self.items:
+            with self.assertRaises(Exception):
+                visualizer.vis_one_sample(item.id, "unknown")
+
+    def test_vis_gallery(self, test_cases: GridSizeTestCase):
+        visualizer = Visualizer(self.dataset)
+
+        # Too small nrows and ncols
+        ids = [item.id for item in self.items]
+
+        cnt = 1
+        while cnt * cnt < len(ids):
+            cnt += 1
+
+        with self.assertRaises(Exception):
+            small_grid_size = (cnt - 1, cnt - 1)
+            visualizer.vis_gallery(ids, self.subset, small_grid_size)
+
+        # Infer grid size for 5 items
+        def _check(infer_grid_size, expected_grid_size):
+            expected_nrows, expected_ncols = expected_grid_size
+            fig = visualizer.vis_gallery(ids, self.subset, infer_grid_size)
+            self.assertIsInstance(fig, Figure)
+            grid_spec = fig.axes[0].get_gridspec()
+            self.assertEqual(grid_spec.nrows, expected_nrows)
+            self.assertEqual(grid_spec.ncols, expected_ncols)
+
+        for test_case in test_cases:
+            _check(test_case.infer_grid_size, test_case.expected_grid_size)
+
+
+class BboxVisualizerTest(TestCase, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
         cls.subset = "train"
@@ -41,57 +100,20 @@ class BboxVisualizerTest(TestCase):
         cls.dataset = Dataset.from_iterable(cls.items)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_vis_one_sample(self):
-        visualizer = Visualizer(self.dataset)
-
-        for item in self.items:
-            with mock.patch("datumaro.components.visualizer.Visualizer._draw_bbox") as mocked:
-                visualizer.vis_one_sample(item.id, self.subset)
-
-                # Check count
-                assert mocked.call_count == len(item.annotations)
-
-                # Check z-order
-                called_z_order = [call[0][0].z_order for call in mocked.call_args_list]
-                assert sorted(called_z_order) == called_z_order
-
-        # Unknown id
-        with self.assertRaises(Exception):
-            visualizer.vis_one_sample("unknown", self.subset)
-
-        # Unknown subset
-        for item in self.items:
-            with self.assertRaises(Exception):
-                visualizer.vis_one_sample(item.id, "unknown")
+    @mock.patch("datumaro.components.visualizer.Visualizer._draw_bbox")
+    def test_vis_one_sample(self, mocked: mock.MagicMock):
+        super().test_vis_one_sample(mocked)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_gallery(self):
-        visualizer = Visualizer(self.dataset)
-
-        # Too small nrows and ncols
-        ids = [item.id for item in self.items]
-
-        cnt = 1
-        while cnt * cnt < len(ids):
-            cnt += 1
-
-        with self.assertRaises(Exception):
-            small_grid_size = (cnt - 1, cnt - 1)
-            visualizer.vis_gallery(ids, self.subset, small_grid_size)
-
-        # Infer grid size for 5 items
-        def _check(infer_grid_size, expected_nrows, expected_ncols):
-            fig = visualizer.vis_gallery(ids, self.subset, infer_grid_size)
-            self.assertIsInstance(fig, Figure)
-            grid_spec = fig.axes[0].get_gridspec()
-            self.assertEqual(grid_spec.nrows, expected_nrows)
-            self.assertEqual(grid_spec.ncols, expected_ncols)
-
-        _check((None, None), 3, 2)
-        _check((3, None), 3, 2)
-        _check((None, 2), 3, 2)
-        _check((3, 2), 3, 2)
-
-        _check((None, 5), 1, 5)
-        _check((5, 1), 5, 1)
-        _check((5, 1), 5, 1)
+        super().test_vis_gallery(
+            [
+                GridSizeTestCase((None, None), (3, 2)),
+                GridSizeTestCase((3, None), (3, 2)),
+                GridSizeTestCase((None, 2), (3, 2)),
+                GridSizeTestCase((3, 2), (3, 2)),
+                GridSizeTestCase((None, 5), (1, 5)),
+                GridSizeTestCase((5, 1), (5, 1)),
+                GridSizeTestCase((5, 1), (5, 1)),
+            ]
+        )

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -4,7 +4,7 @@ from unittest import TestCase, mock
 import numpy as np
 from matplotlib.figure import Figure
 
-from datumaro.components.annotation import Bbox
+from datumaro.components.annotation import Bbox, Caption, Label, Points, PolyLine, Polygon
 from datumaro.components.dataset import Dataset
 from datumaro.components.extractor import DatasetItem
 from datumaro.components.media import Image
@@ -20,7 +20,17 @@ class GridSizeTestCase:
 
 
 class VisualizerTestBase:
-    def test_vis_one_sample(self, mocked: mock.MagicMock):
+    DEFAULT_GRID_SIZE_TEST_CASES = [
+        GridSizeTestCase((None, None), (3, 2)),
+        GridSizeTestCase((3, None), (3, 2)),
+        GridSizeTestCase((None, 2), (3, 2)),
+        GridSizeTestCase((3, 2), (3, 2)),
+        GridSizeTestCase((None, 5), (1, 5)),
+        GridSizeTestCase((5, 1), (5, 1)),
+        GridSizeTestCase((5, 1), (5, 1)),
+    ]
+
+    def test_vis_one_sample(self, mocked: mock.MagicMock, check_z_order: bool = True):
         visualizer = Visualizer(self.dataset)
 
         for item in self.items:
@@ -30,8 +40,9 @@ class VisualizerTestBase:
             assert mocked.call_count == len(item.annotations)
 
             # Check z-order
-            called_z_order = [call[0][0].z_order for call in mocked.call_args_list]
-            assert sorted(called_z_order) == called_z_order
+            if check_z_order:
+                called_z_order = [call[0][0].z_order for call in mocked.call_args_list]
+                assert sorted(called_z_order) == called_z_order
 
             mocked.reset_mock()
 
@@ -71,6 +82,144 @@ class VisualizerTestBase:
             _check(test_case.infer_grid_size, test_case.expected_grid_size)
 
 
+class LabelVisualizerTest(TestCase, VisualizerTestBase):
+    @classmethod
+    def setUpClass(cls):
+        cls.subset = "train"
+        cls.items = [
+            DatasetItem(
+                "image_%03d" % img_idx,
+                subset=cls.subset,
+                media=Image(data=np.ones((4, 6, 3))),
+                annotations=[
+                    Label(
+                        label=label_idx,
+                        id=img_idx * img_idx + label_idx,
+                        group=1,
+                        attributes={},
+                    )
+                    for label_idx in range(img_idx)
+                ],
+            )
+            for img_idx in range(1, 6)
+        ]
+        cls.dataset = Dataset.from_iterable(cls.items)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    @mock.patch("datumaro.components.visualizer.Visualizer._draw_label")
+    def test_vis_one_sample(self, mocked: mock.MagicMock):
+        super().test_vis_one_sample(mocked, check_z_order=False)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_vis_gallery(self):
+        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+
+
+class PointsVisualizerTest(TestCase, VisualizerTestBase):
+    @classmethod
+    def setUpClass(cls):
+        cls.subset = "train"
+        cls.items = [
+            DatasetItem(
+                "image_%03d" % img_idx,
+                subset=cls.subset,
+                media=Image(data=np.ones((4, 6, 3))),
+                annotations=[
+                    Points(
+                        np.random.random_integers(0, 6, size=10 * 2),
+                        label=label_idx,
+                        id=img_idx * img_idx + label_idx,
+                        group=1,
+                        z_order=label_idx,
+                        attributes={},
+                    )
+                    for label_idx in range(img_idx)
+                ],
+            )
+            for img_idx in range(1, 6)
+        ]
+        cls.dataset = Dataset.from_iterable(cls.items)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    @mock.patch("datumaro.components.visualizer.Visualizer._draw_points")
+    def test_vis_one_sample(self, mocked: mock.MagicMock):
+        super().test_vis_one_sample(mocked, check_z_order=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_vis_gallery(self):
+        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+
+
+class PolygonVisualizerTest(TestCase, VisualizerTestBase):
+    @classmethod
+    def setUpClass(cls):
+        cls.subset = "train"
+        cls.items = [
+            DatasetItem(
+                "image_%03d" % img_idx,
+                subset=cls.subset,
+                media=Image(data=np.ones((4, 6, 3))),
+                annotations=[
+                    Polygon(
+                        np.random.random_integers(0, 6, size=10 * 2),
+                        label=label_idx,
+                        id=img_idx * img_idx + label_idx,
+                        group=1,
+                        z_order=label_idx,
+                        attributes={},
+                    )
+                    for label_idx in range(img_idx)
+                ],
+            )
+            for img_idx in range(1, 6)
+        ]
+        cls.dataset = Dataset.from_iterable(cls.items)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    @mock.patch("datumaro.components.visualizer.Visualizer._draw_polygon")
+    def test_vis_one_sample(self, mocked: mock.MagicMock):
+        super().test_vis_one_sample(mocked, check_z_order=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_vis_gallery(self):
+        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+
+
+class PolyLineVisualizerTest(TestCase, VisualizerTestBase):
+    @classmethod
+    def setUpClass(cls):
+        cls.subset = "train"
+        cls.items = [
+            DatasetItem(
+                "image_%03d" % img_idx,
+                subset=cls.subset,
+                media=Image(data=np.ones((4, 6, 3))),
+                annotations=[
+                    PolyLine(
+                        np.random.random_integers(0, 6, size=10 * 2),
+                        label=label_idx,
+                        id=img_idx * img_idx + label_idx,
+                        group=1,
+                        z_order=label_idx,
+                        attributes={},
+                    )
+                    for label_idx in range(img_idx)
+                ],
+            )
+            for img_idx in range(1, 6)
+        ]
+        cls.dataset = Dataset.from_iterable(cls.items)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    @mock.patch("datumaro.components.visualizer.Visualizer._draw_polygon")
+    def test_vis_one_sample(self, mocked: mock.MagicMock):
+        super().test_vis_one_sample(mocked, check_z_order=True)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_vis_gallery(self):
+        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+
+
 class BboxVisualizerTest(TestCase, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
@@ -106,14 +255,36 @@ class BboxVisualizerTest(TestCase, VisualizerTestBase):
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_gallery(self):
-        super().test_vis_gallery(
-            [
-                GridSizeTestCase((None, None), (3, 2)),
-                GridSizeTestCase((3, None), (3, 2)),
-                GridSizeTestCase((None, 2), (3, 2)),
-                GridSizeTestCase((3, 2), (3, 2)),
-                GridSizeTestCase((None, 5), (1, 5)),
-                GridSizeTestCase((5, 1), (5, 1)),
-                GridSizeTestCase((5, 1), (5, 1)),
-            ]
-        )
+        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+
+
+class CaptionVisualizerTest(TestCase, VisualizerTestBase):
+    @classmethod
+    def setUpClass(cls):
+        cls.subset = "train"
+        cls.items = [
+            DatasetItem(
+                "image_%03d" % img_idx,
+                subset=cls.subset,
+                media=Image(data=np.ones((4, 6, 3))),
+                annotations=[
+                    Caption(
+                        caption="".join([str(label_idx)] * 10),
+                        id=img_idx * img_idx + label_idx,
+                        attributes={},
+                    )
+                    for label_idx in range(img_idx)
+                ],
+            )
+            for img_idx in range(1, 6)
+        ]
+        cls.dataset = Dataset.from_iterable(cls.items)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    @mock.patch("datumaro.components.visualizer.Visualizer._draw_caption")
+    def test_vis_one_sample(self, mocked: mock.MagicMock):
+        super().test_vis_one_sample(mocked, check_z_order=False)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_vis_gallery(self):
+        super().test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -4,7 +4,7 @@ from unittest import TestCase, mock
 import numpy as np
 from matplotlib.figure import Figure
 
-from datumaro.components.annotation import Bbox, Caption, Label, Points, PolyLine, Polygon
+from datumaro.components.annotation import Bbox, Caption, Label, Points, Polygon, PolyLine
 from datumaro.components.dataset import Dataset
 from datumaro.components.extractor import DatasetItem
 from datumaro.components.media import Image


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
- Related ticket no. 94413.
- Add Label, Points, Polygon, PolyLine, and Caption visualization features.
- Did some code and test code refactoring

| Label | Points | 
|-----------------------|------------------------|
|![image](https://user-images.githubusercontent.com/26541465/196653520-f2ab587f-186d-44ec-b562-31ec1511d530.png)|![image](https://user-images.githubusercontent.com/26541465/196653971-25b9decc-700f-43ae-a8cb-aedc2b6a2d10.png)|

|Polygon and PolyLine | Caption |
|------------------------|------------------------|
|![image](https://user-images.githubusercontent.com/26541465/196653631-7f9dcf79-d11b-4b79-b5dd-ff2a1d4f3a8c.png)|![image](https://user-images.githubusercontent.com/26541465/196653591-9451ca22-dcff-4ce3-ab3b-0e7ec4cb1bca.png)|


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
- Unit tests are added

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
