### PR TITLE
Refactor merge cli command

### DIFF
--- a/datumaro/cli/commands/merge.py
+++ b/datumaro/cli/commands/merge.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -22,18 +22,35 @@ from ..util.project import generate_next_file_name, load_project, parse_full_rev
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Merge few projects",
+        help="Merge few datasets or projects",
         description="""
         Merges multiple datasets into one and produces a new dataset.
-        The command can be useful if you have few annotations and wish
-        to merge them, taking into consideration potential overlaps and
-        conflicts. This command can try to find common ground by voting or
-        return a list of conflicts.|n
+        The command can be useful if you want to merge several datasets
+        which have homogeneous or heterogeneous label categories.
+        We provide three merge policies: 1) "exact" for homogenous datasets;
+        2) "union", or 3) "intersect" for heterogenous datasets. The default merge
+        policy is "union".
+        |n
         |n
         In simple cases, when dataset images do not intersect and new
-        labels are not added, the recommended way of merging is using the
-        "patch" command. It will offer better performance and provide the same
-        results.|n
+        labels are not added, we can use the "exact" merge policy for this situation.
+        |n
+        |n
+        On the other hand, when two datasets have different label categories or
+        have the same (id, subset) pairs in their dataset items. you have to use
+        the "union" or "intersect" merge.
+        |n
+        The "union" merge is more simple way to merge them.
+        It tries to obtain a union set from their label categories and attempts to merge
+        their dataset items. However, if there exist the same (id, subset) pairs, it appends
+        a suffix to each item's id to prevent the same (id, subset) pair in the merged dataset.
+        |n
+        The "intersect" policy is a more complicated way to merge heterogeneous datasets. If you want to merge
+        the annotations in the same (id, subset) pairs which coming from the different datasets
+        each other you wish to merge. You have to taking into consideration potential overlaps
+        and conflicts between the annotations. "intersect" merge policy can try to find common
+        ground by voting or return a list of conflicts.
+        |n
         |n
         This command has multiple forms:|n
         1) %(prog)s <revpath>|n
@@ -63,11 +80,14 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         options, which are passed after the '--' separator (see examples),
         pass '-- -h' for more info. If not stated otherwise, by default
         only annotations are exported; to include images pass
-        '--save-images' parameter.|n
+        '--save-media' parameter.|n
         |n
         Examples:|n
         - Merge annotations from 3 (or more) annotators:|n
         |s|s%(prog)s project1/ project2/ project3/|n
+        |n
+        - Merge datasets with varying merge policies:|n
+        |s|s%(prog)s project1/ project2/ -m <union|intersect|exact>|n
         |n
         - Check groups of the merged dataset for consistency:|n
         |s|s|slook for groups consising of 'person', 'hand' 'head', 'foot'|n
@@ -83,7 +103,7 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         |s|s%(prog)s HEAD~2:source-2 path/to/dataset2:yolo
         |n
         - Merge datasets and save in different format:|n
-        |s|s%(prog)s -f voc dataset1/:yolo path2/:coco -- --save-images
+        |s|s%(prog)s -f voc dataset1/:yolo path2/:coco -- --save-media
         """,
         formatter_class=MultilineFormatter,
     )
@@ -96,34 +116,11 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
     )  # workaround for -- eaten by positionals
     parser.add_argument("targets", nargs="+", help="Target dataset revpaths (repeatable)")
     parser.add_argument(
-        "-iou",
-        "--iou-thresh",
-        default=0.25,
-        type=float,
-        help="IoU match threshold for segments (default: %(default)s)",
-    )
-    parser.add_argument(
-        "-oconf",
-        "--output-conf-thresh",
-        default=0.0,
-        type=float,
-        help="Confidence threshold for output " "annotations (default: %(default)s)",
-    )
-    parser.add_argument(
-        "--quorum",
-        default=0,
-        type=int,
-        help="Minimum count for a label and attribute voting "
-        "results to be counted (default: %(default)s)",
-    )
-    parser.add_argument(
-        "-g",
-        "--groups",
-        action="append",
-        type=_group,
-        help="A comma-separated list of labels in "
-        "annotation groups to check. '?' postfix can be added to a label to "
-        "make it optional in the group (repeatable)",
+        "-m",
+        "--merge-policy",
+        default="union",
+        type=str,
+        help="Policy for how to merge datasets (default: %(default)s)",
     )
     parser.add_argument(
         "-o",
@@ -151,6 +148,42 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         "Must be specified after the main command arguments and after "
         "the '--' separator",
     )
