### PR TITLE
Refactor PointCloud

### DIFF
--- a/datumaro/components/exporter.py
+++ b/datumaro/components/exporter.py
@@ -273,9 +273,7 @@ class Exporter(CliPlugin):
         path = osp.abspath(path)
 
         os.makedirs(osp.dirname(path), exist_ok=True)
-        if item.media and osp.isfile(item.media.path):
-            if item.media.path != path:
-                shutil.copyfile(item.media.path, path)
+        item.media.save(path, crypter=NULL_CRYPTER)
 
     def _save_meta_file(self, path):
         save_meta_file(path, self._extractor.categories())
@@ -366,9 +364,7 @@ class ExportContextComponent:
         path = osp.abspath(path)
 
         os.makedirs(osp.dirname(path), exist_ok=True)
-        if item.media and osp.isfile(item.media.path):
-            if item.media.path != path:
-                shutil.copyfile(item.media.path, path)
+        item.media.save(path, crypter=NULL_CRYPTER)
 
     @property
     def images_dir(self) -> str:

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -608,6 +608,11 @@ class PointCloud(MediaElement):
         extra_images: Union[List[Image], Callable[[], List[Image]], None] = None,
         crypter: Crypter = NULL_CRYPTER,
     ):
+        assert self.__class__ != PointCloud, (
+            f"Directly initalizing {self.__class__.__name__} is not supported. "
+            f"Please use fractory function '{self.__class__.__name__}.from_file()' "
+            f"or '{self.__class__.__name__}.from_data()'."
+        )
         super().__init__(crypter)
         self._extra_images = extra_images or []
 

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -258,11 +258,6 @@ class Image(MediaElement):
         """Path to the media file"""
         return self._path
 
-    @property
-    def ext(self) -> str:
-        """Media file extension (with the leading dot)"""
-        return osp.splitext(osp.basename(self.path))[1]
-
 
 class ByteImage(Image):
     _type = MediaType.BYTE_IMAGE
@@ -610,6 +605,16 @@ class Video(MediaElement, Iterable[VideoFrame]):
         # Required for caching
         return hash((self._path, self._step, self._start_frame, self._end_frame))
 
+    @property
+    def path(self) -> str:
+        """Path to the media file"""
+        return self._path
+
+    @property
+    def ext(self) -> str:
+        """Media file extension (with the leading dot)"""
+        return osp.splitext(osp.basename(self.path))[1]
+
 
 class PointCloud(MediaElement):
     _type = MediaType.POINT_CLOUD
@@ -735,6 +740,16 @@ class MultiframeImage(MediaElement):
     @property
     def data(self) -> List[Image]:
         return self._images
+
+    @property
+    def path(self) -> str:
+        """Path to the media file"""
+        return self._path
+
+    @property
+    def ext(self) -> str:
+        """Media file extension (with the leading dot)"""
+        return osp.splitext(osp.basename(self.path))[1]
 
 
 class RoIImage(Image):

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -253,6 +253,16 @@ class Image(MediaElement):
         if isinstance(self._data, lazy_image):
             self._data._crypter = crypter
 
+    @property
+    def path(self) -> str:
+        """Path to the media file"""
+        return self._path
+
+    @property
+    def ext(self) -> str:
+        """Media file extension (with the leading dot)"""
+        return osp.splitext(osp.basename(self.path))[1]
+
 
 class ByteImage(Image):
     _type = MediaType.BYTE_IMAGE
@@ -440,7 +450,8 @@ class Video(MediaElement, Iterable[VideoFrame]):
     def __init__(
         self, path: str, *, step: int = 1, start_frame: int = 0, end_frame: Optional[int] = None
     ) -> None:
-        super().__init__(path)
+        super().__init__()
+        self._path = path
 
         if end_frame:
             assert start_frame < end_frame

--- a/datumaro/plugins/data_formats/datumaro/base.py
+++ b/datumaro/plugins/data_formats/datumaro/base.py
@@ -172,7 +172,7 @@ class DatumaroBase(SubsetBase):
                         Image(size=ri.get("size"), path=ri.get("path")) for ri in ri_info
                     ]
 
-                media = PointCloud(point_cloud, extra_images=related_images)
+                media = PointCloud(path=point_cloud, extra_images=related_images)
                 self._media_type = PointCloud
 
             media_desc = item_desc.get("media")

--- a/datumaro/plugins/data_formats/datumaro/base.py
+++ b/datumaro/plugins/data_formats/datumaro/base.py
@@ -172,7 +172,7 @@ class DatumaroBase(SubsetBase):
                         Image(size=ri.get("size"), path=ri.get("path")) for ri in ri_info
                     ]
 
-                media = PointCloud(path=point_cloud, extra_images=related_images)
+                media = PointCloud.from_file(path=point_cloud, extra_images=related_images)
                 self._media_type = PointCloud
 
             media_desc = item_desc.get("media")

--- a/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -100,13 +100,12 @@ class _SubsetWriter:
             image._path = path
         elif isinstance(item.media, PointCloud):
             pcd = item.media_as(PointCloud)
-            path = pcd.path
 
             if context.save_media:
                 # Temporarily update pcd path and save it.
                 fname = context.make_pcd_filename(item)
                 context.save_point_cloud(item, fname=fname, subdir=item.subset)
-                pcd._path = fname
+                item.media = PointCloud.from_file(path=fname, extra_images=pcd._extra_images)
 
                 # Temporarily update pcd related images paths and save them.
                 for i, img in enumerate(sorted(pcd.extra_images, key=lambda v: v.path)):
