### PR TITLE
Added toxenv for snyk scanning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 isolated_build = true
 skip_missing_interpreters = true
 
+[testenv]
+deps =
+    -r{toxinidir}/requirements.txt
 
 [testenv:pre-commit]
 basepython = python3
@@ -15,3 +18,28 @@ deps =
     bandit
 commands =
     - bandit -r -c {toxinidir}/ipas_default.config {toxinidir}/ -f txt -o {toxworkdir}/bandit-report.txt
+
+[testenv:snyk-scan]
+deps =
+    {[testenv]deps}
+allowlist_externals =
+    bash
+    curl
+    wget
+    chmod
+    rm
+    *snyk*
+commands =
+    bash -c "pip freeze > snyk-req.txt"
+    curl https://static.snyk.io/cli/latest/snyk-linux -o {toxworkdir}/snyk
+    chmod +x {toxworkdir}/snyk
+    {toxworkdir}/snyk config set endpoint={env:SNYK_ENDPOINT}
+    {toxworkdir}/snyk config set disable-analytics=1
+    - {toxworkdir}/snyk test --file=snyk-req.txt --package-manager=pip --sarif-file-output={toxworkdir}/snyk.sarif --json-file-output={toxworkdir}/snyk.json
+    - {toxworkdir}/snyk monitor --file=snyk-req.txt --package-manager=pip
+    wget -P .tox/ https://github.com/snyk/snyk-to-html/releases/download/v2.3.6/snyk-to-html-linux
+    chmod +x {toxworkdir}/snyk-to-html-linux
+    {toxworkdir}/snyk-to-html-linux -i {toxworkdir}/snyk.json -o {toxworkdir}/snyk.html -d
+    rm {toxworkdir}/snyk
+    rm {toxworkdir}/snyk-to-html-linux
+    rm snyk-req.txt


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This one would be used to perform snyk code scanning from the internal development environment only because the API endpoint cannot be accessed from the external.

Once we setup the self-hosted CI instance, this one will be used by code-scanning workflow to automate snyk scanning & reporting. before that, this will be used to generate snyk report manually.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
