### PR TITLE
Skip nbqa-ruff installation with python3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
 
   # notebooks
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.6.3
+    rev: 1.5.3
     hooks:
       - id: nbqa-black
       - id: nbqa-ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,8 @@ repos:
 
   # notebooks
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.5.3
+    rev: 1.6.3
     hooks:
       - id: nbqa-black
       - id: nbqa-ruff
+        language_version: python3.8

--- a/tests/requirements-linters.txt
+++ b/tests/requirements-linters.txt
@@ -2,5 +2,5 @@
 bandit>=1.7.0
 isort==5.11.5
 black==23.1.0
-nbqa[toolchain]==1.6.3
+nbqa[toolchain]==1.6.3;python_version>"3.7"
 ruff==0.0.258

--- a/tests/requirements-linters.txt
+++ b/tests/requirements-linters.txt
@@ -2,5 +2,5 @@
 bandit>=1.7.0
 isort==5.11.5
 black==23.1.0
-nbqa[toolchain]==1.5.3
+nbqa[toolchain]==1.6.3
 ruff==0.0.258

--- a/tests/requirements-linters.txt
+++ b/tests/requirements-linters.txt
@@ -2,5 +2,5 @@
 bandit>=1.7.0
 isort==5.11.5
 black==23.1.0
-nbqa[toolchain]==1.6.3
+nbqa[toolchain]==1.5.3
 ruff==0.0.258


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
- Skip `nbqa-ruff` installation with python3.7. `nbqa[toolchain]==1.6.3` is not supported for python 3.7 but `nbqa-ruff` is supported with `nbqa>1.5.3`)
- Related PR: #892 

<img width="1486" alt="image" src="https://user-images.githubusercontent.com/72460430/227581743-3df880f5-665b-431f-8df8-a393c8e8a02c.png">

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