@@ -123,7 +122,7 @@ class _SubsetWriter:
                         )
 
             yield
-            pcd._path = path
+            item.media = pcd
             if context.save_media:
                 for img in pcd.extra_images:
                     img._path = img.__path

--- a/datumaro/plugins/data_formats/datumaro_binary/mapper/media.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/mapper/media.py
@@ -147,4 +147,4 @@ class PointCloudMapper(MediaElementMapper):
             img, offset = ImageMapper.backward(_bytes, offset)
             extra_images.append(img)
 
-        return PointCloud(media_dict["path"], extra_images), offset
+        return PointCloud(path=media_dict["path"], extra_images=extra_images), offset

--- a/datumaro/plugins/data_formats/datumaro_binary/mapper/media.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/mapper/media.py
@@ -48,13 +48,15 @@ class MediaMapper(Mapper):
 
 
 class MediaElementMapper(Mapper):
+    MAGIC_PATH = "/NOT/A/REAL/PATH"
     MEDIA_TYPE = MediaType.MEDIA_ELEMENT
 
     @classmethod
     def forward(cls, obj: MediaElement) -> bytes:
         bytes_arr = bytearray()
         bytes_arr.extend(struct.pack("<I", obj.type))
-        bytes_arr.extend(StringMapper.forward(obj.path))
+        path = getattr(obj, "path", cls.MAGIC_PATH)
+        bytes_arr.extend(StringMapper.forward(path))
 
         return bytes(bytes_arr)
 
@@ -69,10 +71,12 @@ class MediaElementMapper(Mapper):
         assert media_type == cls.MEDIA_TYPE, f"Expect {cls.MEDIA_TYPE} but actual is {media_type}."
         offset += 4
         path, offset = StringMapper.backward(_bytes, offset)
+        if path == cls.MAGIC_PATH:
+            path = None
         return {
             "type": media_type,
             "path": path
-            if media_path_prefix is None
+            if path == cls.MAGIC_PATH or media_path_prefix is None
             else osp.join(media_path_prefix[cls.MEDIA_TYPE], path),
         }, offset
 
@@ -83,8 +87,8 @@ class MediaElementMapper(Mapper):
         offset: int = 0,
         media_path_prefix: Optional[Dict[MediaType, str]] = None,
     ) -> Tuple[MediaElement, int]:
-        media_dict, offset = cls.backward_dict(_bytes, offset, media_path_prefix)
-        return MediaElement(path=media_dict["path"]), offset
+        _, offset = cls.backward_dict(_bytes, offset, media_path_prefix)
+        return MediaElement(), offset
 
 
 class ImageMapper(MediaElementMapper):
@@ -147,4 +151,4 @@ class PointCloudMapper(MediaElementMapper):
             img, offset = ImageMapper.backward(_bytes, offset)
             extra_images.append(img)
 
-        return PointCloud(path=media_dict["path"], extra_images=extra_images), offset
+        return PointCloud.from_file(path=media_dict["path"], extra_images=extra_images), offset

--- a/datumaro/plugins/data_formats/kitti_raw/base.py
+++ b/datumaro/plugins/data_formats/kitti_raw/base.py
@@ -242,7 +242,7 @@ class KittiRawBase(SubsetBase):
                 id=name,
                 subset=self._subset,
                 media=PointCloud(
-                    osp.join(self._rootdir, KittiRawPath.PCD_DIR, name + ".pcd"),
+                    path=osp.join(self._rootdir, KittiRawPath.PCD_DIR, name + ".pcd"),
                     extra_images=[Image(path=image) for image in sorted(images.get(name, []))],
                 ),
                 annotations=item_desc.get("annotations"),
@@ -257,7 +257,7 @@ class KittiRawBase(SubsetBase):
                 id=name,
                 subset=self._subset,
                 media=PointCloud(
-                    osp.join(self._rootdir, KittiRawPath.PCD_DIR, name + ".pcd"),
+                    path=osp.join(self._rootdir, KittiRawPath.PCD_DIR, name + ".pcd"),
                     extra_images=[Image(path=image) for image in sorted(images.get(name, []))],
                 ),
                 attributes={"frame": int(frame_id)},

