### PR TITLE
Fix to not export absolute media path in Datumaro and DatumaroBinary formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+## xx/xx/2023 - Release 1.1.1
+### Bug fixes
+- Fix to not export absolute media path in Datumaro and DatumaroBinary formats
+  (<https://github.com/openvinotoolkit/datumaro/pull/896>)
+
 ## 23/03/2023 - Release 1.1.0
 ### New features
 - Add with_subset_dirs decorator (Add ImagenetWithSubsetDirsImporter)

--- a/datumaro/components/exporter.py
+++ b/datumaro/components/exporter.py
@@ -328,46 +328,41 @@ class ExportContextComponent:
     def save_image(
         self,
         item: DatasetItem,
-        encryption: bool = False,
-        path: Optional[str] = None,
         *,
-        name: Optional[str] = None,
-        subdir: Optional[str] = None,
+        encryption: bool = False,
         basedir: Optional[str] = None,
+        subdir: Optional[str] = None,
+        fname: Optional[str] = None,
     ):
-        assert not (
-            (subdir or name or basedir) and path
-        ), "Can't use both subdir or name or basedir and path arguments"
-
         if not isinstance(item.media, Image) or not item.media.has_data:
             log.warning("Item '%s' has no image", item.id)
             return
 
-        basedir = basedir or self._save_dir
-        path = path or osp.join(basedir, self.make_image_filename(item, name=name, subdir=subdir))
+        basedir = self._images_dir if basedir is None else basedir
+        basedir = osp.join(basedir, subdir) if subdir is not None else basedir
+        fname = self.make_image_filename(item) if fname is None else fname
+        path = osp.join(basedir, fname)
         path = osp.abspath(path)
 
+        os.makedirs(osp.dirname(path), exist_ok=True)
         item.media.save(path, crypter=self._crypter if encryption else NULL_CRYPTER)
 
     def save_point_cloud(
         self,
         item: DatasetItem,
-        path: Optional[str] = None,
         *,
-        name: Optional[str] = None,
-        subdir: Optional[str] = None,
         basedir: Optional[str] = None,
+        subdir: Optional[str] = None,
+        fname: Optional[str] = None,
     ):
-        assert not (
-            (subdir or name or basedir) and path
-        ), "Can't use both subdir or name or basedir and path arguments"
-
         if not item.media or not isinstance(item.media, PointCloud):
             log.warning("Item '%s' has no pcd", item.id)
             return
 
-        basedir = basedir or self._save_dir
-        path = path or osp.join(basedir, self.make_pcd_filename(item, name=name, subdir=subdir))
+        basedir = self._pcd_dir if basedir is None else basedir
+        basedir = osp.join(basedir, subdir) if subdir is not None else basedir
+        fname = self.make_pcd_filename(item) if fname is None else fname
+        path = osp.join(basedir, fname)
         path = osp.abspath(path)
 
         os.makedirs(osp.dirname(path), exist_ok=True)

--- a/datumaro/plugins/data_formats/datumaro/base.py
+++ b/datumaro/plugins/data_formats/datumaro/base.py
@@ -59,6 +59,7 @@ class DatumaroBase(SubsetBase):
         rootpath = ""
         if path.endswith(osp.join(DatumaroPath.ANNOTATIONS_DIR, osp.basename(path))):
             rootpath = path.rsplit(DatumaroPath.ANNOTATIONS_DIR, maxsplit=1)[0]
+        self._rootpath = rootpath
 
         images_dir = ""
         if rootpath and osp.isdir(osp.join(rootpath, DatumaroPath.IMAGES_DIR)):

--- a/datumaro/plugins/data_formats/datumaro_binary/base.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/base.py
@@ -98,7 +98,7 @@ class DatumaroBinaryBase(DatumaroBase):
 
         self._items = []
 
-        path_prefixes = {
+        media_path_prefix = {
             MediaType.IMAGE: osp.join(self._images_dir, self._subset),
             MediaType.POINT_CLOUD: osp.join(self._pcd_dir, self._subset),
         }
@@ -109,7 +109,7 @@ class DatumaroBinaryBase(DatumaroBase):
             offset = 0
 
             while offset < len(blob_bytes):
-                item, offset = DatasetItemMapper.backward(blob_bytes, offset, path_prefixes)
+                item, offset = DatasetItemMapper.backward(blob_bytes, offset, media_path_prefix)
                 if item.media is not None and self._media_encryption:
                     item.media.set_crypter(self._crypter)
                 self._items.append(item)

--- a/datumaro/plugins/data_formats/datumaro_binary/base.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/base.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import os.path as osp
 import struct
 from io import BufferedReader
 from typing import Any, Dict, Optional
@@ -97,13 +98,18 @@ class DatumaroBinaryBase(DatumaroBase):
 
         self._items = []
 
+        path_prefixes = {
+            MediaType.IMAGE: osp.join(self._images_dir, self._subset),
+            MediaType.POINT_CLOUD: osp.join(self._pcd_dir, self._subset),
+        }
+
         # For each blob, we decrypt the blob first, then extract items.
         for blob_size in blob_sizes:
             blob_bytes = self._crypter.decrypt(self._fp.read(blob_size))
             offset = 0
 
             while offset < len(blob_bytes):
-                item, offset = DatasetItemMapper.backward(blob_bytes, offset)
+                item, offset = DatasetItemMapper.backward(blob_bytes, offset, path_prefixes)
                 if item.media is not None and self._media_encryption:
                     item.media.set_crypter(self._crypter)
                 self._items.append(item)

--- a/datumaro/plugins/data_formats/datumaro_binary/mapper/dataset_item.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/mapper/dataset_item.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-from typing import Tuple
+from typing import Dict, Optional, Tuple
 
 from datumaro.components.dataset_base import DatasetItem
+from datumaro.components.media import MediaType
 from datumaro.plugins.data_formats.datumaro_binary.mapper.annotation import AnnotationListMapper
 
 from .common import DictMapper, Mapper, StringMapper
@@ -23,10 +24,12 @@ class DatasetItemMapper(Mapper):
         return bytes(bytes_arr)
 
     @staticmethod
-    def backward(_bytes: bytes, offset: int = 0) -> Tuple[DatasetItem, int]:
+    def backward(
+        _bytes: bytes, offset: int = 0, media_path_prefix: Optional[Dict[MediaType, str]] = None
+    ) -> Tuple[DatasetItem, int]:
         id, offset = StringMapper.backward(_bytes, offset)
         subset, offset = StringMapper.backward(_bytes, offset)
-        media, offset = MediaMapper.backward(_bytes, offset)
+        media, offset = MediaMapper.backward(_bytes, offset, media_path_prefix)
         attributes, offset = DictMapper.backward(_bytes, offset)
         annotations, offset = AnnotationListMapper.backward(_bytes, offset)
         return (

--- a/tests/unit/data_formats/datumaro/test_datumaro_format.py
+++ b/tests/unit/data_formats/datumaro/test_datumaro_format.py
@@ -54,6 +54,7 @@ class DatumaroFormatTest:
             target_dataset=target_dataset,
             importer_args=importer_args,
             compare=compare,
+            move_save_dir=True,
             **kwargs,
         )
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -250,8 +250,10 @@ def compare_datasets_3d(
 
         if (require_point_cloud and item_a.media) or (item_a.media and item_b.media):
             # TODO: Currently, this legacy test is very weird just to compare the path of point cloud files.
-            # However, Datumaro format keeps an absolute path in the media after import.
-            # The absolute path is also required to import the content of point cloud too.
+            # However, although the Datumaro format annotation file has a relative path in it,
+            # Datumaro Dataset stores an absolute path in the media after import.
+            # For example, {"path": relative/path/to/image.jpg} => {Media.path: absolute/path/to/image.jpg}
+            # The absolute path is also required to import the content of media too.
             # As a result, it cannot pass this test to the two same datasets in different locations.
             # So I changed this test just to compare both file names temporariliy.
             # Ultimately, we must implement a comparison of the contents of the point cloud as same as images.

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -259,7 +259,6 @@ def compare_datasets_3d(
             # Ultimately, we must implement a comparison of the contents of the point cloud as same as images.
             item_a_fname = osp.basename(item_a.media.path)
             item_b_fname = osp.basename(item_b.media.path)
-            test.assertEqual(item_a_fname, item_b_fname)
             test.assertEqual(item_a_fname, item_b_fname, item_a.id)
             test.assertEqual(
                 set(osp.basename(img.path) for img in item_a.media.extra_images),

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -6,12 +6,14 @@ import contextlib
 import inspect
 import os
 import os.path as osp
+import shutil
 import tempfile
 import unittest
 import unittest.mock
 import warnings
 from enum import Enum, auto
 from glob import glob
+from tempfile import TemporaryDirectory
 from typing import Any, Collection, List, Optional, Union
 
 from typing_extensions import Literal
@@ -247,10 +249,19 @@ def compare_datasets_3d(
             test.assertEqual(item_a.attributes, item_b.attributes, item_a.id)
 
         if (require_point_cloud and item_a.media) or (item_a.media and item_b.media):
-            test.assertEqual(item_a.media.path, item_b.media.path, item_a.id)
+            # TODO: Currently, this legacy test is very weird just to compare the path of point cloud files.
+            # However, Datumaro format keeps an absolute path in the media after import.
+            # The absolute path is also required to import the content of point cloud too.
+            # As a result, it cannot pass this test to the two same datasets in different locations.
+            # So I changed this test just to compare both file names temporariliy.
+            # Ultimately, we must implement a comparison of the contents of the point cloud as same as images.
+            item_a_fname = osp.basename(item_a.media.path)
+            item_b_fname = osp.basename(item_b.media.path)
+            test.assertEqual(item_a_fname, item_b_fname)
+            test.assertEqual(item_a_fname, item_b_fname, item_a.id)
             test.assertEqual(
-                set(img.path for img in item_a.media.extra_images),
-                set(img.path for img in item_b.media.extra_images),
+                set(osp.basename(img.path) for img in item_a.media.extra_images),
+                set(osp.basename(img.path) for img in item_b.media.extra_images),
                 item_a.id,
             )
         test.assertEqual(len(item_a.annotations), len(item_b.annotations))
@@ -279,23 +290,37 @@ def check_save_and_load(
     target_dataset=None,
     importer_args=None,
     compare=None,
+    move_save_dir: bool = False,
     **cmp_kwargs,
 ):
-    converter(source_dataset, test_dir)
+    """
+    Parameters
+    ----------
+        move_save_dir: If true, move the saved directory again to somewhere.
+        This option is useful for testing whether an absolute path exists in the exported dataset.
+    """
+    with TemporaryDirectory(prefix=test_dir) as tmp_dir:
+        converter(source_dataset, test_dir)
+        if move_save_dir:
+            save_dir = tmp_dir
+            for file in os.listdir(test_dir):
+                shutil.move(osp.join(test_dir, file), save_dir)
+        else:
+            save_dir = test_dir
 
-    if importer_args is None:
-        importer_args = {}
-    parsed_dataset = Dataset.import_from(test_dir, importer, **importer_args)
+        if importer_args is None:
+            importer_args = {}
+        parsed_dataset = Dataset.import_from(save_dir, importer, **importer_args)
 
-    if target_dataset is None:
-        target_dataset = source_dataset
+        if target_dataset is None:
+            target_dataset = source_dataset
 
-    if not compare and cmp_kwargs.get("dimension") is Dimensions.dim_3d:
-        compare = compare_datasets_3d
-        del cmp_kwargs["dimension"]
-    elif not compare:
-        compare = compare_datasets
-    compare(test, expected=target_dataset, actual=parsed_dataset, **cmp_kwargs)
+        if not compare and cmp_kwargs.get("dimension") is Dimensions.dim_3d:
+            compare = compare_datasets_3d
+            del cmp_kwargs["dimension"]
+        elif not compare:
+            compare = compare_datasets
+        compare(test, expected=target_dataset, actual=parsed_dataset, **cmp_kwargs)
 
 
 def compare_dirs(test, expected: str, actual: str):


### PR DESCRIPTION
### Summary

- Ticket no. 106811

### How to test
This change will be covered by `move_save_dir=True`:

https://github.com/openvinotoolkit/datumaro/blob/7c6541a41277c9e14701188a4d5ca47314e2255d/tests/utils/test_utils.py#L304-L307

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
