### PR TITLE
Fix warnings in test_visualizer.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1036>)
 
 ### Bug fixes
+- Fix warnings in test_visualizer.py
+  (<https://github.com/openvinotoolkit/datumaro/pull/1039>)
 
 ## 26/05/2023 - Release 1.3.1
 ### Bug fixes

--- a/tests/unit/test_visualizer.py
+++ b/tests/unit/test_visualizer.py
@@ -1,6 +1,11 @@
+# Copyright (C) 2022-2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from dataclasses import dataclass
 from unittest import TestCase, mock
 
+import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.figure import Figure
 
@@ -123,7 +128,13 @@ class VisualizerTestBase:
             _check(test_case.infer_grid_size, test_case.expected_grid_size)
 
 
-class LabelVisualizerTest(TestCase, VisualizerTestBase):
+class TestCaseClosePltFigure(TestCase):
+    def tearDown(self) -> None:
+        plt.close("all")
+        return super().tearDown()
+
+
+class LabelVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
         cls.subset = "train"
@@ -155,7 +166,7 @@ class LabelVisualizerTest(TestCase, VisualizerTestBase):
         self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
-class PointsVisualizerTest(TestCase, VisualizerTestBase):
+class PointsVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
         cls.subset = "train"
@@ -166,7 +177,7 @@ class PointsVisualizerTest(TestCase, VisualizerTestBase):
                 media=Image.from_numpy(data=np.ones((4, 6, 3))),
                 annotations=[
                     Points(
-                        np.random.random_integers(0, 6, size=10 * 2),
+                        np.random.randint(0, 6, size=10 * 2),
                         label=label_idx,
                         id=img_idx * img_idx + label_idx,
                         group=1,
@@ -189,7 +200,7 @@ class PointsVisualizerTest(TestCase, VisualizerTestBase):
         self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
-class MaskVisualizerTest(TestCase, VisualizerTestBase):
+class MaskVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
         cls.subset = "train"
@@ -223,7 +234,7 @@ class MaskVisualizerTest(TestCase, VisualizerTestBase):
         self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
-class PolygonVisualizerTest(TestCase, VisualizerTestBase):
+class PolygonVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
         cls.subset = "train"
@@ -234,7 +245,7 @@ class PolygonVisualizerTest(TestCase, VisualizerTestBase):
                 media=Image.from_numpy(data=np.ones((4, 6, 3))),
                 annotations=[
                     Polygon(
-                        np.random.random_integers(0, 6, size=10 * 2),
+                        np.random.randint(0, 6, size=10 * 2),
                         label=label_idx,
                         id=img_idx * img_idx + label_idx,
                         group=1,
@@ -257,7 +268,7 @@ class PolygonVisualizerTest(TestCase, VisualizerTestBase):
         self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
-class PolyLineVisualizerTest(TestCase, VisualizerTestBase):
+class PolyLineVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
         cls.subset = "train"
@@ -268,7 +279,7 @@ class PolyLineVisualizerTest(TestCase, VisualizerTestBase):
                 media=Image.from_numpy(data=np.ones((4, 6, 3))),
                 annotations=[
                     PolyLine(
-                        np.random.random_integers(0, 6, size=10 * 2),
+                        np.random.randint(0, 6, size=10 * 2),
                         label=label_idx,
                         id=img_idx * img_idx + label_idx,
                         group=1,
@@ -291,7 +302,7 @@ class PolyLineVisualizerTest(TestCase, VisualizerTestBase):
         self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
-class BboxVisualizerTest(TestCase, VisualizerTestBase):
+class BboxVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
         cls.subset = "train"
@@ -328,7 +339,7 @@ class BboxVisualizerTest(TestCase, VisualizerTestBase):
         self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
-class CaptionVisualizerTest(TestCase, VisualizerTestBase):
+class CaptionVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
         cls.subset = "train"
@@ -359,7 +370,7 @@ class CaptionVisualizerTest(TestCase, VisualizerTestBase):
         self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
-class SuperResolutionVisualizerTest(TestCase, VisualizerTestBase):
+class SuperResolutionVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
         cls.subset = "train"
@@ -389,7 +400,7 @@ class SuperResolutionVisualizerTest(TestCase, VisualizerTestBase):
         self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
-class DepthVisualizerTest(TestCase, VisualizerTestBase):
+class DepthVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
         cls.subset = "train"
@@ -419,7 +430,7 @@ class DepthVisualizerTest(TestCase, VisualizerTestBase):
         self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
-class EllipseVisualizerTest(TestCase, VisualizerTestBase):
+class EllipseVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
         cls.subset = "train"


### PR DESCRIPTION
### Summary
 - Ticket no. 112846
 - Close plt.Figure each time the test teardowns
 - Replace deprecated function usage: np.random.random_integers() ->
   np.random.randint()


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
