### PR TITLE
Fixes ignored --loglevel by adding force=True when configuring with basicConfig.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## \[Unreleased\]
 
 ### Fixed
-- Fix problem setting loglevel via CLI 
+- Fix problem setting loglevel via CLI
   (<https://github.com/openvinotoolkit/datumaro/pull/800>)
 
 ## 27/01/2023 - Release v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+### Fixed
+- Fix problem setting loglevel via CLI 
+  (<https://github.com/openvinotoolkit/datumaro/pull/800>)
+
 ## 27/01/2023 - Release v0.5.0
 ### Added
 - Add Tile transformation

--- a/datumaro/cli/__main__.py
+++ b/datumaro/cli/__main__.py
@@ -41,7 +41,7 @@ class _LogManager:
         cls._define_loglevel_option(parser)
         args, _ = parser.parse_known_args(args)
 
-        log.basicConfig(format="%(asctime)s %(levelname)s: %(message)s", level=args.loglevel)
+        log.basicConfig(format="%(asctime)s %(levelname)s: %(message)s", level=args.loglevel, force=True)
 
         # Suppress own deprecation warnings
         warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"datumaro\..*")

--- a/datumaro/cli/__main__.py
+++ b/datumaro/cli/__main__.py
@@ -40,10 +40,17 @@ class _LogManager:
         parser = argparse.ArgumentParser(add_help=False)
         cls._define_loglevel_option(parser)
         args, _ = parser.parse_known_args(args)
+        log_format = "%(asctime)s %(levelname)s: %(message)s"
 
-        log.basicConfig(
-            format="%(asctime)s %(levelname)s: %(message)s", level=args.loglevel, force=True
-        )
+        # Try setting up logging with basicConfig.
+        # This does nothing, if other parts of the software
+        # already configured handlers, i.e. during imports and when
+        # main is called programmatically.
+        log.basicConfig(format=log_format, level=args.loglevel)
+        # Force-overwrite the log level and formatter
+        log.root.setLevel(args.loglevel)
+        for h in log.root.handlers:
+            h.setFormatter(log.Formatter(log_format))
 
         # Suppress own deprecation warnings
         warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"datumaro\..*")

--- a/datumaro/cli/__main__.py
+++ b/datumaro/cli/__main__.py
@@ -41,7 +41,9 @@ class _LogManager:
         cls._define_loglevel_option(parser)
         args, _ = parser.parse_known_args(args)
 
-        log.basicConfig(format="%(asctime)s %(levelname)s: %(message)s", level=args.loglevel, force=True)
+        log.basicConfig(
+            format="%(asctime)s %(levelname)s: %(message)s", level=args.loglevel, force=True
+        )
 
         # Suppress own deprecation warnings
         warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"datumaro\..*")


### PR DESCRIPTION
Setting `force=True` removes any existing handlers from the root logger before configuring it.
If not specified and any handlers have been set before the call to basicConfig, then the changes are not applied.
During the import process, there are other calls to `logging.basicConfig`. Specifically, when tensorflow is not installed, then     [this line](https://github.com/openvinotoolkit/datumaro/blob/15c592609239ea23c3c49e30cc54c922d1ef5703/datumaro/components/extractor_tfds.py#L25) calls `log.debug`, which in turn calls `log.basicConfig`.

Since the call to basicConfig in `datumaro/cli/__main__.py` is the only deliberate call to basicConfig, it should be forced and overwrite any other inadvertent config changes.

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Resolves #627

Fixes bug, which prevented setting of log level when calling CLI tool.


### How to test
Before this patch is applied setting `--loglevel`did nothing (atleast if tensorflow is not installed, haven't tested with tf).
To test it just check if calling `datum --loglevel debug <any command>` works before and after applying this test.
 

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
