### PR TITLE
Fix wrong __len__() of Subset when the item is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/836>)
 - Choose the top priority detect format for all directory depths
   (<https://github.com/openvinotoolkit/datumaro/pull/839>)
+- Fix wrong `__len__()` of Subset when the item is removed
+  (<https://github.com/openvinotoolkit/datumaro/pull/854>)
 
 ## 24/02/2023 - Release v1.0.0
 ### Added

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -432,6 +432,7 @@ class DatasetTest(TestCase):
         dataset.remove(1)
 
         self.assertEqual(2, len(dataset))
+        self.assertEqual(2, len(dataset.get_subset(DEFAULT_SUBSET_NAME)))
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_compute_length_when_created_from_extractor(self):


### PR DESCRIPTION
### Summary
 - @sungmanc reported that the subset length is not correctly obtained if we remove the item from the dataset as follows.
![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/26541465/224908631-f7ad82a7-c87c-457b-919c-631926b3440e.png)
 - Ticket no. 105934

### How to test
Added a test for this bug

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