+
+    intersect_args = parser.add_argument_group(
+        title="intersect policy arguments",
+        description="These parameters are optional for the intersect policy only.",
+    )
+    intersect_args.add_argument(
+        "-iou",
+        "--iou-thresh",
+        default=0.25,
+        type=float,
+        help="IoU match threshold for segments (default: %(default)s)",
+    )
+    intersect_args.add_argument(
+        "-oconf",
+        "--output-conf-thresh",
+        default=0.0,
+        type=float,
+        help="Confidence threshold for output " "annotations (default: %(default)s)",
+    )
+    intersect_args.add_argument(
+        "--quorum",
+        default=0,
+        type=int,
+        help="Minimum count for a label and attribute voting "
+        "results to be counted (default: %(default)s)",
+    )
+    intersect_args.add_argument(
+        "-g",
+        "--groups",
+        action="append",
+        type=_group,
+        help="A comma-separated list of labels in "
+        "annotation groups to check. '?' postfix can be added to a label to "
+        "make it optional in the group (repeatable)",
+    )
+
     parser.set_defaults(command=merge_command)
 
     return parser
@@ -222,16 +255,20 @@ def merge_command(args):
         raise CliException(str(e))
 
     report_path = osp.join(dst_dir, "merge_report.json")
+    options = (
+        {
+            "conf": IntersectMerge.Conf(
+                pairwise_dist=args.iou_thresh,
+                groups=args.groups or [],
+                output_conf_thresh=args.output_conf_thresh,
+                quorum=args.quorum,
+            )
+        }
+        if args.merge_policy == "intersect"
+        else {}
+    )
     merged_dataset = HLOps.merge(
-        *source_datasets,
-        merge_policy="intersect",
-        report_path=report_path,
-        conf=IntersectMerge.Conf(
-            pairwise_dist=args.iou_thresh,
-            groups=args.groups or [],
-            output_conf_thresh=args.output_conf_thresh,
-            quorum=args.quorum,
-        ),
+        *source_datasets, merge_policy=args.merge_policy, report_path=report_path, **options
     )
 
     merged_dataset.export(save_dir=dst_dir, format=exporter, **export_args)

--- a/datumaro/components/hl_ops/__init__.py
+++ b/datumaro/components/hl_ops/__init__.py
@@ -105,18 +105,9 @@ class HLOps:
         **kwargs,
     ) -> Dataset:
         """
-        Merges several datasets using the "simple" (exact matching) algorithm:
-
-            - items are matched by (id, subset) pairs
-            - matching items share the fields available
-
-                - nothing + nothing = nothing,
-                - nothing + something = something
-                - something A + something B = conflict
-            - annotations are matched by value and shared
-            - in case of conflicts, throws an error
-
-        Returns: a wrapper around the input datasets
+        Merge `datasets` according to `merge_policy`. You have to choose an appropriate `merge_policy`
+        for your purpose. The available merge policies are "union", "intersect", and "exact".
+        For more details about the merge policies, please refer to :func:`get_merger`.
         """
 
         merger = get_merger(merge_policy, **kwargs)

--- a/datumaro/components/merge/__init__.py
+++ b/datumaro/components/merge/__init__.py
@@ -7,10 +7,78 @@ from .exact_merge import ExactMerge
 from .intersect_merge import IntersectMerge
 from .union_merge import UnionMerge
 
-DEFAULT_MERGE_POLICY = "exact"
+DEFAULT_MERGE_POLICY = "union"
 
 
 def get_merger(merge_policy: str = DEFAULT_MERGE_POLICY, *args, **kwargs) -> Merger:
