### PR TITLE
Add tabulate to requirements-core.txt

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -48,5 +48,8 @@ pyarrow
 # ava data format
 protobuf<4
 
+# Comparator
+tabulate
+
 # Model inference launcher from the dedicated inference server
 ovmsclient


### PR DESCRIPTION
### Summary

- Resolve #1065 
- `tabulate` was introduced in https://github.com/openvinotoolkit/datumaro/pull/1012, but not added to requirements-core.txt
- The reason why we haven't found it is because `tabulate` is dependency of `dvc`, so that there has been no problem if we install `datumaro[default]`.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
