### PR TITLE
Fix media contents error in arrow format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## \[Unreleased\]
-
 ### Bug fixes
+- Fix project level CVAT for images format import
+  (<https://github.com/openvinotoolkit/datumaro/pull/980>)
 - Fix media contents not returning bytes in arrow format
   (<https://github.com/openvinotoolkit/datumaro/pull/986>)
 
@@ -53,8 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/918>)
 - Fix log issue when importing celeba and align celeba dataset
   (<https://github.com/openvinotoolkit/datumaro/pull/919>)
-- Fix project level CVAT for images format import
-  (<https://github.com/openvinotoolkit/datumaro/pull/980>)
 
 ## 28/03/2023 - Release 1.1.1
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+### Bug fixes
+- Fix media contents not returning bytes in arrow format
+  (<https://github.com/openvinotoolkit/datumaro/pull/986>)
+
 ## 20/04/2023 - Release 1.2.0
 ### New features
 - Add Skill Up section to documentation

--- a/datumaro/components/media.py
+++ b/datumaro/components/media.py
@@ -184,9 +184,7 @@ class FromDataMixin(Generic[AnyData]):
     @property
     def bytes(self) -> Optional[bytes]:
         if self.has_data:
-            if callable(self._data):
-                _bytes = self._data()
-            _bytes = self._data
+            _bytes = self._data() if callable(self._data) else self._data
             if isinstance(_bytes, bytes):
                 return _bytes
         return None

--- a/datumaro/plugins/data_formats/arrow/mapper/media.py
+++ b/datumaro/plugins/data_formats/arrow/mapper/media.py
@@ -217,7 +217,7 @@ class PointCloudMapper(MediaElementMapper):
         _bytes = None
         if isinstance(encoder, Callable):
             _bytes = encoder(obj)
-        else:
+        elif encoder != "NONE":
             _bytes = obj.data
         out["bytes"] = _bytes
 

--- a/tests/unit/data_formats/arrow/test_arrow_format.py
+++ b/tests/unit/data_formats/arrow/test_arrow_format.py
@@ -368,25 +368,25 @@ class ArrowFormatTest:
             ),
         ],
     )
-    def test_media_contents(self, fxt_dataset, save_media, test_dir, helper_tc, request):
+    def test_media_contents(self, fxt_dataset, save_media, test_dir, request):
         fxt_dataset = request.getfixturevalue(fxt_dataset)
 
         fxt_dataset.export(test_dir, format=self.format, save_media=save_media)
         imported_dataset = Dataset.import_from(test_dir)
         for item_a, item_b in zip(fxt_dataset, imported_dataset):
             if isinstance(item_a.media, FromFileMixin):
-                helper_tc.assertTrue(item_a.media.bytes is not None)
-            helper_tc.assertTrue(item_a.media.data is not None)
+                assert item_a.media.bytes is not None
+            assert item_a.media.data is not None
             if save_media:
-                helper_tc.assertTrue(item_b.media.bytes is not None)
-                helper_tc.assertTrue(item_b.media.data is not None)
+                assert item_b.media.bytes is not None
+                assert item_b.media.data is not None
             else:
                 if isinstance(item_a.media, FromFileMixin):
-                    helper_tc.assertTrue(item_b.media.bytes is not None)
-                    helper_tc.assertTrue(item_b.media.data is not None)
+                    assert item_b.media.bytes is not None
+                    assert item_b.media.data is not None
                 else:
-                    helper_tc.assertTrue(item_b.media.bytes is None)
-                    helper_tc.assertTrue(item_b.media.data is None)
+                    assert item_b.media.bytes is None
+                    assert item_b.media.data is None
 
     # Below is testing special cases...
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)

--- a/tests/unit/data_formats/arrow/test_arrow_format.py
+++ b/tests/unit/data_formats/arrow/test_arrow_format.py
@@ -12,7 +12,7 @@ import pytest
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.environment import Environment
 from datumaro.components.importer import DatasetImportError
-from datumaro.components.media import Image
+from datumaro.components.media import FromFileMixin, Image
 from datumaro.components.project import Dataset
 from datumaro.plugins.data_formats.arrow import ArrowExporter, ArrowImporter
 from datumaro.plugins.data_formats.arrow.arrow_dataset import ArrowDataset
@@ -342,6 +342,51 @@ class ArrowFormatTest:
 
         detected_formats = Environment().detect_dataset(test_dir)
         assert [self.importer.NAME] == detected_formats
+
+    @pytest.mark.parametrize(
+        ["fxt_dataset", "save_media"],
+        [
+            pytest.param(
+                "fxt_image",
+                True,
+                id="image_with_media",
+            ),
+            pytest.param(
+                "fxt_point_cloud",
+                True,
+                id="point_cloud_with_media",
+            ),
+            pytest.param(
+                "fxt_image",
+                False,
+                id="image_without_media",
+            ),
+            pytest.param(
+                "fxt_point_cloud",
+                False,
+                id="point_cloud_without_media",
+            ),
+        ],
+    )
+    def test_media_contents(self, fxt_dataset, save_media, test_dir, helper_tc, request):
+        fxt_dataset = request.getfixturevalue(fxt_dataset)
+
+        fxt_dataset.export(test_dir, format=self.format, save_media=save_media)
+        imported_dataset = Dataset.import_from(test_dir)
+        for item_a, item_b in zip(fxt_dataset, imported_dataset):
+            if isinstance(item_a.media, FromFileMixin):
+                helper_tc.assertTrue(item_a.media.bytes is not None)
+            helper_tc.assertTrue(item_a.media.data is not None)
+            if save_media:
+                helper_tc.assertTrue(item_b.media.bytes is not None)
+                helper_tc.assertTrue(item_b.media.data is not None)
+            else:
+                if isinstance(item_a.media, FromFileMixin):
+                    helper_tc.assertTrue(item_b.media.bytes is not None)
+                    helper_tc.assertTrue(item_b.media.data is not None)
+                else:
+                    helper_tc.assertTrue(item_b.media.bytes is None)
+                    helper_tc.assertTrue(item_b.media.data is None)
 
     # Below is testing special cases...
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -161,8 +161,7 @@ class ImageTest(TestCase):
                     img = Image.from_bytes(**args)
                     self.assertTrue(img.has_data)
                     np.testing.assert_array_equal(img.data, image)
-                    if img.bytes:
-                        self.assertEqual(img.bytes, image_bytes)
+                    self.assertEqual(img.bytes, image_bytes)
                     self.assertEqual(img.size, tuple(image.shape[:2]))
 
             with self.subTest():


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
- Fixed to initialize `Image` media from bytes not a decoded numpy array
- Fixed not to save `PointCloud` when `save_media=False`

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
Signed-off-by: Inhyuk Andy Cho <andy.inhyuk.jo@intel.com>