### PR TITLE
Enrich stack trace while importing dataset to improve user experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements
 - Use autosummary for fully-automatic Python module docs generation
   (<https://github.com/openvinotoolkit/datumaro/pull/973>)
+- Enrich stack trace for better user experience when importing
+  (<https://github.com/openvinotoolkit/datumaro/pull/992>)
 
 ### Bug fixes
 - Fix Mapillary Vistas data format

--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -1249,10 +1249,12 @@ class Dataset(IDataset):
             dataset = cls.from_extractors(*extractors, env=env, merge_policy=merge_policy)
             if eager:
                 dataset.init_cache()
-        except (_ImportFail, DatasetImportError, NotADirectoryError, FileNotFoundError) as e:
-            cause = e.__cause__ if isinstance(e, _ImportFail) else e
+        except _ImportFail as e:
+            cause = e.__cause__ if getattr(e, "__cause__", None) is not None else e
             cause.__traceback__ = e.__traceback__
             raise DatasetImportError(f"Failed to import dataset '{format}' at '{path}'.") from cause
+        except Exception as e:
+            raise DatasetImportError(f"Failed to import dataset '{format}' at '{path}'.") from e
 
         dataset._source_path = path
         dataset._format = format

--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -1249,8 +1249,8 @@ class Dataset(IDataset):
             dataset = cls.from_extractors(*extractors, env=env, merge_policy=merge_policy)
             if eager:
                 dataset.init_cache()
-        except _ImportFail as e:
-            cause = e.__cause__
+        except (_ImportFail, DatasetImportError) as e:
+            cause = e.__cause__ if isinstance(e, _ImportFail) else e
             cause.__traceback__ = e.__traceback__
             raise DatasetImportError(f"Failed to import dataset '{format}' at '{path}'.") from cause
 

--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -32,6 +32,7 @@ from datumaro.components.environment import DEFAULT_ENVIRONMENT, Environment
 from datumaro.components.errors import (
     CategoriesRedefinedError,
     ConflictingCategoriesError,
+    DatasetImportError,
     DatasetInfosRedefinedError,
     MediaTypeError,
     MultipleFormatsMatchError,
@@ -1249,7 +1250,9 @@ class Dataset(IDataset):
             if eager:
                 dataset.init_cache()
         except _ImportFail as e:
-            raise e.__cause__
+            cause = e.__cause__
+            cause.__traceback__ = e.__traceback__
+            raise DatasetImportError(f"Failed to import dataset '{format}' at '{path}'.") from cause
 
         dataset._source_path = path
         dataset._format = format

--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -1249,7 +1249,7 @@ class Dataset(IDataset):
             dataset = cls.from_extractors(*extractors, env=env, merge_policy=merge_policy)
             if eager:
                 dataset.init_cache()
-        except (_ImportFail, DatasetImportError) as e:
+        except (_ImportFail, DatasetImportError, NotADirectoryError, FileNotFoundError) as e:
             cause = e.__cause__ if isinstance(e, _ImportFail) else e
             cause.__traceback__ = e.__traceback__
             raise DatasetImportError(f"Failed to import dataset '{format}' at '{path}'.") from cause

--- a/datumaro/components/environment.py
+++ b/datumaro/components/environment.py
@@ -294,7 +294,9 @@ class Environment:
             else FormatDetectionConfidence.NONE
         )
 
-        return [str(format) for format in all_matched_formats if format.confidence == max_conf]
+        return sorted(
+            [str(format) for format in all_matched_formats if format.confidence == max_conf]
+        )
 
     def __reduce__(self):
         return (self.__class__, ())

--- a/datumaro/components/errors.py
+++ b/datumaro/components/errors.py
@@ -272,10 +272,12 @@ class AnnotationImportError(ItemImportError):
 
 @define(auto_exc=False)
 class DatasetNotFoundError(DatasetImportError):
-    path = field()
+    path: str = field()
+    format: str = field()
+    template: str = field(default="Failed to find dataset '{format}' at '{path}'")
 
     def __str__(self):
-        return f"Failed to find dataset at '{self.path}'"
+        return self.template.format(path=self.path, format=self.format)
 
 
 @define(auto_exc=False)

--- a/datumaro/components/importer.py
+++ b/datumaro/components/importer.py
@@ -113,11 +113,11 @@ class Importer(CliPlugin):
 
     def __call__(self, path, **extra_params):
         if not path or not osp.exists(path):
-            raise DatasetNotFoundError(path)
+            raise DatasetNotFoundError(path, self.NAME)
 
         found_sources = self.find_sources_with_params(osp.normpath(path), **extra_params)
         if not found_sources:
-            raise DatasetNotFoundError(path)
+            raise DatasetNotFoundError(path, self.NAME)
 
         sources = []
         for desc in found_sources:

--- a/datumaro/plugins/data_formats/ade20k2017.py
+++ b/datumaro/plugins/data_formats/ade20k2017.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import glob
 import logging as log
 import os
@@ -33,12 +34,12 @@ class Ade20k2017Path:
 class Ade20k2017Base(DatasetBase):
     def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         # exclude dataset meta file
         subsets = [subset for subset in os.listdir(path) if osp.splitext(subset)[-1] != ".json"]
         if len(subsets) < 1:
-            raise FileNotFoundError("Can't read subsets in directory '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find subsets in directory", path)
 
         super().__init__(subsets=sorted(subsets), ctx=ctx)
         self._path = path
@@ -129,7 +130,9 @@ class Ade20k2017Base(DatasetBase):
     def _load_item_info(self, path):
         attr_path = osp.splitext(path)[0] + "_atr.txt"
         if not osp.isfile(attr_path):
-            raise FileNotFoundError("Can't find annotation file for image %s" % path)
+            raise FileNotFoundError(
+                errno.ENOENT, "Can't find annotation file for image %s" % path, attr_path
+            )
 
         item_info = []
         with open(attr_path, "r", encoding="utf-8") as f:

--- a/datumaro/plugins/data_formats/ade20k2017.py
+++ b/datumaro/plugins/data_formats/ade20k2017.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -7,13 +7,14 @@ import logging as log
 import os
 import os.path as osp
 import re
+from typing import Optional
 
 import numpy as np
 
 from datumaro.components.annotation import AnnotationType, CompiledMask, LabelCategories, Mask
 from datumaro.components.dataset_base import DatasetBase, DatasetItem
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.image import IMAGE_EXTENSIONS, find_images, lazy_image, load_image
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
@@ -29,7 +30,7 @@ class Ade20k2017Path:
 
 
 class Ade20k2017Base(DatasetBase):
-    def __init__(self, path):
+    def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
             raise FileNotFoundError("Can't read dataset directory '%s'" % path)
 
@@ -38,7 +39,7 @@ class Ade20k2017Base(DatasetBase):
         if len(subsets) < 1:
             raise FileNotFoundError("Can't read subsets in directory '%s'" % path)
 
-        super().__init__(subsets=sorted(subsets))
+        super().__init__(subsets=sorted(subsets), ctx=ctx)
         self._path = path
 
         self._items = []

--- a/datumaro/plugins/data_formats/ade20k2017.py
+++ b/datumaro/plugins/data_formats/ade20k2017.py
@@ -13,6 +13,7 @@ import numpy as np
 
 from datumaro.components.annotation import AnnotationType, CompiledMask, LabelCategories, Mask
 from datumaro.components.dataset_base import DatasetBase, DatasetItem
+from datumaro.components.errors import InvalidAnnotationError
 from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
@@ -32,7 +33,7 @@ class Ade20k2017Path:
 class Ade20k2017Base(DatasetBase):
     def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
-            raise FileNotFoundError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
 
         # exclude dataset meta file
         subsets = [subset for subset in os.listdir(path) if osp.splitext(subset)[-1] != ".json"]
@@ -128,16 +129,16 @@ class Ade20k2017Base(DatasetBase):
     def _load_item_info(self, path):
         attr_path = osp.splitext(path)[0] + "_atr.txt"
         if not osp.isfile(attr_path):
-            raise Exception("Can't find annotation file for image %s" % path)
+            raise FileNotFoundError("Can't find annotation file for image %s" % path)
 
         item_info = []
         with open(attr_path, "r", encoding="utf-8") as f:
             for line in f:
                 columns = [s.strip() for s in line.split("#")]
                 if len(columns) != 6:
-                    raise Exception("Invalid line in %s" % attr_path)
+                    raise InvalidAnnotationError("Invalid line in %s" % attr_path)
                 if columns[5][0] != '"' or columns[5][-1] != '"':
-                    raise Exception(
+                    raise InvalidAnnotationError(
                         "Attributes column are expected \
                         in double quotes, file %s"
                         % attr_path

--- a/datumaro/plugins/data_formats/ade20k2020.py
+++ b/datumaro/plugins/data_formats/ade20k2020.py
@@ -40,7 +40,7 @@ class Ade20k2020Path:
 class Ade20k2020Base(DatasetBase):
     def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
-            raise FileNotFoundError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
 
         # exclude dataset meta file
         subsets = [subset for subset in os.listdir(path) if osp.splitext(subset)[-1] != ".json"]
@@ -168,7 +168,7 @@ class Ade20k2020Base(DatasetBase):
         json_path = osp.splitext(path)[0] + ".json"
         item_info = []
         if not osp.isfile(json_path):
-            raise Exception(
+            raise FileNotFoundError(
                 "Can't find annotation file (*.json) \
                 for image %s"
                 % path

--- a/datumaro/plugins/data_formats/ade20k2020.py
+++ b/datumaro/plugins/data_formats/ade20k2020.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -7,6 +7,7 @@ import logging as log
 import os
 import os.path as osp
 import re
+from typing import Optional
 
 import numpy as np
 
@@ -19,7 +20,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.dataset_base import DatasetBase, DatasetItem
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import parse_json
 from datumaro.util.image import IMAGE_EXTENSIONS, find_images, lazy_image, load_image
@@ -37,7 +38,7 @@ class Ade20k2020Path:
 
 
 class Ade20k2020Base(DatasetBase):
-    def __init__(self, path):
+    def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
             raise FileNotFoundError("Can't read dataset directory '%s'" % path)
 
@@ -46,7 +47,7 @@ class Ade20k2020Base(DatasetBase):
         if len(subsets) < 1:
             raise FileNotFoundError("Can't read subsets in directory '%s'" % path)
 
-        super().__init__(subsets=sorted(subsets))
+        super().__init__(subsets=sorted(subsets), ctx=ctx)
         self._path = path
 
         self._items = []

--- a/datumaro/plugins/data_formats/ade20k2020.py
+++ b/datumaro/plugins/data_formats/ade20k2020.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import glob
 import logging as log
 import os
@@ -40,12 +41,12 @@ class Ade20k2020Path:
 class Ade20k2020Base(DatasetBase):
     def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         # exclude dataset meta file
         subsets = [subset for subset in os.listdir(path) if osp.splitext(subset)[-1] != ".json"]
         if len(subsets) < 1:
-            raise FileNotFoundError("Can't read subsets in directory '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find subsets in directory", path)
 
         super().__init__(subsets=sorted(subsets), ctx=ctx)
         self._path = path
@@ -169,9 +170,7 @@ class Ade20k2020Base(DatasetBase):
         item_info = []
         if not osp.isfile(json_path):
             raise FileNotFoundError(
-                "Can't find annotation file (*.json) \
-                for image %s"
-                % path
+                errno.ENOENT, "Can't find annotation file for image %s" % path, json_path
             )
 
         with open(json_path, "r", encoding="latin-1") as f:

--- a/datumaro/plugins/data_formats/arrow/base.py
+++ b/datumaro/plugins/data_formats/arrow/base.py
@@ -4,11 +4,13 @@
 
 import os.path as osp
 import struct
+from typing import List, Optional
 
 import pyarrow as pa
 
 from datumaro.components.dataset_base import SubsetBase
 from datumaro.components.errors import MediaTypeError
+from datumaro.components.importer import ImportContext
 from datumaro.components.media import MediaType
 from datumaro.components.merge import get_merger
 from datumaro.plugins.data_formats.datumaro.base import DatumaroBase
@@ -19,10 +21,19 @@ from .mapper.dataset_item import DatasetItemMapper
 
 
 class ArrowBase(SubsetBase):
-    def __init__(self, path, ctx, subset, additional_paths=[]):
+    def __init__(
+        self,
+        path: str,
+        additional_paths: Optional[List[str]] = None,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         super().__init__(subset=subset, ctx=ctx)
 
-        self._paths = [path] + additional_paths
+        self._paths = [path]
+        if additional_paths:
+            self._paths += additional_paths
 
         self._load()
 

--- a/datumaro/plugins/data_formats/ava/ava.py
+++ b/datumaro/plugins/data_formats/ava/ava.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import csv
+import errno
 import os
 import os.path as osp
 from typing import Optional
@@ -41,7 +42,7 @@ class AvaBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError(f"Can't find CSV file at '{path}'")
+            raise FileNotFoundError(errno.ENOENT, "Can't find CSV file", path)
         self._path = path
 
         if not subset:
@@ -56,16 +57,18 @@ class AvaBase(SubsetBase):
             self._rootpath = path.rsplit(AvaPath.ANNOTATION_DIR, maxsplit=1)[0]
         else:
             raise FileNotFoundError(
+                errno.ENOENT,
                 f"Annotation path ({path}) should be under the directory which is named {AvaPath.ANNOTATION_DIR}. "
-                "If not, Datumaro fails to find the root path for this dataset."
+                "If not, Datumaro fails to find the root path for this dataset.",
             )
 
         if self._rootpath and osp.isdir(osp.join(self._rootpath, AvaPath.IMAGE_DIR)):
             self._images_dir = osp.join(self._rootpath, AvaPath.IMAGE_DIR)
         else:
             raise FileNotFoundError(
+                errno.ENOENT,
                 f"Root path ({self._rootpath}) should contain the directory which is named {AvaPath.IMAGE_DIR}. "
-                "If not, Datumaro fails to find the image directory path."
+                "If not, Datumaro fails to find the image directory path.",
             )
 
         self._infos = self._load_infos(osp.dirname(path))
@@ -87,8 +90,9 @@ class AvaBase(SubsetBase):
     def _load_categories(self, category_path):
         if not osp.exists(category_path):
             raise FileNotFoundError(
+                errno.ENOENT,
                 f"Label lists cannot be found in ({category_path}). "
-                "If not, Datumaro fails to import AVA action dataset."
+                "If not, Datumaro fails to import AVA action dataset.",
             )
 
         with open(category_path, "r") as f:

--- a/datumaro/plugins/data_formats/ava/ava.py
+++ b/datumaro/plugins/data_formats/ava/ava.py
@@ -11,7 +11,7 @@ import google.protobuf.text_format as text_format
 
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
-from datumaro.components.errors import DatasetImportError, MediaTypeError
+from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
 from datumaro.components.importer import ImportContext, Importer
@@ -41,7 +41,7 @@ class AvaBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise DatasetImportError(f"Can't find CSV file at '{path}'")
+            raise FileNotFoundError(f"Can't find CSV file at '{path}'")
         self._path = path
 
         if not subset:
@@ -55,7 +55,7 @@ class AvaBase(SubsetBase):
         if path.endswith(osp.join(AvaPath.ANNOTATION_DIR, osp.basename(path))):
             self._rootpath = path.rsplit(AvaPath.ANNOTATION_DIR, maxsplit=1)[0]
         else:
-            raise DatasetImportError(
+            raise FileNotFoundError(
                 f"Annotation path ({path}) should be under the directory which is named {AvaPath.ANNOTATION_DIR}. "
                 "If not, Datumaro fails to find the root path for this dataset."
             )
@@ -63,7 +63,7 @@ class AvaBase(SubsetBase):
         if self._rootpath and osp.isdir(osp.join(self._rootpath, AvaPath.IMAGE_DIR)):
             self._images_dir = osp.join(self._rootpath, AvaPath.IMAGE_DIR)
         else:
-            raise DatasetImportError(
+            raise FileNotFoundError(
                 f"Root path ({self._rootpath}) should contain the directory which is named {AvaPath.IMAGE_DIR}. "
                 "If not, Datumaro fails to find the image directory path."
             )
@@ -86,7 +86,7 @@ class AvaBase(SubsetBase):
 
     def _load_categories(self, category_path):
         if not osp.exists(category_path):
-            raise DatasetImportError(
+            raise FileNotFoundError(
                 f"Label lists cannot be found in ({category_path}). "
                 "If not, Datumaro fails to import AVA action dataset."
             )

--- a/datumaro/plugins/data_formats/ava/ava.py
+++ b/datumaro/plugins/data_formats/ava/ava.py
@@ -1,10 +1,11 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import csv
 import os
 import os.path as osp
+from typing import Optional
 
 import google.protobuf.text_format as text_format
 
@@ -13,7 +14,7 @@ from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import DatasetImportError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.os_util import find_files
 
@@ -32,17 +33,24 @@ class AvaPath:
 
 
 class AvaBase(SubsetBase):
-    def __init__(self, path):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise DatasetImportError(f"Can't find CSV file at '{path}'")
         self._path = path
 
-        subset = (
-            osp.splitext(osp.basename(path))[0]
-            .replace(AvaPath.ANNOTATION_PREFIX, "")
-            .replace(AvaPath.ANNOTATION_VERSION, "")
-        )
-        super().__init__(subset=subset)
+        if not subset:
+            subset = (
+                osp.splitext(osp.basename(path))[0]
+                .replace(AvaPath.ANNOTATION_PREFIX, "")
+                .replace(AvaPath.ANNOTATION_VERSION, "")
+            )
+        super().__init__(subset=subset, ctx=ctx)
 
         if path.endswith(osp.join(AvaPath.ANNOTATION_DIR, osp.basename(path))):
             self._rootpath = path.rsplit(AvaPath.ANNOTATION_DIR, maxsplit=1)[0]

--- a/datumaro/plugins/data_formats/brats.py
+++ b/datumaro/plugins/data_formats/brats.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import glob
 import os.path as osp
 from typing import Optional
@@ -25,7 +26,7 @@ class BratsPath:
 class BratsBase(SubsetBase):
     def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         self._subset_suffix = osp.basename(path)[len(BratsPath.IMAGES_DIR) :]
         subset = None

--- a/datumaro/plugins/data_formats/brats.py
+++ b/datumaro/plugins/data_formats/brats.py
@@ -1,9 +1,10 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import glob
 import os.path as osp
+from typing import Optional
 
 import nibabel as nib
 import numpy as np
@@ -11,7 +12,7 @@ import numpy as np
 from datumaro.components.annotation import AnnotationType, LabelCategories, Mask
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import MultiframeImage
 
 
@@ -22,7 +23,7 @@ class BratsPath:
 
 
 class BratsBase(SubsetBase):
-    def __init__(self, path):
+    def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
             raise FileNotFoundError("Can't read dataset directory '%s'" % path)
 
@@ -32,7 +33,7 @@ class BratsBase(SubsetBase):
             subset = "train"
         elif self._subset_suffix == "Ts":
             subset = "test"
-        super().__init__(subset=subset, media_type=MultiframeImage)
+        super().__init__(subset=subset, media_type=MultiframeImage, ctx=ctx)
 
         self._root_dir = osp.dirname(path)
         self._categories = self._load_categories()

--- a/datumaro/plugins/data_formats/brats.py
+++ b/datumaro/plugins/data_formats/brats.py
@@ -25,7 +25,7 @@ class BratsPath:
 class BratsBase(SubsetBase):
     def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
-            raise FileNotFoundError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
 
         self._subset_suffix = osp.basename(path)[len(BratsPath.IMAGES_DIR) :]
         subset = None

--- a/datumaro/plugins/data_formats/brats_numpy.py
+++ b/datumaro/plugins/data_formats/brats_numpy.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os.path as osp
 from typing import Optional
 
@@ -32,7 +33,7 @@ class BratsNumpyBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Can't read annotation file '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
 
         super().__init__(subset=subset, media_type=MultiframeImage, ctx=ctx)
 

--- a/datumaro/plugins/data_formats/brats_numpy.py
+++ b/datumaro/plugins/data_formats/brats_numpy.py
@@ -1,15 +1,16 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
+from typing import Optional
 
 import numpy as np
 
 from datumaro.components.annotation import AnnotationType, Cuboid3d, LabelCategories, Mask
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import MultiframeImage
 from datumaro.util.pickle_util import PickleLoader
 
@@ -23,11 +24,17 @@ class BratsNumpyPath:
 
 
 class BratsNumpyBase(SubsetBase):
-    def __init__(self, path):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise FileNotFoundError("Can't read annotation file '%s'" % path)
 
-        super().__init__(media_type=MultiframeImage)
+        super().__init__(subset=subset, media_type=MultiframeImage, ctx=ctx)
 
         self._root_dir = osp.dirname(path)
         self._categories = self._load_categories()

--- a/datumaro/plugins/data_formats/camvid.py
+++ b/datumaro/plugins/data_formats/camvid.py
@@ -21,7 +21,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.dataset import ItemStatus
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
-from datumaro.components.errors import MediaTypeError
+from datumaro.components.errors import AnnotationExportError, InvalidAnnotationError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.importer import ImportContext, Importer
@@ -100,7 +100,7 @@ def parse_label_map(path):
                 color = None
 
             if name in label_map:
-                raise ValueError("Label '%s' is already defined" % name)
+                raise InvalidAnnotationError("Label '%s' is already defined" % name)
 
             label_map[name] = color
     return label_map
@@ -160,7 +160,9 @@ def _parse_annotation_line(line: str) -> Tuple[str, Optional[str]]:
             objects[0] = objects[1]
             objects[1] = objects[3]
         else:
-            raise Exception("Line %s: unexpected number " "of quotes in filename" % line)
+            raise InvalidAnnotationError(
+                "Line %s: unexpected number " "of quotes in filename" % line
+            )
     else:
         objects = line.split()
 
@@ -422,7 +424,7 @@ class CamvidExporter(Exporter):
                 label_map = parse_label_map(label_map_source)
 
         else:
-            raise Exception(
+            raise AnnotationExportError(
                 "Wrong labelmap specified, "
                 "expected one of %s or a file path" % ", ".join(t.name for t in LabelmapType)
             )

--- a/datumaro/plugins/data_formats/camvid.py
+++ b/datumaro/plugins/data_formats/camvid.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -24,7 +24,7 @@ from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import find, str_to_bool
 from datumaro.util.annotation_util import make_label_id_mapping
@@ -171,14 +171,21 @@ def _parse_annotation_line(line: str) -> Tuple[str, Optional[str]]:
 
 
 class CamvidBase(SubsetBase):
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         assert osp.isfile(path), path
         self._path = path
         self._dataset_dir = osp.dirname(path)
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]
-        super().__init__(subset=subset)
+
+        super().__init__(subset=subset, ctx=ctx)
 
         self._categories = self._load_categories(self._dataset_dir)
         self._items = list(self._load_items(path).values())

--- a/datumaro/plugins/data_formats/celeba/align_celeba.py
+++ b/datumaro/plugins/data_formats/celeba/align_celeba.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
+import os
 import os.path as osp
 from typing import Optional
 
@@ -40,7 +42,7 @@ class AlignCelebaBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         super().__init__(subset=subset, ctx=ctx)
         self._anno_dir = osp.dirname(path)
@@ -70,7 +72,7 @@ class AlignCelebaBase(SubsetBase):
 
         labels_path = osp.join(root_dir, AlignCelebaPath.LABELS_FILE)
         if not osp.isfile(labels_path):
-            raise FileNotFoundError("File '%s': was not found" % labels_path)
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), labels_path)
 
         with open(labels_path, encoding="utf-8") as f:
             for line in f:

--- a/datumaro/plugins/data_formats/celeba/celeba.py
+++ b/datumaro/plugins/data_formats/celeba/celeba.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
+from typing import Optional
 
 from datumaro.components.annotation import (
     AnnotationType,
@@ -15,7 +16,7 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import DatasetImportError
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.image import find_images
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
@@ -33,11 +34,17 @@ class CelebaPath:
 
 
 class CelebaBase(SubsetBase):
-    def __init__(self, path):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isdir(path):
-            raise FileNotFoundError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
 
-        super().__init__()
+        super().__init__(subset=subset, ctx=ctx)
 
         self._categories = {AnnotationType.label: LabelCategories()}
         if has_meta_file(path):
@@ -64,7 +71,9 @@ class CelebaBase(SubsetBase):
 
         labels_path = osp.join(root_dir, CelebaPath.LABELS_FILE)
         if not osp.isfile(labels_path):
-            raise DatasetImportError("File '%s': was not found" % labels_path)
+            self._ctx.error_policy.fail(
+                DatasetImportError("File '%s': was not found" % labels_path)
+            )
 
         with open(labels_path, encoding="utf-8") as f:
             for line in f:
@@ -98,16 +107,23 @@ class CelebaBase(SubsetBase):
                     landmarks = [float(id) for id in item_ann]
 
                     if len(landmarks) != len(point_cat):
-                        raise DatasetImportError(
-                            "File '%s', line %s: "
-                            "points do not match the header of this file" % (landmark_path, line)
+                        self._ctx.error_policy.report_annotation_error(
+                            DatasetImportError(
+                                "File '%s', line %s: "
+                                "points do not match the header of this file"
+                                % (landmark_path, line)
+                            ),
+                            item_id=(item_id, self._subset),
                         )
 
                     if item_id not in items:
-                        raise DatasetImportError(
-                            "File '%s', line %s: "
-                            "for this item are not label in %s "
-                            % (landmark_path, line, CelebaPath.LABELS_FILE)
+                        self._ctx.error_policy.report_annotation_error(
+                            DatasetImportError(
+                                "File '%s', line %s: "
+                                "for this item are not label in %s "
+                                % (landmark_path, line, CelebaPath.LABELS_FILE)
+                            ),
+                            item_id=(item_id, self._subset),
                         )
 
                     anno = items[item_id].annotations
@@ -115,10 +131,12 @@ class CelebaBase(SubsetBase):
                     anno.append(Points(landmarks, label=label))
 
                 if landmarks_number - 1 != counter:
-                    raise DatasetImportError(
-                        "File '%s': the number of "
-                        "landmarks does not match the specified number "
-                        "at the beginning of the file " % landmark_path
+                    self._ctx.error_policy.fail(
+                        DatasetImportError(
+                            "File '%s': the number of "
+                            "landmarks does not match the specified number "
+                            "at the beginning of the file " % landmark_path
+                        )
                     )
 
         bbox_path = osp.join(root_dir, CelebaPath.BBOXES_FILE)
@@ -127,10 +145,12 @@ class CelebaBase(SubsetBase):
                 bboxes_number = int(f.readline().strip())
 
                 if f.readline().strip() != CelebaPath.BBOXES_HEADER:
-                    raise DatasetImportError(
-                        "File '%s': the header "
-                        "does not match the expected format '%s'"
-                        % (bbox_path, CelebaPath.BBOXES_HEADER)
+                    self._ctx.error_policy.fail(
+                        DatasetImportError(
+                            "File '%s': the header "
+                            "does not match the expected format '%s'"
+                            % (bbox_path, CelebaPath.BBOXES_HEADER)
+                        )
                     )
 
                 counter = 0
@@ -139,10 +159,13 @@ class CelebaBase(SubsetBase):
                     bbox = [float(id) for id in item_ann]
 
                     if item_id not in items:
-                        raise DatasetImportError(
-                            "File '%s', line %s: "
-                            "for this item are not label in %s "
-                            % (bbox_path, line, CelebaPath.LABELS_FILE)
+                        self._ctx.error_policy.report_annotation_error(
+                            DatasetImportError(
+                                "File '%s', line %s: "
+                                "for this item are not label in %s "
+                                % (bbox_path, line, CelebaPath.LABELS_FILE)
+                            ),
+                            item_id=(item_id, self._subset),
                         )
 
                     anno = items[item_id].annotations
@@ -150,10 +173,12 @@ class CelebaBase(SubsetBase):
                     anno.append(Bbox(bbox[0], bbox[1], bbox[2], bbox[3], label=label))
 
                 if bboxes_number - 1 != counter:
-                    raise DatasetImportError(
-                        "File '%s': the number of bounding "
-                        "boxes does not match the specified number "
-                        "at the beginning of the file " % bbox_path
+                    self._ctx.error_policy.fail(
+                        DatasetImportError(
+                            "File '%s': the number of bounding "
+                            "boxes does not match the specified number "
+                            "at the beginning of the file " % bbox_path
+                        )
                     )
 
         attr_path = osp.join(root_dir, CelebaPath.ATTRS_FILE)
@@ -166,11 +191,14 @@ class CelebaBase(SubsetBase):
                 for counter, line in enumerate(f):
                     item_id, item_ann = self.split_annotation(line)
                     if len(attr_names) != len(item_ann):
-                        raise DatasetImportError(
-                            "File '%s', line %s: "
-                            "the number of attributes "
-                            "in the line does not match the number at the "
-                            "beginning of the file " % (attr_path, line)
+                        self._ctx.error_policy.report_item_error(
+                            DatasetImportError(
+                                "File '%s', line %s: "
+                                "the number of attributes "
+                                "in the line does not match the number at the "
+                                "beginning of the file " % (attr_path, line)
+                            ),
+                            item_id=(item_id, self._subset),
                         )
 
                     attrs = {name: 0 < int(ann) for name, ann in zip(attr_names, item_ann)}
@@ -185,10 +213,12 @@ class CelebaBase(SubsetBase):
                     items[item_id].attributes = attrs
 
                 if attr_number - 1 != counter:
-                    raise DatasetImportError(
-                        "File %s: the number of items "
-                        "with attributes does not match the specified number "
-                        "at the beginning of the file " % attr_path
+                    self._ctx.error_policy.fail(
+                        DatasetImportError(
+                            "File %s: the number of items "
+                            "with attributes does not match the specified number "
+                            "at the beginning of the file " % attr_path
+                        )
                     )
 
         subset_path = osp.join(root_dir, CelebaPath.SUBSETS_FILE)

--- a/datumaro/plugins/data_formats/celeba/celeba.py
+++ b/datumaro/plugins/data_formats/celeba/celeba.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
+import os
 import os.path as osp
 from typing import Optional
 
@@ -42,7 +44,7 @@ class CelebaBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         super().__init__(subset=subset, ctx=ctx)
 
@@ -71,7 +73,7 @@ class CelebaBase(SubsetBase):
 
         labels_path = osp.join(root_dir, CelebaPath.LABELS_FILE)
         if not osp.isfile(labels_path):
-            raise FileNotFoundError("File '%s': was not found" % labels_path)
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), labels_path)
 
         with open(labels_path, encoding="utf-8") as f:
             for line in f:

--- a/datumaro/plugins/data_formats/cifar.py
+++ b/datumaro/plugins/data_formats/cifar.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os
 import os.path as osp
 import pickle  # nosec import_pickle
@@ -56,7 +57,7 @@ class CifarBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Can't read annotation file '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]

--- a/datumaro/plugins/data_formats/cifar.py
+++ b/datumaro/plugins/data_formats/cifar.py
@@ -13,7 +13,7 @@ import numpy as np
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.dataset import ItemStatus
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
-from datumaro.components.errors import MediaTypeError
+from datumaro.components.errors import InvalidAnnotationError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
 from datumaro.components.importer import ImportContext, Importer
@@ -127,10 +127,14 @@ class CifarBase(SubsetBase):
         size = annotation_dict.get("image_sizes")
 
         if len(labels) != len(filenames):
-            raise Exception("The sizes of the arrays 'filenames', " "'labels' don't match.")
+            raise InvalidAnnotationError(
+                "The sizes of the arrays 'filenames', " "'labels' don't match."
+            )
 
         if 0 < len(images_data) and len(images_data) != len(filenames):
-            raise Exception("The sizes of the arrays 'data', " "'filenames', 'labels' don't match.")
+            raise InvalidAnnotationError(
+                "The sizes of the arrays 'data', " "'filenames', 'labels' don't match."
+            )
 
         for i, (filename, label) in enumerate(zip(filenames, labels)):
             item_id = osp.splitext(filename)[0]

--- a/datumaro/plugins/data_formats/cifar.py
+++ b/datumaro/plugins/data_formats/cifar.py
@@ -16,7 +16,7 @@ from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import cast
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
@@ -48,14 +48,20 @@ Cifar10Label = [
 
 
 class CifarBase(SubsetBase):
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise FileNotFoundError("Can't read annotation file '%s'" % path)
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]
 
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
 
         self._categories = self._load_categories(osp.dirname(path))
         self._items = list(self._load_items(path).values())

--- a/datumaro/plugins/data_formats/cityscapes.py
+++ b/datumaro/plugins/data_formats/cityscapes.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -8,6 +8,7 @@ import os
 import os.path as osp
 from collections import OrderedDict
 from enum import Enum, auto
+from typing import Optional
 
 import numpy as np
 
@@ -23,7 +24,7 @@ from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import find
 from datumaro.util.annotation_util import make_label_id_mapping
@@ -182,7 +183,13 @@ def write_label_map(path, label_map):
 
 
 class CityscapesBase(SubsetBase):
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         assert osp.isdir(path), path
 
         if not subset:
@@ -199,11 +206,10 @@ class CityscapesBase(SubsetBase):
             images_dir = path
             annotations_dir = osp.join(self._path, CityscapesPath.GT_FINE_DIR, subset)
 
-        self._subset = subset
         self._images_dir = images_dir
         self._gt_anns_dir = annotations_dir
 
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
 
         self._items = list(self._load_items().values())
 

--- a/datumaro/plugins/data_formats/cityscapes.py
+++ b/datumaro/plugins/data_formats/cityscapes.py
@@ -21,7 +21,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.dataset import ItemStatus
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
-from datumaro.components.errors import MediaTypeError
+from datumaro.components.errors import AnnotationExportError, InvalidAnnotationError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.importer import ImportContext, Importer
@@ -166,7 +166,7 @@ def parse_label_map(path):
                 color = None
 
             if name in label_map:
-                raise ValueError("Label '%s' is already defined" % name)
+                raise InvalidAnnotationError("Label '%s' is already defined" % name)
 
             label_map[name] = color
     return label_map
@@ -481,7 +481,7 @@ class CityscapesExporter(Exporter):
                 label_map = parse_label_map(label_map_source)
 
         else:
-            raise Exception(
+            raise AnnotationExportError(
                 "Wrong labelmap specified, "
                 "expected one of %s or a file path" % ", ".join(t.name for t in LabelmapType)
             )

--- a/datumaro/plugins/data_formats/coco/base.py
+++ b/datumaro/plugins/data_formats/coco/base.py
@@ -120,7 +120,7 @@ class _CocoBase(SubsetBase):
             self._rootpath = RoboflowDirPathExtracter.find_rootpath(path)
             self._images_dir = RoboflowDirPathExtracter.find_images_dir(self._rootpath, subset)
         else:
-            raise ValueError(coco_importer_type)
+            raise DatasetImportError(f"Not supported type: {coco_importer_type}")
 
         self._task = task
 

--- a/datumaro/plugins/data_formats/coco/base.py
+++ b/datumaro/plugins/data_formats/coco/base.py
@@ -5,7 +5,7 @@
 import logging as log
 import os.path as osp
 from inspect import isclass
-from typing import Any, Dict, Tuple, Type, TypeVar, Union, overload
+from typing import Any, Dict, Optional, Tuple, Type, TypeVar, Union, overload
 
 import pycocotools.mask as mask_utils
 from attrs import define
@@ -31,6 +31,7 @@ from datumaro.components.errors import (
     MissingFieldError,
     UndeclaredLabelError,
 )
+from datumaro.components.importer import ImportContext
 from datumaro.components.media import Image
 from datumaro.util import NOTSET, parse_json_file, take_by
 from datumaro.util.image import lazy_image, load_image
@@ -96,11 +97,11 @@ class _CocoBase(SubsetBase):
         path,
         task,
         *,
-        merge_instance_polygons=False,
-        subset=None,
-        keep_original_category_ids=False,
+        merge_instance_polygons: bool = False,
+        keep_original_category_ids: bool = False,
         coco_importer_type: CocoImporterType = CocoImporterType.default,
-        **kwargs,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
             raise DatasetImportError(f"Can't find JSON file at '{path}'")
@@ -109,7 +110,7 @@ class _CocoBase(SubsetBase):
         if not subset:
             parts = osp.splitext(osp.basename(path))[0].split(task.name + "_", maxsplit=1)
             subset = parts[1] if len(parts) == 2 else None
-        super().__init__(subset=subset, **kwargs)
+        super().__init__(subset=subset, ctx=ctx)
 
         if coco_importer_type == CocoImporterType.default:
             self._rootpath = DirPathExtracter.find_rootpath(path)

--- a/datumaro/plugins/data_formats/coco/base.py
+++ b/datumaro/plugins/data_formats/coco/base.py
@@ -104,7 +104,7 @@ class _CocoBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise DatasetImportError(f"Can't find JSON file at '{path}'")
+            raise FileNotFoundError(f"Can't find JSON file at '{path}'")
         self._path = path
 
         if not subset:

--- a/datumaro/plugins/data_formats/coco/base.py
+++ b/datumaro/plugins/data_formats/coco/base.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import logging as log
 import os.path as osp
 from inspect import isclass
@@ -104,7 +105,7 @@ class _CocoBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError(f"Can't find JSON file at '{path}'")
+            raise FileNotFoundError(errno.ENOENT, "Can't find JSON file", path)
         self._path = path
 
         if not subset:

--- a/datumaro/plugins/data_formats/coco/importer.py
+++ b/datumaro/plugins/data_formats/coco/importer.py
@@ -7,6 +7,7 @@ import os.path as osp
 from glob import glob
 
 from datumaro.components.dataset_base import DEFAULT_SUBSET_NAME
+from datumaro.components.errors import DatasetNotFoundError
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
 from datumaro.components.importer import Importer
 from datumaro.plugins.data_formats.coco.base import (
@@ -67,7 +68,7 @@ class CocoImporter(Importer):
         subsets = self.find_sources(path)
 
         if len(subsets) == 0:
-            raise Exception("Failed to find 'coco' dataset at '%s'" % path)
+            raise DatasetNotFoundError(path, self.NAME)
 
         # TODO: should be removed when proper label merging is implemented
         conflicting_types = {

--- a/datumaro/plugins/data_formats/common_semantic_segmentation.py
+++ b/datumaro/plugins/data_formats/common_semantic_segmentation.py
@@ -1,9 +1,10 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import glob
 import os.path as osp
+from typing import Optional
 
 import numpy as np
 
@@ -11,7 +12,7 @@ from datumaro.components.annotation import AnnotationType, LabelCategories, Mask
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import DatasetImportError
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
-from datumaro.components.importer import Importer, with_subset_dirs
+from datumaro.components.importer import ImportContext, Importer, with_subset_dirs
 from datumaro.components.media import Image
 from datumaro.util.image import find_images
 from datumaro.util.mask_tools import generate_colormap, lazy_mask
@@ -48,15 +49,17 @@ def make_categories(label_map=None):
 class CommonSemanticSegmentationBase(SubsetBase):
     def __init__(
         self,
-        path,
-        subset=None,
-        image_prefix="",
-        mask_prefix="",
+        path: str,
+        *,
+        image_prefix: str = "",
+        mask_prefix: str = "",
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
             raise FileNotFoundError("Can't read dataset directory '%s'" % path)
 
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
 
         self._image_prefix = image_prefix
         self._mask_prefix = mask_prefix

--- a/datumaro/plugins/data_formats/common_semantic_segmentation.py
+++ b/datumaro/plugins/data_formats/common_semantic_segmentation.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import glob
 import os.path as osp
 from typing import Optional
@@ -56,7 +57,7 @@ class CommonSemanticSegmentationBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         super().__init__(subset=subset, ctx=ctx)
 
@@ -70,7 +71,7 @@ class CommonSemanticSegmentationBase(SubsetBase):
             label_map = parse_meta_file(meta_file[0])
             self._categories = make_categories(label_map)
         else:
-            raise FileNotFoundError("Dataset meta info file was not found in %s" % path)
+            raise FileNotFoundError(errno.ENOENT, "Dataset meta info file was not found", path)
 
         self._items = list(self._load_items().values())
 

--- a/datumaro/plugins/data_formats/common_semantic_segmentation.py
+++ b/datumaro/plugins/data_formats/common_semantic_segmentation.py
@@ -10,7 +10,6 @@ import numpy as np
 
 from datumaro.components.annotation import AnnotationType, LabelCategories, Mask, MaskCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
-from datumaro.components.errors import DatasetImportError
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
 from datumaro.components.importer import ImportContext, Importer, with_subset_dirs
 from datumaro.components.media import Image
@@ -57,7 +56,7 @@ class CommonSemanticSegmentationBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise FileNotFoundError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
 
         super().__init__(subset=subset, ctx=ctx)
 
@@ -71,7 +70,7 @@ class CommonSemanticSegmentationBase(SubsetBase):
             label_map = parse_meta_file(meta_file[0])
             self._categories = make_categories(label_map)
         else:
-            raise DatasetImportError("Dataset meta info file was not found in %s" % path)
+            raise FileNotFoundError("Dataset meta info file was not found in %s" % path)
 
         self._items = list(self._load_items().values())
 

--- a/datumaro/plugins/data_formats/common_super_resolution.py
+++ b/datumaro/plugins/data_formats/common_super_resolution.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os.path as osp
 from typing import Optional
 
@@ -28,7 +29,7 @@ class CommonSuperResolutionBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         super().__init__(subset=subset, ctx=ctx)
 

--- a/datumaro/plugins/data_formats/common_super_resolution.py
+++ b/datumaro/plugins/data_formats/common_super_resolution.py
@@ -28,7 +28,7 @@ class CommonSuperResolutionBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise FileNotFoundError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
 
         super().__init__(subset=subset, ctx=ctx)
 

--- a/datumaro/plugins/data_formats/common_super_resolution.py
+++ b/datumaro/plugins/data_formats/common_super_resolution.py
@@ -1,13 +1,14 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
+from typing import Optional
 
 from datumaro.components.annotation import SuperResolutionAnnotation
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.image import find_images
 
@@ -19,11 +20,17 @@ class CommonSuperResolutionPath:
 
 
 class CommonSuperResolutionBase(SubsetBase):
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isdir(path):
             raise FileNotFoundError("Can't read dataset directory '%s'" % path)
 
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
 
         self._items = list(self._load_items(path).values())
 

--- a/datumaro/plugins/data_formats/cvat/base.py
+++ b/datumaro/plugins/data_formats/cvat/base.py
@@ -1,10 +1,11 @@
-# Copyright (C) 2019-2021 Intel Corporation
+# Copyright (C) 2019-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
 from collections import OrderedDict
 from copy import deepcopy
+from typing import Optional
 
 from defusedxml import ElementTree
 
@@ -20,7 +21,7 @@ from datumaro.components.annotation import (
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import DatasetImportError
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 
 from .format import CvatPath
@@ -47,7 +48,13 @@ def _find_meta_root(path: str):
 class CvatBase(SubsetBase):
     _SUPPORTED_SHAPES = ("box", "polygon", "polyline", "points")
 
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         assert osp.isfile(path), path
         rootpath = osp.dirname(path)
         images_dir = ""
@@ -58,7 +65,7 @@ class CvatBase(SubsetBase):
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
 
         items, categories = self._parse(path)
         self._items = list(self._load_items(items).values())

--- a/datumaro/plugins/data_formats/datumaro/base.py
+++ b/datumaro/plugins/data_formats/datumaro/base.py
@@ -21,7 +21,7 @@ from datumaro.components.annotation import (
     RleMask,
 )
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
-from datumaro.components.errors import DatasetImportError
+from datumaro.components.errors import DatasetImportError, MediaTypeError
 from datumaro.components.importer import ImportContext
 from datumaro.components.media import Image, MediaElement, PointCloud
 from datumaro.util import parse_json_file
@@ -166,7 +166,7 @@ class DatumaroBase(SubsetBase):
 
             pcd_info = item_desc.get("point_cloud")
             if media and pcd_info:
-                raise DatasetImportError("Dataset cannot contain multiple media types")
+                raise MediaTypeError("Dataset cannot contain multiple media types")
             if pcd_info:
                 pcd_path = pcd_info.get("path")
                 point_cloud = osp.join(self._pcd_dir, self._subset, pcd_path)

--- a/datumaro/plugins/data_formats/datumaro_binary/base.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/base.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 from datumaro.components.crypter import NULL_CRYPTER, Crypter
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.errors import DatasetImportError
+from datumaro.components.importer import ImportContext
 from datumaro.components.media import Image, MediaElement, MediaType, PointCloud
 from datumaro.plugins.data_formats.datumaro_binary.format import DatumaroBinaryPath
 from datumaro.plugins.data_formats.datumaro_binary.mapper import DictMapper
@@ -23,7 +24,15 @@ from ..datumaro.base import DatumaroBase
 class DatumaroBinaryBase(DatumaroBase):
     """"""
 
-    def __init__(self, path: str, encryption_key: Optional[bytes] = None, num_workers: int = 0):
+    def __init__(
+        self,
+        path: str,
+        *,
+        encryption_key: Optional[bytes] = None,
+        num_workers: int = 0,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         """
         Parameters
         ----------
@@ -38,7 +47,7 @@ class DatumaroBinaryBase(DatumaroBase):
         self._crypter = Crypter(encryption_key) if encryption_key is not None else NULL_CRYPTER
         self._media_encryption = False
         self._num_workers = num_workers
-        super().__init__(path)
+        super().__init__(path, subset=subset, ctx=ctx)
 
     def _get_dm_format_version(self, path: str) -> str:
         with open(path, "rb") as fp:

--- a/datumaro/plugins/data_formats/icdar/base.py
+++ b/datumaro/plugins/data_formats/icdar/base.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import csv
+import errno
 import glob
 import logging as log
 import os.path as osp
@@ -36,7 +37,7 @@ class _IcdarBase(SubsetBase):
 
         if task is IcdarTask.word_recognition:
             if not osp.isfile(path):
-                raise FileNotFoundError("Can't read annotation file '%s'" % path)
+                raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
 
             if not subset:
                 subset = osp.basename(osp.dirname(path))
@@ -48,7 +49,7 @@ class _IcdarBase(SubsetBase):
         elif task in {IcdarTask.text_localization, IcdarTask.text_segmentation}:
             if not osp.isdir(path):
                 raise NotADirectoryError(
-                    "Can't read dataset directory with annotation files '%s'" % path
+                    errno.ENOTDIR, "Can't read dataset directory with annotation files", path
                 )
 
             if not subset:

--- a/datumaro/plugins/data_formats/icdar/base.py
+++ b/datumaro/plugins/data_formats/icdar/base.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from datumaro.components.annotation import Bbox, Caption, Mask, MaskCategories, Polygon
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
+from datumaro.components.errors import InvalidAnnotationError
 from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
@@ -46,7 +47,9 @@ class _IcdarBase(SubsetBase):
             self._items = list(self._load_recognition_items().values())
         elif task in {IcdarTask.text_localization, IcdarTask.text_segmentation}:
             if not osp.isdir(path):
-                raise NotADirectoryError("Can't open folder with annotation files '%s'" % path)
+                raise NotADirectoryError(
+                    "Can't read dataset directory with annotation files '%s'" % path
+                )
 
             if not subset:
                 subset = osp.basename(path)
@@ -126,7 +129,7 @@ class _IcdarBase(SubsetBase):
                         if len(objects) == 3:
                             text = objects[1]
                         else:
-                            raise Exception(
+                            raise InvalidAnnotationError(
                                 "Line %s: unexpected number " "of quotes in filename" % line
                             )
                     else:
@@ -212,7 +215,7 @@ class _IcdarBase(SubsetBase):
                         objects[9] = '" "'
                         objects.pop()
                     if len(objects) != 10:
-                        raise Exception(
+                        raise InvalidAnnotationError(
                             "Line %s contains the wrong number "
                             'of arguments, e.g. \'241 73 144 1 4 0 3 1 4 "h"' % line
                         )

--- a/datumaro/plugins/data_formats/icdar/base.py
+++ b/datumaro/plugins/data_formats/icdar/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -6,13 +6,14 @@ import csv
 import glob
 import logging as log
 import os.path as osp
+from typing import Optional
 
 import numpy as np
 
 from datumaro.components.annotation import Bbox, Caption, Mask, MaskCategories, Polygon
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.image import IMAGE_EXTENSIONS, find_images
 from datumaro.util.mask_tools import lazy_mask
@@ -21,7 +22,14 @@ from .format import IcdarPath, IcdarTask
 
 
 class _IcdarBase(SubsetBase):
-    def __init__(self, path, task, subset=None):
+    def __init__(
+        self,
+        path: str,
+        task: IcdarTask,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         self._path = path
         self._task = task
 
@@ -31,7 +39,7 @@ class _IcdarBase(SubsetBase):
 
             if not subset:
                 subset = osp.basename(osp.dirname(path))
-            super().__init__(subset=subset)
+            super().__init__(subset=subset, ctx=ctx)
 
             self._dataset_dir = osp.dirname(osp.dirname(path))
 
@@ -42,7 +50,7 @@ class _IcdarBase(SubsetBase):
 
             if not subset:
                 subset = osp.basename(path)
-            super().__init__(subset=subset)
+            super().__init__(subset=subset, ctx=ctx)
 
             self._dataset_dir = osp.dirname(path)
 

--- a/datumaro/plugins/data_formats/icdar/exporter.py
+++ b/datumaro/plugins/data_formats/icdar/exporter.py
@@ -6,7 +6,7 @@ import os
 import os.path as osp
 
 from datumaro.components.annotation import AnnotationType, CompiledMask
-from datumaro.components.errors import DatumaroError, MediaTypeError
+from datumaro.components.errors import DatasetExportError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.media import Image
 from datumaro.util.image import save_image
@@ -113,7 +113,9 @@ class IcdarTextSegmentationExporter(Exporter):
                 if color:
                     color = color.split()
                     if len(color) != 3:
-                        raise DatumaroError("Item %s: mask #%s has invalid color" % (item.id, i))
+                        raise DatasetExportError(
+                            "Item %s: mask #%s has invalid color" % (item.id, i)
+                        )
 
                     color = tuple(map(int, color))
                 else:

--- a/datumaro/plugins/data_formats/image_dir.py
+++ b/datumaro/plugins/data_formats/image_dir.py
@@ -1,15 +1,16 @@
-# Copyright (C) 2019-2021 Intel Corporation
+# Copyright (C) 2019-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import logging as log
 import os
 import os.path as osp
+from typing import Optional
 
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionConfidence
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.image import find_images
 
@@ -38,8 +39,14 @@ class ImageDirImporter(Importer):
 
 
 class ImageDirBase(SubsetBase):
-    def __init__(self, url, subset=None):
-        super().__init__(subset=subset)
+    def __init__(
+        self,
+        url: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
+        super().__init__(subset=subset, ctx=ctx)
 
         assert osp.isdir(url), url
 

--- a/datumaro/plugins/data_formats/image_zip.py
+++ b/datumaro/plugins/data_formats/image_zip.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -6,11 +6,12 @@ import logging as log
 import os
 import os.path as osp
 from enum import Enum
+from typing import Optional
 from zipfile import ZIP_BZIP2, ZIP_DEFLATED, ZIP_LZMA, ZIP_STORED, ZipFile
 
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.exporter import Exporter
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import parse_str_enum_value
 from datumaro.util.image import IMAGE_EXTENSIONS, encode_image
@@ -29,8 +30,14 @@ class ImageZipPath:
 
 
 class ImageZipBase(SubsetBase):
-    def __init__(self, url, subset=None):
-        super().__init__(subset=subset, media_type=Image)
+    def __init__(
+        self,
+        url: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
+        super().__init__(subset=subset, media_type=Image, ctx=ctx)
 
         assert url.endswith(".zip"), url
 

--- a/datumaro/plugins/data_formats/imagenet.py
+++ b/datumaro/plugins/data_formats/imagenet.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
-from datumaro.components.errors import DatasetImportError, MediaTypeError
+from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
 from datumaro.components.importer import ImportContext, Importer, with_subset_dirs
@@ -43,9 +43,7 @@ class ImagenetBase(SubsetBase):
         label_cat = LabelCategories()
         for dirname in sorted(os.listdir(path)):
             if not os.path.isdir(os.path.join(path, dirname)):
-                self._ctx.error_policy.fail(
-                    DatasetImportError(f"'{os.path.join(path, dirname)}' is not a directory.")
-                )
+                raise NotADirectoryError(f"'{os.path.join(path, dirname)}' is not a directory.")
             if dirname != ImagenetPath.IMAGE_DIR_NO_LABEL:
                 label_cat.add(dirname)
         return {AnnotationType.label: label_cat}

--- a/datumaro/plugins/data_formats/imagenet.py
+++ b/datumaro/plugins/data_formats/imagenet.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import logging as log
 import os
 import os.path as osp
@@ -32,7 +33,7 @@ class ImagenetBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         super().__init__(subset=subset, ctx=ctx)
 
@@ -43,7 +44,7 @@ class ImagenetBase(SubsetBase):
         label_cat = LabelCategories()
         for dirname in sorted(os.listdir(path)):
             if not os.path.isdir(os.path.join(path, dirname)):
-                raise NotADirectoryError(f"'{os.path.join(path, dirname)}' is not a directory.")
+                raise NotADirectoryError(errno.ENOTDIR, os.strerror(errno.ENOTDIR), path)
             if dirname != ImagenetPath.IMAGE_DIR_NO_LABEL:
                 label_cat.add(dirname)
         return {AnnotationType.label: label_cat}

--- a/datumaro/plugins/data_formats/imagenet_txt.py
+++ b/datumaro/plugins/data_formats/imagenet_txt.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os
 import os.path as osp
 from enum import Enum, auto
@@ -61,7 +62,7 @@ class ImagenetTxtBase(SubsetBase):
         image_dir: Optional[str] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Can't read dataset '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find dataset file", path)
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]

--- a/datumaro/plugins/data_formats/imagenet_txt.py
+++ b/datumaro/plugins/data_formats/imagenet_txt.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -13,7 +13,7 @@ from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import DatasetImportError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
 
@@ -52,16 +52,17 @@ class ImagenetTxtBase(SubsetBase):
         self,
         path: str,
         *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
         labels: Union[Iterable[str], str] = _LabelsSource.file.name,
         labels_file: str = ImagenetTxtPath.LABELS_FILE,
         image_dir: Optional[str] = None,
-        subset: Optional[str] = None,
     ):
         assert osp.isfile(path), path
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
 
         root_dir = osp.dirname(path)
         if not image_dir:

--- a/datumaro/plugins/data_formats/imagenet_txt.py
+++ b/datumaro/plugins/data_formats/imagenet_txt.py
@@ -10,7 +10,7 @@ from typing import Iterable, Optional, Sequence, Tuple, Union
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.cli_plugin import CliPlugin
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
-from datumaro.components.errors import DatasetImportError, MediaTypeError
+from datumaro.components.errors import DatasetImportError, InvalidAnnotationError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.importer import ImportContext, Importer
@@ -37,7 +37,9 @@ def _parse_annotation_line(line: str) -> Tuple[str, str, Sequence[int]]:
             image = item_id + item[0]
             label_ids = [int(id) for id in item[1:]]
         else:
-            raise Exception("Line %s: unexpected number " "of quotes in filename" % line)
+            raise InvalidAnnotationError(
+                "Line %s: unexpected number " "of quotes in filename" % line
+            )
     else:
         item = line.split()
         item_id = osp.splitext(item[0])[0]
@@ -58,7 +60,8 @@ class ImagenetTxtBase(SubsetBase):
         labels_file: str = ImagenetTxtPath.LABELS_FILE,
         image_dir: Optional[str] = None,
     ):
-        assert osp.isfile(path), path
+        if not osp.isfile(path):
+            raise FileNotFoundError("Can't read dataset '%s'" % path)
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]

--- a/datumaro/plugins/data_formats/kinetics.py
+++ b/datumaro/plugins/data_formats/kinetics.py
@@ -20,7 +20,7 @@ from datumaro.util.os_util import find_files
 class KineticsBase(DatasetBase):
     def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
-            raise FileNotFoundError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
         self._path = path
 
         super().__init__(media_type=Video, ctx=ctx)

--- a/datumaro/plugins/data_formats/kinetics.py
+++ b/datumaro/plugins/data_formats/kinetics.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import csv
+import errno
 import os
 import os.path as osp
 from typing import Optional
@@ -20,7 +21,7 @@ from datumaro.util.os_util import find_files
 class KineticsBase(DatasetBase):
     def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
         self._path = path
 
         super().__init__(media_type=Video, ctx=ctx)

--- a/datumaro/plugins/data_formats/kinetics.py
+++ b/datumaro/plugins/data_formats/kinetics.py
@@ -1,15 +1,16 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import csv
 import os
 import os.path as osp
+from typing import Optional
 
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.dataset_base import DatasetBase, DatasetItem
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Video
 from datumaro.plugins.data_formats.video import VIDEO_EXTENSIONS
 from datumaro.util import parse_json, parse_json_file
@@ -17,12 +18,12 @@ from datumaro.util.os_util import find_files
 
 
 class KineticsBase(DatasetBase):
-    def __init__(self, path):
+    def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
             raise FileNotFoundError("Can't read dataset directory '%s'" % path)
         self._path = path
 
-        super().__init__(media_type=Video)
+        super().__init__(media_type=Video, ctx=ctx)
 
         self._annotation_files = {}
         for ann_file in find_files(path, ["csv", "json"]):

--- a/datumaro/plugins/data_formats/kitti/base.py
+++ b/datumaro/plugins/data_formats/kitti/base.py
@@ -1,14 +1,16 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import glob
 import os.path as osp
+from typing import Optional
 
 import numpy as np
 
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories, Mask
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
+from datumaro.components.importer import ImportContext
 from datumaro.components.media import Image
 from datumaro.util.image import find_images, load_image
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
@@ -17,15 +19,21 @@ from .format import KittiLabelMap, KittiPath, KittiTask, make_kitti_categories, 
 
 
 class _KittiBase(SubsetBase):
-    def __init__(self, path, task, subset=None):
+    def __init__(
+        self,
+        path: str,
+        task: KittiTask,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         assert osp.isdir(path), path
         self._path = path
         self._task = task
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]
-        self._subset = subset
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
 
         self._categories = self._load_categories(osp.dirname(self._path))
         self._items = list(self._load_items().values())
@@ -155,10 +163,10 @@ class _KittiBase(SubsetBase):
 
 
 class KittiSegmentationBase(_KittiBase):
-    def __init__(self, path):
-        super().__init__(path, task=KittiTask.segmentation)
+    def __init__(self, path, **kwargs):
+        super().__init__(path, task=KittiTask.segmentation, **kwargs)
 
 
 class KittiDetectionBase(_KittiBase):
-    def __init__(self, path):
-        super().__init__(path, task=KittiTask.detection)
+    def __init__(self, path, **kwargs):
+        super().__init__(path, task=KittiTask.detection, **kwargs)

--- a/datumaro/plugins/data_formats/kitti/exporter.py
+++ b/datumaro/plugins/data_formats/kitti/exporter.py
@@ -11,7 +11,7 @@ from enum import Enum, auto
 import numpy as np
 
 from datumaro.components.annotation import AnnotationType, CompiledMask, LabelCategories
-from datumaro.components.errors import MediaTypeError
+from datumaro.components.errors import InvalidAnnotationError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.media import Image
 from datumaro.util import cast, parse_str_enum_value, str_to_bool
@@ -241,7 +241,7 @@ class KittiExporter(Exporter):
                 label_map = parse_label_map(label_map_source)
 
         else:
-            raise Exception(
+            raise InvalidAnnotationError(
                 "Wrong labelmap specified, "
                 "expected one of %s or a file path" % ", ".join(t.name for t in LabelmapType)
             )

--- a/datumaro/plugins/data_formats/kitti/importer.py
+++ b/datumaro/plugins/data_formats/kitti/importer.py
@@ -6,6 +6,7 @@ import logging as log
 import os.path as osp
 from glob import glob
 
+from datumaro.components.errors import DatasetNotFoundError
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
 from datumaro.components.importer import Importer
 
@@ -24,7 +25,7 @@ class KittiImporter(Importer):
         subsets = self.find_sources(path)
 
         if len(subsets) == 0:
-            raise Exception("Failed to find 'kitti' dataset at '%s'" % path)
+            raise DatasetNotFoundError(path, self.NAME)
 
         # TODO: should be removed when proper label merging is implemented
         conflicting_types = {"kitti_segmentation", "kitti_detection"}

--- a/datumaro/plugins/data_formats/kitti_raw/base.py
+++ b/datumaro/plugins/data_formats/kitti_raw/base.py
@@ -1,16 +1,17 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os
 import os.path as osp
+from typing import Optional
 
 from defusedxml import ElementTree as ET
 
 from datumaro.components.annotation import AnnotationType, Cuboid3d, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image, PointCloud
 from datumaro.util import cast
 from datumaro.util.image import find_images
@@ -24,11 +25,17 @@ class KittiRawBase(SubsetBase):
     # https://s3.eu-central-1.amazonaws.com/avg-kitti/devkit_raw_data.zip
     # Check cpp header implementation for field meaning
 
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         assert osp.isfile(path), path
         self._rootdir = osp.dirname(path)
 
-        super().__init__(subset=subset, media_type=PointCloud)
+        super().__init__(subset=subset, media_type=PointCloud, ctx=ctx)
 
         items, categories = self._parse(path)
         self._items = list(self._load_items(items).values())

--- a/datumaro/plugins/data_formats/kitti_raw/base.py
+++ b/datumaro/plugins/data_formats/kitti_raw/base.py
@@ -10,6 +10,7 @@ from defusedxml import ElementTree as ET
 
 from datumaro.components.annotation import AnnotationType, Cuboid3d, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
+from datumaro.components.errors import InvalidAnnotationError
 from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image, PointCloud
@@ -128,7 +129,7 @@ class KittiRawBase(SubsetBase):
                 # common tags
                 elif attr is not None and elem.tag == "name":
                     if not elem.text:
-                        raise ValueError("Attribute name can't be empty")
+                        raise InvalidAnnotationError("Attribute name can't be empty")
                     attr["name"] = elem.text
                 elif attr is not None and elem.tag == "value":
                     attr["value"] = elem.text or ""
@@ -140,7 +141,7 @@ class KittiRawBase(SubsetBase):
                     attr = None
 
         if track is not None or shape is not None or attr is not None:
-            raise Exception("Failed to parse annotations from '%s'" % path)
+            raise InvalidAnnotationError("Failed to parse annotations from '%s'" % path)
 
         special_attrs = KittiRawPath.SPECIAL_ATTRS
         common_attrs = ["occluded"]

--- a/datumaro/plugins/data_formats/kitti_raw/exporter.py
+++ b/datumaro/plugins/data_formats/kitti_raw/exporter.py
@@ -13,7 +13,7 @@ from xml.sax.saxutils import XMLGenerator  # nosec
 from datumaro.components.annotation import AnnotationType, LabelCategories
 from datumaro.components.dataset import ItemStatus
 from datumaro.components.dataset_base import DatasetItem
-from datumaro.components.errors import MediaTypeError
+from datumaro.components.errors import DatasetExportError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.media import PointCloud
 from datumaro.util import cast
@@ -302,7 +302,7 @@ class KittiRawExporter(Exporter):
             frame_id = self._write_item(item, frame_id)
 
             if frame_id in name_mapping:
-                raise Exception(
+                raise DatasetExportError(
                     "Item %s: frame id %s is repeated in the dataset" % (item.id, frame_id)
                 )
             name_mapping[frame_id] = item.id
@@ -329,7 +329,7 @@ class KittiRawExporter(Exporter):
                     # unused id. A negative one, for example.
                     track_id = -(len(tracks) + 1)
                 if track_id is None:
-                    raise Exception(
+                    raise DatasetExportError(
                         "Item %s: expected track annotations "
                         "having 'track_id' (integer) attribute. "
                         "Use --reindex to export single shapes." % item.id
@@ -350,13 +350,13 @@ class KittiRawExporter(Exporter):
                 else:
                     if [track["w"], track["h"], track["l"]] != ann.scale:
                         # Tracks have fixed scale in the format
-                        raise Exception(
+                        raise DatasetExportError(
                             "Item %s: mismatching track shapes, "
                             "track id %s" % (item.id, track_id)
                         )
 
                     if track["objectType"] != label:
-                        raise Exception(
+                        raise DatasetExportError(
                             "Item %s: mismatching track labels, "
                             "track id %s: %s vs. %s"
                             % (item.id, track_id, track["objectType"], label)

--- a/datumaro/plugins/data_formats/labelme.py
+++ b/datumaro/plugins/data_formats/labelme.py
@@ -232,7 +232,7 @@ class LabelMeBase(DatasetBase):
                     subset_root, LabelMePath.MASKS_DIR, segm_elem.find("mask").text
                 )
                 if not osp.isfile(mask_path):
-                    raise Exception("Can't find mask at '%s'" % mask_path)
+                    raise FileNotFoundError("Can't find mask at '%s'" % mask_path)
                 mask = load_mask(mask_path)
                 mask = np.any(mask, axis=2)
                 ann_items.append(Mask(image=mask, label=label, id=obj_id, attributes=attributes))

--- a/datumaro/plugins/data_formats/labelme.py
+++ b/datumaro/plugins/data_formats/labelme.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -7,6 +7,7 @@ import os
 import os.path as osp
 from collections import defaultdict
 from glob import glob, iglob
+from typing import Optional
 
 import numpy as np
 from defusedxml import ElementTree
@@ -16,7 +17,7 @@ from datumaro.components.dataset_base import DatasetBase, DatasetItem
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import cast, escape, unescape
 from datumaro.util.image import save_image
@@ -44,9 +45,9 @@ class LabelMePath:
 
 
 class LabelMeBase(DatasetBase):
-    def __init__(self, path):
+    def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         assert osp.isdir(path), path
-        super().__init__()
+        super().__init__(ctx=ctx)
 
         self._items, self._categories, self._subsets = self._parse(path)
         self._length = len(self._items)

--- a/datumaro/plugins/data_formats/labelme.py
+++ b/datumaro/plugins/data_formats/labelme.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import logging as log
 import os
 import os.path as osp
@@ -232,7 +233,7 @@ class LabelMeBase(DatasetBase):
                     subset_root, LabelMePath.MASKS_DIR, segm_elem.find("mask").text
                 )
                 if not osp.isfile(mask_path):
-                    raise FileNotFoundError("Can't find mask at '%s'" % mask_path)
+                    raise FileNotFoundError(errno.ENOENT, "Can't find mask", mask_path)
                 mask = load_mask(mask_path)
                 mask = np.any(mask, axis=2)
                 ann_items.append(Mask(image=mask, label=label, id=obj_id, attributes=attributes))

--- a/datumaro/plugins/data_formats/lfw.py
+++ b/datumaro/plugins/data_formats/lfw.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os
 import os.path as osp
 import re
@@ -37,7 +38,7 @@ class LfwBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Can't read annotation file '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
 
         if not subset:
             subset = osp.basename(osp.dirname(osp.dirname(path)))

--- a/datumaro/plugins/data_formats/lfw.py
+++ b/datumaro/plugins/data_formats/lfw.py
@@ -1,17 +1,18 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os
 import os.path as osp
 import re
+from typing import Optional
 
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories, Points
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.image import find_images
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
@@ -28,13 +29,20 @@ class LfwPath:
 
 
 class LfwBase(SubsetBase):
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise FileNotFoundError("Can't read annotation file '%s'" % path)
 
         if not subset:
             subset = osp.basename(osp.dirname(osp.dirname(path)))
-        super().__init__(subset=subset)
+
+        super().__init__(subset=subset, ctx=ctx)
 
         self._dataset_dir = osp.dirname(osp.dirname(osp.dirname(path)))
         self._annotations_dir = osp.dirname(path)

--- a/datumaro/plugins/data_formats/mapillary_vistas/base.py
+++ b/datumaro/plugins/data_formats/mapillary_vistas/base.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import logging as log
 import os
 import os.path as osp
@@ -65,8 +66,9 @@ class _MapillaryVistasBase(SubsetBase):
         if len(annotations_dirs) == 0:
             expected_dirs = ",".join(MapillaryVistasPath.ANNOTATION_DIRS[format_version])
             raise NotADirectoryError(
+                errno.ENOTDIR,
                 f"Can't find annotation directory at {path}. "
-                f"Expected one of these directories: {expected_dirs}."
+                f"Expected one of these directories: {expected_dirs}.",
             )
         elif len(annotations_dirs) > 1:
             skipped_dirs = ",".join(annotations_dirs[1:])
@@ -103,7 +105,7 @@ class _MapillaryVistasBase(SubsetBase):
 
         if not osp.isfile(panoptic_config_path):
             raise FileNotFoundError(
-                f"Can't find panoptic config file: {MapillaryVistasPath.PANOPTIC_CONFIG} at {panoptic_config_path}"
+                errno.ENOENT, "Can't find panoptic config file", panoptic_config_path
             )
 
         return parse_json_file(panoptic_config_path)

--- a/datumaro/plugins/data_formats/mapillary_vistas/base.py
+++ b/datumaro/plugins/data_formats/mapillary_vistas/base.py
@@ -18,6 +18,7 @@ from datumaro.components.annotation import (
     Polygon,
 )
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
+from datumaro.components.errors import DatasetImportError
 from datumaro.components.importer import ImportContext
 from datumaro.components.media import Image
 from datumaro.util import parse_json_file
@@ -48,7 +49,7 @@ class _MapillaryVistasBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if format_version == "v1.2" and parse_polygon is True:
-            raise ImportError(
+            raise DatasetImportError(
                 f"Format version {format_version} is not available for polygons. "
                 "Please try with v2.0 for parsing polygons."
             )

--- a/datumaro/plugins/data_formats/mapillary_vistas/base.py
+++ b/datumaro/plugins/data_formats/mapillary_vistas/base.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2022-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
+
 import logging as log
 import os
 import os.path as osp
+from typing import Optional
 
 import numpy as np
 
@@ -16,6 +18,7 @@ from datumaro.components.annotation import (
     Polygon,
 )
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
+from datumaro.components.importer import ImportContext
 from datumaro.components.media import Image
 from datumaro.util import parse_json_file
 from datumaro.util.image import find_images, lazy_image, load_image
@@ -34,13 +37,15 @@ from .format import (
 class _MapillaryVistasBase(SubsetBase):
     def __init__(
         self,
-        path,
-        task,
-        subset=None,
-        use_original_config=False,
-        keep_original_category_ids=False,
-        format_version="v2.0",
-        parse_polygon=False,
+        path: str,
+        task: MapillaryVistasTask,
+        *,
+        use_original_config: bool = False,
+        keep_original_category_ids: bool = False,
+        format_version: str = "v2.0",
+        parse_polygon: bool = False,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
     ):
         if format_version == "v1.2" and parse_polygon is True:
             raise ImportError(
@@ -52,7 +57,7 @@ class _MapillaryVistasBase(SubsetBase):
         self._path = path
         if subset is None:
             subset = osp.basename(self._path)
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
 
         annotations_dirs = [d for d in os.listdir(path) if d in MapillaryVistasPath.ANNOTATION_DIRS]
 

--- a/datumaro/plugins/data_formats/mapillary_vistas/importer.py
+++ b/datumaro/plugins/data_formats/mapillary_vistas/importer.py
@@ -6,6 +6,7 @@ import logging as log
 import os.path as osp
 
 from datumaro.components.dataset_base import DEFAULT_SUBSET_NAME
+from datumaro.components.errors import DatasetNotFoundError
 from datumaro.components.importer import Importer
 from datumaro.util import str_to_bool
 
@@ -52,7 +53,7 @@ class MapillaryVistasImporter(Importer):
         subsets = self.find_sources(path)
 
         if len(subsets) == 0:
-            raise Exception(f"Failed to find Mapillary Vistas dataset at {path}")
+            raise DatasetNotFoundError(path, self.NAME)
 
         tasks = list(set(task for subset in subsets.values() for task in subset))
         selected_task = tasks[0]
@@ -72,9 +73,11 @@ class MapillaryVistasImporter(Importer):
             )
 
             if not has_config and not extra_params.get("use_original_config"):
-                raise Exception(
-                    f"Failed to find config*.json at {path}. "
-                    "See extra args for using original config."
+                raise DatasetNotFoundError(
+                    path,
+                    self.NAME,
+                    "Failed to find config*.json at '{path}'. "
+                    "See extra args for using original configs.",
                 )
 
         sources = [

--- a/datumaro/plugins/data_formats/market1501.py
+++ b/datumaro/plugins/data_formats/market1501.py
@@ -1,16 +1,17 @@
-# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os
 import os.path as osp
 import re
+from typing import Optional
 
 from datumaro.components.dataset_base import DatasetBase, DatasetItem
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionConfidence
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import str_to_bool
 from datumaro.util.image import find_images
@@ -27,12 +28,12 @@ class Market1501Path:
 
 
 class Market1501Base(DatasetBase):
-    def __init__(self, path):
+    def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
             raise NotADirectoryError("Can't open folder with annotation files '%s'" % path)
 
         self._path = path
-        super().__init__()
+        super().__init__(ctx=ctx)
 
         subsets = {}
         for p in os.listdir(path):

--- a/datumaro/plugins/data_formats/market1501.py
+++ b/datumaro/plugins/data_formats/market1501.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os
 import os.path as osp
 import re
@@ -30,7 +31,7 @@ class Market1501Path:
 class Market1501Base(DatasetBase):
     def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         self._path = path
         super().__init__(ctx=ctx)

--- a/datumaro/plugins/data_formats/market1501.py
+++ b/datumaro/plugins/data_formats/market1501.py
@@ -30,7 +30,7 @@ class Market1501Path:
 class Market1501Base(DatasetBase):
     def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't open folder with annotation files '%s'" % path)
+            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
 
         self._path = path
         super().__init__(ctx=ctx)

--- a/datumaro/plugins/data_formats/mars.py
+++ b/datumaro/plugins/data_formats/mars.py
@@ -1,17 +1,19 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
+
 import fnmatch
 import glob
 import logging as log
 import os
 import os.path as osp
+from typing import Optional
 
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.dataset import DatasetItem
 from datumaro.components.dataset_base import DatasetBase
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.image import find_images
 
@@ -23,9 +25,9 @@ class MarsPath:
 
 
 class MarsBase(DatasetBase):
-    def __init__(self, path):
+    def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         assert osp.isdir(path), path
-        super().__init__()
+        super().__init__(ctx=ctx)
 
         self._dataset_dir = path
         self._subsets = {

--- a/datumaro/plugins/data_formats/mnist.py
+++ b/datumaro/plugins/data_formats/mnist.py
@@ -1,10 +1,11 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import gzip
 import os
 import os.path as osp
+from typing import Optional
 
 import numpy as np
 
@@ -12,7 +13,7 @@ from datumaro.components.annotation import AnnotationType, Label, LabelCategorie
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
 
@@ -27,9 +28,16 @@ class MnistPath:
 
 
 class MnistBase(SubsetBase):
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise FileNotFoundError("Can't read annotation file '%s'" % path)
+        self._dataset_dir = osp.dirname(path)
 
         if not subset:
             file_name = osp.splitext(osp.basename(path))[0]
@@ -38,11 +46,9 @@ class MnistBase(SubsetBase):
             else:
                 subset = file_name.split("-", maxsplit=1)[0]
 
-        super().__init__(subset=subset)
-        self._dataset_dir = osp.dirname(path)
+        super().__init__(subset=subset, ctx=ctx)
 
         self._categories = self._load_categories()
-
         self._items = list(self._load_items(path).values())
 
     def _load_categories(self):

--- a/datumaro/plugins/data_formats/mnist.py
+++ b/datumaro/plugins/data_formats/mnist.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import gzip
 import os
 import os.path as osp
@@ -36,7 +37,7 @@ class MnistBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Can't read annotation file '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
         self._dataset_dir = osp.dirname(path)
 
         if not subset:

--- a/datumaro/plugins/data_formats/mnist_csv.py
+++ b/datumaro/plugins/data_formats/mnist_csv.py
@@ -1,9 +1,10 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os
 import os.path as osp
+from typing import Optional
 
 import numpy as np
 
@@ -11,7 +12,7 @@ from datumaro.components.annotation import AnnotationType, Label, LabelCategorie
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
 
@@ -22,7 +23,13 @@ class MnistCsvPath:
 
 
 class MnistCsvBase(SubsetBase):
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise FileNotFoundError("Can't read annotation file '%s'" % path)
 
@@ -30,7 +37,7 @@ class MnistCsvBase(SubsetBase):
             file_name = osp.splitext(osp.basename(path))[0]
             subset = file_name.rsplit("_", maxsplit=1)[-1]
 
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
         self._dataset_dir = osp.dirname(path)
 
         self._categories = self._load_categories()

--- a/datumaro/plugins/data_formats/mnist_csv.py
+++ b/datumaro/plugins/data_formats/mnist_csv.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os
 import os.path as osp
 from typing import Optional
@@ -31,7 +32,7 @@ class MnistCsvBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Can't read annotation file '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
 
         if not subset:
             file_name = osp.splitext(osp.basename(path))[0]

--- a/datumaro/plugins/data_formats/mot.py
+++ b/datumaro/plugins/data_formats/mot.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -12,13 +12,14 @@ import os
 import os.path as osp
 from collections import OrderedDict
 from enum import Enum
+from typing import List, Optional, Union
 
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import cast
 from datumaro.util.image import find_images
@@ -66,8 +67,17 @@ class MotPath:
 
 
 class MotSeqBase(SubsetBase):
-    def __init__(self, path, labels=None, occlusion_threshold=0, is_gt=None, subset=None):
-        super().__init__(subset=subset)
+    def __init__(
+        self,
+        path: str,
+        *,
+        labels: Optional[Union[str, List[str]]] = None,
+        occlusion_threshold: float = 0.0,
+        is_gt: Optional[bool] = None,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
+        super().__init__(subset=subset, ctx=ctx)
 
         assert osp.isfile(path)
         seq_root = osp.dirname(osp.dirname(path))

--- a/datumaro/plugins/data_formats/mots.py
+++ b/datumaro/plugins/data_formats/mots.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -9,6 +9,7 @@ import os
 import os.path as osp
 from enum import Enum
 from glob import iglob
+from typing import Optional
 
 import numpy as np
 
@@ -16,7 +17,7 @@ from datumaro.components.annotation import AnnotationType, LabelCategories, Mask
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.image import find_images, load_image, save_image
 from datumaro.util.mask_tools import merge_masks
@@ -45,9 +46,15 @@ class MotsPngExtractor(SubsetBase):
             return [{"url": path, "format": MotsPngExtractor.NAME}]
         return []
 
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         assert osp.isdir(path), path
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
         self._images_dir = osp.join(path, "images")
         self._anno_dir = osp.join(path, MotsPath.MASKS_DIR)
         if has_meta_file(path):

--- a/datumaro/plugins/data_formats/mpii/mpii_json.py
+++ b/datumaro/plugins/data_formats/mpii/mpii_json.py
@@ -1,8 +1,9 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
+from typing import Optional
 
 import numpy as np
 
@@ -15,7 +16,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import parse_json_file
 
@@ -30,11 +31,17 @@ class MpiiJsonPath:
 
 
 class MpiiJsonBase(SubsetBase):
-    def __init__(self, path):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise FileNotFoundError("Can't read annotation file '%s'" % path)
 
-        super().__init__()
+        super().__init__(subset=subset, ctx=ctx)
 
         self._categories = {
             AnnotationType.label: LabelCategories.from_iterable(["human"]),

--- a/datumaro/plugins/data_formats/mpii/mpii_json.py
+++ b/datumaro/plugins/data_formats/mpii/mpii_json.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os.path as osp
 from typing import Optional
 
@@ -39,7 +40,7 @@ class MpiiJsonBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Can't read annotation file '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
 
         super().__init__(subset=subset, ctx=ctx)
 

--- a/datumaro/plugins/data_formats/mpii/mpii_mat.py
+++ b/datumaro/plugins/data_formats/mpii/mpii_mat.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os.path as osp
 from typing import Optional
 
@@ -31,7 +32,7 @@ class MpiiBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Can't read annotation file '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
 
         super().__init__(subset=subset, ctx=ctx)
 

--- a/datumaro/plugins/data_formats/mpii/mpii_mat.py
+++ b/datumaro/plugins/data_formats/mpii/mpii_mat.py
@@ -1,8 +1,9 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
+from typing import Optional
 
 import scipy.io as spio
 
@@ -15,18 +16,24 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 
 from .format import MPII_POINTS_JOINTS, MPII_POINTS_LABELS
 
 
 class MpiiBase(SubsetBase):
-    def __init__(self, path):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise FileNotFoundError("Can't read annotation file '%s'" % path)
 
-        super().__init__()
+        super().__init__(subset=subset, ctx=ctx)
 
         self._categories = {
             AnnotationType.label: LabelCategories.from_iterable(["human"]),

--- a/datumaro/plugins/data_formats/mvtec/base.py
+++ b/datumaro/plugins/data_formats/mvtec/base.py
@@ -4,11 +4,13 @@
 
 import os
 import os.path as osp
+from typing import Optional
 
 import numpy as np
 
 from datumaro.components.annotation import AnnotationType, Bbox, Label, LabelCategories, Mask
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
+from datumaro.components.importer import ImportContext
 from datumaro.components.media import Image
 from datumaro.util.image import find_images, load_image
 
@@ -16,15 +18,21 @@ from .format import MvtecPath, MvtecTask
 
 
 class _MvtecBase(SubsetBase):
-    def __init__(self, path, task, subset=None):
+    def __init__(
+        self,
+        path: str,
+        task: MvtecTask,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         assert osp.isdir(path), path
         self._path = path
         self._task = task
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]
-        self._subset = subset
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
 
         self._categories = self._load_categories()
         self._items = list(self._load_items().values())
@@ -95,14 +103,17 @@ class _MvtecBase(SubsetBase):
 
 class MvtecClassificationBase(_MvtecBase):
     def __init__(self, path, **kwargs):
-        super().__init__(path, task=MvtecTask.classification)
+        kwargs.pop("merge_policy")
+        super().__init__(path, task=MvtecTask.classification, **kwargs)
 
 
 class MvtecSegmentationBase(_MvtecBase):
     def __init__(self, path, **kwargs):
-        super().__init__(path, task=MvtecTask.segmentation)
+        kwargs.pop("merge_policy")
+        super().__init__(path, task=MvtecTask.segmentation, **kwargs)
 
 
 class MvtecDetectionBase(_MvtecBase):
     def __init__(self, path, **kwargs):
-        super().__init__(path, task=MvtecTask.detection)
+        kwargs.pop("merge_policy")
+        super().__init__(path, task=MvtecTask.detection, **kwargs)

--- a/datumaro/plugins/data_formats/nyu_depth_v2.py
+++ b/datumaro/plugins/data_formats/nyu_depth_v2.py
@@ -1,9 +1,10 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import glob
 import os.path as osp
+from typing import Optional
 
 import h5py
 import numpy as np
@@ -11,16 +12,22 @@ import numpy as np
 from datumaro.components.annotation import DepthAnnotation
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 
 
 class NyuDepthV2Base(SubsetBase):
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isdir(path):
             raise FileNotFoundError("Can't read dataset directory '%s'" % path)
 
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
 
         self._items = list(self._load_items(path).values())
 

--- a/datumaro/plugins/data_formats/nyu_depth_v2.py
+++ b/datumaro/plugins/data_formats/nyu_depth_v2.py
@@ -25,7 +25,7 @@ class NyuDepthV2Base(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise FileNotFoundError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
 
         super().__init__(subset=subset, ctx=ctx)
 

--- a/datumaro/plugins/data_formats/nyu_depth_v2.py
+++ b/datumaro/plugins/data_formats/nyu_depth_v2.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import glob
 import os.path as osp
 from typing import Optional
@@ -25,7 +26,7 @@ class NyuDepthV2Base(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         super().__init__(subset=subset, ctx=ctx)
 

--- a/datumaro/plugins/data_formats/open_images.py
+++ b/datumaro/plugins/data_formats/open_images.py
@@ -177,7 +177,7 @@ class OpenImagesBase(DatasetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise FileNotFoundError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
 
         super().__init__(ctx=ctx)
 

--- a/datumaro/plugins/data_formats/open_images.py
+++ b/datumaro/plugins/data_formats/open_images.py
@@ -4,6 +4,7 @@
 
 import contextlib
 import csv
+import errno
 import fnmatch
 import functools
 import glob
@@ -177,7 +178,7 @@ class OpenImagesBase(DatasetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         super().__init__(ctx=ctx)
 
@@ -245,9 +246,10 @@ class OpenImagesBase(DatasetBase):
 
         if not class_desc_files:
             raise FileNotFoundError(
+                errno.ENOENT,
                 "Can't find class description file, the "
-                "annotations directory does't contain any of these files: %s"
-                % ", ".join(class_desc_patterns)
+                "annotations directory does't contain any of these files",
+                ", ".join(class_desc_patterns),
             )
 
         # In OID v6, the class description file is prefixed with `oidv6-`, whereas

--- a/datumaro/plugins/data_formats/open_images.py
+++ b/datumaro/plugins/data_formats/open_images.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -14,6 +14,7 @@ import os
 import os.path as osp
 import re
 import types
+from typing import Optional, Union
 
 import cv2
 import numpy as np
@@ -30,7 +31,7 @@ from datumaro.components.errors import (
 )
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.components.validator import Severity
 from datumaro.util import parse_json_file
@@ -168,11 +169,17 @@ class OpenImagesPath:
 
 
 class OpenImagesBase(DatasetBase):
-    def __init__(self, path, image_meta=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        image_meta: Optional[Union[dict, str]] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isdir(path):
             raise FileNotFoundError("Can't read dataset directory '%s'" % path)
 
-        super().__init__()
+        super().__init__(ctx=ctx)
 
         self._dataset_dir = path
 

--- a/datumaro/plugins/data_formats/sly_pointcloud/base.py
+++ b/datumaro/plugins/data_formats/sly_pointcloud/base.py
@@ -1,13 +1,14 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
 from glob import iglob
+from typing import Optional
 
 from datumaro.components.annotation import AnnotationType, Cuboid3d, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image, PointCloud
 from datumaro.util import parse_json_file
 from datumaro.util.image import find_images
@@ -19,14 +20,20 @@ class SuperviselyPointCloudBase(SubsetBase):
     NAME = "sly_pointcloud"
     _SUPPORTED_SHAPES = "cuboid"
 
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise FileNotFoundError("Expected a path to 'meta.json', " "got '%s'" % path)
 
         rootdir = osp.abspath(osp.dirname(path))
         self._rootdir = rootdir
 
-        super().__init__(subset=subset, media_type=PointCloud)
+        super().__init__(subset=subset, media_type=PointCloud, ctx=ctx)
 
         items, categories = self._parse(rootdir)
         self._items = list(self._load_items(items).values())

--- a/datumaro/plugins/data_formats/sly_pointcloud/base.py
+++ b/datumaro/plugins/data_formats/sly_pointcloud/base.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os.path as osp
 from glob import iglob
 from typing import Optional
@@ -29,7 +30,7 @@ class SuperviselyPointCloudBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Expected a path to 'meta.json', " "got '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
 
         rootdir = osp.abspath(osp.dirname(path))
         self._rootdir = rootdir

--- a/datumaro/plugins/data_formats/sly_pointcloud/base.py
+++ b/datumaro/plugins/data_formats/sly_pointcloud/base.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from datumaro.components.annotation import AnnotationType, Cuboid3d, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
+from datumaro.components.errors import InvalidFieldError, UndeclaredLabelError
 from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image, PointCloud
 from datumaro.util import parse_json_file
@@ -58,7 +59,7 @@ class SuperviselyPointCloudBase(SubsetBase):
             if applicable_to == "imagesOnly":
                 continue  # an image attribute
             elif applicable_to not in {"all", "objectsOnly"}:
-                raise Exception("Unexpected tag 'applicable_type' value '%s'" % applicable_to)
+                raise InvalidFieldError(applicable_to)
 
             applicable_classes = tag.get("classes", [])
             if not applicable_classes:
@@ -67,7 +68,7 @@ class SuperviselyPointCloudBase(SubsetBase):
                 for label_name in applicable_classes:
                     _, label = label_cat.find(label_name)
                     if label is None:
-                        raise Exception("Unknown class for tag '%s'" % label_name)
+                        raise UndeclaredLabelError(label_name)
 
                     label.attributes.add(tag["name"])
 

--- a/datumaro/plugins/data_formats/sly_pointcloud/exporter.py
+++ b/datumaro/plugins/data_formats/sly_pointcloud/exporter.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from datumaro.components.annotation import AnnotationType, LabelCategories
 from datumaro.components.dataset import ItemStatus
 from datumaro.components.dataset_base import DatasetItem, IDataset
-from datumaro.components.errors import MediaTypeError
+from datumaro.components.errors import DatasetExportError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.media import PointCloud
 from datumaro.util import cast, dump_json_file
@@ -142,7 +142,7 @@ class _SuperviselyPointCloudDumper:
             if tag["value_type"] is None:
                 tag["value_type"] = value_type
             elif tag["value_type"] != value_type:
-                raise Exception(
+                raise DatasetExportError(
                     "Item %s: mismatching "
                     "value types for tag %s: %s vs %s"
                     % (item.id, attr_name, tag["value_type"], value_type)
@@ -228,7 +228,7 @@ class _SuperviselyPointCloudDumper:
                     if tag["value_type"] is None:
                         tag["value_type"] = value_type
                     elif tag["value_type"] != value_type:
-                        raise Exception(
+                        raise DatasetExportError(
                             "Item %s: mismatching "
                             "value types for tag %s: %s vs %s"
                             % (item.id, attr_name, tag["value_type"], value_type)

--- a/datumaro/plugins/data_formats/synthia/base.py
+++ b/datumaro/plugins/data_formats/synthia/base.py
@@ -1,15 +1,18 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
 from collections import OrderedDict
 from glob import glob
+from typing import Optional
 
 import numpy as np
 
 from datumaro.components.annotation import AnnotationType, LabelCategories, Mask, MaskCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
+from datumaro.components.errors import InvalidAnnotationError
+from datumaro.components.importer import ImportContext
 from datumaro.components.media import Image
 from datumaro.util.image import find_images
 from datumaro.util.mask_tools import generate_colormap, load_mask
@@ -25,7 +28,7 @@ from .format import (
 )
 
 
-def make_categories(label_map=None):
+def make_categories(label_map):
     categories = {}
     label_categories = LabelCategories()
     for label in label_map:
@@ -73,11 +76,19 @@ def parse_label_map(path):
 
 
 class _SynthiaBase(SubsetBase):
-    def __init__(self, path, path_formats, label_map):
-        super().__init__()
-
+    def __init__(
+        self,
+        path: str,
+        path_formats,
+        label_map,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isdir(path):
             raise FileNotFoundError("Can't read dataset directory '%s'" % path)
+
+        super().__init__(subset=subset, ctx=ctx)
 
         self._path_formats = path_formats
         self._label_map = label_map
@@ -167,15 +178,21 @@ class _SynthiaBase(SubsetBase):
 
 
 class SynthiaRandBase(_SynthiaBase):
-    def __init__(self, path):
-        super().__init__(path=path, path_formats=SynthiaRandPath, label_map=SynthiaRandLabelMap)
+    def __init__(self, path: str, **kwargs):
+        super().__init__(
+            path=path, path_formats=SynthiaRandPath, label_map=SynthiaRandLabelMap, **kwargs
+        )
 
 
 class SynthiaSfBase(_SynthiaBase):
-    def __init__(self, path):
-        super().__init__(path=path, path_formats=SynthiaSfPath, label_map=SynthiaSfLabelMap)
+    def __init__(self, path, **kwargs):
+        super().__init__(
+            path=path, path_formats=SynthiaSfPath, label_map=SynthiaSfLabelMap, **kwargs
+        )
 
 
 class SynthiaAlBase(_SynthiaBase):
-    def __init__(self, path):
-        super().__init__(path=path, path_formats=SynthiaAlPath, label_map=SynthiaAlLabelMap)
+    def __init__(self, path, **kwargs):
+        super().__init__(
+            path=path, path_formats=SynthiaAlPath, label_map=SynthiaAlLabelMap, **kwargs
+        )

--- a/datumaro/plugins/data_formats/synthia/base.py
+++ b/datumaro/plugins/data_formats/synthia/base.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os.path as osp
 from collections import OrderedDict
 from glob import glob
@@ -86,7 +87,7 @@ class _SynthiaBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
 
         super().__init__(subset=subset, ctx=ctx)
 

--- a/datumaro/plugins/data_formats/synthia/base.py
+++ b/datumaro/plugins/data_formats/synthia/base.py
@@ -69,7 +69,7 @@ def parse_label_map(path):
                 color = None
 
             if name in label_map:
-                raise ValueError("Label '%s' is already defined" % name)
+                raise InvalidAnnotationError("Label '%s' is already defined" % name)
 
             label_map[name] = color
     return label_map
@@ -86,7 +86,7 @@ class _SynthiaBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isdir(path):
-            raise FileNotFoundError("Can't read dataset directory '%s'" % path)
+            raise NotADirectoryError("Can't read dataset directory '%s'" % path)
 
         super().__init__(subset=subset, ctx=ctx)
 

--- a/datumaro/plugins/data_formats/tf_detection_api/base.py
+++ b/datumaro/plugins/data_formats/tf_detection_api/base.py
@@ -1,16 +1,17 @@
-# Copyright (C) 2019-2020 Intel Corporation
+# Copyright (C) 2019-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
 import re
 from collections import OrderedDict
+from typing import Optional
 
 import numpy as np
 
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories, Mask
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.image import decode_image, lazy_image
 from datumaro.util.tf_util import import_tf as _import_tf
@@ -25,7 +26,13 @@ def clamp(value, _min, _max):
 
 
 class TfDetectionApiBase(SubsetBase):
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         assert osp.isfile(path), path
         images_dir = ""
         root_dir = osp.dirname(osp.abspath(path))
@@ -37,7 +44,7 @@ class TfDetectionApiBase(SubsetBase):
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0]
-        super().__init__(subset=subset)
+        super().__init__(subset=subset, ctx=ctx)
 
         items, labels = self._parse_tfrecord_file(path, self._subset, images_dir)
         self._items = items

--- a/datumaro/plugins/data_formats/tf_detection_api/exporter.py
+++ b/datumaro/plugins/data_formats/tf_detection_api/exporter.py
@@ -11,6 +11,7 @@ import string
 from collections import OrderedDict
 
 from datumaro.components.annotation import AnnotationType, LabelCategories
+from datumaro.components.errors import DatasetExportError
 from datumaro.components.exporter import Exporter
 from datumaro.components.media import ByteImage, Image, ImageFromBytes
 from datumaro.util.annotation_util import find_group_leader, find_instances, max_bbox
@@ -168,7 +169,7 @@ class TfDetectionApiExporter(Exporter):
         features["image/filename"] = bytes_feature(filename.encode("utf-8"))
 
         if not isinstance(item.media, Image):
-            raise Exception(
+            raise DatasetExportError(
                 "Failed to export dataset item '%s': " "item has no image info" % item.id
             )
         height, width = item.media.size

--- a/datumaro/plugins/data_formats/vgg_face2.py
+++ b/datumaro/plugins/data_formats/vgg_face2.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import csv
+import errno
 import os
 import os.path as osp
 from typing import Optional
@@ -54,7 +55,7 @@ class VggFace2Base(DatasetBase):
         ]
 
         if len(annotation_files) < 1:
-            raise FileNotFoundError("Can't find annotations in the directory '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations in the directory", path)
 
         super().__init__(ctx=ctx)
 

--- a/datumaro/plugins/data_formats/vgg_face2.py
+++ b/datumaro/plugins/data_formats/vgg_face2.py
@@ -1,17 +1,18 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import csv
 import os
 import os.path as osp
+from typing import Optional
 
 from datumaro.components.annotation import AnnotationType, Bbox, Label, LabelCategories, Points
 from datumaro.components.dataset_base import DatasetBase, DatasetItem
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.image import find_images
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
@@ -27,7 +28,7 @@ class VggFace2Path:
 
 
 class VggFace2Base(DatasetBase):
-    def __init__(self, path):
+    def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         subset = None
         if osp.isdir(path):
             self._path = path
@@ -50,7 +51,7 @@ class VggFace2Base(DatasetBase):
         if len(annotation_files) < 1:
             raise Exception("Can't find annotations in the directory '%s'" % path)
 
-        super().__init__()
+        super().__init__(ctx=ctx)
 
         self._dataset_dir = osp.dirname(self._path)
         self._subsets = (

--- a/datumaro/plugins/data_formats/video.py
+++ b/datumaro/plugins/data_formats/video.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -10,7 +10,7 @@ import numpy as np
 
 from datumaro.components.dataset_base import DEFAULT_SUBSET_NAME, DatasetBase, DatasetItem
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Video, VideoFrame
 from datumaro.util.os_util import find_files
 
@@ -103,14 +103,15 @@ class VideoFramesBase(DatasetBase):
         self,
         url: str,
         *,
-        subset: Optional[str] = None,
         name_pattern: str = "%06d",
         step: int = 1,
         start_frame: int = 0,
         end_frame: Optional[int] = None,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
     ) -> None:
         self._subset = subset or DEFAULT_SUBSET_NAME
-        super().__init__(subsets=[self._subset], media_type=VideoFrame)
+        super().__init__(subsets=[self._subset], media_type=VideoFrame, ctx=ctx)
 
         assert osp.isfile(url), url
 

--- a/datumaro/plugins/data_formats/voc/base.py
+++ b/datumaro/plugins/data_formats/voc/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2022 Intel Corporation
+# Copyright (C) 2019-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -25,6 +25,7 @@ from datumaro.components.errors import (
     MissingFieldError,
     UndeclaredLabelError,
 )
+from datumaro.components.importer import ImportContext
 from datumaro.components.media import Image
 from datumaro.util.image import find_images
 from datumaro.util.mask_tools import invert_colormap, lazy_mask
@@ -45,7 +46,14 @@ T = TypeVar("T")
 
 
 class _VocBase(SubsetBase):
-    def __init__(self, path, task, **kwargs):
+    def __init__(
+        self,
+        path: str,
+        task: VocTask,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise DatasetImportError(f"Can't find txt subset list file at '{path}'")
         self._path = path
@@ -53,7 +61,10 @@ class _VocBase(SubsetBase):
 
         self._task = task
 
-        super().__init__(subset=osp.splitext(osp.basename(path))[0], **kwargs)
+        if not subset:
+            subset = osp.splitext(osp.basename(path))[0]
+
+        super().__init__(subset=subset, ctx=ctx)
 
         self._categories = self._load_categories(self._dataset_dir)
 

--- a/datumaro/plugins/data_formats/voc/exporter.py
+++ b/datumaro/plugins/data_formats/voc/exporter.py
@@ -25,7 +25,7 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.dataset import ItemStatus
 from datumaro.components.dataset_base import DatasetItem
-from datumaro.components.errors import MediaTypeError
+from datumaro.components.errors import InvalidAnnotationError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.media import Image
 from datumaro.util import find, str_to_bool
@@ -627,7 +627,7 @@ class VocExporter(Exporter):
                 label_map = parse_label_map(label_map_source)
 
         else:
-            raise Exception(
+            raise InvalidAnnotationError(
                 "Wrong labelmap specified: '%s', "
                 "expected one of %s or a file path"
                 % (label_map_source, ", ".join(t.name for t in LabelmapType))

--- a/datumaro/plugins/data_formats/vott_csv.py
+++ b/datumaro/plugins/data_formats/vott_csv.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import csv
+import errno
 import os.path as osp
 from typing import Optional
 
@@ -27,7 +28,7 @@ class VottCsvBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Can't read annotation file '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0].rsplit("-", maxsplit=1)[0]

--- a/datumaro/plugins/data_formats/vott_csv.py
+++ b/datumaro/plugins/data_formats/vott_csv.py
@@ -1,14 +1,15 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import csv
 import os.path as osp
+from typing import Optional
 
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
 
@@ -18,11 +19,20 @@ class VottCsvPath:
 
 
 class VottCsvBase(SubsetBase):
-    def __init__(self, path):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise FileNotFoundError("Can't read annotation file '%s'" % path)
 
-        super().__init__(subset=osp.splitext(osp.basename(path))[0].rsplit("-", maxsplit=1)[0])
+        if not subset:
+            subset = osp.splitext(osp.basename(path))[0].rsplit("-", maxsplit=1)[0]
+
+        super().__init__(subset=subset, ctx=ctx)
 
         if has_meta_file(path):
             self._categories = {

--- a/datumaro/plugins/data_formats/vott_json.py
+++ b/datumaro/plugins/data_formats/vott_json.py
@@ -1,13 +1,14 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
+from typing import Optional
 
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import parse_json_file
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
@@ -18,11 +19,20 @@ class VottJsonPath:
 
 
 class VottJsonBase(SubsetBase):
-    def __init__(self, path):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
             raise FileNotFoundError("Can't read annotation file '%s'" % path)
 
-        super().__init__(subset=osp.splitext(osp.basename(path))[0].rsplit("-", maxsplit=1)[0])
+        if not subset:
+            subset = osp.splitext(osp.basename(path))[0].rsplit("-", maxsplit=1)[0]
+
+        super().__init__(subset=subset, ctx=ctx)
 
         if has_meta_file(path):
             self._categories = {

--- a/datumaro/plugins/data_formats/vott_json.py
+++ b/datumaro/plugins/data_formats/vott_json.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os.path as osp
 from typing import Optional
 
@@ -27,7 +28,7 @@ class VottJsonBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Can't read annotation file '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
 
         if not subset:
             subset = osp.splitext(osp.basename(path))[0].rsplit("-", maxsplit=1)[0]

--- a/datumaro/plugins/data_formats/widerface.py
+++ b/datumaro/plugins/data_formats/widerface.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import os
 import os.path as osp
 import re
@@ -38,7 +39,7 @@ class WiderFaceBase(SubsetBase):
         ctx: Optional[ImportContext] = None,
     ):
         if not osp.isfile(path):
-            raise FileNotFoundError("Can't read annotation file '%s'" % path)
+            raise FileNotFoundError(errno.ENOENT, "Can't find annotations file", path)
         self._path = path
         self._dataset_dir = osp.dirname(osp.dirname(path))
 

--- a/datumaro/plugins/data_formats/widerface.py
+++ b/datumaro/plugins/data_formats/widerface.py
@@ -1,17 +1,18 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import os
 import os.path as osp
 import re
+from typing import Optional
 
 from datumaro.components.annotation import AnnotationType, Bbox, Label, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import str_to_bool
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
@@ -29,9 +30,15 @@ class WiderFacePath:
 
 
 class WiderFaceBase(SubsetBase):
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         if not osp.isfile(path):
-            raise Exception("Can't read annotation file '%s'" % path)
+            raise FileNotFoundError("Can't read annotation file '%s'" % path)
         self._path = path
         self._dataset_dir = osp.dirname(osp.dirname(path))
 
@@ -39,7 +46,8 @@ class WiderFaceBase(SubsetBase):
             subset = osp.splitext(osp.basename(path))[0]
             if re.fullmatch(r"wider_face_\S+((_bbx_gt)|(_filelist))", subset):
                 subset = subset.split("_")[2]
-        super().__init__(subset=subset)
+
+        super().__init__(subset=subset, ctx=ctx)
 
         self._categories = self._load_categories()
         self._items = list(self._load_items(path).values())

--- a/datumaro/plugins/data_formats/yolo/base.py
+++ b/datumaro/plugins/data_formats/yolo/base.py
@@ -18,6 +18,7 @@ from datumaro.components.errors import (
     InvalidAnnotationError,
     UndeclaredLabelError,
 )
+from datumaro.components.importer import ImportContext
 from datumaro.components.media import Image, ImageFromFile
 from datumaro.util.image import (
     DEFAULT_IMAGE_META_FILE_NAME,
@@ -57,9 +58,11 @@ class YoloStrictBase(SubsetBase):
         self,
         config_path: str,
         image_info: Union[None, str, ImageMeta] = None,
-        **kwargs,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
     ) -> None:
-        super().__init__(**kwargs)
+        super().__init__(subset=subset, ctx=ctx)
 
         if not osp.isfile(config_path):
             raise DatasetImportError(f"Can't read dataset descriptor file '{config_path}'")
@@ -297,9 +300,11 @@ class YoloLooseBase(SubsetBase):
         config_path: str,
         image_info: Union[None, str, ImageMeta] = None,
         urls: Optional[List[str]] = None,
-        **kwargs,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
     ) -> None:
-        super().__init__(**kwargs)
+        super().__init__(subset=subset, ctx=ctx)
 
         if not osp.isdir(config_path):
             raise DatasetImportError(f"{config_path} should be a directory.")

--- a/datumaro/plugins/data_formats/yolo/exporter.py
+++ b/datumaro/plugins/data_formats/yolo/exporter.py
@@ -124,7 +124,9 @@ class YoloExporter(Exporter):
     def _export_media(self, item: DatasetItem, subset_img_dir: str) -> str:
         try:
             if not item.media or not (item.media.has_data or item.media.has_size):
-                raise Exception("Failed to export item '%s': " "item has no image info" % item.id)
+                raise DatasetExportError(
+                    "Failed to export item '%s': " "item has no image info" % item.id
+                )
 
             image_name = self._make_image_filename(item)
             image_fpath = osp.join(subset_img_dir, image_name)

--- a/tests/unit/test_cifar_format.py
+++ b/tests/unit/test_cifar_format.py
@@ -14,6 +14,7 @@ from datumaro.components.annotation import Label
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.environment import Environment
+from datumaro.components.errors import DatasetImportError
 from datumaro.components.media import Image
 from datumaro.plugins.data_formats.cifar import CifarExporter, CifarImporter
 
@@ -271,7 +272,12 @@ class CifarFormatTest(TestCase):
             with open(anno_file, "wb") as file:
                 pickle.dump(enumerate([1, 2, 3]), file)
             with self.assertRaisesRegex(pickle.UnpicklingError, "Global"):
-                Dataset.import_from(dst_dir, "cifar")
+                try:
+                    Dataset.import_from(dst_dir, "cifar")
+                except Exception as e:
+                    if isinstance(e, DatasetImportError) and e.__cause__:
+                        raise e.__cause__
+                    raise
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_and_load_with_meta_file(self):

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -1104,7 +1104,7 @@ class CocoExtractorTests(TestCase):
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
     def test_can_report_unexpected_file(self):
         with TestDir() as test_dir:
-            with self.assertRaisesRegex(DatasetImportError, "JSON file"):
+            with self.assertRaisesRegex(FileNotFoundError, "JSON file"):
                 CocoInstancesBase(test_dir)
 
     @staticmethod
@@ -1128,7 +1128,12 @@ class CocoExtractorTests(TestCase):
                     dump_json_file(ann_path, anns)
 
                     with self.assertRaises(ItemImportError) as capture:
-                        Dataset.import_from(ann_path, "coco_instances")
+                        try:
+                            Dataset.import_from(ann_path, "coco_instances")
+                        except DatasetImportError as e:
+                            if str(e).startswith("Failed to import dataset"):
+                                raise e.__cause__
+                            raise e
                     self.assertIsInstance(capture.exception.__cause__, MissingFieldError)
                     self.assertEqual(capture.exception.__cause__.name, field)
 
@@ -1143,7 +1148,12 @@ class CocoExtractorTests(TestCase):
                     dump_json_file(ann_path, anns)
 
                     with self.assertRaises(AnnotationImportError) as capture:
-                        Dataset.import_from(ann_path, "coco_instances")
+                        try:
+                            Dataset.import_from(ann_path, "coco_instances")
+                        except DatasetImportError as e:
+                            if str(e).startswith("Failed to import dataset"):
+                                raise e.__cause__
+                            raise e
                     self.assertIsInstance(capture.exception.__cause__, MissingFieldError)
                     self.assertEqual(capture.exception.__cause__.name, field)
 
@@ -1184,7 +1194,12 @@ class CocoExtractorTests(TestCase):
             dump_json_file(ann_path, anns)
 
             with self.assertRaises(AnnotationImportError) as capture:
-                Dataset.import_from(ann_path, "coco_instances")
+                try:
+                    Dataset.import_from(ann_path, "coco_instances")
+                except DatasetImportError as e:
+                    if str(e).startswith("Failed to import dataset"):
+                        raise e.__cause__
+                    raise e
             self.assertIsInstance(capture.exception.__cause__, UndeclaredLabelError)
             self.assertEqual(capture.exception.__cause__.id, "2")
 
@@ -1197,7 +1212,12 @@ class CocoExtractorTests(TestCase):
             dump_json_file(ann_path, anns)
 
             with self.assertRaises(AnnotationImportError) as capture:
-                Dataset.import_from(ann_path, "coco_instances")
+                try:
+                    Dataset.import_from(ann_path, "coco_instances")
+                except DatasetImportError as e:
+                    if str(e).startswith("Failed to import dataset"):
+                        raise e.__cause__
+                    raise e
             self.assertIsInstance(capture.exception.__cause__, InvalidAnnotationError)
             self.assertIn("Bbox has wrong value count", str(capture.exception.__cause__))
 
@@ -1210,7 +1230,12 @@ class CocoExtractorTests(TestCase):
             dump_json_file(ann_path, anns)
 
             with self.assertRaises(AnnotationImportError) as capture:
-                Dataset.import_from(ann_path, "coco_instances")
+                try:
+                    Dataset.import_from(ann_path, "coco_instances")
+                except DatasetImportError as e:
+                    if str(e).startswith("Failed to import dataset"):
+                        raise e.__cause__
+                    raise e
             self.assertIsInstance(capture.exception.__cause__, InvalidAnnotationError)
             self.assertIn("not divisible by 2", str(capture.exception.__cause__))
 
@@ -1223,7 +1248,12 @@ class CocoExtractorTests(TestCase):
             dump_json_file(ann_path, anns)
 
             with self.assertRaises(AnnotationImportError) as capture:
-                Dataset.import_from(ann_path, "coco_instances")
+                try:
+                    Dataset.import_from(ann_path, "coco_instances")
+                except DatasetImportError as e:
+                    if str(e).startswith("Failed to import dataset"):
+                        raise e.__cause__
+                    raise e
             self.assertIsInstance(capture.exception.__cause__, InvalidAnnotationError)
             self.assertIn("at least 3 (x, y) pairs", str(capture.exception.__cause__))
 
@@ -1236,7 +1266,12 @@ class CocoExtractorTests(TestCase):
             dump_json_file(ann_path, anns)
 
             with self.assertRaises(AnnotationImportError) as capture:
-                Dataset.import_from(ann_path, "coco_instances")
+                try:
+                    Dataset.import_from(ann_path, "coco_instances")
+                except DatasetImportError as e:
+                    if str(e).startswith("Failed to import dataset"):
+                        raise e.__cause__
+                    raise e
             self.assertIsInstance(capture.exception.__cause__, InvalidAnnotationError)
             self.assertIn("Unknown image id", str(capture.exception.__cause__))
 
@@ -1251,7 +1286,12 @@ class CocoExtractorTests(TestCase):
                     dump_json_file(ann_path, anns)
 
                     with self.assertRaises(ItemImportError) as capture:
-                        Dataset.import_from(ann_path, "coco_instances")
+                        try:
+                            Dataset.import_from(ann_path, "coco_instances")
+                        except DatasetImportError as e:
+                            if str(e).startswith("Failed to import dataset"):
+                                raise e.__cause__
+                            raise e
                     self.assertIsInstance(capture.exception.__cause__, InvalidFieldTypeError)
                     self.assertEqual(capture.exception.__cause__.name, field)
                     self.assertEqual(capture.exception.__cause__.actual, str(type(value)))
@@ -1275,7 +1315,12 @@ class CocoExtractorTests(TestCase):
                     dump_json_file(ann_path, anns)
 
                     with self.assertRaises(AnnotationImportError) as capture:
-                        Dataset.import_from(ann_path, "coco_instances")
+                        try:
+                            Dataset.import_from(ann_path, "coco_instances")
+                        except DatasetImportError as e:
+                            if str(e).startswith("Failed to import dataset"):
+                                raise e.__cause__
+                            raise e
                     self.assertIsInstance(capture.exception.__cause__, InvalidFieldTypeError)
                     self.assertEqual(capture.exception.__cause__.name, field)
                     self.assertEqual(capture.exception.__cause__.actual, str(type(value)))

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -1168,7 +1168,12 @@ class CocoExtractorTests(TestCase):
                     dump_json_file(ann_path, anns)
 
                     with self.assertRaises(MissingFieldError) as capture:
-                        Dataset.import_from(ann_path, "coco_instances")
+                        try:
+                            Dataset.import_from(ann_path, "coco_instances")
+                        except Exception as e:
+                            if isinstance(e, DatasetImportError) and e.__cause__:
+                                raise e.__cause__
+                            raise
                     self.assertEqual(capture.exception.name, field)
 
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
@@ -1182,7 +1187,12 @@ class CocoExtractorTests(TestCase):
                     dump_json_file(ann_path, anns)
 
                     with self.assertRaises(MissingFieldError) as capture:
-                        Dataset.import_from(ann_path, "coco_instances")
+                        try:
+                            Dataset.import_from(ann_path, "coco_instances")
+                        except Exception as e:
+                            if isinstance(e, DatasetImportError) and e.__cause__:
+                                raise e.__cause__
+                            raise
                     self.assertEqual(capture.exception.name, field)
 
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)

--- a/tests/unit/test_voc_format.py
+++ b/tests/unit/test_voc_format.py
@@ -22,6 +22,7 @@ from datumaro.components.dataset_base import DatasetBase, DatasetItem
 from datumaro.components.environment import Environment
 from datumaro.components.errors import (
     AnnotationImportError,
+    DatasetImportError,
     InvalidAnnotationError,
     InvalidFieldError,
     ItemImportError,
@@ -618,7 +619,12 @@ class VocExtractorTest(TestCase):
             with self.assertRaisesRegex(
                 InvalidAnnotationError, "unexpected number of quotes in filename"
             ):
-                Dataset.import_from(test_dir, format="voc_layout")
+                try:
+                    Dataset.import_from(test_dir, format="voc_layout")
+                except Exception as e:
+                    if isinstance(e, DatasetImportError) and e.__cause__:
+                        raise e.__cause__
+                    raise
 
     @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
     def test_can_report_invalid_label_in_xml(self):

--- a/tests/unit/test_yolo_format.py
+++ b/tests/unit/test_yolo_format.py
@@ -465,4 +465,9 @@ class YoloStrictBaseTest(TestCase):
             os.remove(osp.join(test_dir, "train.txt"))
 
             with self.assertRaisesRegex(InvalidAnnotationError, "subset list file"):
-                Dataset.import_from(test_dir, "yolo").init_cache()
+                try:
+                    Dataset.import_from(test_dir, "yolo").init_cache()
+                except Exception as e:
+                    if isinstance(e, DatasetImportError) and e.__cause__:
+                        raise e.__cause__
+                    raise


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
- Sorted detection results to make it consistent if something went wrong
- Added a verbose error output with what and where Datumaro tried to import
- Changed to consume `ctx` for all data formats supported officially to lift up one level of stack trace
- Narrowed down exception type for verbosity

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