+    """
+    Get :class:`Merger` according to `merge_policy`. You have to choose an appropriate `Merger`
+    for your purpose. The available merge policies are "union", "intersect", and "exact".
+
+    1. :class:`UnionMerge`
+
+    Merge several datasets with "union" policy:
+
+    - Label categories are merged according to the union of their label names.
+    For example, if Dataset-A has {"car", "cat", "dog"} and Dataset-B has
+    {"car", "bus", "truck"} labels, the merged dataset will have
+    {"bust", "car", "cat", "dog", "truck"} labels.
+
+    - If there are two or more dataset items whose (id, subset) pairs match each other,
+    both are included in the merged dataset. At this time, since the same (id, subset)
+    pair cannot be duplicated in the dataset, we add a suffix to the id of each source item.
+    For example, if Dataset-A has DatasetItem(id="magic", subset="train") and Dataset-B has
+    also DatasetItem(id="magic", subset="train"), the merged dataset will have
+    DatasetItem(id="magic-0", subset="train") and DatasetItem(id="magic-1", subset="train").
+
+    2. :class:`IntersectMerge`
+
+    Merge several datasets with "intersect" policy:
+
+    - If there are two or more dataset items whose (id, subset) pairs match each other,
+    we can consider this as having an intersection in our dataset. This method merges
+    the annotations of the corresponding :class:`DatasetItem` into one :class:`DatasetItem`
+    to handle this intersection. The rule to handle merging annotations is provided by
+    :class:`AnnotationMerger` according to their annotation types. For example,
+    DatasetItem(id="item_1", subset="train", annotations=[Bbox(0, 0, 1, 1)]) from Dataset-A and
+    DatasetItem(id="item_1", subset="train", annotations=[Bbox(.5, .5, 1, 1)]) from Dataset-B can be
+    merged into DatasetItem(id="item_1", subset="train", annotations=[Bbox(0, 0, 1, 1)]).
+
+    - Label categories are merged according to the union of their label names
+    (Same as `UnionMerge`). For example, if Dataset-A has {"car", "cat", "dog"}
+    and Dataset-B has {"car", "bus", "truck"} labels, the merged dataset will have
+    {"bust", "car", "cat", "dog", "truck"} labels.
+
+    - This merge has configuration parameters (`conf`) to control the annotation merge behaviors.
+
+    For example,
+
+    ```python
+    merge = IntersectMerge(
+        conf=IntersectMerge.Conf(
+            pairwise_dist=0.25,
+            groups=[],
+            output_conf_thresh=0.0,
+            quorum=0,
+        )
+    )
+    ```
+
+    For more details for the parameters, please refer to :class:`IntersectMerge.Conf`.
+
+    3. :class:`ExactMerge`
+
+    Merges several datasets using the "simple" algorithm:
+
+    - All datasets should have the same categories
+    - items are matched by (id, subset) pairs
+    - matching items share the media info available:
+        - nothing + nothing = nothing
+        - nothing + something = something
+        - something A + something B = conflict
+    - annotations are matched by value and shared
+    - in case of conflicts, throws an error
+    """
     if merge_policy == "union":
         return UnionMerge(*args, **kwargs)
     elif merge_policy == "intersect":

--- a/datumaro/components/merge/__init__.py
+++ b/datumaro/components/merge/__init__.py
@@ -7,7 +7,7 @@ from .exact_merge import ExactMerge
 from .intersect_merge import IntersectMerge
 from .union_merge import UnionMerge
 
-DEFAULT_MERGE_POLICY = "union"
+DEFAULT_MERGE_POLICY = "exact"
 
 
 def get_merger(merge_policy: str = DEFAULT_MERGE_POLICY, *args, **kwargs) -> Merger:

--- a/datumaro/components/merge/base.py
+++ b/datumaro/components/merge/base.py
@@ -26,6 +26,7 @@ class Merger(IMerger, CliPlugin):
     def __init__(self, **options):
         super().__init__(**options)
         self.__dict__["_sources"] = None
+        self.errors = []
 
     def merge_infos(self, sources: Sequence[IDataset]) -> Dict:
         """Merge several :class:`IDataset` into one :class:`IDataset`"""

--- a/datumaro/components/merge/base.py
+++ b/datumaro/components/merge/base.py
@@ -21,11 +21,14 @@ from datumaro.util import dump_json_file
 
 
 class Merger(IMerger, CliPlugin):
+    """Merge multiple datasets into one dataset"""
+
     def __init__(self, **options):
         super().__init__(**options)
         self.__dict__["_sources"] = None
 
     def merge_infos(self, sources: Sequence[IDataset]) -> Dict:
+        """Merge several :class:`IDataset` into one :class:`IDataset`"""
         infos = {}
         for source in sources:
             for k, v in source.items():

--- a/datumaro/components/merge/exact_merge.py
+++ b/datumaro/components/merge/exact_merge.py
@@ -27,9 +27,9 @@ __all__ = ["ExactMerge"]
 class ExactMerge(Merger):
     """
     Merges several datasets using the "simple" algorithm:
+        - All datasets should have the same categories
         - items are matched by (id, subset) pairs
         - matching items share the media info available:
-
             - nothing + nothing = nothing
             - nothing + something = something
             - something A + something B = conflict

--- a/datumaro/components/merge/exact_merge.py
+++ b/datumaro/components/merge/exact_merge.py
@@ -4,8 +4,6 @@
 
 from typing import Any, Dict, Iterable, List, Sequence, Tuple, Union
 
-from attr import attrs
-
 from datumaro.components.annotation import Annotation
 from datumaro.components.dataset_base import DatasetItem, IDataset
 from datumaro.components.dataset_item_storage import DatasetItemStorage
@@ -23,7 +21,6 @@ from datumaro.components.merge import Merger
 __all__ = ["ExactMerge"]
 
 
-@attrs
 class ExactMerge(Merger):
     """
     Merges several datasets using the "simple" algorithm:

--- a/datumaro/components/merge/union_merge.py
+++ b/datumaro/components/merge/union_merge.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: MIT
 
-from typing import Dict, Sequence
+from collections import defaultdict
+from typing import Dict, List, Sequence, Tuple
 
 from datumaro.components.annotation import AnnotationType, LabelCategories