--- a/datumaro/plugins/data_formats/kitti_raw/base.py
+++ b/datumaro/plugins/data_formats/kitti_raw/base.py
@@ -241,7 +241,7 @@ class KittiRawBase(SubsetBase):
             items[frame_id] = DatasetItem(
                 id=name,
                 subset=self._subset,
-                media=PointCloud(
+                media=PointCloud.from_file(
                     path=osp.join(self._rootdir, KittiRawPath.PCD_DIR, name + ".pcd"),
                     extra_images=[Image(path=image) for image in sorted(images.get(name, []))],
                 ),
@@ -256,7 +256,7 @@ class KittiRawBase(SubsetBase):
             items[frame_id] = DatasetItem(
                 id=name,
                 subset=self._subset,
-                media=PointCloud(
+                media=PointCloud.from_file(
                     path=osp.join(self._rootdir, KittiRawPath.PCD_DIR, name + ".pcd"),
                     extra_images=[Image(path=image) for image in sorted(images.get(name, []))],
                 ),

--- a/datumaro/plugins/data_formats/sly_pointcloud/base.py
+++ b/datumaro/plugins/data_formats/sly_pointcloud/base.py
@@ -166,7 +166,7 @@ class SuperviselyPointCloudBase(SubsetBase):
             parsed[frame_id] = DatasetItem(
                 id=name,
                 subset=self._subset,
-                media=PointCloud(pcd_path, extra_images=related_images),
+                media=PointCloud(path=pcd_path, extra_images=related_images),
                 annotations=frame_desc.get("annotations"),
                 attributes={"frame": int(frame_id), **frame_desc["attributes"]},
             )

--- a/datumaro/plugins/data_formats/sly_pointcloud/base.py
+++ b/datumaro/plugins/data_formats/sly_pointcloud/base.py
@@ -166,7 +166,7 @@ class SuperviselyPointCloudBase(SubsetBase):
             parsed[frame_id] = DatasetItem(
                 id=name,
                 subset=self._subset,
-                media=PointCloud(path=pcd_path, extra_images=related_images),
+                media=PointCloud.from_file(path=pcd_path, extra_images=related_images),
                 annotations=frame_desc.get("annotations"),
                 attributes={"frame": int(frame_id), **frame_desc["attributes"]},
             )

--- a/tests/integration/cli/test_kitti_raw_format.py
+++ b/tests/integration/cli/test_kitti_raw_format.py
@@ -45,7 +45,7 @@ class KittiRawIntegrationScenarios(TestCase):
                             ),
                         ],
                         media=PointCloud(
-                            osp.join(export_dir, "ds0", "pointcloud", "0000000000.pcd"),
+                            path=osp.join(export_dir, "ds0", "pointcloud", "0000000000.pcd"),
                             extra_images=[
                                 Image(
                                     path=osp.join(
@@ -72,7 +72,7 @@ class KittiRawIntegrationScenarios(TestCase):
                             )
                         ],
                         media=PointCloud(
-                            osp.join(export_dir, "ds0", "pointcloud", "0000000001.pcd"),
+                            path=osp.join(export_dir, "ds0", "pointcloud", "0000000001.pcd"),
                             extra_images=[
                                 Image(
                                     path=osp.join(
@@ -98,7 +98,7 @@ class KittiRawIntegrationScenarios(TestCase):
                             )
                         ],
                         media=PointCloud(
-                            osp.join(export_dir, "ds0", "pointcloud", "0000000002.pcd"),
+                            path=osp.join(export_dir, "ds0", "pointcloud", "0000000002.pcd"),
                             extra_images=[
                                 Image(
                                     path=osp.join(

--- a/tests/integration/cli/test_kitti_raw_format.py
+++ b/tests/integration/cli/test_kitti_raw_format.py
@@ -44,7 +44,7 @@ class KittiRawIntegrationScenarios(TestCase):
                                 attributes={"occluded": False, "track_id": 2},
                             ),
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(export_dir, "ds0", "pointcloud", "0000000000.pcd"),
                             extra_images=[
                                 Image(
@@ -71,7 +71,7 @@ class KittiRawIntegrationScenarios(TestCase):
                                 attributes={"occluded": True, "track_id": 2},
                             )
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(export_dir, "ds0", "pointcloud", "0000000001.pcd"),
                             extra_images=[
                                 Image(
@@ -97,7 +97,7 @@ class KittiRawIntegrationScenarios(TestCase):
                                 attributes={"occluded": False, "track_id": 3},
                             )
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(export_dir, "ds0", "pointcloud", "0000000002.pcd"),
                             extra_images=[
                                 Image(

--- a/tests/integration/cli/test_sly_point_cloud_format.py
+++ b/tests/integration/cli/test_sly_point_cloud_format.py
@@ -52,7 +52,7 @@ class SlyPointCloudIntegrationScenarios(TestCase):
                             ),
                         ],
                         media=PointCloud(
-                            osp.join(export_dir, "velodyne_points", "data", "frame1.pcd"),
+                            path=osp.join(export_dir, "velodyne_points", "data", "frame1.pcd"),
                             extra_images=[
                                 Image(path=osp.join(export_dir, "image_00", "data", "frame1.png"))
                             ],
@@ -74,7 +74,7 @@ class SlyPointCloudIntegrationScenarios(TestCase):
                             )
                         ],
                         media=PointCloud(
-                            osp.join(export_dir, "velodyne_points", "data", "frame2.pcd"),
+                            path=osp.join(export_dir, "velodyne_points", "data", "frame2.pcd"),
                             extra_images=[
                                 Image(path=osp.join(export_dir, "image_00", "data", "frame2.png"))
                             ],

--- a/tests/integration/cli/test_sly_point_cloud_format.py
+++ b/tests/integration/cli/test_sly_point_cloud_format.py
@@ -51,7 +51,7 @@ class SlyPointCloudIntegrationScenarios(TestCase):
                                 },
                             ),
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(export_dir, "velodyne_points", "data", "frame1.pcd"),
                             extra_images=[
                                 Image(path=osp.join(export_dir, "image_00", "data", "frame1.png"))
@@ -73,7 +73,7 @@ class SlyPointCloudIntegrationScenarios(TestCase):
                                 },
                             )
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(export_dir, "velodyne_points", "data", "frame2.pcd"),
                             extra_images=[
                                 Image(path=osp.join(export_dir, "image_00", "data", "frame2.png"))

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -297,7 +297,7 @@ def fxt_point_cloud_dataset_pair(test_dir):
                 id=1,
                 subset="test",
                 media=PointCloud(
-                    "1.pcd",
+                    path="1.pcd",
                     extra_images=[
                         Image(data=np.ones((5, 5, 3)), path="1/a.jpg"),
                         Image(data=np.ones((5, 4, 3)), path="1/b.jpg"),
@@ -327,7 +327,7 @@ def fxt_point_cloud_dataset_pair(test_dir):
                 id=1,
                 subset="test",
                 media=PointCloud(
-                    osp.join(test_dir, "point_clouds", "test", "1.pcd"),
+                    path=osp.join(test_dir, "point_clouds", "test", "1.pcd"),
                     extra_images=[
                         Image(
                             data=np.ones((5, 5, 3)),

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -296,8 +296,8 @@ def fxt_point_cloud_dataset_pair(test_dir):
             DatasetItem(
                 id=1,
                 subset="test",
-                media=PointCloud(
-                    path="1.pcd",
+                media=PointCloud.from_data(
+                    data=b"11111111",
                     extra_images=[
                         Image(data=np.ones((5, 5, 3)), path="1/a.jpg"),
                         Image(data=np.ones((5, 4, 3)), path="1/b.jpg"),
@@ -326,7 +326,7 @@ def fxt_point_cloud_dataset_pair(test_dir):
             DatasetItem(
                 id=1,
                 subset="test",
-                media=PointCloud(
+                media=PointCloud.from_file(
                     path=osp.join(test_dir, "point_clouds", "test", "1.pcd"),
                     extra_images=[
                         Image(

--- a/tests/unit/operations/test_statistics.py
+++ b/tests/unit/operations/test_statistics.py
@@ -50,7 +50,7 @@ def fxt_point_cloud_dataset():
         [
             DatasetItem(
                 id=i,
-                media=PointCloud(path="dummy.pcd"),
+                media=PointCloud.from_file(path="dummy.pcd"),
             )
             for i in range(5)
         ],

--- a/tests/unit/test_kitti_raw_format.py
+++ b/tests/unit/test_kitti_raw_format.py
@@ -55,7 +55,7 @@ class KittiRawImporterTest(TestCase):
                             attributes={"occluded": False, "track_id": 2},
                         ),
                     ],
-                    media=PointCloud(pcd1, extra_images=[image1]),
+                    media=PointCloud(path=pcd1, extra_images=[image1]),
                     attributes={"frame": 0},
                 ),
                 DatasetItem(
@@ -69,7 +69,7 @@ class KittiRawImporterTest(TestCase):
                             attributes={"occluded": True, "track_id": 2},
                         )
                     ],
-                    media=PointCloud(pcd2, extra_images=[image2]),
+                    media=PointCloud(path=pcd2, extra_images=[image2]),
                     attributes={"frame": 1},
                 ),
                 DatasetItem(
@@ -82,7 +82,7 @@ class KittiRawImporterTest(TestCase):
                             attributes={"occluded": False, "track_id": 3},
                         )
                     ],
-                    media=PointCloud(pcd3, extra_images=[image3]),
+                    media=PointCloud(path=pcd3, extra_images=[image3]),
                     attributes={"frame": 2},
                 ),
             ],
@@ -144,7 +144,7 @@ class KittiRawExporterTest(TestCase):
                             attributes={"occluded": True, "track_id": 2},
                         ),
                     ],
-                    media=PointCloud(self.pcd1, extra_images=[self.image1]),
+                    media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
                     attributes={"frame": 0},
                 ),
                 DatasetItem(
@@ -169,7 +169,7 @@ class KittiRawExporterTest(TestCase):
                             attributes={"track_id": 3},
                         ),
                     ],
-                    media=PointCloud(self.pcd3),
+                    media=PointCloud(path=self.pcd3),
                     attributes={"frame": 2},
                 ),
             ],
@@ -199,7 +199,7 @@ class KittiRawExporterTest(TestCase):
                             ),
                         ],
                         media=PointCloud(
-                            osp.join(test_dir, "velodyne_points", "data", "0000000000.pcd"),
+                            path=osp.join(test_dir, "velodyne_points", "data", "0000000000.pcd"),
                             extra_images=[
                                 Image(path=osp.join(test_dir, "image_00", "data", "0000000000.png"))
                             ],
@@ -234,7 +234,7 @@ class KittiRawExporterTest(TestCase):
                             ),
                         ],
                         media=PointCloud(
-                            osp.join(test_dir, "velodyne_points", "data", "0000000002.pcd")
+                            path=osp.join(test_dir, "velodyne_points", "data", "0000000002.pcd")
                         ),
                         attributes={"frame": 2},
                     ),
@@ -449,7 +449,7 @@ class KittiRawExporterTest(TestCase):
                 DatasetItem(
                     id="a/d",
                     annotations=[Cuboid3d(position=[1, 2, 3], label=0, attributes={"track_id": 1})],
-                    media=PointCloud(self.pcd1, extra_images=[self.image1]),
+                    media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
                     attributes={"frame": 3},
                 ),
             ],
@@ -472,7 +472,7 @@ class KittiRawExporterTest(TestCase):
                             )
                         ],
                         media=PointCloud(
-                            osp.join(test_dir, "velodyne_points", "data", "a", "d.pcd"),
+                            path=osp.join(test_dir, "velodyne_points", "data", "a", "d.pcd"),
                             extra_images=[
                                 Image(path=osp.join(test_dir, "image_00", "data", "a", "d.png")),
                             ],
@@ -501,7 +501,7 @@ class KittiRawExporterTest(TestCase):
                     id="a/d",
                     annotations=[Cuboid3d(position=[1, 2, 3], label=0, attributes={"track_id": 1})],
                     media=PointCloud(
-                        self.pcd1, extra_images=[self.image1, self.image2, self.image3]
+                        path=self.pcd1, extra_images=[self.image1, self.image2, self.image3]
                     ),
                     attributes={"frame": 3},
                 ),
@@ -525,7 +525,7 @@ class KittiRawExporterTest(TestCase):
                             )
                         ],
                         media=PointCloud(
-                            osp.join(test_dir, "velodyne_points", "data", "a", "d.pcd"),
+                            path=osp.join(test_dir, "velodyne_points", "data", "a", "d.pcd"),
                             extra_images=[
                                 Image(path=osp.join(test_dir, "image_00", "data", "a", "d.png")),
                                 Image(path=osp.join(test_dir, "image_01", "data", "a", "d.png")),
@@ -560,7 +560,7 @@ class KittiRawExporterTest(TestCase):
                         annotations=[
                             Cuboid3d(position=[3.5, 9.8, 0.3], label=0, attributes={"track_id": 1})
                         ],
-                        media=PointCloud(self.pcd1, extra_images=[self.image1]),
+                        media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
                         attributes={"frame": 0},
                     )
                 ],
