### PR TITLE
Fix detect unit tests to test false negatives as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/854>)
 - Fix mask visualization bug
   (<https://github.com/openvinotoolkit/datumaro/pull/860>)
+- Fix detect unit tests to test false negatives as well
+  (<https://github.com/openvinotoolkit/datumaro/pull/868>)
 
 ## 24/02/2023 - Release v1.0.0
 ### New features

--- a/datumaro/components/format_detection.py
+++ b/datumaro/components/format_detection.py
@@ -35,14 +35,21 @@ class FormatDetectionConfidence(IntEnum):
     """
 
     NONE = 1
+    """
+    """
+    EXTREME_LOW = 5
+    """
+    EXTREME_LOW: This is currently only assigned to ImageDir format. This is because
+    ImageDir format can be detected in every image dataset format.
+    """
     LOW = 10
     """
-    The dataset seems to belong to the format, but the format is too loosely
+    LOW: The dataset seems to belong to the format, but the format is too loosely
     defined to be able to distinguish it from other formats.
     """
     MEDIUM = 20
     """
-    The dataset seems to belong to the format, and is likely not to belong
+    MEDIUM: The dataset seems to belong to the format, and is likely not to belong
     to any other format.
     """
     # There's no HIGH confidence yet, because none of the detectors

--- a/datumaro/components/importer.py
+++ b/datumaro/components/importer.py
@@ -24,6 +24,7 @@ from datumaro.components.errors import (
 )
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
 from datumaro.components.progress_reporting import NullProgressReporter, ProgressReporter
+from datumaro.util.definitions import SUBSET_NAME_BLACKLIST
 
 T = TypeVar("T")
 
@@ -90,15 +91,17 @@ class NullImportContext(ImportContext):
 
 
 class Importer(CliPlugin):
+    DETECT_CONFIDENCE = FormatDetectionConfidence.LOW
+
     @classmethod
     def detect(
         cls,
         context: FormatDetectionContext,
-    ) -> Optional[FormatDetectionConfidence]:
+    ) -> FormatDetectionConfidence:
         if not cls.find_sources_with_params(context.root_path):
             context.fail("specific requirement information unavailable")
 
-        return FormatDetectionConfidence.LOW
+        return cls.DETECT_CONFIDENCE
 
     @classmethod
     def find_sources(cls, path: str) -> List[Dict]:
@@ -218,6 +221,9 @@ def with_subset_dirs(input_cls: Importer):
                 )
 
             for sub_dir in os.listdir(path):
+                if sub_dir.lower() in SUBSET_NAME_BLACKLIST:
+                    continue
+
                 sub_path = osp.join(path, sub_dir)
                 if osp.isdir(sub_path):
                     with _change_context_root_path(context, sub_path):

--- a/datumaro/plugins/data_formats/image_dir.py
+++ b/datumaro/plugins/data_formats/image_dir.py
@@ -8,7 +8,7 @@ import os.path as osp
 
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.exporter import Exporter
-from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
+from datumaro.components.format_detection import FormatDetectionConfidence
 from datumaro.components.importer import Importer
 from datumaro.components.media import Image
 from datumaro.util.image import find_images
@@ -19,10 +19,7 @@ class ImageDirImporter(Importer):
     Reads images from a directory as a dataset.
     """
 
-    @classmethod
-    def detect(cls, context: FormatDetectionContext) -> FormatDetectionConfidence:
-        super().detect(context)
-        return FormatDetectionConfidence.LOW
+    DETECT_CONFIDENCE = FormatDetectionConfidence.EXTREME_LOW
 
     @classmethod
     def build_cmdline_parser(cls, **kwargs):

--- a/datumaro/plugins/data_formats/market1501.py
+++ b/datumaro/plugins/data_formats/market1501.py
@@ -9,6 +9,7 @@ import re
 from datumaro.components.dataset_base import DatasetBase, DatasetItem
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
+from datumaro.components.format_detection import FormatDetectionConfidence
 from datumaro.components.importer import Importer
 from datumaro.components.media import Image
 from datumaro.util import str_to_bool
@@ -102,6 +103,8 @@ class Market1501Base(DatasetBase):
 
 
 class Market1501Importer(Importer):
+    DETECT_CONFIDENCE = FormatDetectionConfidence.MEDIUM
+
     @classmethod
     def find_sources(cls, path):
         for dirname in os.listdir(path):

--- a/datumaro/plugins/data_formats/mvtec/importer.py
+++ b/datumaro/plugins/data_formats/mvtec/importer.py
@@ -5,7 +5,7 @@
 import os.path as osp
 from glob import glob
 
-from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
+from datumaro.components.format_detection import FormatDetectionConfidence
 from datumaro.components.importer import Importer
 
 from .format import MvtecPath, MvtecTask
@@ -42,30 +42,18 @@ class MvtecImporter(Importer):
 
 
 class MvtecClassificationImporter(MvtecImporter):
+    DETECT_CONFIDENCE = FormatDetectionConfidence.MEDIUM
     _TASK = MvtecTask.classification
     _TASKS = {_TASK: MvtecImporter._TASKS[_TASK]}
 
-    @classmethod
-    def detect(cls, context: FormatDetectionContext) -> FormatDetectionConfidence:
-        super().detect(context)
-        return FormatDetectionConfidence.MEDIUM
-
 
 class MvtecDetectionImporter(MvtecImporter):
+    DETECT_CONFIDENCE = FormatDetectionConfidence.MEDIUM
     _TASK = MvtecTask.detection
     _TASKS = {_TASK: MvtecImporter._TASKS[_TASK]}
 
-    @classmethod
-    def detect(cls, context: FormatDetectionContext) -> FormatDetectionConfidence:
-        super().detect(context)
-        return FormatDetectionConfidence.MEDIUM
-
 
 class MvtecSegmentationImporter(MvtecImporter):
+    DETECT_CONFIDENCE = FormatDetectionConfidence.MEDIUM
     _TASK = MvtecTask.segmentation
     _TASKS = {_TASK: MvtecImporter._TASKS[_TASK]}
-
-    @classmethod
-    def detect(cls, context: FormatDetectionContext) -> FormatDetectionConfidence:
-        super().detect(context)
-        return FormatDetectionConfidence.MEDIUM

--- a/datumaro/util/definitions.py
+++ b/datumaro/util/definitions.py
@@ -6,3 +6,4 @@ from typing import Tuple
 
 DEFAULT_SUBSET_NAME = "default"
 BboxIntCoords = Tuple[int, int, int, int]  # (x, y, w, h)
+SUBSET_NAME_BLACKLIST = {"labels", "images", "annotations", "instances"}

--- a/tests/unit/test_align_celeba_format.py
+++ b/tests/unit/test_align_celeba_format.py
@@ -167,4 +167,4 @@ class AlignCelebaImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_475)
     def test_can_detect_align_dataset(self):
         detected_formats = Environment().detect_dataset(DUMMY_ALIGN_DATASET_DIR)
-        self.assertIn(AlignCelebaImporter.NAME, detected_formats)
+        self.assertEqual([AlignCelebaImporter.NAME], detected_formats)

--- a/tests/unit/test_celeba_format.py
+++ b/tests/unit/test_celeba_format.py
@@ -171,4 +171,4 @@ class CelebaImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_475)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(CelebaImporter.NAME, detected_formats)
+        self.assertEqual([CelebaImporter.NAME], detected_formats)

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -953,7 +953,7 @@ class CocoImporterTest(TestCase):
                 shutil.copytree(osp.join(DUMMY_DATASET_DIR, "coco"), dataset_dir)
                 move_func(dataset_dir)
                 with self.assertRaises(DatasetImportError):
