### PR TITLE
Abbreviate "detect-format" to "detect" for prettifying

### DIFF
--- a/datumaro/cli/commands/__init__.py
+++ b/datumaro/cli/commands/__init__.py
@@ -16,12 +16,13 @@ __all__ = [
 def get_non_project_commands():
     return [
         ("convert", convert, "Convert dataset between formats"),
-        ("detect-format", detect_format, "Detect the format of a dataset"),
+        ("detect", detect_format, "Detect the format of a dataset"),
         ("download", download, "Download a publicly available dataset"),
         ("explain", explain, "Run Explainable AI algorithm for model"),
         ("filter", filter, "Filter dataset items"),
         ("generate", generate, "Generate synthetic dataset"),
         ("merge", merge, "Merge datasets"),
         ("patch", patch, "Update dataset from another one"),
+        ("search", search, "Search similar datasetitems of query"),
         ("search", search, "Search similar datasetitems of query"),
     ]

--- a/datumaro/cli/commands/__init__.py
+++ b/datumaro/cli/commands/__init__.py
@@ -24,5 +24,4 @@ def get_non_project_commands():
         ("merge", merge, "Merge datasets"),
         ("patch", patch, "Update dataset from another one"),
         ("search", search, "Search similar datasetitems of query"),
-        ("search", search, "Search similar datasetitems of query"),
     ]

--- a/docs/source/docs/command-reference/detect.md
+++ b/docs/source/docs/command-reference/detect.md
@@ -48,7 +48,7 @@ Other reason codes may be defined in the future.
 Usage:
 
 ``` bash
-datum detect-format [-h] [-p PROJECT_DIR] [--show-rejections]
+datum detect [-h] [-p PROJECT_DIR] [--show-rejections]
                     [--json-report JSON_REPORT]
                     url
 ```
@@ -70,5 +70,5 @@ Example: detect the format of a dataset in a given directory,
 showing rejection information:
 
 ``` bash
-datum detect-format --show-rejections path/to/dataset
+datum detect --show-rejections path/to/dataset
 ```

--- a/docs/source/docs/command-reference/index.rst
+++ b/docs/source/docs/command-reference/index.rst
@@ -41,7 +41,7 @@ Parameters:
    convert
    create
    describe-downloads
-   detect-format
+   detect
    diff
    download
    explain

--- a/docs/source/docs/level-up/basic_skills/04_detect_data_format.rst
+++ b/docs/source/docs/level-up/basic_skills/04_detect_data_format.rst
@@ -16,7 +16,7 @@ Detect data format
 
     .. code-block:: bash
 
-      datum detect-format <path/to/data>
+      datum detect <path/to/data>
 
     The printed format can be utilized as `format` argument when importing a dataset as following the
     :ref:`previous level <Level 3: Data Import and Export>`.

--- a/tests/integration/cli/test_detect_format.py
+++ b/tests/integration/cli/test_detect_format.py
@@ -39,7 +39,7 @@ class DetectFormatTest(TestCase):
         output_file = io.StringIO()
 
         with contextlib.redirect_stdout(output_file):
-            run(self, "detect-format", ADE20K2017_DIR)
+            run(self, "detect", ADE20K2017_DIR)
 
         output = self._extract_detect_format_name(output_file)
 
@@ -56,7 +56,7 @@ class DetectFormatTest(TestCase):
             shutil.copy(osp.join(LFW_DIR, "test", "annotations", "pairs.txt"), annotation_dir)
 
             with contextlib.redirect_stdout(output_file):
-                run(self, "detect-format", test_dir, "--depth", "3")
+                run(self, "detect", test_dir, "--depth", "3")
 
             output = self._extract_detect_format_name(output_file)
 
@@ -72,7 +72,7 @@ class DetectFormatTest(TestCase):
             shutil.copy(osp.join(ADE20K2020_DIR, "training/street/1.json"), annotation_dir)
 
             with contextlib.redirect_stdout(output_file):
-                run(self, "detect-format", test_dir)
+                run(self, "detect", test_dir)
 
             output = self._extract_detect_format_name(output_file)
 
@@ -93,7 +93,7 @@ class DetectFormatTest(TestCase):
             output_file = io.StringIO()
 
             with contextlib.redirect_stdout(output_file):
-                run(self, "detect-format", test_dir)
+                run(self, "detect", test_dir)
 
             output = self._extract_detect_format_name(output_file)
 
@@ -108,7 +108,7 @@ class DetectFormatTest(TestCase):
         output_file = io.StringIO()
 
         with contextlib.redirect_stdout(output_file):
-            run(self, "detect-format", "--show-rejections", ADE20K2017_DIR)
+            run(self, "detect", "--show-rejections", ADE20K2017_DIR)
 
         output = output_file.getvalue()
 
@@ -126,7 +126,7 @@ class DetectFormatTest(TestCase):
 
             run(
                 self,
-                "detect-format",
+                "detect",
                 "--show-rejections",
                 "--json-report",
                 report_path,


### PR DESCRIPTION
### Summary
- Abbreviate "detect-format" to "detect" for prettifying
- This is because "detect-format" is only one who has hyphen in itself.

### How to test
I corrected the existing CLI tests for this change.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [x] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
