### PR TITLE
Fix links in Explanation-Formats

### DIFF
--- a/docs/source/docs/explanation/formats/ade20k2017.md
+++ b/docs/source/docs/explanation/formats/ade20k2017.md
@@ -112,4 +112,4 @@ dataset.export('save_dir', 'coco')
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_ade20k2017_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_ade20k2017_format.py)

--- a/docs/source/docs/explanation/formats/ade20k2020.md
+++ b/docs/source/docs/explanation/formats/ade20k2020.md
@@ -131,4 +131,4 @@ dataset.export('save_dir', 'voc')
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_ade20k2020_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_ade20k2020_format.py)

--- a/docs/source/docs/explanation/formats/align_celeba.md
+++ b/docs/source/docs/explanation/formats/align_celeba.md
@@ -99,4 +99,4 @@ dataset.export('save_dir', 'voc')
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_align_celeba_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_align_celeba_format.py)

--- a/docs/source/docs/explanation/formats/brats.md
+++ b/docs/source/docs/explanation/formats/brats.md
@@ -84,4 +84,4 @@ dataset.export('save_dir', 'voc')
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_brats_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_brats_format.py)

--- a/docs/source/docs/explanation/formats/brats_numpy.md
+++ b/docs/source/docs/explanation/formats/brats_numpy.md
@@ -78,4 +78,4 @@ dataset.export('save_dir', 'voc')
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_brats_numpy_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_brats_numpy_format.py)

--- a/docs/source/docs/explanation/formats/celeba.md
+++ b/docs/source/docs/explanation/formats/celeba.md
@@ -101,4 +101,4 @@ dataset.export('save_dir', 'voc')
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_celeba_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_celeba_format.py)

--- a/docs/source/docs/explanation/formats/cifar.md
+++ b/docs/source/docs/explanation/formats/cifar.md
@@ -197,4 +197,4 @@ datum convert --input-format cifar --input-path <path/to/cifar> \
 ```
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_cifar_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_cifar_format.py)

--- a/docs/source/docs/explanation/formats/common_semantic_segmentation.md
+++ b/docs/source/docs/explanation/formats/common_semantic_segmentation.md
@@ -75,4 +75,4 @@ dataset.export('save_dir', 'camvid', save_media=True)
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_common_semantic_segmentation_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_common_semantic_segmentation_format.py)

--- a/docs/source/docs/explanation/formats/common_semantic_segmentation.md
+++ b/docs/source/docs/explanation/formats/common_semantic_segmentation.md
@@ -75,4 +75,4 @@ dataset.export('save_dir', 'camvid', save_media=True)
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_common_semantic_segmentation_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/data_formats/test_common_semantic_segmentation_format.py)

--- a/docs/source/docs/explanation/formats/common_super_resolution.md
+++ b/docs/source/docs/explanation/formats/common_super_resolution.md
@@ -44,4 +44,4 @@ run `datum project info`, which will display the project information.
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_common_super_resolution_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_common_super_resolution_format.py)

--- a/docs/source/docs/explanation/formats/mpii.md
+++ b/docs/source/docs/explanation/formats/mpii.md
@@ -77,4 +77,4 @@ dataset.export('save_dir', 'voc')
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_mpii_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_mpii_format.py)

--- a/docs/source/docs/explanation/formats/mpii_json.md
+++ b/docs/source/docs/explanation/formats/mpii_json.md
@@ -80,4 +80,4 @@ dataset.export('save_dir', 'voc')
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_mpii_json_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_mpii_json_format.py)

--- a/docs/source/docs/explanation/formats/nyu_depth_v2.md
+++ b/docs/source/docs/explanation/formats/nyu_depth_v2.md
@@ -44,4 +44,4 @@ run `datum project info`, which will display the project information.
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_nyu_depth_v2_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_nyu_depth_v2_format.py)

--- a/docs/source/docs/explanation/formats/synthia.md
+++ b/docs/source/docs/explanation/formats/synthia.md
@@ -127,4 +127,4 @@ dataset.export('save_dir', 'voc')
 ## Examples
 
 Examples of using this format from the code can be found in
-[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_synthia_format.py)
+[the format tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_synthia_format.py)

--- a/docs/source/docs/explanation/formats/vott_csv.md
+++ b/docs/source/docs/explanation/formats/vott_csv.md
@@ -77,4 +77,4 @@ dataset.export('save_dir', 'voc')
 ## Examples
 
 Examples of using this format from the code can be found in
-[VoTT CSV tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_vott_csv_format.py).
+[VoTT CSV tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_vott_csv_format.py).

--- a/docs/source/docs/explanation/formats/vott_json.md
+++ b/docs/source/docs/explanation/formats/vott_json.md
@@ -77,4 +77,4 @@ dataset.export('save_dir', 'voc')
 ## Examples
 
 Examples of using this format from the code can be found in
-[VoTT JSON tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_vott_json_format.py).
+[VoTT JSON tests](https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_vott_json_format.py).


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
- Find and replace: `https://github.com/openvinotoolkit/datumaro/blob/develop/tests/test_` -> `https://github.com/openvinotoolkit/datumaro/blob/develop/tests/unit/test_`
- Fix `common_semantic_segmentation.md`'s test link

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
