### PR TITLE
Add a documentation tab menu for Python API examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (<https://github.com/openvinotoolkit/datumaro/pull/744>)
   - Add Label, Points, Polygon, PolyLine, and Caption visualization features
     (<https://github.com/openvinotoolkit/datumaro/pull/746>)
+- Add a documentation tab menu for Python API
+  (<https://github.com/openvinotoolkit/datumaro/pull/753>)
 
 ### Changed
 - Updated `networkx` version to 2.6

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ CVAT annotations                             ---> Publication, statistics etc.
 - [Features](#features)
 - [User manual](https://openvinotoolkit.github.io/datumaro/docs/user-manual)
 - [Developer manual](https://openvinotoolkit.github.io/datumaro/api)
+- [Python API](https://openvinotoolkit.github.io/datumaro/docs/python-api)
 - [Contributing](#contributing)
 
 ## Features

--- a/site/content/en/docs/python-api/_index.md
+++ b/site/content/en/docs/python-api/_index.md
@@ -1,0 +1,17 @@
+---
+title: 'Python API'
+linkTitle: 'Python API'
+description: ''
+weight: 3
+---
+
+## What is Python API
+Need to update the description.
+
+## Contents
+- [Python API examples](./python-api-examples)
+  - [Visualizer](./python-api-examples/visualizer)
+  - [Filter](./python-api-examples/filter)
+  - [Transform](./python-api-examples/transform)
+  - [Generate](./python-api-examples/generate)
+  - [Validate](./python-api-examples/validate)

--- a/site/content/en/docs/python-api/python-api-examples/_index.md
+++ b/site/content/en/docs/python-api/python-api-examples/_index.md
@@ -1,0 +1,9 @@
+---
+title: 'Python API examples'
+linkTitle: 'Python API examples'
+description: ''
+weight: 6
+---
+
+### How to use Python API
+Need to update the description.

--- a/site/content/en/docs/python-api/python-api-examples/filter.md
+++ b/site/content/en/docs/python-api/python-api-examples/filter.md
@@ -1,0 +1,10 @@
+---
+title: 'Filter'
+linkTitle: 'filter'
+description: ''
+---
+
+Need to update the description.
+
+Jupyter Notebook Examples:
+Need to update the description.

--- a/site/content/en/docs/python-api/python-api-examples/generate.md
+++ b/site/content/en/docs/python-api/python-api-examples/generate.md
@@ -1,0 +1,10 @@
+---
+title: 'Generate'
+linkTitle: 'generate'
+description: ''
+---
+
+Need to update the description.
+
+Jupyter Notebook Examples:
+Need to update the description.

--- a/site/content/en/docs/python-api/python-api-examples/transform.md
+++ b/site/content/en/docs/python-api/python-api-examples/transform.md
@@ -1,0 +1,10 @@
+---
+title: 'Transform'
+linkTitle: 'transform'
+description: ''
+---
+
+Need to update the description.
+
+Jupyter Notebook Examples:
+Need to update the description.

--- a/site/content/en/docs/python-api/python-api-examples/validate.md
+++ b/site/content/en/docs/python-api/python-api-examples/validate.md
@@ -1,0 +1,10 @@
+---
+title: 'Validate'
+linkTitle: 'validate'
+description: ''
+---
+
+Need to update the description.
+
+Jupyter Notebook Examples:
+Need to update the description.

--- a/site/content/en/docs/python-api/python-api-examples/visualizer.md
+++ b/site/content/en/docs/python-api/python-api-examples/visualizer.md
@@ -1,0 +1,10 @@
+---
+title: 'Visualizer'
+linkTitle: 'visualizer'
+description: ''
+---
+
+Need to update the description.
+
+Jupyter Notebook Examples:
+Need to update the description.


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Add a documentation tab menu for Python API examples

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [x] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```