-                    Dataset.import_from(dataset_dir)
+                    Dataset.import_from(dataset_dir, format="coco")
 
         # Wrong structure: ./annotations -> ./labels
         _test(

--- a/tests/unit/test_imagenet_format.py
+++ b/tests/unit/test_imagenet_format.py
@@ -161,7 +161,7 @@ class ImagenetImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect_imagenet(self):
         detected_formats = Environment().detect_dataset(self.DUMMY_DATASET_DIR)
-        self.assertIn(self.IMPORTER_NAME, detected_formats)
+        self.assertEqual([self.IMPORTER_NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_673)
     def test_can_pickle(self):

--- a/tests/unit/test_kitti_format.py
+++ b/tests/unit/test_kitti_format.py
@@ -224,6 +224,11 @@ class KittiImportTest(TestCase):
             with self.subTest(path=path, task=subtask):
                 detected_formats = env.detect_dataset(path)
                 self.assertIn(subtask.NAME, detected_formats)
+                # Test false positives too
+                for detected_format in detected_formats:
+                    self.assertIn(
+                        detected_format, {"kitti", "kitti_segmentation", "kitti_detection"}
+                    )
 
 
 class TestExtractorBase(DatasetBase):

--- a/tests/unit/test_market1501_format.py
+++ b/tests/unit/test_market1501_format.py
@@ -216,7 +216,7 @@ class Market1501ImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(Market1501Importer.NAME, detected_formats)
+        self.assertEqual([Market1501Importer.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import(self):

--- a/tests/unit/test_mnist_csv_format.py
+++ b/tests/unit/test_mnist_csv_format.py
@@ -235,4 +235,4 @@ class MnistCsvImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(MnistCsvImporter.NAME, detected_formats)
+        self.assertEqual([MnistCsvImporter.NAME], detected_formats)

--- a/tests/unit/test_mnist_format.py
+++ b/tests/unit/test_mnist_format.py
@@ -233,4 +233,4 @@ class MnistImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(MnistImporter.NAME, detected_formats)
+        self.assertEqual([MnistImporter.NAME], detected_formats)

--- a/tests/unit/test_mots_format.py
+++ b/tests/unit/test_mots_format.py
@@ -232,7 +232,7 @@ class MotsImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(MotsImporter.NAME, detected_formats)
+        self.assertEqual([MotsImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import(self):

--- a/tests/unit/test_sly_pointcloud_format.py
+++ b/tests/unit/test_sly_pointcloud_format.py
@@ -23,7 +23,7 @@ class SuperviselyPointcloudImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(SuperviselyPointCloudImporter.NAME, detected_formats)
+        self.assertEqual([SuperviselyPointCloudImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_load(self):

--- a/tests/unit/test_tfrecord_format.py
+++ b/tests/unit/test_tfrecord_format.py
@@ -316,7 +316,7 @@ class TfrecordImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(TfDetectionApiImporter.NAME, detected_formats)
+        self.assertEqual([TfDetectionApiImporter.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import(self):

--- a/tests/unit/test_vgg_face2_format.py
+++ b/tests/unit/test_vgg_face2_format.py
@@ -283,7 +283,7 @@ class VggFace2ImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_detect(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertIn(VggFace2Importer.NAME, detected_formats)
+        self.assertEqual([VggFace2Importer.NAME], detected_formats)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import(self):


### PR DESCRIPTION
### Summary

 - Ticket no. 104511
 - To test false positive, change detect() test from assertIn() to assertEqual().
 - In addition, add false positive test code as well to some datasets which must have multiple candidates from
detect() in nature (e.g. kitti).
 - Refactor Importer.detect() confidence return logic.
 - Some addition fixes for dataset format plugins during this work.

### How to test
This changes includes tests as well.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
