### PR TITLE
Remedying apache-beam dependency conflicts

### DIFF
--- a/.github/workflows/nightly_check.yml
+++ b/.github/workflows/nightly_check.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-11']
-        python-version: ['3.10']
+        os: ['macos-11', 'ubuntu-20.04', 'windows-2019']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     name: nightly regression test (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     steps:
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
       - name: Installing dependencies
         run: |
           python -m pip install -r tests/requirements.txt

--- a/.github/workflows/nightly_check.yml
+++ b/.github/workflows/nightly_check.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-11', 'ubuntu-20.04', 'windows-2019']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        os: ['macos-11']
+        python-version: ['3.10']
     name: nightly regression test (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     steps:

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -43,4 +43,7 @@ cryptography>= 38.03
 pyemd
 
 # apache arrow
+# apache-beam>=2.46.0
 pyarrow
+
+protobuf==3.19.4;python_version=="3.10" and sys_platform=="darwin"

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -43,7 +43,6 @@ cryptography>= 38.03
 pyemd
 
 # apache arrow
-# apache-beam>=2.46.0
+# protobuf >= 3.20 causes apache-beam installation failure on MacOS with Python 3.10
+protobuf==3.19.4; python_version == '3.10' and sys_platform == "darwin"
 pyarrow
-
-protobuf==3.19.4;python_version=="3.10" and sys_platform=="darwin"

--- a/setup.py
+++ b/setup.py
@@ -86,10 +86,10 @@ setuptools.setup(
     extras_require={
         "tf": ["tensorflow"],
         "tfds": [
-            "tensorflow-datasets>=4.9.1"
+            "tensorflow-datasets<4.9.0"
         ],  # 4.9.0 fails on Windows and MacOS, https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
         "tfds-dev": [
-            "tensorflow-datasets[dev]>=4.9.1"
+            "tensorflow-datasets[dev]<4.9.0"
         ],  # 4.9.0 fails on Windows and MacOS, https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
         "tf-gpu": ["tensorflow-gpu"],
         "default": DEFAULT_REQUIREMENTS,

--- a/setup.py
+++ b/setup.py
@@ -86,10 +86,10 @@ setuptools.setup(
     extras_require={
         "tf": ["tensorflow"],
         "tfds": [
-            "tensorflow-datasets<4.9.0"
+            "tensorflow-datasets>=4.9.1"
         ],  # 4.9.0 fails on Windows and MacOS, https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
         "tfds-dev": [
-            "tensorflow-datasets[dev]<4.9.0"
+            "tensorflow-datasets[dev]>=4.9.1"
         ],  # 4.9.0 fails on Windows and MacOS, https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
         "tf-gpu": ["tensorflow-gpu"],
         "default": DEFAULT_REQUIREMENTS,


### PR DESCRIPTION
### Summary

Fixing the failure of regression tests on MacOS11-Python3.10.

Verified on this actions: https://github.com/openvinotoolkit/datumaro/actions/runs/4861593576

![image](https://user-images.githubusercontent.com/5232387/235686973-5f9fd1f0-26fc-4062-8d25-783853e027fb.png)
