### PR TITLE
Give notice that the deprecation works will be done in datumaro==1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## \[Unreleased\]
+
+## 07/07/2023 - Release 1.4.0rc1
 ### New features
 - Changed supported Python version range (>=3.8, <=3.11)
   (<https://github.com/openvinotoolkit/datumaro/pull/1083>)
@@ -45,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1069>)
 - Refactor dataset.py to seperate DatasetStorage
   (<https://github.com/openvinotoolkit/datumaro/pull/1073>)
+- Give notice that the deprecation works will be done in datumaro==1.5.0
+  (<https://github.com/openvinotoolkit/datumaro/pull/1085>)
 
 ### Bug fixes
 - Fix warnings in test_visualizer.py

--- a/src/datumaro/__init__.py
+++ b/src/datumaro/__init__.py
@@ -2,6 +2,15 @@
 #
 # SPDX-License-Identifier: MIT
 
+import warnings
+
+warnings.warn(
+    "We are planning to clean up the entities in datumaro/__init__.py until datumaro==1.5.0. "
+    'This will affect the following import pattern: "import datumaro as dm; dm.<entity>". '
+    "If you are using this pattern in your code, please revisit it after upgrading datumaro>=1.5.0.",
+    DeprecationWarning,
+)
+
 from . import errors as errors
 from . import ops as ops
 from . import project as project
@@ -32,7 +41,7 @@ from .components.annotation import (
     RleMask,
 )
 from .components.cli_plugin import CliPlugin
-from .components.dataset import Dataset, eager_mode
+from .components.dataset import Dataset, DatasetPatch, DatasetSubset, ItemStatus, eager_mode
 from .components.dataset_base import (
     DEFAULT_SUBSET_NAME,
     CategoriesInfo,

--- a/src/datumaro/__init__.py
+++ b/src/datumaro/__init__.py
@@ -41,7 +41,7 @@ from .components.annotation import (
     RleMask,
 )
 from .components.cli_plugin import CliPlugin
-from .components.dataset import Dataset, DatasetPatch, DatasetSubset, ItemStatus, eager_mode
+from .components.dataset import Dataset, DatasetPatch, DatasetSubset, eager_mode
 from .components.dataset_base import (
     DEFAULT_SUBSET_NAME,
     CategoriesInfo,
@@ -50,6 +50,7 @@ from .components.dataset_base import (
     IDataset,
     SubsetBase,
 )
+from .components.dataset_item_storage import ItemStatus
 from .components.environment import Environment, PluginRegistry
 from .components.exporter import Exporter, ExportErrorPolicy, FailingExportErrorPolicy
 from .components.hl_ops import HLOps

--- a/src/datumaro/components/dataset.py
+++ b/src/datumaro/components/dataset.py
@@ -600,9 +600,9 @@ class Dataset(IDataset):
 
                     if has_ctx_args:
                         warnings.warn(
-                            "It seems that '%s' exporter "
+                            f"It seems that '{format}' exporter "
                             "does not support progress and error reporting, "
-                            "it will be disabled" % format,
+                            "It will be disabled in datumaro==1.5.0.",
                             DeprecationWarning,
                         )
                     exporter_kwargs.pop("ctx")
@@ -618,9 +618,9 @@ class Dataset(IDataset):
 
                     if has_ctx_args:
                         warnings.warn(
-                            "It seems that '%s' exporter "
+                            f"It seems that '{format}' exporter "
                             "does not support progress and error reporting, "
-                            "it will be disabled" % format,
+                            "It will be disabled in datumaro==1.5.0.",
                             DeprecationWarning,
                         )
                     exporter_kwargs.pop("ctx")
@@ -724,9 +724,9 @@ class Dataset(IDataset):
 
                     if has_ctx_args:
                         warnings.warn(
-                            "It seems that '%s' extractor "
-                            "does not support progress and error reporting, "
-                            "it will be disabled" % src_conf.format,
+                            f"It seems that '{src_conf.format}' extractor "
+                            "does not support progress and error reporting. "
+                            "It will be disabled in datumaro==1.5.0.",
                             DeprecationWarning,
                         )
                     extractor_kwargs.pop("ctx")

--- a/src/datumaro/components/dataset_base.py
+++ b/src/datumaro/components/dataset_base.py
@@ -56,7 +56,8 @@ class DatasetItem:
     ):
         if image is not None:
             warnings.warn(
-                "'image' is deprecated and will be " "removed in future. Use 'media' instead.",
+                "'image' is deprecated and will be removed in future. Use 'media' instead. "
+                "It will be deprecated in datumaro==1.5.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -71,14 +72,16 @@ class DatasetItem:
         elif point_cloud is not None:
             warnings.warn(
                 "'point_cloud' is deprecated and will be "
-                "removed in future. Use 'media' instead.",
+                "removed in future. Use 'media' instead. "
+                "It will be deprecated in datumaro==1.5.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
             if related_images is not None:
                 warnings.warn(
                     "'related_images' is deprecated and will be "
-                    "removed in future. Use 'media' instead.",
+                    "removed in future. Use 'media' instead. "
+                    "It will be deprecated in datumaro==1.5.0.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -98,7 +101,8 @@ class DatasetItem:
     def image(self) -> Optional[Image]:
         warnings.warn(
             "'DatasetItem.image' is deprecated and will be "
-            "removed in future. Use '.media' and '.media_as()' instead.",
+            "removed in future. Use '.media' and '.media_as()' instead. "
+            "It will be deprecated in datumaro==1.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -111,7 +115,8 @@ class DatasetItem:
     def point_cloud(self) -> Optional[str]:
         warnings.warn(
             "'DatasetItem.point_cloud' is deprecated and will be "
-            "removed in future. Use '.media' and '.media_as()' instead.",
+            "removed in future. Use '.media' and '.media_as()' instead. "
+            "It will be deprecated in datumaro==1.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -124,7 +129,8 @@ class DatasetItem:
     def related_images(self) -> List[Image]:
         warnings.warn(
             "'DatasetItem.related_images' is deprecated and will be "
-            "removed in future. Use '.media' and '.media_as()' instead.",
+            "removed in future. Use '.media' and '.media_as()' instead. "
+            "It will be deprecated in datumaro==1.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -137,7 +143,8 @@ class DatasetItem:
     def has_image(self):
         warnings.warn(
             "'DatasetItem.has_image' is deprecated and will be "
-            "removed in future. Use '.media' and '.media_as()' instead.",
+            "removed in future. Use '.media' and '.media_as()' instead. "
+            "It will be deprecated in datumaro==1.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -148,7 +155,8 @@ class DatasetItem:
     def has_point_cloud(self):
         warnings.warn(
             "'DatasetItem.has_point_cloud' is deprecated and will be "
-            "removed in future. Use '.media' and '.media_as()' instead.",
+            "removed in future. Use '.media' and '.media_as()' instead. "
+            "It will be deprecated in datumaro==1.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/datumaro/components/exporter.py
+++ b/src/datumaro/components/exporter.py
@@ -197,7 +197,8 @@ class Exporter(CliPlugin):
             self._save_media = save_images
             warnings.warn(
                 "'save-images' is deprecated and will be "
-                "removed in future. Use 'save-media' instead.",
+                "removed in future. Use 'save-media' instead. "
+                "It will be deprecated in datumaro==1.5.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -454,7 +454,8 @@ class ByteImage(ImageFromBytes):
     ):
         warnings.warn(
             f"Using {self.__class__.__name__} is deprecated. "
-            "Please use 'Image.from_bytes()' instead.",
+            "Please use 'Image.from_bytes()' instead. "
+            "It will be deprecated in datumaro==1.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -49,7 +49,8 @@ def __getattr__(name: str):
     if name in {"Image", "ByteImage"}:
         warnings.warn(
             f"Using {name} from 'util.image' is deprecated, "
-            "the class is moved to 'components.media'",
+            "the class is moved to 'components.media' "
+            "It will be deprecated in datumaro==1.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -172,7 +172,8 @@ def compare_datasets(
         if require_images:
             warnings.warn(
                 "'require_images' is deprecated and will be "
-                "removed in future. Use 'require_media' instead.",
+                "removed in future. Use 'require_media' instead. "
+                "It will be deprecated in datumaro==1.5.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
### Summary

- Same as title
- The deprecation works remaining in the project will be done until datumaro==1.5.0.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
