### PR TITLE
Bugfix for explore cli test

### DIFF
--- a/src/datumaro/cli/commands/explore.py
+++ b/src/datumaro/cli/commands/explore.py
@@ -133,7 +133,7 @@ def explore_command(args):
                 query_datasetitem = dataset.get_datasetitem_by_path(args.query)
             except Exception:
                 continue
-            if not query_datasetitem:
+            if query_datasetitem:
                 break
     else:
         query_datasetitem = args.query

--- a/tests/integration/cli/test_explore.py
+++ b/tests/integration/cli/test_explore.py
@@ -1,7 +1,7 @@
 import os.path as osp
 import platform
 from glob import glob
-from unittest import TestCase, skip, skipIf
+from unittest import TestCase, skipIf
 
 import numpy as np
 
@@ -82,7 +82,6 @@ class ExploreTest(TestCase):
         )
         return dataset
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "
@@ -118,7 +117,6 @@ class ExploreTest(TestCase):
 
         self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "
@@ -143,7 +141,6 @@ class ExploreTest(TestCase):
 
         self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "
@@ -194,7 +191,6 @@ class ExploreTest(TestCase):
 
         self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "
@@ -243,7 +239,6 @@ class ExploreTest(TestCase):
 
         self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "
@@ -276,8 +271,11 @@ class ExploreTest(TestCase):
             result_dir,
             dataset1_url,
             dataset2_url,
+            "--",
+            "--save-media",
         )
         run(self, "project", "import", "-n", "result", "-p", proj_dir, "-f", "datumaro", result_dir)
+        train_image_path = osp.join(proj_dir, "result", "images", "train", "1.jpg")
         run(
             self,
             "explore",
@@ -296,7 +294,6 @@ class ExploreTest(TestCase):
 
         self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "

--- a/tests/integration/cli/test_explore.py
+++ b/tests/integration/cli/test_explore.py
@@ -94,7 +94,7 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset_url = osp.join(test_dir, "dataset")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset_url, "datumaro", save_media=True)
 
@@ -116,7 +116,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -130,7 +130,7 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset_url = osp.join(test_dir, "dataset")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset_url, "datumaro", save_media=True)
 
@@ -141,7 +141,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -155,7 +155,7 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset1_url = osp.join(test_dir, "dataset1")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset1_url, "datumaro", save_media=True)
         run(self, "project", "create", "-o", proj_dir)
@@ -192,7 +192,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -206,7 +206,7 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset1_url = osp.join(test_dir, "dataset1")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset1_url, "datumaro", save_media=True)
         run(self, "project", "create", "-o", proj_dir)
@@ -241,7 +241,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -255,7 +255,7 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset1_url = osp.join(test_dir, "dataset1")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset1_url, "datumaro", save_media=True)
 
@@ -294,7 +294,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -310,7 +310,7 @@ class ExploreTest(TestCase):
         dataset1_url = osp.join(test_dir, "dataset1")
         self.test_dataset.export(dataset1_url, "datumaro", save_media=True)
 
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
         run(self, "project", "create", "-o", proj_dir)
         run(self, "project", "import", "-p", proj_dir, "-f", "datumaro", dataset1_url)
         run(self, "explore", "-q", train_image_path, "-topk", "2", "-p", proj_dir)
@@ -345,7 +345,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skipIf(
         platform.system() == "Darwin",

--- a/tests/integration/cli/test_explore.py
+++ b/tests/integration/cli/test_explore.py
@@ -116,7 +116,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -141,7 +141,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -192,7 +192,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -241,7 +241,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -294,7 +294,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -345,7 +345,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skipIf(
         platform.system() == "Darwin",


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Fix explore cli fail tests : https://github.com/openvinotoolkit/datumaro/actions/runs/5464396553/jobs/9960479229
- Due to `train_path` not matched with `dataset._source_path`, `query` is considered as `string` input, not coverted to `Datasetitem` through `dataset.get_datasetitem_by_path(args.query)`.
- Match `train_path` of CLI path as `project/source-1/images/train/1.jpg'.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
