### PR TITLE
Fix the issue that py37 has no typing.get_args()

### DIFF
--- a/datumaro/components/lazy_plugin.py
+++ b/datumaro/components/lazy_plugin.py
@@ -4,7 +4,7 @@
 
 from abc import ABC, abstractclassmethod
 from importlib import import_module
-from typing import List, Optional, Sequence, Type, Union, get_args
+from typing import List, Optional, Sequence, Type, Union
 
 from datumaro.components.dataset_base import DatasetBase
 from datumaro.components.errors import DatumaroError
@@ -27,7 +27,18 @@ _PLUGIN_TYPES = Union[
     DatasetBase,
 ]
 PLUGIN_TYPES = Type[_PLUGIN_TYPES]
-STR_TO_PLUGIN_TYPES = {t.__name__: t for t in get_args(_PLUGIN_TYPES)}
+STR_TO_PLUGIN_TYPES = {
+    t.__name__: t
+    for t in [
+        Transform,
+        Exporter,
+        DatasetGenerator,
+        Importer,
+        Launcher,
+        Validator,
+        DatasetBase,
+    ]
+}
 _EXTRA_DEPS_ATTR_NAME = "__extra_deps__"
 
 


### PR DESCRIPTION
### Summary
 - Fix for the error from CI: https://github.com/openvinotoolkit/datumaro/actions/runs/5140500036

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
