### PR TITLE
Add multiprocessing to DatumaroBinaryBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## \[Unreleased\]
+### Enhancements
+- Add multiprocessing to DatumaroBinaryBase
+  (<https://github.com/openvinotoolkit/datumaro/pull/897>)
 
 ### Bug fixes
 - Add UserWarning if an invalid media_type comes to image statistics computation

--- a/datumaro/components/importer.py
+++ b/datumaro/components/importer.py
@@ -189,10 +189,6 @@ class Importer(CliPlugin):
                     break
         return sources
 
-    @classmethod
-    def get_extractor_name(cls) -> str:
-        return cls.NAME.replace("_importer", "")
-
 
 def with_subset_dirs(input_cls: Importer):
     @wraps(input_cls, updated=())

--- a/datumaro/plugins/data_formats/datumaro/importer.py
+++ b/datumaro/plugins/data_formats/datumaro/importer.py
@@ -37,6 +37,6 @@ class DatumaroImporter(Importer):
         return cls._find_sources_recursive(
             path,
             cls.PATH_CLS.ANNOTATION_EXT,
-            cls.get_extractor_name(),
+            cls.NAME,
             dirname=cls.PATH_CLS.ANNOTATIONS_DIR,
         )

--- a/datumaro/plugins/data_formats/datumaro_binary/base.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/base.py
@@ -5,9 +5,11 @@
 import os.path as osp
 import struct
 from io import BufferedReader
-from typing import Any, Dict, Optional
+from multiprocessing.pool import AsyncResult, Pool
+from typing import Any, Dict, List, Optional
 
 from datumaro.components.crypter import NULL_CRYPTER, Crypter
+from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.errors import DatasetImportError
 from datumaro.components.media import Image, MediaElement, MediaType, PointCloud
 from datumaro.plugins.data_formats.datumaro_binary.format import DatumaroBinaryPath
@@ -16,15 +18,27 @@ from datumaro.plugins.data_formats.datumaro_binary.mapper.common import IntListM
 from datumaro.plugins.data_formats.datumaro_binary.mapper.dataset_item import DatasetItemMapper
 
 from ..datumaro.base import DatumaroBase
+from .format import DatumaroBinaryPath
 
 
 class DatumaroBinaryBase(DatumaroBase):
     """"""
 
-    def __init__(self, path: str, encryption_key: Optional[bytes] = None):
+    def __init__(self, path: str, encryption_key: Optional[bytes] = None, num_workers: int = 0):
+        """
+        Parameters
+        ----------
+        path
+            Directory path to import DatumaroBinary format dataset
+        encryption_key
+            If the dataset is encrypted, it (secret key) is needed to import the dataset.
+        num_workers
+            The number of multi-processing workers for import. If num_workers = 0, do not use multiprocessing.
+        """
         self._fp: Optional[BufferedReader] = None
         self._crypter = Crypter(encryption_key) if encryption_key is not None else NULL_CRYPTER
         self._media_encryption = False
+        self._num_workers = num_workers
         super().__init__(path)
 
     def _get_dm_format_version(self, path: str) -> str:
@@ -91,27 +105,75 @@ class DatumaroBinaryBase(DatumaroBase):
         else:
             raise NotImplementedError(f"media_type={media_type} is currently not supported.")
 
-    def _read_items(self):
+    def _read_items(self) -> None:
         (n_blob_sizes_bytes,) = struct.unpack("<I", self._fp.read(4))
         blob_sizes_bytes = self._crypter.decrypt(self._fp.read(n_blob_sizes_bytes))
         blob_sizes, _ = IntListMapper.backward(blob_sizes_bytes, 0)
-
-        self._items = []
 
         media_path_prefix = {
             MediaType.IMAGE: osp.join(self._images_dir, self._subset),
             MediaType.POINT_CLOUD: osp.join(self._pcd_dir, self._subset),
         }
 
-        # For each blob, we decrypt the blob first, then extract items.
-        for blob_size in blob_sizes:
-            blob_bytes = self._crypter.decrypt(self._fp.read(blob_size))
-            offset = 0
+        if self._num_workers > 0:
+            self._items = self._read_items_mp(blob_sizes, media_path_prefix)
+        else:
+            self._items = self._read_items_sp(blob_sizes, media_path_prefix)
 
-            while offset < len(blob_bytes):
-                item, offset = DatasetItemMapper.backward(blob_bytes, offset, media_path_prefix)
-                if item.media is not None and self._media_encryption:
-                    item.media.set_crypter(self._crypter)
-                self._items.append(item)
+        for item in self._items:
+            if item.media is not None and self._media_encryption:
+                item.media.set_crypter(self._crypter)
 
-            assert offset == len(blob_bytes)
+    def _read_items_mp(
+        self, blob_sizes: List[int], media_path_prefix: Dict[MediaType, str]
+    ) -> List[DatasetItem]:
+        async_results: List[AsyncResult] = []
+
+        with Pool(processes=self._num_workers) as pool:
+            for blob_size in blob_sizes:
+                blob_bytes = self._fp.read(blob_size)
+                async_results += [
+                    pool.apply_async(
+                        self._read_blob,
+                        (
+                            blob_bytes,
+                            self._crypter,
+                            media_path_prefix,
+                        ),
+                    )
+                ]
+
+            return [
+                item
+                for async_result in async_results
+                for item in async_result.get(timeout=DatumaroBinaryPath.MP_TIMEOUT)
+            ]
+
+    def _read_items_sp(
+        self, blob_sizes: List[int], media_path_prefix: Dict[MediaType, str]
+    ) -> List[DatasetItem]:
+        items_list = [
+            self._read_blob(self._fp.read(blob_size), self._crypter, media_path_prefix)
+            for blob_size in blob_sizes
+        ]
+
+        return [item for items in items_list for item in items]
+
+    @staticmethod
+    def _read_blob(
+        blob_bytes: bytes, crypter: Crypter, media_path_prefix: Dict[MediaType, str]
+    ) -> List[DatasetItem]:
+        items = []
+        offset = 0
+
+        # Decrypt bytes first
+        blob_bytes = crypter.decrypt(blob_bytes)
+
+        # Extract items
+        while offset < len(blob_bytes):
+            item, offset = DatasetItemMapper.backward(blob_bytes, offset, media_path_prefix)
+            items.append(item)
+
+        assert offset == len(blob_bytes)
+
+        return items

--- a/datumaro/plugins/data_formats/datumaro_binary/base.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/base.py
@@ -18,7 +18,6 @@ from datumaro.plugins.data_formats.datumaro_binary.mapper.common import IntListM
 from datumaro.plugins.data_formats.datumaro_binary.mapper.dataset_item import DatasetItemMapper
 
 from ..datumaro.base import DatumaroBase
-from .format import DatumaroBinaryPath
 
 
 class DatumaroBinaryBase(DatumaroBase):

--- a/datumaro/plugins/data_formats/datumaro_binary/exporter.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/exporter.py
@@ -129,7 +129,9 @@ class _SubsetWriter(__SubsetWriter):
         # Await async results
         if pool is not None:
             self._bytes = [
-                result.get() for result in self._bytes if isinstance(result, ApplyResult)
+                result.get(timeout=DatumaroBinaryPath.MP_TIMEOUT)
+                for result in self._bytes
+                if isinstance(result, ApplyResult)
             ]
 
         # Divide items to blobs

--- a/datumaro/plugins/data_formats/datumaro_binary/format.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/format.py
@@ -23,7 +23,7 @@ class DatumaroBinaryPath:
     SECRET_KEY_FILE = "secret_key.txt"
 
     MAX_BLOB_SIZE = 2**20  # 1 Mega bytes
-    MP_TIMEOUT = 30.0  # 30 secs
+    MP_TIMEOUT = 300.0  # 5 minutes
 
     @classmethod
     def check_signature(cls, signature: str):

--- a/datumaro/plugins/data_formats/datumaro_binary/format.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/format.py
@@ -23,6 +23,7 @@ class DatumaroBinaryPath:
     SECRET_KEY_FILE = "secret_key.txt"
 
     MAX_BLOB_SIZE = 2**20  # 1 Mega bytes
+    MP_TIMEOUT = 30.0  # 30 secs
 
     @classmethod
     def check_signature(cls, signature: str):

--- a/datumaro/plugins/data_formats/datumaro_binary/importer.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/importer.py
@@ -23,6 +23,13 @@ class DatumaroBinaryImporter(DatumaroImporter):
             default=None,
             help="Encryption key",
         )
