### PR TITLE
Fix bugs in mvtec exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor Datumaro format code and test code
   (<https://github.com/openvinotoolkit/datumaro/pull/824>)
 
+### Fixed
+- Fix image filenames and anomaly mask appearance in MVTec exporter
+  (<https://github.com/openvinotoolkit/datumaro/pull/835>)
+
 ## 24/02/2023 - Release v1.0.0
 ### Added
 - Add Data Explorer

--- a/datumaro/plugins/data_formats/mvtec/exporter.py
+++ b/datumaro/plugins/data_formats/mvtec/exporter.py
@@ -92,7 +92,7 @@ class MvtecExporter(Exporter):
 
                     if not osp.exists(osp.join(self._save_dir, osp.dirname(mask_path))):
                         os.mkdir(osp.join(self._save_dir, osp.dirname(mask_path)))
-                    cv2.imwrite(osp.join(self._save_dir, mask_path), mask)
+                    cv2.imwrite(osp.join(self._save_dir, mask_path), mask * 255)
 
                 masks = [a for a in item.annotations if a.type == AnnotationType.mask]
                 if masks and MvtecTask.segmentation in self._tasks:

--- a/datumaro/plugins/data_formats/mvtec/exporter.py
+++ b/datumaro/plugins/data_formats/mvtec/exporter.py
@@ -77,7 +77,7 @@ class MvtecExporter(Exporter):
                         labels.append(self.get_label(ann.label))
 
                 if self._save_media:
-                    self._save_image(item, subdir=osp.join(subset_name, labels[0]))
+                    self._save_image(item, subdir=subset_name)
 
                 bboxes = [a for a in item.annotations if a.type == AnnotationType.bbox]
                 if bboxes and MvtecTask.detection in self._tasks:
@@ -103,7 +103,7 @@ class MvtecExporter(Exporter):
                     if not osp.exists(osp.join(self._save_dir, osp.dirname(mask_path))):
                         os.mkdir(osp.join(self._save_dir, osp.dirname(mask_path)))
                     cv2.imwrite(
-                        osp.join(self._save_dir, mask_path), masks[0].image.astype(np.uint8)
+                        osp.join(self._save_dir, mask_path), masks[0].image.astype(np.uint8) * 255
                     )
 
     def get_label(self, label_id):

--- a/tests/unit/test_mvtec_format.py
+++ b/tests/unit/test_mvtec_format.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
-import numpy as np
 import cv2
+import numpy as np
 
 from datumaro.components.annotation import AnnotationType, Bbox, Label, LabelCategories, Mask
 from datumaro.components.dataset import Dataset
@@ -230,7 +230,6 @@ class MvtecImporterTest(TestCase):
 
 
 class MVTecExporterTest(TestCase):
-
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_segmentation_masks_saved_as_binary_image(self):
         source_dataset = Dataset.from_iterable(


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
This PR fixes two small bugs in the MVTec exporter:
- When writing images, the defect type was added to the save path as part of the subdirectory, but the defect type was also added by `_make_item_filename` as part of the item id. So the final path contained the defect type twice (`bottle/test/broken_large/broken_large/000.png` instead of `bottle/test/broken_large/000.png`). This was fixed by not appending the defect type to the subdirectory.
- Binary anomaly masks were not multiplied by 255 before writing the image, resulting in empty masks.


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
