### PR TITLE
Get list of subsets and support only Image media in visualizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/758>)
 
 ### Changed
-- N/A
+- Get list of subsets and support only Image media type in visualizer
+  (<https://github.com/openvinotoolkit/datumaro/pull/768>)
 
 ### Deprecated
 - N/A

--- a/datumaro/components/visualizer.py
+++ b/datumaro/components/visualizer.py
@@ -219,7 +219,7 @@ class Visualizer:
 
         item: DatasetItem = self.dataset.get(id, subset)
         assert item is not None, f"Cannot find id={id}, subset={subset}"
-        assert item is Image, f"Media type should be Image, Current media type={type(item.media)}"
+        assert item is not Image, f"Media type should be Image, Current media type={type(item.media)}"
 
         img = item.media.data.astype(np.uint8)
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)

--- a/datumaro/components/visualizer.py
+++ b/datumaro/components/visualizer.py
@@ -192,14 +192,17 @@ class Visualizer:
     def vis_gallery(
         self,
         ids: List[Union[str, DatasetItem]],
-        subset: Optional[str] = None,
+        subset: Optional[Union[str, List[str]]] = None,
         grid_size: Tuple[Optional[int], Optional[int]] = (None, None),
     ) -> Figure:
         nrows, ncols = _infer_grid_size(len(ids), grid_size)
         fig, axs = plt.subplots(nrows, ncols, figsize=self.figsize)
 
-        for dataset_id, ax in zip(ids, axs.flatten()):
-            self.vis_one_sample(dataset_id, subset, ax)
+        for i, (dataset_id, ax) in enumerate(zip(ids, axs.flatten())):
+            if isinstance(subset, List):
+                self.vis_one_sample(dataset_id, subset[i], ax)
+            else:
+                self.vis_one_sample(dataset_id, subset, ax)
 
         return fig
 

--- a/datumaro/components/visualizer.py
+++ b/datumaro/components/visualizer.py
@@ -33,6 +33,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.dataset import IDataset
 from datumaro.components.extractor import DatasetItem
+from datumaro.components.media import Image
 
 CAPTION_BBOX_PAD = 0.2
 DEFAULT_COLOR_CYCLES: List[str] = [
@@ -218,6 +219,7 @@ class Visualizer:
 
         item: DatasetItem = self.dataset.get(id, subset)
         assert item is not None, f"Cannot find id={id}, subset={subset}"
+        assert item is Image, f"Media type should be Image, Current media type={type(item.media)}"
 
         img = item.media.data.astype(np.uint8)
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)

--- a/datumaro/components/visualizer.py
+++ b/datumaro/components/visualizer.py
@@ -200,7 +200,9 @@ class Visualizer:
         fig, axs = plt.subplots(nrows, ncols, figsize=self.figsize)
 
         if isinstance(subset, list):
-            assert len(ids) == len(subset), "If subset is a list, it should have the same length as ids."
+            assert len(ids) == len(
+                subset
+            ), "If subset is a list, it should have the same length as ids."
 
         for i, (dataset_id, ax) in enumerate(zip(ids, axs.flatten())):
             if isinstance(subset, List):

--- a/datumaro/components/visualizer.py
+++ b/datumaro/components/visualizer.py
@@ -199,6 +199,7 @@ class Visualizer:
         nrows, ncols = _infer_grid_size(len(ids), grid_size)
         fig, axs = plt.subplots(nrows, ncols, figsize=self.figsize)
 
+        assert isinstance(subset, list) and len(ids) == len(subset)
         for i, (dataset_id, ax) in enumerate(zip(ids, axs.flatten())):
             if isinstance(subset, List):
                 self.vis_one_sample(dataset_id, subset[i], ax)
@@ -219,7 +220,9 @@ class Visualizer:
 
         item: DatasetItem = self.dataset.get(id, subset)
         assert item is not None, f"Cannot find id={id}, subset={subset}"
-        assert item is not Image, f"Media type should be Image, Current media type={type(item.media)}"
+        assert (
+            item is not Image
+        ), f"Media type should be Image, Current media type={type(item.media)}"
 
         img = item.media.data.astype(np.uint8)
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)

--- a/datumaro/components/visualizer.py
+++ b/datumaro/components/visualizer.py
@@ -199,7 +199,7 @@ class Visualizer:
         nrows, ncols = _infer_grid_size(len(ids), grid_size)
         fig, axs = plt.subplots(nrows, ncols, figsize=self.figsize)
 
-        assert isinstance(subset, list) and len(ids) == len(subset)
+        assert not isinstance(subset, list) and len(ids) == len(subset)
         for i, (dataset_id, ax) in enumerate(zip(ids, axs.flatten())):
             if isinstance(subset, List):
                 self.vis_one_sample(dataset_id, subset[i], ax)

--- a/datumaro/components/visualizer.py
+++ b/datumaro/components/visualizer.py
@@ -199,7 +199,9 @@ class Visualizer:
         nrows, ncols = _infer_grid_size(len(ids), grid_size)
         fig, axs = plt.subplots(nrows, ncols, figsize=self.figsize)
 
-        assert not isinstance(subset, list) and len(ids) == len(subset)
+        if isinstance(subset, list):
+            assert len(ids) == len(subset), "If subset is a list, it should have the same length as ids."
+
         for i, (dataset_id, ax) in enumerate(zip(ids, axs.flatten())):
             if isinstance(subset, List):
                 self.vis_one_sample(dataset_id, subset[i], ax)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Support list of subsets to show data of all subsets
- Support only `Image` media type in Visualizer
  - For brats_dataset, `MultiframeImage` media type is used


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
