### PR TITLE
Exclude some subfolders for bandit scan

### DIFF
--- a/.ci/ipas_default.config
+++ b/.ci/ipas_default.config
@@ -95,6 +95,8 @@ exclude_dirs: [
   '.tox/',
   '.vscode/',
   '.git/',
+  'build/',
+  'tests/',
 ]
 
 ### (optional) plugin settings - some test plugins require configuration data

--- a/src/datumaro/components/visualizer.py
+++ b/src/datumaro/components/visualizer.py
@@ -202,7 +202,8 @@ class Visualizer:
                 f"n_samples={n_samples} should be less than the dataset size ({len(self.dataset)})."
             )
 
-        return random.choices(self._items, k=n_samples)
+        # Disable B311: random - used for general random sampling not for security/crypto
+        return random.choices(self._items, k=n_samples)  # nosec B311
 
     @overload
     def vis_gallery(

--- a/src/datumaro/plugins/data_formats/cifar.py
+++ b/src/datumaro/plugins/data_formats/cifar.py
@@ -5,7 +5,7 @@
 import errno
 import os
 import os.path as osp
-import pickle  # nosec import_pickle
+import pickle  # nosec B403
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 

--- a/src/datumaro/util/pickle_util.py
+++ b/src/datumaro/util/pickle_util.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-import pickle  # nosec import_pickle
+import pickle  # nosec B403
 
 import numpy.core.multiarray
 

--- a/tests/unit/test_cifar_format.py
+++ b/tests/unit/test_cifar_format.py
@@ -4,7 +4,7 @@
 
 import os
 import os.path as osp
-import pickle  # nosec import_pickle
+import pickle  # nosec B403
 import shutil
 from unittest import TestCase
 

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import os.path as osp
-import pickle  # nosec import_pickle
+import pickle  # nosec B403
 import shutil
 from copy import deepcopy
 from functools import partial

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -5,7 +5,7 @@
 import logging
 import os
 import os.path as osp
-import pickle  # nosec import_pickle
+import pickle  # nosec B403
 from unittest import TestCase, mock
 
 import numpy as np

--- a/tests/unit/test_imagenet_format.py
+++ b/tests/unit/test_imagenet_format.py
@@ -1,4 +1,4 @@
-import pickle  # nosec import_pickle
+import pickle  # nosec B403
 from copy import deepcopy
 from unittest import TestCase
 

--- a/tests/unit/test_voc_format.py
+++ b/tests/unit/test_voc_format.py
@@ -1,6 +1,6 @@
 import os
 import os.path as osp
-import pickle  # nosec import_pickle
+import pickle  # nosec B403
 from collections import OrderedDict
 from functools import partial
 from unittest import TestCase

--- a/tests/unit/test_yolo_format.py
+++ b/tests/unit/test_yolo_format.py
@@ -1,6 +1,6 @@
 import os
 import os.path as osp
-import pickle  # nosec import_pickle
+import pickle  # nosec B403
 from unittest import TestCase
 
 import numpy as np


### PR DESCRIPTION
### Summary

Added some subfolders to the excludes setting of the bandit configuration.

### How to test
$ tox -e bandit-scan
$ cat .tox/bandit-report.txt