@@ -573,7 +573,7 @@ class KittiRawExporterTest(TestCase):
                 DatasetItem(
                     "frame2",
                     annotations=[Cuboid3d(position=[1, 2, 0], label=1, attributes={"track_id": 1})],
-                    media=PointCloud(self.pcd2, extra_images=[self.image2]),
+                    media=PointCloud(path=self.pcd2, extra_images=[self.image2]),
                     attributes={"frame": 1},
                 )
             )
@@ -598,7 +598,7 @@ class KittiRawExporterTest(TestCase):
                             attributes={"occluded": False, "track_id": 1},
                         )
                     ],
-                    media=PointCloud(self.pcd1, extra_images=[self.image1]),
+                    media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
                     attributes={"frame": 0},
                 ),
                 DatasetItem(
@@ -629,7 +629,7 @@ class KittiRawExporterTest(TestCase):
                             )
                         ],
                         media=PointCloud(
-                            osp.join(test_dir, "velodyne_points", "data", "0000000000.pcd"),
+                            path=osp.join(test_dir, "velodyne_points", "data", "0000000000.pcd"),
                             extra_images=[
                                 Image(path=osp.join(test_dir, "image_00", "data", "0000000000.png"))
                             ],

--- a/tests/unit/test_kitti_raw_format.py
+++ b/tests/unit/test_kitti_raw_format.py
@@ -55,7 +55,7 @@ class KittiRawImporterTest(TestCase):
                             attributes={"occluded": False, "track_id": 2},
                         ),
                     ],
