### PR TITLE
Move tfds-dev dependency to tests requirements

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Installing dependencies
         run: |
           python -m pip install -r tests/requirements.txt
-          python -m pip install -e '.[default,tf,tfds-dev]'
+          python -m pip install -e '.[default,tf]'
       - name: Code instrumentation
         run: |
           python -m pytest -v --cov --cov-report xml:coverage.xml

--- a/.github/workflows/nightly_check.yml
+++ b/.github/workflows/nightly_check.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Installing dependencies
         run: |
           python -m pip install -r tests/requirements.txt
-          python -m pip install -e '.[default,tf,tfds-dev]'
+          python -m pip install -e '.[default,tf]'
       - name: Nightly regression testing
         run: |
           python -m pytest -v --html=nightly_regression_test_report.html

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Installing dependencies
         run: |
           python -m pip install -r tests/requirements.txt
-          python -m pip install -e '.[default,tf,tfds-dev]'
+          python -m pip install -e '.[default,tf]'
       - name: Unit testing
         run: |
           python -m pytest -v tests/unit/ --cov

--- a/.github/workflows/weekly_check.yml
+++ b/.github/workflows/weekly_check.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Installing dependencies
         run: |
           python -m pip install -r tests/requirements.txt
-          python -m pip install -e '.[default,tf,tfds-dev]'
+          python -m pip install -e '.[default,tf]'
       - name: Stability testing
         run: |
           python -m pytest --html=stability_test_report.html --minutes 5

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -43,6 +43,7 @@ cryptography>= 38.03
 pyemd
 
 # apache arrow
-# protobuf >= 3.20 causes apache-beam installation failure on MacOS with Python 3.10
-protobuf==3.19.4; python_version == '3.10' and sys_platform == "darwin"
 pyarrow
+
+# ava data format
+protobuf

--- a/setup.py
+++ b/setup.py
@@ -88,9 +88,6 @@ setuptools.setup(
         "tfds": [
             "tensorflow-datasets<4.9.0"
         ],  # 4.9.0 fails on Windows and MacOS, https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
-        "tfds-dev": [
-            "tensorflow-datasets[dev]<4.9.0"
-        ],  # 4.9.0 fails on Windows and MacOS, https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
         "tf-gpu": ["tensorflow-gpu"],
         "default": DEFAULT_REQUIREMENTS,
     },

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,3 +6,7 @@ pytest-cov>=4.0.0
 pytest-stress
 pytest-html
 coverage
+
+# testing tensorflow-dataset
+# 4.9.0 fails on Windows and MacOS, https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
+tensorflow-datasets[dev]<4.9.0


### PR DESCRIPTION
### Summary

Moved tensorflow-datasets[dev] dependency, which is used for the tfds-extractor testing, from setup.py to tests/requirements.txt

nightly testing passed without any issues
https://github.com/openvinotoolkit/datumaro/actions/runs/4878913667/jobs/8704983352
