### PR TITLE
Add CodeCov coverage reporting feature to CI/CD

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -19,13 +19,6 @@ jobs:
       matrix:
         os: ['macos-10.15', 'ubuntu-20.04', 'windows-2019']
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        include:
-          - codecov-os: 'macos'
-            os: 'macos-10.15'
-          - codecov-os: 'linux'
-            os: 'ubuntu-20.04'
-          - codecov-os: 'windows'
-            os: 'windows-2019'
     name: build and test (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     steps:
@@ -36,15 +29,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Installing dependencies
         run: |
-          pip install -e '.[default,tf,tfds]' pytest
+          pip install -e '.[default,tf,tfds]' pytest pytest-cov
       - name: Unit testing
         run: |
           pytest -v --cov
           datum -h
       - name: Upload coverage reports to Codecov
-        run: |
-          # Replace `linux` below with the appropriate OS
-          # Options are `alpine`, `linux`, `macos`, `windows`
-          curl -Os https://uploader.codecov.io/latest/${{ matrix.codecov-os }}/codecov
-          chmod +x codecov
-          ./codecov -t ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'develop'
   pull_request:
     types: [edited, ready_for_review, opened, synchronize, reopened]
 defaults:
@@ -36,3 +37,5 @@ jobs:
           datum -h
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          flags: ${{ matrix.os }}, Python ${{ matrix.python-version }}

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -19,6 +19,13 @@ jobs:
       matrix:
         os: ['macos-10.15', 'ubuntu-20.04', 'windows-2019']
         python-version: ['3.7', '3.8', '3.9', '3.10']
+        include:
+          - codecov-os: 'macos'
+            os: 'macos-10.15'
+          - codecov-os: 'linux'
+            os: 'ubuntu-20.04'
+          - codecov-os: 'windows'
+            os: 'windows-2019'
     name: build and test (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,5 +39,12 @@ jobs:
           pip install -e '.[default,tf,tfds]' pytest
       - name: Unit testing
         run: |
-          pytest -v
+          pytest -v --cov
           datum -h
+      - name: Upload coverage reports to Codecov
+        run: |
+          # Replace `linux` below with the appropriate OS
+          # Options are `alpine`, `linux`, `macos`, `windows`
+          curl -Os https://uploader.codecov.io/latest/${{ matrix.codecov-os }}/codecov
+          chmod +x codecov
+          ./codecov -t ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          flags: ${{ matrix.os }}, Python ${{ matrix.python-version }}
+          flags: ${{ matrix.os }}_Python-${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/750>)
 - Add CodeCov coverage reporting feature to CI/CD
   (<https://github.com/openvinotoolkit/datumaro/pull/756>)
-  
+
 ### Changed
 - N/A
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/753>)
 - Add `__repr__` for Dataset
   (<https://github.com/openvinotoolkit/datumaro/pull/750>)
-
+- Add CodeCov coverage reporting feature to CI/CD
+  (<https://github.com/openvinotoolkit/datumaro/pull/756>)
 ### Changed
 - N/A
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/750>)
 - Add CodeCov coverage reporting feature to CI/CD
   (<https://github.com/openvinotoolkit/datumaro/pull/756>)
+  
 ### Changed
 - N/A
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build status](https://github.com/openvinotoolkit/datumaro/actions/workflows/health_check.yml/badge.svg)](https://github.com/openvinotoolkit/datumaro/actions/workflows/health_check.yml)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/759d2d873b59495aa3d3f8c51b786246)](https://app.codacy.com/gh/openvinotoolkit/datumaro?utm_source=github.com&utm_medium=referral&utm_content=openvinotoolkit/datumaro&utm_campaign=Badge_Grade_Dashboard)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/9511b691ff134e739ea6fc524f7cc760)](https://www.codacy.com/gh/openvinotoolkit/datumaro?utm_source=github.com&utm_medium=referral&utm_content=openvinotoolkit/datumaro&utm_campaign=Badge_Coverage)
+[![codecov](https://codecov.io/gh/openvinotoolkit/datumaro/branch/develop/graph/badge.svg?token=FG25VU096Q)](https://codecov.io/gh/openvinotoolkit/datumaro)
 
 A framework and CLI tool to build, transform, and analyze datasets.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ openvino-telemetry>=2022.1.0
 
 # testing
 pytest>=5.3.5
+pytest-cov>=4.0.0
 
 # linters
 bandit>=1.7.0


### PR DESCRIPTION
Signed-off-by: Kim, Vinnam <vinnam.kim@intel.com>

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
 - Add CodeCov coverage reporting feature to CI/CD
 - Related JIRA ticket no. 94968
 
### How to test
See Github Action changes and CodeCov bot's report below.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
