### PR TITLE
Fix code format with the latest black==23.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## \[Unreleased\]
+### Fixed
+- Fix code format with the latest black==23.1.0
+(<https://github.com/openvinotoolkit/datumaro/pull/802>)
 
 ## 27/01/2023 - Release v0.5.0
 ### Added

--- a/datumaro/components/operations.py
+++ b/datumaro/components/operations.py
@@ -544,7 +544,7 @@ class IntersectMerge(MergingStrategy):
         item_map = {}  # id(item) -> (item, id(dataset))
 
         matches = OrderedDict()
-        for (item_id, item_subset) in sorted(item_ids, key=lambda e: e[0]):
+        for item_id, item_subset in sorted(item_ids, key=lambda e: e[0]):
             items = {}
             for d in datasets:
                 item = d.get(item_id, subset=item_subset)

--- a/datumaro/plugins/data_formats/camvid.py
+++ b/datumaro/plugins/data_formats/camvid.py
@@ -361,7 +361,7 @@ class CamvidExporter(Exporter):
             return
 
         with open(ann_file, "w", encoding="utf-8") as f:
-            for (image_path, mask_path) in segm_list.values():
+            for image_path, mask_path in segm_list.values():
                 image_path = "/" + image_path.replace("\\", "/")
                 mask_path = mask_path.replace("\\", "/")
                 if 1 < len(image_path.split()) or 1 < len(mask_path.split()):

--- a/datumaro/plugins/data_formats/imagenet_txt.py
+++ b/datumaro/plugins/data_formats/imagenet_txt.py
@@ -172,7 +172,6 @@ class ImagenetTxtImporter(Importer, CliPlugin):
     @classmethod
     def find_sources_with_params(cls, path, **extra_params):
         if "labels" not in extra_params or extra_params["labels"] == _LabelsSource.file.name:
-
             labels_file_name = osp.basename(
                 extra_params.get("labels_file") or ImagenetTxtPath.LABELS_FILE
             )

--- a/datumaro/plugins/data_formats/mpii/mpii_mat.py
+++ b/datumaro/plugins/data_formats/mpii/mpii_mat.py
@@ -117,7 +117,6 @@ class MpiiBase(SubsetBase):
                     )
 
                 if x1 is not None and x2 is not None and y1 is not None and y2 is not None:
-
                     annotations.append(Bbox(x1, y1, x2 - x1, y2 - y1, label=0, group=group_num))
 
                 group_num += 1

--- a/datumaro/plugins/openvino_plugin/samples/ssd_face_detection_interp.py
+++ b/datumaro/plugins/openvino_plugin/samples/ssd_face_detection_interp.py
@@ -41,7 +41,6 @@ def process_outputs(inputs, outputs):
 
     results = []
     for input_, detections in zip(inputs, outputs["detection_out"]):
-
         input_height, input_width = input_.shape[:2]
 
         confs = outputs["Softmax_189/Softmax_"]

--- a/datumaro/plugins/openvino_plugin/samples/ssd_mobilenet_coco_detection_interp.py
+++ b/datumaro/plugins/openvino_plugin/samples/ssd_mobilenet_coco_detection_interp.py
@@ -44,7 +44,6 @@ def process_outputs(inputs, outputs):
     for input_, confs, detections in zip(
         inputs, outputs["do_ExpandDims_conf/sigmoid"], outputs["DetectionOutput"]
     ):
-
         input_height, input_width = input_.shape[:2]
 
         confs = confs[0].reshape(-1, model_class_num)

--- a/datumaro/plugins/openvino_plugin/samples/ssd_person_detection_interp.py
+++ b/datumaro/plugins/openvino_plugin/samples/ssd_person_detection_interp.py
@@ -41,7 +41,6 @@ def process_outputs(inputs, outputs):
 
     results = []
     for input_, detections in zip(inputs, outputs["detection_out"]):
-
         input_height, input_width = input_.shape[:2]
 
         confs = outputs["Softmax_189/Softmax_"]

--- a/datumaro/plugins/openvino_plugin/samples/ssd_person_vehicle_bike_detection_interp.py
+++ b/datumaro/plugins/openvino_plugin/samples/ssd_person_vehicle_bike_detection_interp.py
@@ -41,7 +41,6 @@ def process_outputs(inputs, outputs):
 
     results = []
     for input_, detections in zip(inputs, outputs["detection_out"]):
-
         input_height, input_width = input_.shape[:2]
 
         confs = outputs["Softmax_189/Softmax_"]

--- a/datumaro/plugins/openvino_plugin/samples/ssd_vehicle_detection_interp.py
+++ b/datumaro/plugins/openvino_plugin/samples/ssd_vehicle_detection_interp.py
@@ -41,7 +41,6 @@ def process_outputs(inputs, outputs):
 
     results = []
     for input_, detections in zip(inputs, outputs["detection_out"]):
-
         input_height, input_width = input_.shape[:2]
 
         confs = outputs["Softmax_189/Softmax_"]

--- a/tests/cli/test_image_zip_format.py
+++ b/tests/cli/test_image_zip_format.py
@@ -15,7 +15,7 @@ from ..requirements import Requirements, mark_requirement
 
 def make_zip_archive(src_path, dst_path):
     with ZipFile(dst_path, "w") as archive:
-        for (dirpath, _, filenames) in os.walk(src_path):
+        for dirpath, _, filenames in os.walk(src_path):
             for name in filenames:
                 path = osp.join(dirpath, name)
                 archive.write(path, osp.relpath(path, src_path))

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -927,7 +927,6 @@ class SplitterTest(TestCase):
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_split_for_segmentation(self):
-
         with self.subTest("mask annotation"):
             dtypes = ["coco", "voc", "labelme", "mot"]
             task = splitter.SplitTask.segmentation.name
@@ -1041,7 +1040,6 @@ class SplitterTest(TestCase):
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_split_for_segmentation_with_unlabeled(self):
-
         with self.subTest("mask annotation"):
             source, _ = self._generate_detection_segmentation_dataset(
                 annotation_type=self._get_append_mask("coco"),
@@ -1076,7 +1074,6 @@ class SplitterTest(TestCase):
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_split_for_segmentation_gives_error(self):
-
         with self.subTest("mask annotation"):
             source, _ = self._generate_detection_segmentation_dataset(
                 annotation_type=self._get_append_mask("coco"),

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -817,7 +817,6 @@ class TestSegmentationValidator(_TestValidatorBase):
 
 
 class TestValidateAnnotations(_TestValidatorBase):
-
     extra_args = {
         "few_samples_thr": 1,
         "imbalance_ratio_thr": 50,

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -47,7 +47,6 @@ class VisualizerTestBase:
             f"datumaro.components.visualizer.Visualizer.{func_name}",
             wraps=getattr(visualizer, func_name),
         ) as mocked:
-
             for item in self.items:
                 fig = visualizer.vis_one_sample(item.id, self.subset)
 

--- a/tests/test_yolo_format.py
+++ b/tests/test_yolo_format.py
@@ -289,7 +289,6 @@ class YoloExportertTest(TestCase):
     @mark_requirement(Requirements.DATUM_565)
     def test_cant_save_with_reserved_subset_name(self):
         for subset in ["backup", "classes"]:
-
             dataset = Dataset.from_iterable(
                 [
                     DatasetItem(


### PR DESCRIPTION
Signed-off-by: Kim, Vinnam <vinnam.kim@intel.com>

<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
- Please see https://github.com/openvinotoolkit/datumaro/actions/runs/4070850339/jobs/7012102925. There are format errors with the latest `black` version (=`23.1.0`)
- This PR fixes it.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
