### PR TITLE
Constraint cityscapes dataset structure

### DIFF
--- a/datumaro/plugins/data_formats/cityscapes.py
+++ b/datumaro/plugins/data_formats/cityscapes.py
@@ -401,11 +401,20 @@ class CityscapesExporter(Exporter):
         os.makedirs(self._save_dir, exist_ok=True)
 
         for subset_name, subset in self._extractor.subsets().items():
+            media_dir = osp.join(
+                self._save_dir,
+                CityscapesPath.IMGS_FINE_DIR,
+                CityscapesPath.ORIGINAL_IMAGE_DIR,
+                subset_name,
+            )
+            os.makedirs(media_dir, exist_ok=True)
+
+            mask_dir = osp.join(self._save_dir, CityscapesPath.GT_FINE_DIR, subset_name)
+            os.makedirs(mask_dir, exist_ok=True)
+
             for item in subset:
                 image_path = osp.join(
-                    CityscapesPath.IMGS_FINE_DIR,
-                    CityscapesPath.ORIGINAL_IMAGE_DIR,
-                    subset_name,
+                    media_dir,
                     item.id + CityscapesPath.ORIGINAL_IMAGE + self._find_image_ext(item),
                 )
                 if self._save_media:
@@ -428,7 +437,6 @@ class CityscapesExporter(Exporter):
                     instance_labels=[self._label_id_mapping(m.label) for m in masks],
                 )
 
-                mask_dir = osp.join(self._save_dir, CityscapesPath.GT_FINE_DIR, subset_name)
                 mask_name = item.id + "_" + CityscapesPath.GT_FINE_DIR
 
                 color_mask_path = osp.join(mask_dir, mask_name + CityscapesPath.COLOR_IMAGE)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

related to https://github.com/openvinotoolkit/datumaro/pull/1023

`cityscapes` dataset is separated into multiple zip files where users have to unarchive them and put them into a certain directory structure to be able to import them into Datumaro.

- Separated annotation and media directories when detecting `cityscapes` dataset to ensure the certain structure.
- Raised an error while importing when directory is not structured in a way that Datumaro can recognise.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
