### PR TITLE
Fix label_groups typing

### DIFF
--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -111,7 +111,7 @@ class LabelCategories(Categories):
         group_type: str = field(default="exclusive", validator=default_if_none(str))
 
     items: List[str] = field(factory=list, validator=default_if_none(list))
-    label_groups: List[str] = field(factory=list, validator=default_if_none(list))
+    label_groups: List[LabelGroup] = field(factory=list, validator=default_if_none(list))
     _indices: Dict[str, int] = field(factory=dict, init=False, eq=False)
 
     @classmethod


### PR DESCRIPTION
### Summary
- I found a small invalid typing during Geti work.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
