### PR TITLE
Fix unit test errors from tensorflow-datasets==4.9.0

### DIFF
--- a/.github/workflows/nightly_check.yml
+++ b/.github/workflows/nightly_check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Installing dependencies
         run: |
           python -m pip install -r tests/requirements.txt
-          python -m pip install -e '.[default,tf]'
+          python -m pip install -e '.[default,tf,tfds-dev]'
       - name: Nightly regression testing
         run: |
           python -m pytest -v --html=nightly_regression_test_report.html

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Installing dependencies
         run: |
           python -m pip install -r tests/requirements.txt
-          python -m pip install -e '.[default,tf]'
+          python -m pip install -e '.[default,tf,tfds-dev]'
       - name: Unit testing
         run: |
           python -m pytest -v tests/unit/ --cov

--- a/.github/workflows/weekly_check.yml
+++ b/.github/workflows/weekly_check.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Installing dependencies
         run: |
           python -m pip install -r tests/requirements.txt
-          python -m pip install -e '.[default,tf]'
+          python -m pip install -e '.[default,tf,tfds-dev]'
       - name: Stability testing
         run: |
           python -m pytest --html=stability_test_report.html --minutes 5

--- a/setup.py
+++ b/setup.py
@@ -86,11 +86,11 @@ setuptools.setup(
     extras_require={
         "tf": ["tensorflow"],
         "tfds": [
-            "tensorflow-datasets!=4.5.0,!=4.5.1"
-        ],  # 4.5.0 fails on Windows, https://github.com/tensorflow/datasets/issues/3709
+            "tensorflow-datasets<4.9.0"
+        ],  # 4.9.0 fails on Windows and MacOS, https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
         "tfds-dev": [
-            "tensorflow-datasets[dev]!=4.5.0,!=4.5.1"
-        ],  # 4.5.0 fails on Windows, https://github.com/tensorflow/datasets/issues/3709
+            "tensorflow-datasets[dev]<4.9.0"
+        ],  # 4.9.0 fails on Windows and MacOS, https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
         "tf-gpu": ["tensorflow-gpu"],
         "default": DEFAULT_REQUIREMENTS,
     },

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,5 +6,3 @@ pytest-cov>=4.0.0
 pytest-stress
 pytest-html
 coverage
-
-tensorflow-datasets[dev]!=4.5.0,!=4.5.1


### PR DESCRIPTION
### Summary
 - The recent change from `tensorflow-datasets==4.8.3` to `4.9.0` makes unit test errors for Windows and MacOS: https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
 - Limit to `tensorflow-datasets<4.9.0`

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
