### PR TITLE
Change default dtype of load_image() to np.uint8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1031>)
 - Migrate OpenVINO v2023.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1036>)
+- Change default dtype of load_image() to np.uint8
+  (<https://github.com/openvinotoolkit/datumaro/pull/1041>)
 
 ### Bug fixes
 

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -60,9 +60,9 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
-def load_image(path: str, dtype: DTypeLike = np.float32, crypter: Crypter = NULL_CRYPTER):
+def load_image(path: str, dtype: DTypeLike = np.uint8, crypter: Crypter = NULL_CRYPTER):
     """
-    Reads an image in the HWC Grayscale/BGR(A) float [0; 255] format.
+    Reads an image in the HWC Grayscale/BGR(A) [0; 255] format (default dtype is uint8).
     """
 
     if _IMAGE_BACKEND == _IMAGE_BACKENDS.cv2:
@@ -83,6 +83,7 @@ def load_image(path: str, dtype: DTypeLike = np.float32, crypter: Crypter = NULL
         image = Image.open(path)
         image = np.asarray(image, dtype=dtype)
         if len(image.shape) == 3 and image.shape[2] in {3, 4}:
+            image = np.array(image)  # Release read-only
             image[:, :, :3] = image[:, :, 2::-1]  # RGB to BGR
     else:
         raise NotImplementedError()
@@ -225,7 +226,7 @@ def encode_image(image: np.ndarray, ext: str, dtype: DTypeLike = np.uint8, **kwa
         raise NotImplementedError()
 
 
-def decode_image(image_bytes: bytes, dtype: DTypeLike = np.float32) -> np.ndarray:
+def decode_image(image_bytes: bytes, dtype: DTypeLike = np.uint8) -> np.ndarray:
     if _IMAGE_BACKEND == _IMAGE_BACKENDS.cv2:
         import cv2
 
@@ -238,6 +239,7 @@ def decode_image(image_bytes: bytes, dtype: DTypeLike = np.float32) -> np.ndarra
         image = Image.open(BytesIO(image_bytes))
         image = np.asarray(image, dtype=dtype)
         if len(image.shape) == 3 and image.shape[2] in {3, 4}:
+            image = np.array(image)  # Release read-only
             image[:, :, :3] = image[:, :, 2::-1]  # RGB to BGR
     else:
         raise NotImplementedError()


### PR DESCRIPTION
### Summary
 - Since default dtype for `load_image()` has been `np.float32`, there has been huge meaningless overheads for Geti dataset import pipeline. This PR fixes it.

### How to test
Our existing tests cover this PR.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
