### PR TITLE
[bug fix] Import a custom Camvid dataset may cause an exception in '_load_items'.

### DIFF
--- a/src/datumaro/plugins/data_formats/camvid.py
+++ b/src/datumaro/plugins/data_formats/camvid.py
@@ -214,7 +214,7 @@ class CamvidBase(SubsetBase):
         with open(path, encoding="utf-8") as f:
             for line in f:
                 image, gt = _parse_annotation_line(line)
-                item_id = osp.splitext(osp.join(*image.split("/")[2:]))[0]
+                item_id = osp.splitext(osp.basename(image))[0]
                 image_path = osp.join(self._dataset_dir, image.lstrip("/"))
 
                 item_annotations = []


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

Fix a bug: 
Import a custom Camvid dataset may cause an empty arguments exception in 'join'.
Replace the previous method with 'basename' to get the item_id.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
Test code:

```
import datumaro as dm

dataset = dm.Dataset.import_from('C:/***/dataset','camvid')

dataset
```
Exception:
```
File ~\AppData\Roaming\Python\Python310\site-packages\datumaro\plugins\data_formats\camvid.py:218, in CamvidBase._load_items(self, path)
    217 # item_id = osp.splitext(osp.basename(image))[0]
--> 218 item_id = osp.splitext(osp.join(*image.split("/")[2:]))[0]
    219 image_path = osp.join(self._dataset_dir, image.lstrip("/"))

TypeError: join() missing 1 required positional argument: 'path'
```
Update version(import success):
![image](https://github.com/openvinotoolkit/datumaro/assets/115517102/154d70c9-2d9b-442c-8065-2667284c2226)

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
