### PR TITLE
Small fix of CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## \[Unreleased\]
+### Fixed
+- Fix for importing CVAT image 1.1 data format exported to project level
+  (<https://github.com/openvinotoolkit/datumaro/pull/795>)
 
 ## 27/01/2023 - Release v0.5.0
 ### Added
@@ -33,8 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/789>)
 - Fix auto-documentation for the data_format plugins
   (<https://github.com/openvinotoolkit/datumaro/pull/793>)
-- Fix CVAT for images 1.1 data format import at project level
-  (<https://github.com/openvinotoolkit/datumaro/pull/795>)
 
 ### Security
 - Add security.md file for the SDL


### PR DESCRIPTION
Signed-off-by: Kim, Vinnam <vinnam.kim@intel.com>

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
 - When merging #795, it mistakenly added a change log to the `datumaro=0.5.0` section. This PR moves that line to the unreleased section.


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
