### PR TITLE
Refactor: change Exporter::apply() to Exporter::_apply_impl()

### DIFF
--- a/datumaro/components/exporter.py
+++ b/datumaro/components/exporter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2022 Intel Corporation
+# Copyright (C) 2019-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/datumaro/components/exporter.py
+++ b/datumaro/components/exporter.py
@@ -130,7 +130,7 @@ class Exporter(CliPlugin):
     @classmethod
     def convert(cls, extractor, save_dir, **options):
         converter = cls(extractor, save_dir, **options)
-        return converter._apply_impl()
+        return converter.apply()
 
     @classmethod
     @scoped

--- a/datumaro/components/exporter.py
+++ b/datumaro/components/exporter.py
@@ -130,7 +130,7 @@ class Exporter(CliPlugin):
     @classmethod
     def convert(cls, extractor, save_dir, **options):
         converter = cls(extractor, save_dir, **options)
-        return converter.apply()
+        return converter._apply_impl()
 
     @classmethod
     @scoped
@@ -162,6 +162,10 @@ class Exporter(CliPlugin):
         return retval
 
     def apply(self):
+        """Execute the data-format conversion"""
+        return self._apply_impl()
+
+    def _apply_impl(self):
         raise NotImplementedError("Should be implemented in a subclass")
 
     def __init__(

--- a/datumaro/plugins/data_formats/arrow/exporter.py
+++ b/datumaro/plugins/data_formats/arrow/exporter.py
@@ -302,7 +302,7 @@ class ArrowExporter(Exporter):
             ctx=ctx,
         )
 
-    def apply(self, *args, **kwargs):
+    def _apply_impl(self, *args, **kwargs):
         if self._num_workers == 0:
             return self._apply()
 

--- a/datumaro/plugins/data_formats/ava/ava.py
+++ b/datumaro/plugins/data_formats/ava/ava.py
@@ -179,7 +179,7 @@ class AvaImporter(Importer):
 class AvaExporter(Exporter):
     DEFAULT_IMAGE_EXT = AvaPath.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/camvid.py
+++ b/datumaro/plugins/data_formats/camvid.py
@@ -322,7 +322,7 @@ class CamvidExporter(Exporter):
             label_map = LabelmapType.source.name
         self._load_categories(label_map)
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 
@@ -469,7 +469,7 @@ class CamvidExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv.apply()
+            conv._apply_impl()
 
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         for (item_id, subset), status in patch.updated_items.items():

--- a/datumaro/plugins/data_formats/camvid.py
+++ b/datumaro/plugins/data_formats/camvid.py
@@ -469,7 +469,7 @@ class CamvidExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv._apply_impl()
+            conv.apply()
 
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         for (item_id, subset), status in patch.updated_items.items():

--- a/datumaro/plugins/data_formats/cifar.py
+++ b/datumaro/plugins/data_formats/cifar.py
@@ -330,7 +330,7 @@ class CifarExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv._apply_impl()
+            conv.apply()
 
         for subset, status in patch.updated_subsets.items():
             if status != ItemStatus.removed:

--- a/datumaro/plugins/data_formats/cifar.py
+++ b/datumaro/plugins/data_formats/cifar.py
@@ -218,7 +218,7 @@ class CifarImporter(Importer):
 class CifarExporter(Exporter):
     DEFAULT_IMAGE_EXT = ".png"
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 
@@ -330,7 +330,7 @@ class CifarExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv.apply()
+            conv._apply_impl()
 
         for subset, status in patch.updated_subsets.items():
             if status != ItemStatus.removed:

--- a/datumaro/plugins/data_formats/cityscapes.py
+++ b/datumaro/plugins/data_formats/cityscapes.py
@@ -533,7 +533,7 @@ class CityscapesExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv._apply_impl()
+            conv.apply()
 
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         for (item_id, subset), status in patch.updated_items.items():

--- a/datumaro/plugins/data_formats/cityscapes.py
+++ b/datumaro/plugins/data_formats/cityscapes.py
@@ -380,7 +380,7 @@ class CityscapesExporter(Exporter):
             label_map = LabelmapType.source.name
         self._load_categories(label_map)
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 
@@ -533,7 +533,7 @@ class CityscapesExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv.apply()
+            conv._apply_impl()
 
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         for (item_id, subset), status in patch.updated_items.items():