-                    media=PointCloud(path=pcd1, extra_images=[image1]),
+                    media=PointCloud.from_file(path=pcd1, extra_images=[image1]),
                     attributes={"frame": 0},
                 ),
                 DatasetItem(
@@ -69,7 +69,7 @@ class KittiRawImporterTest(TestCase):
                             attributes={"occluded": True, "track_id": 2},
                         )
                     ],
-                    media=PointCloud(path=pcd2, extra_images=[image2]),
+                    media=PointCloud.from_file(path=pcd2, extra_images=[image2]),
                     attributes={"frame": 1},
                 ),
                 DatasetItem(
@@ -82,7 +82,7 @@ class KittiRawImporterTest(TestCase):
                             attributes={"occluded": False, "track_id": 3},
                         )
                     ],
-                    media=PointCloud(path=pcd3, extra_images=[image3]),
+                    media=PointCloud.from_file(path=pcd3, extra_images=[image3]),
                     attributes={"frame": 2},
                 ),
             ],
@@ -144,7 +144,7 @@ class KittiRawExporterTest(TestCase):
                             attributes={"occluded": True, "track_id": 2},
                         ),
                     ],
-                    media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
+                    media=PointCloud.from_file(path=self.pcd1, extra_images=[self.image1]),
                     attributes={"frame": 0},
                 ),
                 DatasetItem(
@@ -169,7 +169,7 @@ class KittiRawExporterTest(TestCase):
                             attributes={"track_id": 3},
                         ),
                     ],
-                    media=PointCloud(path=self.pcd3),
+                    media=PointCloud.from_file(path=self.pcd3),
                     attributes={"frame": 2},
                 ),
             ],
@@ -198,7 +198,7 @@ class KittiRawExporterTest(TestCase):
                                 attributes={"occluded": True, "track_id": 2},
                             ),
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(test_dir, "velodyne_points", "data", "0000000000.pcd"),
                             extra_images=[
                                 Image(path=osp.join(test_dir, "image_00", "data", "0000000000.png"))
@@ -233,7 +233,7 @@ class KittiRawExporterTest(TestCase):
                                 attributes={"occluded": False, "track_id": 3},
                             ),
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(test_dir, "velodyne_points", "data", "0000000002.pcd")
                         ),
                         attributes={"frame": 2},
@@ -449,7 +449,7 @@ class KittiRawExporterTest(TestCase):
                 DatasetItem(
                     id="a/d",
                     annotations=[Cuboid3d(position=[1, 2, 3], label=0, attributes={"track_id": 1})],
-                    media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
+                    media=PointCloud.from_file(path=self.pcd1, extra_images=[self.image1]),
                     attributes={"frame": 3},
                 ),
             ],
