### PR TITLE
Fix TypeError in validate command

### DIFF
--- a/datumaro/cli/commands/validate.py
+++ b/datumaro/cli/commands/validate.py
@@ -137,7 +137,7 @@ def validate_command(args):
     def _make_serializable(d):
         for key, val in list(d.items()):
             # tuple key to str
-            if isinstance(key, tuple):
+            if isinstance(key, tuple) or isinstance(key, int):
                 d[str(key)] = val
                 d.pop(key)
             if isinstance(val, dict):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
When using the command `validate` in detection task, there is a TypeError in the dictionary that is being saved in a json file. 

To reproduce the error:
1. Create a project and import a dataset (cvat format in my case) for object detection
2. Execute the command: `datum validate -t detection`
3. It appears the following error: **TypeError: Dict key must be str**

The error appears because there are some keys that are `int` type, so a second check have been added alongside the check for type `tuple`.


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
Taking into account the fix, if we execute the following command it generates the json file correctly instead of being empty:

`datum validate -t detection`

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
