### PR TITLE
Fix CIFAR10 and 100 detect function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix image filenames and anomaly mask appearance in MVTec exporter
   (<https://github.com/openvinotoolkit/datumaro/pull/835>)
+- Fix CIFAR10 and 100 detect function
+  (<https://github.com/openvinotoolkit/datumaro/pull/836>)
 
 ## 24/02/2023 - Release v1.0.0
 ### Added
@@ -28,10 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/807>)
 - Add MVTec anomaly data support
   (<https://github.com/openvinotoolkit/datumaro/pull/810>)
-
-### Fixed
-- Fix CIFAR10 and 100 detect function
-  (<https://github.com/openvinotoolkit/datumaro/pull/836>)
 
 ### Changed
 - Refactor existing tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add MVTec anomaly data support
   (<https://github.com/openvinotoolkit/datumaro/pull/810>)
 
+### Fixed
+- Fix CIFAR10 and 100 detect function
+  (<https://github.com/openvinotoolkit/datumaro/pull/836>)
+
 ### Changed
 - Refactor existing tests
   (<https://github.com/openvinotoolkit/datumaro/pull/803>)

--- a/datumaro/plugins/data_formats/cifar.py
+++ b/datumaro/plugins/data_formats/cifar.py
@@ -13,7 +13,7 @@ import numpy as np
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.dataset import ItemStatus
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
-from datumaro.components.errors import DatasetImportError, MediaTypeError
+from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
 from datumaro.components.importer import Importer

--- a/tests/unit/test_cifar_format.py
+++ b/tests/unit/test_cifar_format.py
@@ -317,8 +317,7 @@ class CifarImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_10(self):
         detected_formats = Environment().detect_dataset(DUMMY_10_DATASET_DIR)
-        self.assertEqual(len(detected_formats), 1)
-        self.assertEqual(detected_formats[0], CifarImporter.NAME)
+        self.assertEqual(detected_formats, [CifarImporter.NAME])
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import_100(self):
@@ -378,5 +377,4 @@ class CifarImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_100(self):
         detected_formats = Environment().detect_dataset(DUMMY_100_DATASET_DIR)
-        self.assertEqual(len(detected_formats), 1)
-        self.assertEqual(detected_formats[0], CifarImporter.NAME)
+        self.assertEqual(detected_formats, [CifarImporter.NAME])


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
- Ticket no. 105476
- Fix CIFAR-10 and CIFAR-100 `detect` function.

### How to test
This change is covered by the existing tests.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [x] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