--- a/datumaro/plugins/data_formats/coco/exporter.py
+++ b/datumaro/plugins/data_formats/coco/exporter.py
@@ -772,7 +772,7 @@ class CocoExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv._apply_impl()
+            conv.apply()
 
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         images_dir = osp.join(save_dir, CocoPath.IMAGES_DIR)

--- a/datumaro/plugins/data_formats/coco/exporter.py
+++ b/datumaro/plugins/data_formats/coco/exporter.py
@@ -713,7 +713,7 @@ class CocoExporter(Exporter):
             self._image_ids[item.id] = image_id
         return image_id
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 
@@ -772,7 +772,7 @@ class CocoExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv.apply()
+            conv._apply_impl()
 
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         images_dir = osp.join(save_dir, CocoPath.IMAGES_DIR)

--- a/datumaro/plugins/data_formats/cvat/exporter.py
+++ b/datumaro/plugins/data_formats/cvat/exporter.py
@@ -572,7 +572,7 @@ class CvatExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv._apply_impl()
+            conv.apply()
 
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         # Find images that needs to be removed

--- a/datumaro/plugins/data_formats/cvat/exporter.py
+++ b/datumaro/plugins/data_formats/cvat/exporter.py
@@ -551,7 +551,7 @@ class CvatExporter(Exporter):
                 return None
         return (item_hw[1], item_hw[0])
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 
@@ -572,7 +572,7 @@ class CvatExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv.apply()
+            conv._apply_impl()
 
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         # Find images that needs to be removed

--- a/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -441,7 +441,7 @@ class DatumaroExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv._apply_impl()
+            conv.apply()
 
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         for (item_id, subset), status in patch.updated_items.items():

--- a/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -392,7 +392,7 @@ class DatumaroExporter(Exporter):
             export_context=export_context,
         )
 
-    def apply(self, pool: Optional[Pool] = None, *args, **kwargs):
+    def _apply_impl(self, pool: Optional[Pool] = None, *args, **kwargs):
         os.makedirs(self._save_dir, exist_ok=True)
 
         images_dir = osp.join(self._save_dir, self.PATH_CLS.IMAGES_DIR)
@@ -441,7 +441,7 @@ class DatumaroExporter(Exporter):
         for subset in patch.updated_subsets:
             conv = cls(dataset.get_subset(subset), save_dir=save_dir, **kwargs)
             conv._patch = patch
-            conv.apply()
+            conv._apply_impl()
 
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         for (item_id, subset), status in patch.updated_items.items():

--- a/datumaro/plugins/data_formats/datumaro_binary/exporter.py
+++ b/datumaro/plugins/data_formats/datumaro_binary/exporter.py
@@ -315,9 +315,9 @@ class DatumaroBinaryExporter(DatumaroExporter):
             max_blob_size=self._max_blob_size,
         )
 
-    def apply(self, *args, **kwargs):
+    def _apply_impl(self, *args, **kwargs):
         if self._num_workers == 0:
-            return super().apply()
+            return super()._apply_impl()
 
         with Pool(processes=self._num_workers) as pool:
-            return super().apply(pool)
+            return super()._apply_impl(pool)

--- a/datumaro/plugins/data_formats/icdar/exporter.py
+++ b/datumaro/plugins/data_formats/icdar/exporter.py
@@ -18,7 +18,7 @@ from .format import IcdarPath
 class IcdarWordRecognitionExporter(Exporter):
     DEFAULT_IMAGE_EXT = IcdarPath.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 
@@ -49,7 +49,7 @@ class IcdarWordRecognitionExporter(Exporter):
 class IcdarTextLocalizationExporter(Exporter):
     DEFAULT_IMAGE_EXT = IcdarPath.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 
@@ -84,7 +84,7 @@ class IcdarTextLocalizationExporter(Exporter):
 class IcdarTextSegmentationExporter(Exporter):
     DEFAULT_IMAGE_EXT = IcdarPath.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/image_dir.py
+++ b/datumaro/plugins/data_formats/image_dir.py
@@ -60,7 +60,7 @@ class ImageDirBase(SubsetBase):
 class ImageDirExporter(Exporter):
     DEFAULT_IMAGE_EXT = ".jpg"
 
-    def apply(self):
+    def _apply_impl(self):
         os.makedirs(self._save_dir, exist_ok=True)
 
         for item in self._extractor:

--- a/datumaro/plugins/data_formats/image_zip.py
+++ b/datumaro/plugins/data_formats/image_zip.py
@@ -102,7 +102,7 @@ class ImageZipExporter(Exporter):
         self._archive_name = name
         self._compression = compression.value
 
-    def apply(self):
+    def _apply_impl(self):
         os.makedirs(self._save_dir, exist_ok=True)
 
         archive_path = osp.join(self._save_dir, self._archive_name)

--- a/datumaro/plugins/data_formats/imagenet.py
+++ b/datumaro/plugins/data_formats/imagenet.py
@@ -159,7 +159,7 @@ class ImagenetExporter(Exporter):
     DEFAULT_IMAGE_EXT = ".jpg"
     USE_SUBSET_DIRS = False
 
-    def apply(self):
+    def _apply_impl(self):
         def _get_name(item: DatasetItem) -> str:
             id_parts = item.id.split(ImagenetPath.SEP_TOKEN)
 

--- a/datumaro/plugins/data_formats/imagenet_txt.py
+++ b/datumaro/plugins/data_formats/imagenet_txt.py
@@ -193,7 +193,7 @@ class ImagenetTxtImporter(Importer, CliPlugin):
 class ImagenetTxtExporter(Exporter):
     DEFAULT_IMAGE_EXT = ".jpg"
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/kitti/exporter.py
+++ b/datumaro/plugins/data_formats/kitti/exporter.py
@@ -111,7 +111,7 @@ class KittiExporter(Exporter):
                 )
             }
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/kitti_raw/exporter.py
+++ b/datumaro/plugins/data_formats/kitti_raw/exporter.py
@@ -483,7 +483,7 @@ class KittiRawExporter(Exporter):
     @classmethod
     def patch(cls, dataset, patch, save_dir, **kwargs):
         conv = cls(patch.as_dataset(dataset), save_dir=save_dir, **kwargs)
-        conv._apply_impl()
+        conv.apply()
 
         pcd_dir = osp.abspath(osp.join(save_dir, KittiRawPath.PCD_DIR))
         for (item_id, subset), status in patch.updated_items.items():

--- a/datumaro/plugins/data_formats/kitti_raw/exporter.py
+++ b/datumaro/plugins/data_formats/kitti_raw/exporter.py
@@ -460,7 +460,7 @@ class KittiRawExporter(Exporter):
 
         return index
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and self._extractor.media_type() is not PointCloud:
             raise MediaTypeError("Media type is not a point cloud")
 
@@ -483,7 +483,7 @@ class KittiRawExporter(Exporter):
     @classmethod
     def patch(cls, dataset, patch, save_dir, **kwargs):
         conv = cls(patch.as_dataset(dataset), save_dir=save_dir, **kwargs)
-        conv.apply()
+        conv._apply_impl()
 
         pcd_dir = osp.abspath(osp.join(save_dir, KittiRawPath.PCD_DIR))
         for (item_id, subset), status in patch.updated_items.items():

--- a/datumaro/plugins/data_formats/labelme.py
+++ b/datumaro/plugins/data_formats/labelme.py
@@ -362,7 +362,7 @@ class LabelMeImporter(Importer):
 class LabelMeExporter(Exporter):
     DEFAULT_IMAGE_EXT = LabelMePath.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/lfw.py
+++ b/datumaro/plugins/data_formats/lfw.py
@@ -239,7 +239,7 @@ class LfwImporter(Importer):
 class LfwExporter(Exporter):
     DEFAULT_IMAGE_EXT = LfwPath.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/market1501.py
+++ b/datumaro/plugins/data_formats/market1501.py
@@ -131,7 +131,7 @@ class Market1501Exporter(Exporter):
             dirname = Market1501Path.QUERY_DIR
         return dirname
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/mnist.py
+++ b/datumaro/plugins/data_formats/mnist.py
@@ -140,7 +140,7 @@ class MnistImporter(Importer):
 class MnistExporter(Exporter):
     DEFAULT_IMAGE_EXT = ".png"
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/mnist_csv.py
+++ b/datumaro/plugins/data_formats/mnist_csv.py
@@ -121,7 +121,7 @@ class MnistCsvImporter(Importer):
 class MnistCsvExporter(Exporter):
     DEFAULT_IMAGE_EXT = ".png"
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/mot.py
+++ b/datumaro/plugins/data_formats/mot.py
@@ -241,7 +241,7 @@ class MotSeqImporter(Importer):
 class MotSeqGtExporter(Exporter):
     DEFAULT_IMAGE_EXT = MotPath.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         extractor = self._extractor
 
         if extractor.media_type() and not issubclass(extractor.media_type(), Image):