@@ -471,7 +471,7 @@ class KittiRawExporterTest(TestCase):
                                 attributes={"track_id": 1, "occluded": False},
                             )
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(test_dir, "velodyne_points", "data", "a", "d.pcd"),
                             extra_images=[
                                 Image(path=osp.join(test_dir, "image_00", "data", "a", "d.png")),
@@ -500,7 +500,7 @@ class KittiRawExporterTest(TestCase):
                 DatasetItem(
                     id="a/d",
                     annotations=[Cuboid3d(position=[1, 2, 3], label=0, attributes={"track_id": 1})],
-                    media=PointCloud(
+                    media=PointCloud.from_file(
                         path=self.pcd1, extra_images=[self.image1, self.image2, self.image3]
                     ),
                     attributes={"frame": 3},
@@ -524,7 +524,7 @@ class KittiRawExporterTest(TestCase):
                                 attributes={"track_id": 1, "occluded": False},
                             )
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(test_dir, "velodyne_points", "data", "a", "d.pcd"),
                             extra_images=[
                                 Image(path=osp.join(test_dir, "image_00", "data", "a", "d.png")),
@@ -560,7 +560,7 @@ class KittiRawExporterTest(TestCase):
                         annotations=[
                             Cuboid3d(position=[3.5, 9.8, 0.3], label=0, attributes={"track_id": 1})
                         ],
-                        media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
+                        media=PointCloud.from_file(path=self.pcd1, extra_images=[self.image1]),
                         attributes={"frame": 0},
                     )
                 ],
@@ -573,7 +573,7 @@ class KittiRawExporterTest(TestCase):
                 DatasetItem(
                     "frame2",
                     annotations=[Cuboid3d(position=[1, 2, 0], label=1, attributes={"track_id": 1})],
-                    media=PointCloud(path=self.pcd2, extra_images=[self.image2]),
+                    media=PointCloud.from_file(path=self.pcd2, extra_images=[self.image2]),
                     attributes={"frame": 1},
                 )
             )
@@ -598,7 +598,7 @@ class KittiRawExporterTest(TestCase):
                             attributes={"occluded": False, "track_id": 1},
                         )
                     ],
-                    media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
+                    media=PointCloud.from_file(path=self.pcd1, extra_images=[self.image1]),
                     attributes={"frame": 0},
                 ),
                 DatasetItem(
@@ -628,7 +628,7 @@ class KittiRawExporterTest(TestCase):
                                 attributes={"occluded": False, "track_id": 1},
                             )
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(test_dir, "velodyne_points", "data", "0000000000.pcd"),
                             extra_images=[
                                 Image(path=osp.join(test_dir, "image_00", "data", "0000000000.png"))

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -935,7 +935,9 @@ class TestMultimerge(TestCase):
         expected = Dataset.from_iterable(
             [
                 DatasetItem(1, media=PointCloud.from_file(path=pcd1, extra_images=[image1])),
-                DatasetItem(2, media=PointCloud.from_file(path=pcd1, extra_images=[image1, image2])),
+                DatasetItem(
+                    2, media=PointCloud.from_file(path=pcd1, extra_images=[image1, image2])
+                ),
                 DatasetItem(3, media=PointCloud.from_file(path=pcd2)),
                 DatasetItem(4, media=PointCloud.from_file(path=pcd2)),
                 DatasetItem(5, media=PointCloud.from_file(path=pcd2, extra_images=[image2])),

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -910,11 +910,11 @@ class TestMultimerge(TestCase):
 
         source0 = Dataset.from_iterable(
             [
-                DatasetItem(1, media=PointCloud(path=pcd1, extra_images=[image1])),
-                DatasetItem(2, media=PointCloud(path=pcd1, extra_images=[image1])),
-                DatasetItem(3, media=PointCloud(path=pcd2)),
+                DatasetItem(1, media=PointCloud.from_file(path=pcd1, extra_images=[image1])),
+                DatasetItem(2, media=PointCloud.from_file(path=pcd1, extra_images=[image1])),
+                DatasetItem(3, media=PointCloud.from_file(path=pcd2)),
                 DatasetItem(4),
-                DatasetItem(5, media=PointCloud(path=pcd2)),
+                DatasetItem(5, media=PointCloud.from_file(path=pcd2)),
             ],
             categories=[],
             media_type=PointCloud,
@@ -922,11 +922,11 @@ class TestMultimerge(TestCase):
 
         source1 = Dataset.from_iterable(
             [
-                DatasetItem(1, media=PointCloud(path=pcd1, extra_images=[image1])),
-                DatasetItem(2, media=PointCloud(path=pcd1, extra_images=[image2])),
+                DatasetItem(1, media=PointCloud.from_file(path=pcd1, extra_images=[image1])),
+                DatasetItem(2, media=PointCloud.from_file(path=pcd1, extra_images=[image2])),
                 DatasetItem(3),
-                DatasetItem(4, media=PointCloud(path=pcd2)),
-                DatasetItem(5, media=PointCloud(path=pcd2, extra_images=[image2])),
+                DatasetItem(4, media=PointCloud.from_file(path=pcd2)),
+                DatasetItem(5, media=PointCloud.from_file(path=pcd2, extra_images=[image2])),
             ],
             categories=[],
             media_type=PointCloud,
@@ -934,11 +934,11 @@ class TestMultimerge(TestCase):
 
         expected = Dataset.from_iterable(
             [
-                DatasetItem(1, media=PointCloud(path=pcd1, extra_images=[image1])),
-                DatasetItem(2, media=PointCloud(path=pcd1, extra_images=[image1, image2])),
-                DatasetItem(3, media=PointCloud(path=pcd2)),
-                DatasetItem(4, media=PointCloud(path=pcd2)),
-                DatasetItem(5, media=PointCloud(path=pcd2, extra_images=[image2])),
+                DatasetItem(1, media=PointCloud.from_file(path=pcd1, extra_images=[image1])),
+                DatasetItem(2, media=PointCloud.from_file(path=pcd1, extra_images=[image1, image2])),
+                DatasetItem(3, media=PointCloud.from_file(path=pcd2)),
+                DatasetItem(4, media=PointCloud.from_file(path=pcd2)),
+                DatasetItem(5, media=PointCloud.from_file(path=pcd2, extra_images=[image2])),
             ],
             categories=[],
             media_type=PointCloud,

--- a/tests/unit/test_sly_pointcloud_format.py
+++ b/tests/unit/test_sly_pointcloud_format.py
@@ -61,7 +61,7 @@ class SuperviselyPointcloudImporterTest(TestCase):
                             attributes={"track_id": 231831, "tag1": "v12", "tag3": ""},
                         ),
                     ],
-                    media=PointCloud(pcd1, extra_images=[image1]),
+                    media=PointCloud(path=pcd1, extra_images=[image1]),
                     attributes={"frame": 0, "description": "", "tag1": "25dsd", "tag2": 65},
                 ),
                 DatasetItem(
@@ -74,7 +74,7 @@ class SuperviselyPointcloudImporterTest(TestCase):
                             attributes={"track_id": 36, "tag1": "", "tag3": ""},
                         )
                     ],
-                    media=PointCloud(pcd2, extra_images=[image2]),
+                    media=PointCloud(path=pcd2, extra_images=[image2]),
                     attributes={"frame": 1, "description": ""},
                 ),
             ],
