### PR TITLE
Prevent installing protobuf>=4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 - Fix warnings in test_visualizer.py
   (<https://github.com/openvinotoolkit/datumaro/pull/1039>)
+- Prevent installing protobuf>=4
+  (<https://github.com/openvinotoolkit/datumaro/pull/1054>)
 
 ## 26/05/2023 - Release 1.3.1
 ### Bug fixes

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -46,4 +46,4 @@ pyemd
 pyarrow
 
 # ava data format
-protobuf
+protobuf<4

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ setuptools.setup(
     extras_require={
         "tf": ["tensorflow"],
         "tfds": ["tensorflow-datasets"],
-        "tfds-dev": ["tensorflow-datasets[dev]; platform_system='Linux'"],
         "tf-gpu": ["tensorflow-gpu"],
         "default": DEFAULT_REQUIREMENTS,
     },

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setuptools.setup(
     extras_require={
         "tf": ["tensorflow"],
         "tfds": ["tensorflow-datasets"],
-        "tfds-dev": ["tensorflow-datasets[dev]"],
+        "tfds-dev": ["tensorflow-datasets[dev]; platform_system='Linux'"],
         "tf-gpu": ["tensorflow-gpu"],
         "default": DEFAULT_REQUIREMENTS,
     },

--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,8 @@ setuptools.setup(
     install_requires=CORE_REQUIREMENTS,
     extras_require={
         "tf": ["tensorflow"],
-        "tfds": [
-            "tensorflow-datasets<4.9.0"
-        ],  # 4.9.0 fails on Windows and MacOS, https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
+        "tfds": ["tensorflow-datasets"],
+        "tfds-dev": ["tensorflow-datasets[dev]"],
         "tf-gpu": ["tensorflow-gpu"],
         "default": DEFAULT_REQUIREMENTS,
     },

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,3 +6,11 @@ pytest-cov>=4.0.0
 pytest-stress
 pytest-html
 coverage
+
+
+# testing tensorflow-dataset
+# `tensorflow-datasets[dev]` (not `tensorflow-datasets`) has a dependency on `jax`,
+# and `jax` has problem in installing it on Windows (Please see https://github.com/google/jax/issues/438)
+# Therefore, we allow to install `tensorflow-datasets[dev]` only for Linux. This dependency is required by
+# `tests\unit\test_extractor_tfds.py`.
+tensorflow-datasets[dev]; platform_system=='Linux'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,11 +6,3 @@ pytest-cov>=4.0.0
 pytest-stress
 pytest-html
 coverage
-
-
-# testing tensorflow-dataset
-# `tensorflow-datasets[dev]` (not `tensorflow-datasets`) has a dependency on `jax`,
-# and `jax` has problem in installing it on Windows (Please see https://github.com/google/jax/issues/438)
-# Therefore, we allow to install `tensorflow-datasets[dev]` only for Linux. This dependency is required by
-# `tests\unit\test_extractor_tfds.py`.
-tensorflow-datasets[dev]; platform_system=='Linux'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,7 +6,3 @@ pytest-cov>=4.0.0
 pytest-stress
 pytest-html
 coverage
-
-# testing tensorflow-dataset
-# 4.9.0 fails on Windows and MacOS, https://github.com/openvinotoolkit/datumaro/actions/runs/4618774184
-tensorflow-datasets[dev]<4.9.0

--- a/tests/unit/test_extractor_tfds.py
+++ b/tests/unit/test_extractor_tfds.py
@@ -14,8 +14,16 @@ from datumaro.util.image import decode_image, encode_image
 from tests.requirements import Requirements, mark_requirement
 from tests.utils.test_utils import compare_datasets, mock_tfds_data
 
-if TFDS_EXTRACTOR_AVAILABLE:
-    import tensorflow_datasets as tfds
+try:
+    if TFDS_EXTRACTOR_AVAILABLE:
+        import tensorflow_datasets as tfds
+        import tensorflow_datasets.testing
+
+        TFDS_DEV_AVAILABLE = True
+    else:
+        TFDS_DEV_AVAILABLE = False
+except ImportError:
+    TFDS_DEV_AVAILABLE = False
 
 
 class TfdsDatasetsTest(TestCase):
@@ -61,7 +69,7 @@ class TfdsDatasetsTest(TestCase):
                 assert remote_meta.subsets[split_name].num_items == sum(split.shard_lengths)
 
 
-@skipIf(not TFDS_EXTRACTOR_AVAILABLE, reason="TFDS is not installed")
+@skipIf(not TFDS_DEV_AVAILABLE, reason="TFDS is not installed")
 class TfdsExtractorTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_data_access(self):

--- a/tests/unit/test_extractor_tfds.py
+++ b/tests/unit/test_extractor_tfds.py
@@ -14,18 +14,11 @@ from datumaro.util.image import decode_image, encode_image
 from tests.requirements import Requirements, mark_requirement
 from tests.utils.test_utils import compare_datasets, mock_tfds_data
 
-try:
-    if TFDS_EXTRACTOR_AVAILABLE:
-        import tensorflow_datasets as tfds
-        import tensorflow_datasets.testing
-
-        TFDS_DEV_AVAILABLE = True
-    else:
-        TFDS_DEV_AVAILABLE = False
-except ImportError:
-    TFDS_DEV_AVAILABLE = False
+if TFDS_EXTRACTOR_AVAILABLE:
+    import tensorflow_datasets as tfds
 
 
+@skipIf(not TFDS_EXTRACTOR_AVAILABLE, reason="TFDS is not installed")
 class TfdsDatasetsTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_metadata(self):
@@ -69,7 +62,7 @@ class TfdsDatasetsTest(TestCase):
                 assert remote_meta.subsets[split_name].num_items == sum(split.shard_lengths)
 
 
-@skipIf(not TFDS_DEV_AVAILABLE, reason="TFDS is not installed")
+@skipIf(not TFDS_EXTRACTOR_AVAILABLE, reason="TFDS is not installed")
 class TfdsExtractorTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_data_access(self):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -433,3 +433,9 @@ class TestCaseHelper:
 
     def fail(self, msg):
         pytest.fail(reason=msg)
+
+    def assertIsNotNone(self, item: Any):
+        assert item is not None
+
+    def assertIsNone(self, item: Any):
+        assert item is None

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -433,9 +433,3 @@ class TestCaseHelper:
 
     def fail(self, msg):
         pytest.fail(reason=msg)
-
-    def assertIsNotNone(self, item: Any):
-        assert item is not None
-
-    def assertIsNone(self, item: Any):
-        assert item is None

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ extras =
     default
     tf
     tfds
-    tfds-dev
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
 extras =
     default
     tf
+    tfds
     tfds-dev
 
 


### PR DESCRIPTION
### Summary
- Ticket no. 113453
- To fix the recent CI failures: https://github.com/openvinotoolkit/datumaro/actions/runs/5305262575
- Add version upper limit to `protobuf<4`
- Remove `tensorflow-datasets[dev]` from `tests/requirements.txt` which has some conflicts with this change (https://github.com/openvinotoolkit/datumaro/actions/runs/5307973967/jobs/9606995668).

### How to test

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
