### PR TITLE
for testing publish workflow

### DIFF
--- a/.github/workflows/publish_sdist_to_pypi.yml
+++ b/.github/workflows/publish_sdist_to_pypi.yml
@@ -1,6 +1,7 @@
 name: Publish Source Distribution to PyPI
 
 on:
+  workflow_dispatch: # for testing purpose. will be removed soon.
   release:
     types: [published]
 


### PR DESCRIPTION
enable manual trigger to publish workflow. this event will be removed once test are done.