@@ -138,7 +138,7 @@ class PointCloudConverterTest(TestCase):
                             attributes={"occluded": True, "track_id": 2},
                         ),
                     ],
-                    media=PointCloud(self.pcd1),
+                    media=PointCloud(path=self.pcd1),
                     attributes={"frame": 0, "description": "zzz"},
                 ),
                 DatasetItem(
@@ -151,7 +151,7 @@ class PointCloudConverterTest(TestCase):
                             attributes={"occluded": False, "track_id": 2},
                         )
                     ],
-                    media=PointCloud(self.pcd2, extra_images=[self.image2]),
+                    media=PointCloud(path=self.pcd2, extra_images=[self.image2]),
                     attributes={"frame": 1},
                 ),
             ],
@@ -182,7 +182,7 @@ class PointCloudConverterTest(TestCase):
                                 attributes={"occluded": True, "track_id": 2},
                             ),
                         ],
-                        media=PointCloud(osp.join(test_dir, "ds0", "pointcloud", "frame_1.pcd")),
+                        media=PointCloud(path=osp.join(test_dir, "ds0", "pointcloud", "frame_1.pcd")),
                         attributes={"frame": 0, "description": "zzz"},
                     ),
                     DatasetItem(
@@ -196,7 +196,7 @@ class PointCloudConverterTest(TestCase):
                             ),
                         ],
                         media=PointCloud(
-                            osp.join(test_dir, "ds0", "pointcloud", "frm2.pcd"),
+                            path=osp.join(test_dir, "ds0", "pointcloud", "frm2.pcd"),
                             extra_images=[
                                 Image(
                                     path=osp.join(
@@ -358,7 +358,7 @@ class PointCloudConverterTest(TestCase):
             [
                 DatasetItem(
                     id="a/b/c235",
-                    media=PointCloud(self.pcd1, extra_images=[self.image1]),
+                    media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
                     attributes={"frame": 20},
                 ),
             ],
@@ -372,7 +372,7 @@ class PointCloudConverterTest(TestCase):
                 [
                     DatasetItem(
                         id="a/b/c235",
-                        media=PointCloud(pcd_path, extra_images=[Image(path=img_path)]),
+                        media=PointCloud(path=pcd_path, extra_images=[Image(path=img_path)]),
                         attributes={"frame": 20},
                     ),
                 ],
@@ -404,7 +404,7 @@ class PointCloudConverterTest(TestCase):
                     DatasetItem(
                         id="frame1",
                         annotations=[Cuboid3d(id=215, position=[320.59, 979.48, 1.03], label=0)],
-                        media=PointCloud(self.pcd1, extra_images=[self.image1]),
+                        media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
                         attributes={"frame": 0},
                     )
                 ],
@@ -417,7 +417,7 @@ class PointCloudConverterTest(TestCase):
                 DatasetItem(
                     id="frame2",
                     annotations=[Cuboid3d(id=216, position=[0.59, 14.41, -0.61], label=1)],
-                    media=PointCloud(self.pcd2, extra_images=[self.image2]),
+                    media=PointCloud(path=self.pcd2, extra_images=[self.image2]),
                     attributes={"frame": 1},
                 )
             )

--- a/tests/unit/test_sly_pointcloud_format.py
+++ b/tests/unit/test_sly_pointcloud_format.py
@@ -182,7 +182,9 @@ class PointCloudConverterTest(TestCase):
                                 attributes={"occluded": True, "track_id": 2},
                             ),
                         ],
