### PR TITLE
Improve mask_to_rle performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Get list of subsets and support only Image media type in visualizer
   (<https://github.com/openvinotoolkit/datumaro/pull/768>)
+- Improve mask_to_rle performance
+  (<https://github.com/openvinotoolkit/datumaro/pull/770>)
 
 ### Deprecated
 - N/A

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Copyright (c) 2022, Intel Corporation
+Copyright (c) 2014, Piotr Dollar and Tsung-Yi Lin
+
+This project is licensed under the MIT license, with exception of datumaro/capi/pybind.cpp which is licensed under the 3 clause BSD license

--- a/datumaro/capi/pybind.cpp
+++ b/datumaro/capi/pybind.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2022, Intel Corporation
+// Copyright (c) 2014, Piotr Dollar and Tsung-Yi Lin
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// The views and conclusions contained in the software and documentation are those
+// of the authors and should not be interpreted as representing official policies,
+// either expressed or implied, of the FreeBSD Project.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <iostream>
+#include <vector>
+#include <memory>
+
+namespace py = pybind11;
+
+typedef unsigned int uint;
+typedef unsigned long siz;
+typedef unsigned char byte;
+typedef double *BB;
+struct RLE
+{
+    RLE(siz h, siz w, siz m, std::unique_ptr<std::vector<uint>> &_cnts)
+        : h(h), w(w), m(m)
+    {
+        cnts = std::move(_cnts);
+    }
+    siz h, w, m;
+    std::unique_ptr<std::vector<uint>> cnts;
+};
+
+RLE rleEncode(const byte *M, siz h, siz w)
+{
+    siz i, j, k, a = w * h;
+    uint c;
+    byte p;
+    auto cnts = std::make_unique<std::vector<uint>>(a + 1);
+
+    const byte *T = M + a * i;
+    k = 0;
+    p = 0;
+    c = 0;
+    for (j = 0; j < a; j++)
+    {
+        if (T[j] != p)
+        {
+            (*cnts)[k++] = c;
+            c = 0;
+            p = T[j];
+        }
+        c++;
+    }
+    (*cnts)[k++] = c;
+
+    return RLE(h, w, k, cnts);
+}
+
+py::dict pyRleEncode(py::array_t<u_int8_t, py::array::f_style | py::array::forcecast> mask)
+{
+    const auto buf = mask.request();
+    if (mask.ndim() != 2)
+        throw std::runtime_error("mask should be 2d array.");
+
+    const siz h = buf.shape[0];
+    const siz w = buf.shape[1];
+    const auto rle = rleEncode(static_cast<const byte *>(buf.ptr), h, w);
+
+    py::array_t<uint> cnts(rle.m);
+    auto r = cnts.mutable_unchecked();
+    for (siz i = 0; i < rle.m; i++)
+        r[i] = (*rle.cnts)[i];
+
+    py::list size(2);
+    size[0] = h;
+    size[1] = w;
+
+    py::dict dict;
+    dict["counts"] = cnts;
+    dict["size"] = size;
+
+    return dict;
+}
+
+PYBIND11_MODULE(_capi, m)
+{
+    m.def("encode",
+          &pyRleEncode,
+          "A function to encode 2D binary mask with uncompressed run-length encoding (RLE).",
+          py::arg("mask"));
+}

--- a/datumaro/capi/pybind.cpp
+++ b/datumaro/capi/pybind.cpp
@@ -41,9 +41,8 @@ typedef double *BB;
 struct RLE
 {
     RLE(siz h, siz w, siz m, std::unique_ptr<std::vector<uint>> &_cnts)
-        : h(h), w(w), m(m)
+        : h(h), w(w), m(m), cnts(std::move(_cnts))
     {
-        cnts = std::move(_cnts);
     }
     siz h, w, m;
     std::unique_ptr<std::vector<uint>> cnts;
@@ -51,12 +50,12 @@ struct RLE
 
 RLE rleEncode(const byte *M, siz h, siz w)
 {
-    siz i, j, k, a = w * h;
+    siz j, k, a = w * h;
     uint c;
     byte p;
     auto cnts = std::make_unique<std::vector<uint>>(a + 1);
 
-    const byte *T = M + a * i;
+    const byte *T = M;
     k = 0;
     p = 0;
     c = 0;

--- a/datumaro/capi/pybind.cpp
+++ b/datumaro/capi/pybind.cpp
@@ -26,11 +26,11 @@
 // of the authors and should not be interpreted as representing official policies,
 // either expressed or implied, of the FreeBSD Project.
 
+#include <cstdint>
+#include <memory>
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
-#include <iostream>
 #include <vector>
-#include <memory>
 
 namespace py = pybind11;
 
@@ -75,7 +75,7 @@ RLE rleEncode(const byte *M, siz h, siz w)
     return RLE(h, w, k, cnts);
 }
 
-py::dict pyRleEncode(py::array_t<u_int8_t, py::array::f_style | py::array::forcecast> mask)
+py::dict pyRleEncode(py::array_t<std::uint8_t, py::array::f_style | py::array::forcecast> mask)
 {
     const auto buf = mask.request();
     if (mask.ndim() != 2)

--- a/datumaro/util/mask_tools.py
+++ b/datumaro/util/mask_tools.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import platform
 from functools import partial
 from itertools import chain
 from typing import Tuple
@@ -154,6 +155,9 @@ def lazy_mask(path, inverse_colormap=None):
 
 
 def mask_to_rle(binary_mask):
+    if platform.system() == "Windows":
+        # C-API encode() raises segfault in Windows.
+        return mask_to_rle_py(binary_mask)
     return encode(binary_mask)
 
 

--- a/datumaro/util/mask_tools.py
+++ b/datumaro/util/mask_tools.py
@@ -8,6 +8,7 @@ from typing import Tuple
 
 import numpy as np
 
+from datumaro._capi import encode
 from datumaro.util.image import lazy_image, load_image
 
 
@@ -153,6 +154,10 @@ def lazy_mask(path, inverse_colormap=None):
 
 
 def mask_to_rle(binary_mask):
+    return encode(binary_mask)
+
+
+def mask_to_rle_py(binary_mask):
     # walk in row-major order as COCO format specifies
     bounded = binary_mask.ravel(order="F")
 

--- a/datumaro/util/mask_tools.py
+++ b/datumaro/util/mask_tools.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import platform
 from functools import partial
 from itertools import chain
 from typing import Tuple
@@ -155,9 +154,6 @@ def lazy_mask(path, inverse_colormap=None):
 
 
 def mask_to_rle(binary_mask):
-    if platform.system() == "Windows":
-        # C-API encode() raises segfault in Windows.
-        return mask_to_rle_py(binary_mask)
     return encode(binary_mask)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "pybind11"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 import os.path as osp
 import re
 from distutils.util import strtobool
-
+from pybind11.setup_helpers import Pybind11Extension, build_ext
 import setuptools
 
 # Snyk scan integration
@@ -54,6 +54,15 @@ DEFAULT_REQUIREMENTS = parse_requirements(DEFAULT_REQUIREMENTS_FILE)
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+ext_modules = [
+    Pybind11Extension(
+        "datumaro._capi",
+        ["datumaro/capi/pybind.cpp"],
+        define_macros=[("VERSION_INFO", find_version(here))],
+        extra_compile_args=["-O3"],
+    ),
+]
+
 setuptools.setup(
     name="datumaro",
     version=find_version(here),
@@ -79,11 +88,13 @@ setuptools.setup(
         "tf-gpu": ["tensorflow-gpu"],
         "default": DEFAULT_REQUIREMENTS,
     },
+    ext_modules=ext_modules,
     entry_points={
         "console_scripts": [
             "datum=datumaro.cli.__main__:main",
         ],
     },
+    cmdclass={"build_ext": build_ext},
     package_data={"datumaro.plugins.synthetic_data": ["background_colors.txt"]},
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,9 @@ import os
 import os.path as osp
 import re
 from distutils.util import strtobool
-from pybind11.setup_helpers import Pybind11Extension, build_ext
+
 import setuptools
+from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 # Snyk scan integration
 here = None


### PR DESCRIPTION
Signed-off-by: Kim, Vinnam <vinnam.kim@intel.com>

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
- Resolve #745 and ticket no. 97760.
- Import a run-length encoding (RLE) code implemented in `pycocotools` and bind it with `pybind11`.
https://github.com/cocodataset/cocoapi/blob/8c9bcc3cf640524c4c20a9c40e89cb6a2f2fa0e9/common/maskApi.c#L32-L41
- This new C-API will provide the uncompressed RLE same function as the previous API but shows the same performance as `pycocotools`.
```python
import numpy as np
from datumaro.util.mask_tools import mask_to_rle, mask_to_rle_py
import pycocotools.mask as mask_utils
from time import time

img_size = 768
mask = np.zeros([img_size, img_size])
# mask = np.random.randint(0, 2, size=[img_size, img_size])

for i in range(img_size):
    mask[i, :i] = 1

mask = mask.astype(dtype=np.uint8)

t1 = time()
for _ in range(10):
    result = mask_to_rle_py(mask)
print(f"Datumaro old implementation: {(time() - t1) * 1000:.2f} (ms)")

t1 = time()
for _ in range(10):
    mask_utils.encode(np.asfortranarray(mask))
print(f"pycocotools compressed RLE: {(time() - t1) * 1000:.2f} (ms)")

t1 = time()
for _ in range(10):
    result = mask_to_rle(mask)
print(f"Datumaro C-API uncompressed RLE: {(time() - t1) * 1000:.2f} (ms)")
```

```bash
Datumaro old implementation: 25.32 (ms)
pycocotools compressed RLE: 10.40 (ms)
Datumaro C-API uncompressed RLE: 9.66 (ms)
```

### How to test
If the new C-API is compatible with the previous API, our existing unit tests should be passed all.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
