### PR TITLE
Grant write permission to auto-issue-assigner

### DIFF
--- a/.github/workflows/issue_assignment.yml
+++ b/.github/workflows/issue_assignment.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+
     steps:
       - name: Auto-assign Issue
         uses: pozil/auto-assign-issue@v1.11.0


### PR DESCRIPTION
### Summary
 - Auto-issue-assigner GH action pipeline is not working for now since it doesn't have write permissions: https://github.com/openvinotoolkit/datumaro/actions/runs/4933109608/jobs/8816769441#step:2:11.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