--- a/datumaro/plugins/data_formats/mots.py
+++ b/datumaro/plugins/data_formats/mots.py
@@ -153,7 +153,7 @@ class MotsImporter(Importer):
 class MotsPngExporter(Exporter):
     DEFAULT_IMAGE_EXT = MotsPath.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/mvtec/exporter.py
+++ b/datumaro/plugins/data_formats/mvtec/exporter.py
@@ -60,7 +60,7 @@ class MvtecExporter(Exporter):
             tasks = set(parse_str_enum_value(t, MvtecTask) for t in tasks)
         self._tasks = tasks
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/open_images.py
+++ b/datumaro/plugins/data_formats/open_images.py
@@ -711,7 +711,7 @@ class _AnnotationWriter:
 class OpenImagesExporter(Exporter):
     DEFAULT_IMAGE_EXT = ".jpg"
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/segment_anything/exporter.py
+++ b/datumaro/plugins/data_formats/segment_anything/exporter.py
@@ -100,7 +100,7 @@ class SegmentAnythingExporter(Exporter):
         }
         return annotation_data
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/sly_pointcloud/exporter.py
+++ b/datumaro/plugins/data_formats/sly_pointcloud/exporter.py
@@ -413,7 +413,7 @@ class SuperviselyPointCloudExporter(Exporter):
     @classmethod
     def patch(cls, dataset, patch, save_dir, **kwargs):
         conv = cls(patch.as_dataset(dataset), save_dir=save_dir, **kwargs)
-        conv._apply_impl()
+        conv.apply()
 
         for (item_id, subset), status in patch.updated_items.items():
             if status != ItemStatus.removed:

--- a/datumaro/plugins/data_formats/sly_pointcloud/exporter.py
+++ b/datumaro/plugins/data_formats/sly_pointcloud/exporter.py
@@ -398,7 +398,7 @@ class SuperviselyPointCloudExporter(Exporter):
         self._reindex = reindex
         self._allow_undeclared_attrs = allow_undeclared_attrs
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and self._extractor.media_type() is not PointCloud:
             raise MediaTypeError("Media type is not an image")
 
@@ -413,7 +413,7 @@ class SuperviselyPointCloudExporter(Exporter):
     @classmethod
     def patch(cls, dataset, patch, save_dir, **kwargs):
         conv = cls(patch.as_dataset(dataset), save_dir=save_dir, **kwargs)
-        conv.apply()
+        conv._apply_impl()
 
         for (item_id, subset), status in patch.updated_items.items():
             if status != ItemStatus.removed:

--- a/datumaro/plugins/data_formats/tf_detection_api/exporter.py
+++ b/datumaro/plugins/data_formats/tf_detection_api/exporter.py
@@ -70,7 +70,7 @@ class TfDetectionApiExporter(Exporter):
 
         self._save_masks = save_masks
 
-    def apply(self):
+    def _apply_impl(self):
         os.makedirs(self._save_dir, exist_ok=True)
 
         label_categories = self._extractor.categories().get(AnnotationType.label, LabelCategories())

--- a/datumaro/plugins/data_formats/vgg_face2.py
+++ b/datumaro/plugins/data_formats/vgg_face2.py
@@ -233,7 +233,7 @@ class VggFace2Importer(Importer):
 class VggFace2Exporter(Exporter):
     DEFAULT_IMAGE_EXT = VggFace2Path.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         def _get_name_id(item_parts, label_name):
             if 1 < len(item_parts) and item_parts[0] == label_name:
                 return "/".join([label_name, *item_parts[1:]])

--- a/datumaro/plugins/data_formats/voc/exporter.py
+++ b/datumaro/plugins/data_formats/voc/exporter.py
@@ -179,7 +179,7 @@ class VocExporter(Exporter):
 
         self._patch = None
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 
@@ -739,7 +739,7 @@ class VocExporter(Exporter):
     def patch(cls, dataset, patch, save_dir, **kwargs):
         conv = cls(patch.as_dataset(dataset), save_dir=save_dir, **kwargs)
         conv._patch = patch
-        conv.apply()
+        conv._apply_impl()
 
         for filename in os.listdir(conv._cls_subsets_dir):
             if "_" not in filename or not filename.endswith(".txt"):

