### PR TITLE
Fix having empty string for `rootpath` in coco format

### DIFF
--- a/datumaro/plugins/data_formats/coco/base.py
+++ b/datumaro/plugins/data_formats/coco/base.py
@@ -47,7 +47,8 @@ class DirPathExtracter:
     def find_rootpath(path: str) -> str:
         """Find root path from annotation json file path."""
         if path.endswith(osp.join(CocoPath.ANNOTATIONS_DIR, osp.basename(path))):
-            return path.rsplit(CocoPath.ANNOTATIONS_DIR, maxsplit=1)[0]
+            root_path = path.rsplit(CocoPath.ANNOTATIONS_DIR, maxsplit=1)[0]
+            return root_path if root_path else "./"
         raise DatasetImportError(
             f"Annotation path ({path}) should be under the directory which is named {CocoPath.ANNOTATIONS_DIR}. "
             "If not, Datumaro fails to find the root path for this dataset. "

--- a/datumaro/plugins/data_formats/coco/base.py
+++ b/datumaro/plugins/data_formats/coco/base.py
@@ -46,9 +46,9 @@ class DirPathExtracter:
     @staticmethod
     def find_rootpath(path: str) -> str:
         """Find root path from annotation json file path."""
-        if path.endswith(osp.join(CocoPath.ANNOTATIONS_DIR, osp.basename(path))):
-            root_path = path.rsplit(CocoPath.ANNOTATIONS_DIR, maxsplit=1)[0]
-            return root_path if root_path else "./"
+        path = osp.abspath(path)
+        if osp.dirname(path).endswith(CocoPath.ANNOTATIONS_DIR):
+            return path.rsplit(CocoPath.ANNOTATIONS_DIR, maxsplit=1)[0]
         raise DatasetImportError(
             f"Annotation path ({path}) should be under the directory which is named {CocoPath.ANNOTATIONS_DIR}. "
             "If not, Datumaro fails to find the root path for this dataset. "


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Datumaro coco format supports initializing from a specific annotation file.

If the given annotation file path is a relative path **not specifying current working directory**

If 1) the current working directory **IS** dataset directory and the given annotation file path is a relative path **not specifying current directory**, 2) the current working directory is **inside of dataset directory**, importing dataset would be failed.


```console
$ ls
annotations/ images/
```
```python
import os
from datumaro import Dataset

Dataset.import_from('annotations/instances_train2017.json', 'coco')    # error -> fixed in this PR
Dataset.import_from('./annotations/instances_train2017.json', 'coco')  # ok

os.chdir('annotations')
Dataset.import_from('instances_train2017.json', 'coco')                # error -> fixed in this PR
```

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
