### PR TITLE
Drop a malformed transform from StackedTransform automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/987>)
 - Fix `person_layout` categories and `action_classification` attributes in imported Pascal-VOC dataset
   (<https://github.com/openvinotoolkit/datumaro/pull/997>)
+- Drop a malformed transform from StackedTransform automatically
+  (<https://github.com/openvinotoolkit/datumaro/pull/1001>)
 
 ## 04/05/2023 - Release 1.2.1
 ### Bug fixes

--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -260,6 +260,7 @@ class DatasetStorage(IDataset):
         #   b. Transforms affect whole dataset
         #
         # The patch is always applied on top of the source / transforms stack.
+
         class _StackedTransform(Transform):
             def __init__(self, source, transforms):
                 super().__init__(source)

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -2179,10 +2179,10 @@ class DatasetTransformTest:
         )
 
         with eager_mode(mode, dataset), caplog.at_level(logging.ERROR):
-            # Call an invalid transform by giving wrong argument name
+            # Call a malformed transform by giving wrong argument name
             dataset.transform("random_split", wrong_argument_name=[("train", 0.67), ("val", 0.33)])
 
-            # The previous invalid transform should be not stacked,
+            # The previous malformed transform should be not stacked,
             # so that the following valid transform should successfully be executed.
             try:
                 dataset = dataset.transform("random_split", splits=[("train", 0.67), ("val", 0.33)])

--- a/tests/unit/test_hl_ops.py
+++ b/tests/unit/test_hl_ops.py
@@ -2,10 +2,19 @@
 #
 # SPDX-License-Identifier: MIT
 
+import numpy as np
 import pytest
 
 from datumaro import Dataset, DatasetItem, HLOps
-from datumaro.components.annotation import Bbox, Ellipse, Label, Polygon
+from datumaro.components.annotation import (
+    AnnotationType,
+    Bbox,
+    Ellipse,
+    Label,
+    LabelCategories,
+    Polygon,
+)
+from datumaro.components.media import Image
 
 from tests.requirements import Requirements, mark_requirement
 from tests.utils.test_utils import TestCaseHelper, TestDir

--- a/tests/unit/test_hl_ops.py
+++ b/tests/unit/test_hl_ops.py
@@ -2,19 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-import numpy as np
 import pytest
 
 from datumaro import Dataset, DatasetItem, HLOps
-from datumaro.components.annotation import (
-    AnnotationType,
-    Bbox,
-    Ellipse,
-    Label,
-    LabelCategories,
-    Polygon,
-)
-from datumaro.components.media import Image
+from datumaro.components.annotation import Bbox, Ellipse, Label, Polygon
 
 from tests.requirements import Requirements, mark_requirement
 from tests.utils.test_utils import TestCaseHelper, TestDir


### PR DESCRIPTION
### Summary

- Ticket no. 106054
- A malformed transform can be stacked on `_StackTransform`. Therefore, it would fail if the user tries to apply several transforms to the dataset sequentially and there exist malformed transforms. Also, once a malformed transform is given to `Dataset.transform()`, that transform permanently remains in the dataset, so creating a new dataset is the only way to solve it.
- This patch pops up the malformed transform from the transform stack automatically if it raises an error at construction.

### How to test
Unit tests are added for this change.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```