--- a/datumaro/plugins/data_formats/voc/exporter.py
+++ b/datumaro/plugins/data_formats/voc/exporter.py
@@ -739,7 +739,7 @@ class VocExporter(Exporter):
     def patch(cls, dataset, patch, save_dir, **kwargs):
         conv = cls(patch.as_dataset(dataset), save_dir=save_dir, **kwargs)
         conv._patch = patch
-        conv._apply_impl()
+        conv.apply()
 
         for filename in os.listdir(conv._cls_subsets_dir):
             if "_" not in filename or not filename.endswith(".txt"):

--- a/datumaro/plugins/data_formats/widerface.py
+++ b/datumaro/plugins/data_formats/widerface.py
@@ -185,7 +185,7 @@ class WiderFaceImporter(Importer):
 class WiderFaceExporter(Exporter):
     DEFAULT_IMAGE_EXT = WiderFacePath.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 

--- a/datumaro/plugins/data_formats/yolo/exporter.py
+++ b/datumaro/plugins/data_formats/yolo/exporter.py
@@ -166,7 +166,7 @@ class YoloExporter(Exporter):
     def patch(cls, dataset, patch, save_dir, **kwargs):
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         conv._patch = patch
-        conv._apply_impl()
+        conv.apply()
 
         for (item_id, subset), status in patch.updated_items.items():
             if status != ItemStatus.removed:
@@ -282,7 +282,7 @@ class YoloUltralyticsExporter(YoloExporter):
     def patch(cls, dataset, patch, save_dir, **kwargs):
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         conv._patch = patch
-        conv._apply_impl()
+        conv.apply()
 
         for (item_id, subset), status in patch.updated_items.items():
             if status != ItemStatus.removed:

--- a/datumaro/plugins/data_formats/yolo/exporter.py
+++ b/datumaro/plugins/data_formats/yolo/exporter.py
@@ -52,7 +52,7 @@ class YoloExporter(Exporter):
 
         self._prefix = "data" if add_path_prefix else ""
 
-    def apply(self):
+    def _apply_impl(self):
         extractor = self._extractor
         save_dir = self._save_dir
 
@@ -166,7 +166,7 @@ class YoloExporter(Exporter):
     def patch(cls, dataset, patch, save_dir, **kwargs):
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         conv._patch = patch
-        conv.apply()
+        conv._apply_impl()
 
         for (item_id, subset), status in patch.updated_items.items():
             if status != ItemStatus.removed:
@@ -223,7 +223,7 @@ class YoloUltralyticsExporter(YoloExporter):
                     "but YoloUltralytics requires both of them."
                 )
 
-    def apply(self):
+    def _apply_impl(self):
         extractor = self._extractor
         save_dir = self._save_dir
 
@@ -282,7 +282,7 @@ class YoloUltralyticsExporter(YoloExporter):
     def patch(cls, dataset, patch, save_dir, **kwargs):
         conv = cls(dataset, save_dir=save_dir, **kwargs)
         conv._patch = patch
-        conv.apply()
+        conv._apply_impl()
 
         for (item_id, subset), status in patch.updated_items.items():
             if status != ItemStatus.removed:

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1611,7 +1611,7 @@ class DatasetTest(TestCase):
         class CustomExporter(Exporter):
             DEFAULT_IMAGE_EXT = ".jpg"
 
-            def apply(self):
+            def _apply_impl(self):
                 assert osp.isdir(self._save_dir)
 
                 for item in self._extractor:
@@ -1885,7 +1885,7 @@ class DatasetTest(TestCase):
         class TestExporter(Exporter):
             DEFAULT_IMAGE_EXT = ".jpg"
 
-            def apply(self):
+            def _apply_impl(self):
                 list(self._ctx.progress_reporter.iter([None] * 5, desc="loading images"))
 
         class TestProgressReporter(ProgressReporter):
@@ -1913,7 +1913,7 @@ class DatasetTest(TestCase):
         class TestExporter(Exporter):
             DEFAULT_IMAGE_EXT = ".jpg"
 
-            def apply(self):
+            def _apply_impl(self):
                 class TestError(Exception):
                     pass
 


### PR DESCRIPTION
### Summary
 - Refactor: change Exporter::apply() to Exporter::_apply_impl()
 - This is required for #1003 to reserve a place to put in code snippets for data-format agnostic hash exportation.

### How to test
Our existing tests will cover it.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
