### PR TITLE
Fixed typo in example command

### DIFF
--- a/docs/source/docs/level-up/intermediate_skills/07_data_merge.rst
+++ b/docs/source/docs/level-up/intermediate_skills/07_data_merge.rst
@@ -73,7 +73,7 @@ Merge datasets
 
     .. code-block:: bash
 
-      datum merge --merge_policy union --format imagenet --output-dir <path/to/output> <path/to/project1> <path/to/project2> -- --save-media
+      datum merge --merge-policy union --format imagenet --output-dir <path/to/output> <path/to/project1> <path/to/project2> -- --save-media
 
     Similar to merge without projects, we have the merge report named by ``merge_report.json`` inside the output directory.
     Finally, we import the merged data (``<path/to/output>``) into a project.


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
I fixed a typo in the example command for the level 7 documentation

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [x] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
