### PR TITLE
Add __init__ to `arrow/mapper`

### DIFF
--- a/datumaro/plugins/data_formats/arrow/mapper/__init__.py
+++ b/datumaro/plugins/data_formats/arrow/mapper/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+# ruff: noqa: F405
+
+from .dataset_item import *
+from .media import *
+
+__all__ = [
+    # dataset_item
+    "DatasetItemMapper",
+    # media
+    "MediaMapper",
+]


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Fix not packaged due to missing `__init__`.

### How to test

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
