### PR TITLE
Fix log issue when importing celeba and align celeba dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/891>)
 - Fix negated `is_encrypted`
   (<https://github.com/openvinotoolkit/datumaro/pull/907>)
+- Fix log issue when importing celeba and align celeba dataset
+  (<https://github.com/openvinotoolkit/datumaro/pull/919>)
 
 ## 28/03/2023 - Release 1.1.1
 ### Bug fixes

--- a/datumaro/plugins/data_formats/celeba/celeba.py
+++ b/datumaro/plugins/data_formats/celeba/celeba.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import logging as log
 import os.path as osp
 
 from datumaro.components.annotation import (

--- a/datumaro/plugins/data_formats/celeba/celeba.py
+++ b/datumaro/plugins/data_formats/celeba/celeba.py
@@ -236,7 +236,10 @@ class CelebaImporter(Importer):
 
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> FormatDetectionConfidence:
-        super().detect(context)
+        try:
+            super().detect(context)
+        except DatasetImportError as e:
+            context.fail(str(e))
         return FormatDetectionConfidence.MEDIUM
 
     @classmethod
@@ -248,19 +251,17 @@ class CelebaImporter(Importer):
         )
 
         if len(sources) > 1:
-            log.error(
+            raise DatasetImportError(
                 f"{cls.NAME} label file ({cls.PATH_CLS.LABELS_FILE}) must be unique "
                 f"but the found sources have multiple duplicates. sources = {sources}"
             )
-            return []
 
         for source in sources:
             anno_dir = osp.dirname(source["url"])
             root_dir = osp.dirname(anno_dir)
             img_dir = osp.join(root_dir, cls.PATH_CLS.IMAGES_DIR)
             if not osp.exists(img_dir):
-                log.error(f"Cannot find {cls.NAME}'s images directory at {img_dir}")
-                return []
+                raise DatasetImportError(f"Cannot find {cls.NAME}'s images directory at {img_dir}")
             source["url"] = root_dir
 
         return sources


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
When import `celeba` or `align_celeba` dataset without format like `dm.Dataset.import_from(path=...)`, we met error like below. The example is the case for importing `align_celeba` dataset.
```
ERROR:root:Cannot find celeba's images directory at tests/assets/align_celeba_dataset/dataset/Img/img_celeba
```

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [X] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
