### PR TITLE
Add --encryption-key arg to datum convert command

### DIFF
--- a/src/datumaro/cli/commands/convert.py
+++ b/src/datumaro/cli/commands/convert.py
@@ -83,6 +83,10 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         % (", ".join(FilterModes.list_options()), "%(default)s"),
     )
     parser.add_argument(
+        "--encryption-key",
+        help="Secret key. It is required only if the input dataset is encrypted.",
+    )
+    parser.add_argument(
         "extra_args",
         nargs=argparse.REMAINDER,
         help="Additional arguments for output format (pass '-- -h' for help). "
@@ -148,7 +152,10 @@ def convert_command(args):
         )
     dst_dir = osp.abspath(dst_dir)
 
-    dataset = Dataset.import_from(source, fmt)
+    import_kwargs = {}
+    if args.encryption_key:
+        import_kwargs["encryption_key"] = args.encryption_key
+    dataset = Dataset.import_from(source, fmt, **import_kwargs)
 
     log.info("Exporting the dataset")
     if args.filter:


### PR DESCRIPTION
### Summary

- Ticket no.112205
- This is required for the example introduced in https://github.com/intel-sandbox/ODT.DWE.MPA.openvino-blog-postings/pull/4.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
