### PR TITLE
Fix negated property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 - Add UserWarning if an invalid media_type comes to image statistics computation
   (<https://github.com/openvinotoolkit/datumaro/pull/891>)
+- Fix negated `is_encrypted`
+  (<https://github.com/openvinotoolkit/datumaro/pull/907>)
 
 ## 28/03/2023 - Release 1.1.1
 ### Bug fixes

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -59,7 +59,7 @@ class MediaElement:
 
     @property
     def is_encrypted(self) -> bool:
-        return self._crypter.is_null_crypter
+        return not self._crypter.is_null_crypter
 
     def set_crypter(self, crypter: Crypter):
         self._crypter = crypter


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Fixed wrong behaviour of `is_encrypted` property.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