-from datumaro.components.dataset_base import IDataset
+from datumaro.components.dataset_base import DatasetItem, IDataset
 from datumaro.components.dataset_item_storage import DatasetItemStorage
 from datumaro.components.merge import Merger
 
@@ -14,14 +15,19 @@ __all__ = ["UnionMerge"]
 
 class UnionMerge(Merger):
     """
-    Merges several datasets using the "simple" algorithm:
-        - items are matched by (id, subset) pairs
-        - matching items share the media info available:
-            - nothing + nothing = nothing
-            - nothing + something = something
-            - something A + something B = something (A + B)
-        - annotations are matched by value and shared
-        - in case of conflicts, throws an error
+    Merge several datasets with "union" policy:
+
+    - Label categories are merged according to the union of their label names.
+    For example, if Dataset-A has {"car", "cat", "dog"} and Dataset-B has
+    {"car", "bus", "truck"} labels, the merged dataset will have
+    {"bust", "car", "cat", "dog", "truck"} labels.
+
+    - If there are two or more dataset items whose (id, subset) pairs match each other,
+    both are included in the merged dataset. At this time, since the same (id, subset)
+    pair cannot be duplicated in the dataset, we add a suffix to the id of each source item.
+    For example, if Dataset-A has DatasetItem(id="magic", subset="train") and Dataset-B has
+    also DatasetItem(id="magic", subset="train"), the merged dataset will have
+    DatasetItem(id="magic-0", subset="train") and DatasetItem(id="magic-1", subset="train").
     """
 
     def __init__(self, **options):
@@ -29,14 +35,26 @@ class UnionMerge(Merger):
         self._matching_table = {}
 
     def merge(self, sources: Sequence[IDataset]) -> DatasetItemStorage:
-        items = DatasetItemStorage()
+        dict_items: Dict[Tuple[str, str], List[DatasetItem]] = defaultdict(list)
+
         for source_idx, source in enumerate(sources):
             for item in source:
                 if self._matching_table.get(source_idx, None):
                     for ann in item.annotations:
                         ann.label = self._matching_table[source_idx][ann.label]
-                items.put(item)
-        return items
+                dict_items[item.id, item.subset].append(item)
+
+        item_storage = DatasetItemStorage()
+
+        for items in dict_items.values():
+            if len(items) == 1:
+                item_storage.put(items[0])
+            else:
+                for idx, item in enumerate(items):
+                    # Add prefix
+                    item_storage.put(item.wrap(id=f"{item.id}-{idx}"))
+
+        return item_storage
 
     def merge_categories(self, sources: Sequence[IDataset]) -> Dict:
         dst_categories = {}

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -1001,13 +1001,13 @@ class TestMultimerge(TestCase):
         source0 = Dataset.from_iterable(
             [
                 DatasetItem(
-                    0,
+                    "0",
                     annotations=[
                         Label(0),
                     ],
                 ),
                 DatasetItem(
-                    1,
+                    "1",
                     annotations=[Mask(image=np.ones((8, 8), dtype=np.uint8), label=1)],
                 ),
             ],
@@ -1019,11 +1019,11 @@ class TestMultimerge(TestCase):
         source1 = Dataset.from_iterable(
             [
                 DatasetItem(
-                    2,
+                    "1",
                     annotations=[Mask(image=np.ones((8, 8), dtype=np.uint8), label=0)],
                 ),
                 DatasetItem(
-                    3,
+                    "2",
                     annotations=[Mask(image=np.ones((8, 8), dtype=np.uint8), label=1)],
                 ),
             ],
@@ -1035,21 +1035,21 @@ class TestMultimerge(TestCase):
         expected = Dataset.from_iterable(
             [
                 DatasetItem(
-                    0,
+                    "0",
                     annotations=[
                         Label(0),
                     ],
                 ),
                 DatasetItem(
-                    1,
+                    "1-0",
                     annotations=[Mask(image=np.ones((8, 8), dtype=np.uint8), label=1)],
                 ),
                 DatasetItem(
-                    2,
+                    "1-1",
                     annotations=[Mask(image=np.ones((8, 8), dtype=np.uint8), label=2)],
                 ),
                 DatasetItem(
-                    3,
+                    "2",
                     annotations=[Mask(image=np.ones((8, 8), dtype=np.uint8), label=1)],
                 ),
             ],


### PR DESCRIPTION
### Summary
 - Ticket no. 107274
 - Add `merge_policy` to the merge CLI command
 - Give a clear role for each merge policy
    - Now, `UnionMerge` tries to include all overlapping `(id,subset)` pairs by appending `-{idx}` suffix to their `id`s and this is the clear difference with `IntersectMerge`.
 -Updated docstrings to help users understand our merge policies.

### How to test
I added an integration CLI tests for `ExactMerge` and `UnionMerge`.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