+        parser.add_argument(
+            "--num-workers",
+            type=int,
+            default=0,
+            help="The number of multi-processing workers for import. "
+            "If num_workers = 0, do not use multiprocessing (default: %(default)s).",
+        )
         return parser
 
     @classmethod

--- a/datumaro/plugins/data_formats/datumaro_binary/importer.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/importer.py
@@ -21,7 +21,10 @@ class DatumaroBinaryImporter(DatumaroImporter):
             "--encryption-key",
             type=str,
             default=None,
-            help="Encryption key",
+            help="If the dataset is encrypted, "
+            "it (secret key) is needed to import the dataset. "
+            "If the incorrect key is given, it cannot be imported."
+            "Ignore this argument if your dataset does not require encryption.",
         )
         parser.add_argument(
             "--num-workers",

--- a/site/content/en/docs/formats/datumaro_binary.md
+++ b/site/content/en/docs/formats/datumaro_binary.md
@@ -9,11 +9,16 @@ description: ""
 DatumaroBinary format is [Datumaro](https://github.com/openvinotoolkit/datumaro)'s own data format as same as [Datumaro format](./datumaro.md).
 Basically, it provides the same function as [Datumaro format](./datumaro.md),
 but the difference is that the annotation file is not JSON but binary format.
-While JSON annotation file in the [Datumaro format](./datumaro.md) has the advantage of being easily viewable using any text viewer,
-the DatumaroBinary format takes up significantly less storage space since it is schemaless and stores data in binary form.
+Including changes in the file format, DatumaroBinary provides three key features compared to the datumaro format:
+
+1. [Efficient storage cost](#efficient-storage-cost)
+2. [Dataset encryption](#dataset-encryption)
+3. [Multi-processing import and export](#multi-processing-import-and-export)
 
 ### Efficient storage cost
 
+While JSON annotation file in the [Datumaro format](./datumaro.md) has the advantage of being easily viewable using any text viewer,
+the DatumaroBinary format takes up significantly less storage space since it is schemaless and stores data in binary form.
 To demonstrate the storage cost-effectiveness of DatumaroBinary,
 we conducted an experiment to compare the annotation file sizes of three dataset formats:
 COCO (JSON), Datumaro (JSON), and DatumaroBinary (binary).
@@ -44,6 +49,10 @@ Dataset/
 ### Dataset encryption
 
 Another advantage of the DatumaroBinary format is that it supports dataset encryption. If your dataset is hijacked by a potential attacker and you are concerned that your intellectual properties may be damaged, you can use this feature to protect your dataset from attackers. Enabling the dataset encryption feature allows you to encrypt both annotations and media or only the annotations. If you export the dataset to DatumaroBinary format with encryption, the secret key is automatically generated at the same time. You must keep this secret key separate from the exported dataset. This is because the secret key should be needed to read the exported dataset. Therefore, you have to be careful not to lose the secret key. If you would like to see an example of dataset encryption using Datumaro's Python API, please see [here](https://github.com/openvinotoolkit/datumaro/blob/develop/notebooks/09_encrypt_dataset.ipynb). For CLI usage of encryption, please see [Import encrypted datasets](#import-encrypted-datasets) and [Export datasets with encryption](#export-datasets-with-encryption) sections.
+
+### Multi-processing import and export
+
+The DatumaroBinary format stores annotation file data as several blobs by sharding, making it easy to export and import using multi-processing. Therefore, this format is suitable to accelerate export and import performance by utilizing multiple cores. You can enable this feature from the CLI or Python API. In the CLI, add `--num-workers #` extra argument, while in the Python API, use extra parameters such as `num_workers=#`. You can check examples of both methods: [Import datasets with multi-processing](#import-datasets-with-multi-processing) and [Export datasets with multi-processing](#export-datasets-with-multi-processing).
 
 ### Usage for model training
 
@@ -123,6 +132,30 @@ datum import --format datumaro_binary <path/to/dataset> -- --encryption-key <sec
 
 `<secret-key>` is a 50-bytes long base64 encoded string prefixed with `datum-`. It is auto-generated in `<output/dir>/secret_key.txt` when the dataset is exported to DatumaroBinary format with `--encryption` option. You must have a correct `<secret-key>` to import the dataset encrypted by Datumaro.
 
+### Import datasets with multi-processing
+
+Using CLI
+
+```console
+# Import DatumaroBinary format dataset with 4 multi-processing workers
+datum create
+datum import --format datumaro_binary <path/to/dataset> -- --num-workers 4
+```
+
+or using Python API
+
+```python
+import datumaro as dm
+
+# Import DatumaroBinary format dataset with 4 multi-processing workers
+dataset = dm.Dataset.import_from('<path/to/dataset>', 'datumaro_binary', num_workers=4)
+```
+
+Extra options for importing DatumaroBinary format:
+
+- `--encryption-key ENCRYPTION_KEY` is a secret key required to import an encrypted dataset. If an incorrect key is provided, the dataset cannot be imported. If your dataset does not require encryption, you can ignore this argument.
+- `--num-workers NUM_WORKERS` allow to multi-processing for the import. If num_workers = 0, do not use multiprocessing (default: 0).
+
 ## Export to other formats
 
 It can convert DatumaroBinary dataset into any other format [Datumaro supports](/docs/user-manual/supported_formats/).
@@ -194,6 +227,26 @@ If you want to encrypt the annotation files only, not the media files, please ad
 # export dataset into DatumaroBinary format from existing project
 datum export -p <path/to/project> -f datumaro_binary -o <output/dir> \
     -- --save-media --encryption --no-media-encryption
+```
+
+## Export datasets with multi-processing
+
+Using CLI
+
+```console
+# Export dataset into DatumaroBinary with 4 multi-processing workers
+datum export -p <path/to/project> -f datumaro_binary -o <output/dir> \
+    -- --save-media --num-workers 4
+```
+
+or using Python API
+
+```python
+import datumaro as dm
+
+dataset = dm.Dataset.import_from('<path/to/dataset>', '<dataset-format>')
+# Export dataset into DatumaroBinary with 4 multi-processing workers
+dataset.export('save_dir', 'datumaro_binary', save_media=True, num_workers=4)
 ```
 
 Extra options for exporting to DatumaroBinary format:

--- a/tests/integration/cli/test_dm_binary_encryption.py
+++ b/tests/integration/cli/test_dm_binary_encryption.py
@@ -125,6 +125,8 @@ def test_yolo_to_dm_binary_encryption(
         "--",
         "--encryption-key",
         true_key.decode(),
+        "--num-workers",
+        str(num_workers),
     )
 
     # 6. Re-export it to the yolo format

--- a/tests/unit/data_formats/datumaro/test_datumaro_binary_format.py
+++ b/tests/unit/data_formats/datumaro/test_datumaro_binary_format.py
@@ -79,7 +79,7 @@ class DatumaroBinaryFormatTest(TestBase):
                 "fxt_test_datumaro_format_dataset",
                 compare_datasets_strict,
                 True,
-                {"encryption_key": ENCRYPTION_KEY},
+                {"encryption_key": ENCRYPTION_KEY, "num_workers": 2},
                 {"encryption_key": ENCRYPTION_KEY, "num_workers": 2},
                 id="test_multi_processing",
             ),


### PR DESCRIPTION
### Summary

- Ticket no. 106632
- Add `--num-workers` option to `DatumaroBinaryBase` for better performance.

### How to test
I updated the tests to cover this change.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [x] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
