### PR TITLE
Fix UnionMerge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1053>)
 - Prevent installing protobuf>=4
   (<https://github.com/openvinotoolkit/datumaro/pull/1054>)
+- Fix UnionMerge
+  (<https://github.com/openvinotoolkit/datumaro/pull/1086>)
 
 ## 26/05/2023 - Release 1.3.2
 ### Enhancements

--- a/src/datumaro/components/merge/union_merge.py
+++ b/src/datumaro/components/merge/union_merge.py
@@ -41,7 +41,7 @@ class UnionMerge(Merger):
             for item in source:
                 if self._matching_table.get(source_idx, None):
                     for ann in item.annotations:
-                        ann.label = self._matching_table[source_idx].get(ann.label, ann.label)
+                        ann.label = self._matching_table[source_idx][ann.label]
                 dict_items[item.id, item.subset].append(item)
 
         item_storage = DatasetItemStorage()
@@ -68,39 +68,21 @@ class UnionMerge(Merger):
 
     def _merge_label_categories(self, sources: Sequence[IDataset]) -> LabelCategories:
         dst_cat = LabelCategories()
-        dst_indices = {}
-        dst_labels = []
-
         for src_id, src_categories in enumerate(sources):
             src_cat = src_categories.get(AnnotationType.label)
             if src_cat is None:
                 continue
 
             for src_label in src_cat.items:
-                if src_label.name not in dst_labels:
+                src_idx = src_cat.find(src_label.name)[0]
+                dst_idx = dst_cat.find(src_label.name)[0]
+                if dst_idx is None:
                     dst_cat.add(src_label.name, src_label.parent, src_label.attributes)
-                    dst_labels.append(src_label.name)
+                    dst_idx = dst_cat.find(src_label.name)[0]
 
-                    if src_cat._indices[src_label.name] in list(dst_indices.values()):
-                        dst_indices[src_label.name] = max(dst_indices.values()) + 1
-                        if self._matching_table.get(src_id, None):
-                            self._matching_table[src_id].update(
-                                {src_cat._indices[src_label.name]: max(dst_indices.values())}
-                            )
-                        else:
-                            self._matching_table[src_id] = {
-                                src_cat._indices[src_label.name]: max(dst_indices.values())
-                            }
-                    else:
-                        dst_indices[src_label.name] = src_cat._indices[src_label.name]
+                if self._matching_table.get(src_id, None):
+                    self._matching_table[src_id].update({src_idx: dst_idx})
                 else:
-                    if self._matching_table.get(src_id, None):
-                        self._matching_table[src_id].update(
-                            {src_cat._indices[src_label.name]: dst_indices[src_label.name]}
-                        )
-                    else:
-                        self._matching_table[src_id] = {
-                            src_cat._indices[src_label.name]: dst_indices[src_label.name]
-                        }
+                    self._matching_table[src_id] = {src_idx: dst_idx}
 
         return dst_cat

--- a/src/datumaro/components/merge/union_merge.py
+++ b/src/datumaro/components/merge/union_merge.py
@@ -41,7 +41,7 @@ class UnionMerge(Merger):
             for item in source:
                 if self._matching_table.get(source_idx, None):
                     for ann in item.annotations:
-                        ann.label = self._matching_table[source_idx][ann.label]
+                        ann.label = self._matching_table[source_idx].get(ann.label, ann.label)
                 dict_items[item.id, item.subset].append(item)
 
         item_storage = DatasetItemStorage()

--- a/tests/integration/cli/test_merge.py
+++ b/tests/integration/cli/test_merge.py
@@ -106,6 +106,117 @@ class MergeTest:
 
         return export_dirs, expected
 
+    @pytest.fixture()
+    def fxt_heterogenous_mixed_categories(self, test_dir):
+        datasets = []
+        datasets.append(
+            Dataset.from_iterable(
+                [
+                    DatasetItem(
+                        id=f"dset_0",
+                        subset="train",
+                        media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                        annotations=[
+                            Bbox(1, 2, 3, 3, label=0),
+                        ],
+                    ),
+                    DatasetItem(
+                        id=f"dset_1",
+                        subset="train",
+                        media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                        annotations=[
+                            Bbox(1, 2, 3, 3, label=0),
+                        ],
+                    ),
+                ],
+                categories=["good"],
+            )
+        )
+        datasets.append(
+            Dataset.from_iterable(
+                [
+                    DatasetItem(
+                        id=f"dset_0",
+                        subset="train",
+                        media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                        annotations=[
+                            Bbox(1, 2, 3, 3, label=0),
+                        ],
+                    ),
+                    DatasetItem(
+                        id=f"dset_1",
+                        subset="train",
+                        media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                        annotations=[
+                            Bbox(1, 2, 3, 3, label=1),
+                        ],
+                    ),
+                    DatasetItem(
+                        id=f"dset_2",
+                        subset="train",
+                        media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                        annotations=[
+                            Bbox(1, 2, 3, 3, label=2),
+                        ],
+                    ),
+                ],
+                categories=["combined", "good", "missing"],
+            )
+        )
+
+        export_dirs = []
+        for n in range(len(datasets)):
+            dir_path = osp.join(test_dir, f"dataset_{n}")
+            datasets[n].export(dir_path, format="datumaro", save_media=True)
+            export_dirs += [dir_path]
+
+        expected = Dataset.from_iterable(
+            [
+                DatasetItem(
+                    id=f"dset_0-0",
+                    subset="train",
+                    media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                    annotations=[
+                        Bbox(1, 2, 3, 3, label=0),
+                    ],
+                ),
+                DatasetItem(
+                    id=f"dset_0-1",
+                    subset="train",
+                    media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                    annotations=[
+                        Bbox(1, 2, 3, 3, label=1),
+                    ],
+                ),
+                DatasetItem(
+                    id=f"dset_1-0",
+                    subset="train",
+                    media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                    annotations=[
+                        Bbox(1, 2, 3, 3, label=0),
+                    ],
+                ),
+                DatasetItem(
+                    id=f"dset_1-1",
+                    subset="train",
+                    media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                    annotations=[
+                        Bbox(1, 2, 3, 3, label=0),
+                    ],
+                ),
+                DatasetItem(
+                    id=f"dset_2",
+                    subset="train",
+                    media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                    annotations=[
+                        Bbox(1, 2, 3, 3, label=2),
+                    ],
+                ),
+            ],
+            categories=["good", "combined", "missing"],
+        )
+        return export_dirs, expected
+
     @pytest.fixture
     def test_case(self, request):
         return request.getfixturevalue(request.param)
@@ -115,6 +226,7 @@ class MergeTest:
         [
             ("fxt_homogenous", "exact"),
             ("fxt_heterogenous", "union"),
+            ("fxt_heterogenous_mixed_categories", "union"),
         ],
         indirect=["test_case"],
     )
@@ -134,6 +246,7 @@ class MergeTest:
 
         run(helper_tc, *cmds)
         actual = Dataset.import_from(result_dir)
+
         compare_datasets(helper_tc, expected, actual, require_media=True)
 
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

When importing `cable` category in MVTec anomaly data, the current implementation shows `KeyError`.
Because `self._matching_table` only stores the label mapping with different indices and some labels should keep the original indices, the codes raises the `KeyError` for keeping labels.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