-                        media=PointCloud(path=osp.join(test_dir, "ds0", "pointcloud", "frame_1.pcd")),
+                        media=PointCloud(
+                            path=osp.join(test_dir, "ds0", "pointcloud", "frame_1.pcd")
+                        ),
                         attributes={"frame": 0, "description": "zzz"},
                     ),
                     DatasetItem(

--- a/tests/unit/test_sly_pointcloud_format.py
+++ b/tests/unit/test_sly_pointcloud_format.py
@@ -61,7 +61,7 @@ class SuperviselyPointcloudImporterTest(TestCase):
                             attributes={"track_id": 231831, "tag1": "v12", "tag3": ""},
                         ),
                     ],
-                    media=PointCloud(path=pcd1, extra_images=[image1]),
+                    media=PointCloud.from_file(path=pcd1, extra_images=[image1]),
                     attributes={"frame": 0, "description": "", "tag1": "25dsd", "tag2": 65},
                 ),
                 DatasetItem(
@@ -74,7 +74,7 @@ class SuperviselyPointcloudImporterTest(TestCase):
                             attributes={"track_id": 36, "tag1": "", "tag3": ""},
                         )
                     ],
-                    media=PointCloud(path=pcd2, extra_images=[image2]),
+                    media=PointCloud.from_file(path=pcd2, extra_images=[image2]),
                     attributes={"frame": 1, "description": ""},
                 ),
             ],
@@ -138,7 +138,7 @@ class PointCloudConverterTest(TestCase):
                             attributes={"occluded": True, "track_id": 2},
                         ),
                     ],
-                    media=PointCloud(path=self.pcd1),
+                    media=PointCloud.from_file(path=self.pcd1),
                     attributes={"frame": 0, "description": "zzz"},
                 ),
                 DatasetItem(
@@ -151,7 +151,7 @@ class PointCloudConverterTest(TestCase):
                             attributes={"occluded": False, "track_id": 2},
                         )
                     ],
-                    media=PointCloud(path=self.pcd2, extra_images=[self.image2]),
+                    media=PointCloud.from_file(path=self.pcd2, extra_images=[self.image2]),
                     attributes={"frame": 1},
                 ),
             ],
@@ -182,7 +182,7 @@ class PointCloudConverterTest(TestCase):
                                 attributes={"occluded": True, "track_id": 2},
                             ),
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(test_dir, "ds0", "pointcloud", "frame_1.pcd")
                         ),
                         attributes={"frame": 0, "description": "zzz"},
@@ -197,7 +197,7 @@ class PointCloudConverterTest(TestCase):
                                 attributes={"occluded": False, "track_id": 2},
                             ),
                         ],
-                        media=PointCloud(
+                        media=PointCloud.from_file(
                             path=osp.join(test_dir, "ds0", "pointcloud", "frm2.pcd"),
                             extra_images=[
                                 Image(
@@ -360,7 +360,7 @@ class PointCloudConverterTest(TestCase):
             [
                 DatasetItem(
                     id="a/b/c235",
-                    media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
+                    media=PointCloud.from_file(path=self.pcd1, extra_images=[self.image1]),
                     attributes={"frame": 20},
                 ),
             ],
@@ -374,7 +374,7 @@ class PointCloudConverterTest(TestCase):
                 [
                     DatasetItem(
                         id="a/b/c235",
-                        media=PointCloud(path=pcd_path, extra_images=[Image(path=img_path)]),
+                        media=PointCloud.from_file(path=pcd_path, extra_images=[Image(path=img_path)]),
                         attributes={"frame": 20},
                     ),
                 ],
@@ -406,7 +406,7 @@ class PointCloudConverterTest(TestCase):
                     DatasetItem(
                         id="frame1",
                         annotations=[Cuboid3d(id=215, position=[320.59, 979.48, 1.03], label=0)],
-                        media=PointCloud(path=self.pcd1, extra_images=[self.image1]),
+                        media=PointCloud.from_file(path=self.pcd1, extra_images=[self.image1]),
                         attributes={"frame": 0},
                     )
                 ],
@@ -419,7 +419,7 @@ class PointCloudConverterTest(TestCase):
                 DatasetItem(
                     id="frame2",
                     annotations=[Cuboid3d(id=216, position=[0.59, 14.41, -0.61], label=1)],
-                    media=PointCloud(path=self.pcd2, extra_images=[self.image2]),
+                    media=PointCloud.from_file(path=self.pcd2, extra_images=[self.image2]),
                     attributes={"frame": 1},
                 )
             )

--- a/tests/unit/test_sly_pointcloud_format.py
+++ b/tests/unit/test_sly_pointcloud_format.py
@@ -374,7 +374,9 @@ class PointCloudConverterTest(TestCase):
                 [
                     DatasetItem(
                         id="a/b/c235",
-                        media=PointCloud.from_file(path=pcd_path, extra_images=[Image(path=img_path)]),
+                        media=PointCloud.from_file(
+                            path=pcd_path, extra_images=[Image(path=img_path)]
+                        ),
                         attributes={"frame": 20},
                     ),
                 ],


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Datumaro format and Datumaro binary format support two medias, namely `Image` and `PointCloud`.
The `PointCloud` should be able to digest functions, just like `Image`, for a single binary file export/import functionality, for example, Apache Arrow.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
