### PR TITLE
Raise ImportError on importing malformed COCO directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/804>)
 - Fix model remove CLI command
   (<https://github.com/openvinotoolkit/datumaro/pull/805>)
+- Raise ImportError on importing malformed COCO directory
+  (<https://github.com/openvinotoolkit/datumaro/pull/812>)
 
 ## 27/01/2023 - Release v0.5.0
 ### Added

--- a/datumaro/components/errors.py
+++ b/datumaro/components/errors.py
@@ -302,6 +302,10 @@ class MediaTypeError(DatumaroError):
     pass
 
 
+class MediaShapeError(DatumaroError):
+    pass
+
+
 class DatasetInfosRedefinedError(DatasetError):
     def __str__(self):
         return "Infos can only be set once for a dataset"

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -108,6 +108,7 @@ class Image(MediaElement):
             data = self._data
 
         if self._size is None and data is not None:
+            assert data.ndim == 3, "An image should have 3 dims."
             self._size = tuple(map(int, data.shape[:2]))
         return data
 

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -108,7 +108,7 @@ class Image(MediaElement):
             data = self._data
 
         if self._size is None and data is not None:
-            assert data.ndim == 3, "An image should have 3 dims."
+            assert 2 <= data.ndim <= 3, "An image should have 2 (gray) or 3 (rgb) dims."
             self._size = tuple(map(int, data.shape[:2]))
         return data
 

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -13,6 +13,7 @@ from typing import Callable, Iterable, Iterator, List, Optional, Tuple, Union
 import cv2
 import numpy as np
 
+from datumaro.components.errors import MediaShapeError
 from datumaro.util.image import _image_loading_errors, decode_image, lazy_image, save_image
 
 BboxIntCoords = Tuple[int, int, int, int]  # (x, y, w, h)
@@ -108,7 +109,8 @@ class Image(MediaElement):
             data = self._data
 
         if self._size is None and data is not None:
-            assert 2 <= data.ndim <= 3, "An image should have 2 (gray) or 3 (rgb) dims."
+            if not 2 <= data.ndim <= 3:
+                raise MediaShapeError("An image should have 2 (gray) or 3 (rgb) dims.")
             self._size = tuple(map(int, data.shape[:2]))
         return data
 

--- a/datumaro/plugins/data_formats/coco/base.py
+++ b/datumaro/plugins/data_formats/coco/base.py
@@ -66,17 +66,9 @@ class _CocoBase(SubsetBase):
             subset = parts[1] if len(parts) == 2 else None
         super().__init__(subset=subset, **kwargs)
 
-        rootpath = ""
-        if path.endswith(osp.join(CocoPath.ANNOTATIONS_DIR, osp.basename(path))):
-            rootpath = path.rsplit(CocoPath.ANNOTATIONS_DIR, maxsplit=1)[0]
-        images_dir = ""
-        if rootpath and osp.isdir(osp.join(rootpath, CocoPath.IMAGES_DIR)):
-            images_dir = osp.join(rootpath, CocoPath.IMAGES_DIR)
-            if osp.isdir(osp.join(images_dir, subset or DEFAULT_SUBSET_NAME)):
-                images_dir = osp.join(images_dir, subset or DEFAULT_SUBSET_NAME)
-        self._images_dir = images_dir
+        self._rootpath = self._find_rootpath(path)
+        self._images_dir = self._find_images_dir(subset)
         self._task = task
-        self._rootpath = rootpath
 
         self._merge_instance_polygons = merge_instance_polygons
 
@@ -90,6 +82,34 @@ class _CocoBase(SubsetBase):
         if self._task == CocoTask.panoptic:
             self._mask_dir = osp.splitext(path)[0]
         self._items = self._load_items(json_data)
+
+    def _find_rootpath(self, path: str) -> str:
+        """Find root path from annotation json file path."""
+        if path.endswith(osp.join(CocoPath.ANNOTATIONS_DIR, osp.basename(path))):
+            return path.rsplit(CocoPath.ANNOTATIONS_DIR, maxsplit=1)[0]
+        raise DatasetImportError(
+            f"Annotation path ({path}) should be under the directory which is named {CocoPath.ANNOTATIONS_DIR}. "
+            "If not, Datumaro fails to find the root path for this dataset. "
+            "Please follow this instruction, https://github.com/cocodataset/cocoapi/blob/master/README.txt"
+        )
+
+    def _find_images_dir(self, subset: str) -> str:
+        """Find images directory from the root path."""
+
+        rootpath = self._rootpath
+
+        if rootpath and osp.isdir(osp.join(rootpath, CocoPath.IMAGES_DIR)):
+            images_dir = osp.join(rootpath, CocoPath.IMAGES_DIR)
+            if osp.isdir(osp.join(images_dir, subset or DEFAULT_SUBSET_NAME)):
+                images_dir = osp.join(images_dir, subset or DEFAULT_SUBSET_NAME)
+            return images_dir
+
+        raise DatasetImportError(
+            f"We found the rootpath ({rootpath}) for this dataset. "
+            f"However, there should exist a directory for images as {osp.join(rootpath, CocoPath.IMAGES_DIR)}. "
+            "If not, Datumaro fails to find the image directory path. "
+            "Please follow this instruction, https://github.com/cocodataset/cocoapi/blob/master/README.txt"
+        )
 
     def __iter__(self):
         yield from self._items.values()

--- a/tests/integration/cli/test_filter.py
+++ b/tests/integration/cli/test_filter.py
@@ -1,10 +1,17 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import os.path as osp
 from unittest import TestCase
+
+import numpy as np
 
 from datumaro.components.annotation import Bbox, Label
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.errors import ReadonlyDatasetError
+from datumaro.components.media import Image
 from datumaro.components.project import Project
 from datumaro.util.scope import scope_add, scoped
 from datumaro.util.test_utils import TestDir, compare_datasets
@@ -56,7 +63,11 @@ class FilterTest(TestCase):
             dataset_url = osp.join(test_dir, "dataset")
             dataset = Dataset.from_iterable(
                 [
-                    DatasetItem(id=1, annotations=[Bbox(1, 2, 3, 4, label=1)]),
+                    DatasetItem(
+                        id=1,
+                        media=Image(data=np.ones((10, 10, 3))),
+                        annotations=[Bbox(1, 2, 3, 4, label=1)],
+                    ),
                 ],
                 categories=["a", "b"],
             )

--- a/tests/integration/cli/test_transform.py
+++ b/tests/integration/cli/test_transform.py
@@ -1,10 +1,17 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import os.path as osp
 from unittest import TestCase
+
+import numpy as np
 
 from datumaro.components.annotation import Bbox, Label
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.errors import ReadonlyDatasetError
+from datumaro.components.media import Image
 from datumaro.components.project import Project
 from datumaro.util.scope import scope_add, scoped
 from datumaro.util.test_utils import TestDir, compare_datasets
@@ -69,7 +76,19 @@ class TransformTest(TestCase):
             dataset_url = osp.join(test_dir, "dataset")
             dataset = Dataset.from_iterable(
                 [
-                    DatasetItem(id=1, annotations=[Bbox(1, 2, 3, 4, label=1)]),
+                    DatasetItem(
+                        id=1,
+                        media=Image(
+                            data=np.ones(
+                                (
+                                    10,
+                                    10,
+                                    3,
+                                )
+                            )
+                        ),
+                        annotations=[Bbox(1, 2, 3, 4, label=1)],
+                    ),
                 ],
                 categories=["a", "b"],
             )

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -1005,12 +1005,22 @@ class CocoExtractorTests(TestCase):
             with self.assertRaisesRegex(DatasetImportError, "JSON file"):
                 CocoInstancesBase(test_dir)
 
+    @staticmethod
+    def _get_dummy_annotation_path(test_dir: str) -> str:
+        ann_dir = osp.join(test_dir, "annotations")
+        if not os.path.exists(ann_dir):
+            os.makedirs(ann_dir)
+        images_dir = osp.join(test_dir, "images")
+        if not os.path.exists(images_dir):
+            os.makedirs(images_dir)
+        return osp.join(test_dir, "annotations", "ann.json")
+
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
     def test_can_report_missing_item_field(self):
         for field in ["id", "file_name"]:
             with self.subTest(field=field):
                 with TestDir() as test_dir:
-                    ann_path = osp.join(test_dir, "ann.json")
+                    ann_path = self._get_dummy_annotation_path(test_dir)
                     anns = deepcopy(self.ANNOTATION_JSON_TEMPLATE)
                     anns["images"][0].pop(field)
                     dump_json_file(ann_path, anns)
@@ -1025,7 +1035,7 @@ class CocoExtractorTests(TestCase):
         for field in ["id", "image_id", "segmentation", "iscrowd", "category_id", "bbox"]:
             with self.subTest(field=field):
                 with TestDir() as test_dir:
-                    ann_path = osp.join(test_dir, "ann.json")
+                    ann_path = self._get_dummy_annotation_path(test_dir)
                     anns = deepcopy(self.ANNOTATION_JSON_TEMPLATE)
                     anns["annotations"][0].pop(field)
                     dump_json_file(ann_path, anns)
@@ -1040,7 +1050,7 @@ class CocoExtractorTests(TestCase):
         for field in ["images", "annotations", "categories"]:
             with self.subTest(field=field):
                 with TestDir() as test_dir:
-                    ann_path = osp.join(test_dir, "ann.json")
+                    ann_path = self._get_dummy_annotation_path(test_dir)
                     anns = deepcopy(self.ANNOTATION_JSON_TEMPLATE)
                     anns.pop(field)
                     dump_json_file(ann_path, anns)
@@ -1054,7 +1064,7 @@ class CocoExtractorTests(TestCase):
         for field in ["id", "name"]:
             with self.subTest(field=field):
                 with TestDir() as test_dir:
-                    ann_path = osp.join(test_dir, "ann.json")
+                    ann_path = self._get_dummy_annotation_path(test_dir)
                     anns = deepcopy(self.ANNOTATION_JSON_TEMPLATE)
                     anns["categories"][0].pop(field)
                     dump_json_file(ann_path, anns)
@@ -1066,7 +1076,7 @@ class CocoExtractorTests(TestCase):
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
     def test_can_report_undeclared_label(self):
         with TestDir() as test_dir:
-            ann_path = osp.join(test_dir, "ann.json")
+            ann_path = self._get_dummy_annotation_path(test_dir)
             anns = deepcopy(self.ANNOTATION_JSON_TEMPLATE)
             anns["annotations"][0]["category_id"] = 2
             dump_json_file(ann_path, anns)
@@ -1079,7 +1089,7 @@ class CocoExtractorTests(TestCase):
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
     def test_can_report_invalid_bbox(self):
         with TestDir() as test_dir:
-            ann_path = osp.join(test_dir, "ann.json")
+            ann_path = self._get_dummy_annotation_path(test_dir)
             anns = deepcopy(self.ANNOTATION_JSON_TEMPLATE)
             anns["annotations"][0]["bbox"] = [1, 2, 3, 4, 5]
             dump_json_file(ann_path, anns)
@@ -1092,7 +1102,7 @@ class CocoExtractorTests(TestCase):
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
     def test_can_report_invalid_polygon_odd_points(self):
         with TestDir() as test_dir:
-            ann_path = osp.join(test_dir, "ann.json")
+            ann_path = self._get_dummy_annotation_path(test_dir)
             anns = deepcopy(self.ANNOTATION_JSON_TEMPLATE)
             anns["annotations"][0]["segmentation"] = [[1, 2, 3]]
             dump_json_file(ann_path, anns)
@@ -1105,7 +1115,7 @@ class CocoExtractorTests(TestCase):
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
     def test_can_report_invalid_polygon_less_than_3_points(self):
         with TestDir() as test_dir:
-            ann_path = osp.join(test_dir, "ann.json")
+            ann_path = self._get_dummy_annotation_path(test_dir)
             anns = deepcopy(self.ANNOTATION_JSON_TEMPLATE)
             anns["annotations"][0]["segmentation"] = [[1, 2, 3, 4]]
             dump_json_file(ann_path, anns)
@@ -1118,7 +1128,7 @@ class CocoExtractorTests(TestCase):
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
     def test_can_report_invalid_image_id(self):
         with TestDir() as test_dir:
-            ann_path = osp.join(test_dir, "ann.json")
+            ann_path = self._get_dummy_annotation_path(test_dir)
             anns = deepcopy(self.ANNOTATION_JSON_TEMPLATE)
             anns["annotations"][0]["image_id"] = 10
             dump_json_file(ann_path, anns)
@@ -1133,7 +1143,7 @@ class CocoExtractorTests(TestCase):
         with TestDir() as test_dir:
             for field, value in [("id", "q"), ("width", "q"), ("height", "q"), ("file_name", 0)]:
                 with self.subTest(field=field, value=value):
-                    ann_path = osp.join(test_dir, "ann.json")
+                    ann_path = self._get_dummy_annotation_path(test_dir)
                     anns = deepcopy(self.ANNOTATION_JSON_TEMPLATE)
                     anns["images"][0][field] = value
                     dump_json_file(ann_path, anns)
@@ -1157,7 +1167,7 @@ class CocoExtractorTests(TestCase):
                 ("score", "a"),
             ]:
                 with self.subTest(field=field):
-                    ann_path = osp.join(test_dir, "ann.json")
+                    ann_path = self._get_dummy_annotation_path(test_dir)
                     anns = deepcopy(self.ANNOTATION_JSON_TEMPLATE)
                     anns["annotations"][0][field] = value
                     dump_json_file(ann_path, anns)

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -1,10 +1,10 @@
 import os
 import os.path as osp
 import pickle  # nosec - disable B403:import_pickle check
+import shutil
 from copy import deepcopy
 from functools import partial
 from itertools import product
-import shutil
 from unittest import TestCase
 
 import numpy as np

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1475,7 +1475,7 @@ class DatasetTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_run_model(self):
         dataset = Dataset.from_iterable(
-            [DatasetItem(i, media=Image(data=np.array([i]))) for i in range(5)],
+            [DatasetItem(i, media=Image(data=np.ones((i, i, 3)))) for i in range(5)],
             categories=["label"],
         )
 
@@ -1485,7 +1485,7 @@ class DatasetTest(TestCase):
             [
                 DatasetItem(
                     i,
-                    media=Image(data=np.array([i])),
+                    media=Image(data=np.ones((i, i, 3))),
                     annotations=[Label(0, attributes={"idx": i % batch_size, "data": i})],
                 )
                 for i in range(5)
@@ -1501,7 +1501,7 @@ class DatasetTest(TestCase):
                 calls += 1
 
                 for i, inp in enumerate(inputs):
-                    yield [Label(0, attributes={"idx": i, "data": inp.item()})]
+                    yield [Label(0, attributes={"idx": i, "data": inp.shape[0]})]
 
         model = TestLauncher()
 

--- a/tests/unit/test_ndr.py
+++ b/tests/unit/test_ndr.py
@@ -5,6 +5,7 @@ import numpy as np
 import datumaro.plugins.ndr as ndr
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.dataset_base import DatasetItem
+from datumaro.components.errors import MediaShapeError
 from datumaro.components.media import Image
 from datumaro.components.project import Dataset
 
@@ -97,7 +98,7 @@ class NDRTest(TestCase):
             result = ndr.NDR(source, working_subset="train")
             len(result)
 
-        with self.assertRaisesRegex(ValueError, "unexpected number of dimensions"):
+        with self.assertRaises(MediaShapeError):
             source = self._generate_dataset(config, 10, "invalid_dimension")
             result = ndr.NDR(source, working_subset="train")
             len(result)

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -379,8 +379,8 @@ class TestOperations(TestCase):
                 DatasetItem(1, subset="a", media=Image(path="1.jpg")),
                 DatasetItem(1, subset="b", media=Image(path="1.jpg")),
                 # same images
-                DatasetItem(2, media=Image(data=np.array([1]))),
-                DatasetItem(3, media=Image(data=np.array([1]))),
+                DatasetItem(2, media=Image(data=np.ones((5, 5, 3)))),
+                DatasetItem(3, media=Image(data=np.ones((5, 5, 3)))),
                 # no image is always a unique image
                 DatasetItem(4),
             ]


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
 - Previously, COCOImporter implicitly set its `rootpath=""` and `images_dir=""` unless the directory structure is not well formed. This makes users cannot know what's happening although their dataset structure is malformed. As a result, after importing, users try to load its images but fail and don't know why.
 - This patch makes [COCO directory structure rule](https://github.com/cocodataset/cocoapi/blob/master/README.txt) more strictly at the dataset import level to prevent misbehavior in the next steps.
 - In addition, add a checker to check whether `Image` has correct dimensions: 2 or 3. There have been many test cases which let `Image()` not having 3 dimensions. This PR also fixes it.

### How to test
I added a unit test for it.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
