### PR TITLE
Warn coco format users

### DIFF
--- a/datumaro/plugins/data_formats/coco/base.py
+++ b/datumaro/plugins/data_formats/coco/base.py
@@ -142,7 +142,8 @@ class _CocoBase(SubsetBase):
         found = [
             self._categories[AnnotationType.label][label_id].name
             for cat_id, label_id in self._label_map.items()
-            if cat_id == 0 and self._categories[AnnotationType.label][label_id].name.lower() != "background"
+            if cat_id == 0
+            and self._categories[AnnotationType.label][label_id].name.lower() != "background"
         ]
         if found:
             category_name = found[0]

--- a/datumaro/plugins/data_formats/coco/base.py
+++ b/datumaro/plugins/data_formats/coco/base.py
@@ -123,18 +123,17 @@ class _CocoBase(SubsetBase):
             self._categories = {AnnotationType.label: LabelCategories.from_iterable(labels)}
             # 0 is reserved for no class
             self._label_map = {i + 1: i for i in range(len(labels))}
-        else:
-            if self._task in [
-                CocoTask.instances,
-                CocoTask.labels,
-                CocoTask.person_keypoints,
-                CocoTask.stuff,
-                CocoTask.panoptic,
-            ]:
-                self._load_label_categories(
-                    self._parse_field(json_data, "categories", list),
-                    keep_original_ids=keep_original_ids,
-                )
+        elif self._task in [
+            CocoTask.instances,
+            CocoTask.labels,
+            CocoTask.person_keypoints,
+            CocoTask.stuff,
+            CocoTask.panoptic,
+        ]:
+            self._load_label_categories(
+                self._parse_field(json_data, "categories", list),
+                keep_original_ids=keep_original_ids,
+            )
 
             if self._task == CocoTask.person_keypoints:
                 self._load_person_kp_categories(self._parse_field(json_data, "categories", list))
@@ -150,7 +149,8 @@ class _CocoBase(SubsetBase):
             log.warning(
                 "Category id of '0' is reserved for no class (background) but "
                 f"category named '{category_name}' with id of '0' is found in {self._path}. "
-                "Please be warned that annotations with category id of '0' would have `None` as label."
+                "Please be warned that annotations with category id of '0' would have `None` as label. "
+                "(https://openvinotoolkit.github.io/datumaro/latest/docs/explanation/formats/coco.html#import-coco-dataset)"
             )
 
     def _load_label_categories(self, json_cat, *, keep_original_ids):

--- a/datumaro/plugins/data_formats/coco/base.py
+++ b/datumaro/plugins/data_formats/coco/base.py
@@ -143,7 +143,7 @@ class _CocoBase(SubsetBase):
         found = [
             self._categories[AnnotationType.label][label_id].name
             for cat_id, label_id in self._label_map.items()
-            if cat_id == 0 and self._categories[AnnotationType.label][label_id].name != "background"
+            if cat_id == 0 and self._categories[AnnotationType.label][label_id].name.lower() != "background"
         ]
         if found:
             category_name = found[0]

--- a/datumaro/plugins/data_formats/coco/base.py
+++ b/datumaro/plugins/data_formats/coco/base.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import logging as log
 import os.path as osp
 from inspect import isclass
 from typing import Any, Dict, Tuple, Type, TypeVar, Union, overload
@@ -115,29 +116,42 @@ class _CocoBase(SubsetBase):
         yield from self._items.values()
 
     def _load_categories(self, json_data, *, keep_original_ids):
+        self._categories = {}
+
         if has_meta_file(self._rootpath):
             labels = parse_meta_file(self._rootpath).keys()
             self._categories = {AnnotationType.label: LabelCategories.from_iterable(labels)}
             # 0 is reserved for no class
             self._label_map = {i + 1: i for i in range(len(labels))}
-            return
+        else:
+            if self._task in [
+                CocoTask.instances,
+                CocoTask.labels,
+                CocoTask.person_keypoints,
+                CocoTask.stuff,
+                CocoTask.panoptic,
+            ]:
+                self._load_label_categories(
+                    self._parse_field(json_data, "categories", list),
+                    keep_original_ids=keep_original_ids,
+                )
 
-        self._categories = {}
+            if self._task == CocoTask.person_keypoints:
+                self._load_person_kp_categories(self._parse_field(json_data, "categories", list))
 
-        if self._task in [
-            CocoTask.instances,
-            CocoTask.labels,
-            CocoTask.person_keypoints,
-            CocoTask.stuff,
-            CocoTask.panoptic,
-        ]:
-            self._load_label_categories(
-                self._parse_field(json_data, "categories", list),
-                keep_original_ids=keep_original_ids,
+        # informs users if 0 is found as category id sicne 0 is reserved for no class
+        found = [
+            self._categories[AnnotationType.label][label_id].name
+            for cat_id, label_id in self._label_map.items()
+            if cat_id == 0 and self._categories[AnnotationType.label][label_id].name != "background"
+        ]
+        if found:
+            category_name = found[0]
+            log.warning(
+                "Category id of '0' is reserved for no class (background) but "
+                f"category named '{category_name}' with id of '0' is found in {self._path}. "
+                "Please be warned that annotations with category id of '0' would have `None` as label."
             )
-
-        if self._task == CocoTask.person_keypoints:
-            self._load_person_kp_categories(self._parse_field(json_data, "categories", list))
 
     def _load_label_categories(self, json_cat, *, keep_original_ids):
         categories = LabelCategories()


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
The category id `0` is reserved for no object (background) but one could define an annotation file containing real category object with id `0` which causes unexpected behaviour (annotation's `label` field is `None`) to users.

- Added warning to inform users that it could be not what they expected.
- Added unit test for warning message.

About reserved category id -> https://github.com/openvinotoolkit/datumaro/issues/156

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
