### PR TITLE
Change default model directory of FractalImageGenerator

### DIFF
--- a/datumaro/cli/commands/generate.py
+++ b/datumaro/cli/commands/generate.py
@@ -10,6 +10,7 @@ from shutil import rmtree
 
 from datumaro.cli.util.errors import CliException
 from datumaro.plugins.synthetic_data import FractalImageGenerator
+from datumaro.util.definitions import DATUMARO_CACHE_DIR
 
 from ..util import MultilineFormatter
 
@@ -56,8 +57,10 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
     )
     parser.add_argument(
         "--model-dir",
+        type=str,
+        default=DATUMARO_CACHE_DIR,
         help="Path to load the colorization model from. "
-        "If no model is found, the model will be downloaded (default: current dir)",
+        "If no model is found, the model will be downloaded (default: %(default)s)",
     )
     parser.add_argument(
         "--overwrite", action="store_true", help="Overwrite existing files in the save directory"

--- a/datumaro/plugins/openvino_plugin/launcher.py
+++ b/datumaro/plugins/openvino_plugin/launcher.py
@@ -5,7 +5,6 @@
 # pylint: disable=exec-used
 
 import logging as log
-import os
 import os.path as osp
 import shutil
 import urllib
@@ -17,6 +16,7 @@ from tqdm import tqdm
 
 from datumaro.components.cli_plugin import CliPlugin
 from datumaro.components.launcher import Launcher
+from datumaro.util.definitions import DATUMARO_CACHE_DIR
 from datumaro.util.samples import get_samples_path
 
 
@@ -110,9 +110,7 @@ class OpenvinoLauncher(Launcher):
         device=None,
     ):
         if model_name:
-            model_dir = os.path.join(os.path.expanduser("~"), ".cache", "datumaro")
-            if not osp.exists(model_dir):
-                os.makedirs(model_dir)
+            model_dir = DATUMARO_CACHE_DIR
 
             # Please visit open-model-zoo repository for OpenVINO public models if you are interested in
             # https://github.com/openvinotoolkit/open_model_zoo/blob/master/models/public/index.md

--- a/datumaro/plugins/synthetic_data/image_generator.py
+++ b/datumaro/plugins/synthetic_data/image_generator.py
@@ -16,6 +16,7 @@ import numpy as np
 import requests
 
 from datumaro.components.generator import DatasetGenerator
+from datumaro.util.definitions import DATUMARO_CACHE_DIR
 from datumaro.util.image import save_image
 from datumaro.util.scope import on_error_do, on_exit_do, scope_add, scoped
 
@@ -34,13 +35,17 @@ class FractalImageGenerator(DatasetGenerator):
     _COLORS_FILE = "background_colors.txt"
 
     def __init__(
-        self, output_dir: str, count: int, shape: Tuple[int, int], model_path: Optional[str] = None
+        self,
+        output_dir: str,
+        count: int,
+        shape: Tuple[int, int],
+        model_path: str = DATUMARO_CACHE_DIR,
     ) -> None:
         assert 0 < count, "Image count cannot be lesser than 1"
         self._count = count
 
         self._output_dir = output_dir
-        self._model_dir = model_path if model_path else os.getcwd()
+        self._model_dir = model_path
 
         self._cpu_count = min(os.cpu_count(), self._count)
 

--- a/datumaro/util/definitions.py
+++ b/datumaro/util/definitions.py
@@ -2,8 +2,15 @@
 #
 # SPDX-License-Identifier: MIT
 
+import os
+import os.path as osp
 from typing import Tuple
 
 DEFAULT_SUBSET_NAME = "default"
 BboxIntCoords = Tuple[int, int, int, int]  # (x, y, w, h)
 SUBSET_NAME_BLACKLIST = {"labels", "images", "annotations", "instances"}
+
+DATUMARO_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "datumaro")
+
+if not osp.exists(DATUMARO_CACHE_DIR):
+    os.makedirs(DATUMARO_CACHE_DIR)

--- a/datumaro/util/definitions.py
+++ b/datumaro/util/definitions.py
@@ -10,7 +10,7 @@ DEFAULT_SUBSET_NAME = "default"
 BboxIntCoords = Tuple[int, int, int, int]  # (x, y, w, h)
 SUBSET_NAME_BLACKLIST = {"labels", "images", "annotations", "instances"}
 
-_CACHE_DIR = os.getenv("XDG_CACHE_HOME", osp.join(osp.expanduser("~"), ".cache"))
+_CACHE_DIR = osp.expanduser(os.getenv("XDG_CACHE_HOME", osp.join("~", ".cache")))
 DATUMARO_CACHE_DIR = osp.join(_CACHE_DIR, "datumaro")
 
 if not osp.exists(DATUMARO_CACHE_DIR):

--- a/datumaro/util/definitions.py
+++ b/datumaro/util/definitions.py
@@ -10,7 +10,8 @@ DEFAULT_SUBSET_NAME = "default"
 BboxIntCoords = Tuple[int, int, int, int]  # (x, y, w, h)
 SUBSET_NAME_BLACKLIST = {"labels", "images", "annotations", "instances"}
 
-DATUMARO_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "datumaro")
+_CACHE_DIR = os.getenv("XDG_CACHE_HOME", osp.join(osp.expanduser("~"), ".cache"))
+DATUMARO_CACHE_DIR = osp.join(_CACHE_DIR, "datumaro")
 
 if not osp.exists(DATUMARO_CACHE_DIR):
     os.makedirs(DATUMARO_CACHE_DIR)


### PR DESCRIPTION
### Summary
- Ticket no. 111922
- Change default model directory of FractalImageGenerator to be aligned with `OpenvinoLauncher`'s cache directory.
- This will prevent storing the model files to the current working directory.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
