### PR TITLE
Fix bytes property bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements
 
 ### Bug fixes
-- Fix Mapillary Vistas data format (<https://github.com/openvinotoolkit/datumaro/pull/977>)
+- Fix Mapillary Vistas data format
+  (<https://github.com/openvinotoolkit/datumaro/pull/977>)
+- Fix `bytes` property returning `None` if function is given to `data`
+  (<https://github.com/openvinotoolkit/datumaro/pull/978>)
 
 ## 20/04/2023 - Release 1.2.0
 ### New features

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -184,9 +184,7 @@ class FromDataMixin(Generic[AnyData]):
     @property
     def bytes(self) -> Optional[bytes]:
         if self.has_data:
-            _bytes = self._data
-            if callable(_bytes):
-                _bytes = _bytes()
+            _bytes = self._data() if callable(self._data) else self._data
             if isinstance(_bytes, bytes):
                 return _bytes
         return None

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -184,9 +184,9 @@ class FromDataMixin(Generic[AnyData]):
     @property
     def bytes(self) -> Optional[bytes]:
         if self.has_data:
-            if callable(self._data):
-                _bytes = self._data()
             _bytes = self._data
+            if callable(_bytes):
+                _bytes = _bytes()
             if isinstance(_bytes, bytes):
                 return _bytes
         return None

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -161,8 +161,7 @@ class ImageTest(TestCase):
                     img = Image.from_bytes(**args)
                     self.assertTrue(img.has_data)
                     np.testing.assert_array_equal(img.data, image)
-                    if img.bytes:
-                        self.assertEqual(img.bytes, image_bytes)
+                    self.assertEqual(img.bytes, image_bytes)
                     self.assertEqual(img.size, tuple(image.shape[:2]))
 
             with self.subTest():


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Fixed returning `None` if function is given to `data`

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
