### PR TITLE
Hotfix: Create Datumaro cache dir

### DIFF
--- a/src/datumaro/cli/commands/generate.py
+++ b/src/datumaro/cli/commands/generate.py
@@ -10,7 +10,7 @@ from shutil import rmtree
 
 from datumaro.cli.util.errors import CliException
 from datumaro.plugins.synthetic_data import FractalImageGenerator
-from datumaro.util.definitions import DATUMARO_CACHE_DIR
+from datumaro.util.definitions import get_datumaro_cache_dir
 
 from ..util import MultilineFormatter
 
@@ -58,7 +58,7 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
     parser.add_argument(
         "--model-dir",
         type=str,
-        default=DATUMARO_CACHE_DIR,
+        default=get_datumaro_cache_dir(),
         help="Path to load the colorization model from. "
         "If no model is found, the model will be downloaded (default: %(default)s)",
     )

--- a/src/datumaro/plugins/openvino_plugin/launcher.py
+++ b/src/datumaro/plugins/openvino_plugin/launcher.py
@@ -20,7 +20,7 @@ from datumaro.components.abstracts.model_interpreter import ModelPred
 from datumaro.components.cli_plugin import CliPlugin
 from datumaro.components.launcher import LauncherWithModelInterpreter
 from datumaro.errors import DatumaroError
-from datumaro.util.definitions import DATUMARO_CACHE_DIR
+from datumaro.util.definitions import get_datumaro_cache_dir
 from datumaro.util.samples import get_samples_path
 
 
@@ -101,7 +101,7 @@ class BuiltinOpenvinoModelInfo(OpenvinoModelInfo):
         interpreter = osp.join(openvino_plugin_samples_dir, model_name + "_interp.py")
         interpreter = interpreter if osp.exists(interpreter) else interpreter
 
-        model_dir = DATUMARO_CACHE_DIR
+        model_dir = get_datumaro_cache_dir()
 
         # Please visit open-model-zoo repository for OpenVINO public models if you are interested in
         # https://github.com/openvinotoolkit/open_model_zoo/blob/master/models/public/index.md

--- a/src/datumaro/plugins/synthetic_data/image_generator.py
+++ b/src/datumaro/plugins/synthetic_data/image_generator.py
@@ -16,7 +16,7 @@ import numpy as np
 import requests
 
 from datumaro.components.generator import DatasetGenerator
-from datumaro.util.definitions import DATUMARO_CACHE_DIR
+from datumaro.util.definitions import get_datumaro_cache_dir
 from datumaro.util.image import save_image
 from datumaro.util.scope import on_error_do, on_exit_do, scope_add, scoped
 
@@ -39,7 +39,7 @@ class FractalImageGenerator(DatasetGenerator):
         output_dir: str,
         count: int,
         shape: Tuple[int, int],
-        model_path: str = DATUMARO_CACHE_DIR,
+        model_path: str = get_datumaro_cache_dir(),
     ) -> None:
         assert 0 < count, "Image count cannot be lesser than 1"
         self._count = count

--- a/src/datumaro/util/definitions.py
+++ b/src/datumaro/util/definitions.py
@@ -14,7 +14,7 @@ SUBSET_NAME_BLACKLIST = {"labels", "images", "annotations", "instances"}
 
 def get_datumaro_cache_dir(
     _CACHE_DIR: str = osp.expanduser(os.getenv("XDG_CACHE_HOME", osp.join("~", ".cache")))
-):
+) -> str:
     """Get DATUMARO_CACHE_DIR. If it does not exists, create it."""
     DATUMARO_CACHE_DIR = osp.join(_CACHE_DIR, "datumaro")
 
@@ -23,3 +23,5 @@ def get_datumaro_cache_dir(
             os.makedirs(DATUMARO_CACHE_DIR)
     except Exception as e:
         log.error(f"Cannot create DATUMARO_CACHE_DIR={DATUMARO_CACHE_DIR} since {e}.")
+
+    return DATUMARO_CACHE_DIR

--- a/src/datumaro/util/definitions.py
+++ b/src/datumaro/util/definitions.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import logging as log
 import os
 import os.path as osp
 from typing import Tuple
@@ -10,8 +11,15 @@ DEFAULT_SUBSET_NAME = "default"
 BboxIntCoords = Tuple[int, int, int, int]  # (x, y, w, h)
 SUBSET_NAME_BLACKLIST = {"labels", "images", "annotations", "instances"}
 
-_CACHE_DIR = osp.expanduser(os.getenv("XDG_CACHE_HOME", osp.join("~", ".cache")))
-DATUMARO_CACHE_DIR = osp.join(_CACHE_DIR, "datumaro")
 
-if not osp.exists(DATUMARO_CACHE_DIR):
-    os.makedirs(DATUMARO_CACHE_DIR)
+def get_datumaro_cache_dir(
+    _CACHE_DIR: str = osp.expanduser(os.getenv("XDG_CACHE_HOME", osp.join("~", ".cache")))
+):
+    """Get DATUMARO_CACHE_DIR. If it does not exists, create it."""
+    DATUMARO_CACHE_DIR = osp.join(_CACHE_DIR, "datumaro")
+
+    try:
+        if not osp.exists(DATUMARO_CACHE_DIR):
+            os.makedirs(DATUMARO_CACHE_DIR)
+    except Exception as e:
+        log.error(f"Cannot create DATUMARO_CACHE_DIR={DATUMARO_CACHE_DIR} since {e}.")

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import os.path as osp
+import platform
 from contextlib import suppress
 from unittest import TestCase, mock
 
@@ -228,6 +229,10 @@ class DefinitionsTest:
         yield dst
         os.chmod(dst, 0o755)
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="os.chmod() cannot be used for Windows.",
+    )
     def test_get_datumaro_cache_dir(
         self, fxt_writable_path: str, fxt_non_writable_path: str, caplog: pytest.LogCaptureFixture
     ):

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,9 +1,17 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import logging
 import os
 import os.path as osp
 from contextlib import suppress
 from unittest import TestCase, mock
 
+import pytest
+
 from datumaro.util import is_method_redefined
+from datumaro.util.definitions import get_datumaro_cache_dir
 from datumaro.util.os_util import walk
 from datumaro.util.scope import Scope, on_error_do, on_exit_do, scoped
 
@@ -202,3 +210,30 @@ class TestMemberRedefined(TestCase):
         obj = self.Base()
         with mock.patch.object(obj, "method"):
             self.assertTrue(is_method_redefined("method", self.Base, obj))
+
+
+class DefinitionsTest:
+    @pytest.fixture
+    def fxt_writable_path(self, test_dir: str) -> str:
+        dst = os.path.join(test_dir, "writable")
+        os.makedirs(dst)
+        os.chmod(dst, 0o755)
+        return dst
+
+    @pytest.fixture
+    def fxt_non_writable_path(self, test_dir: str) -> str:
+        dst = os.path.join(test_dir, "non-writable")
+        os.makedirs(dst)
+        os.chmod(dst, 0o000)
+        yield dst
+        os.chmod(dst, 0o755)
+
+    def test_get_datumaro_cache_dir(
+        self, fxt_writable_path: str, fxt_non_writable_path: str, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(logging.ERROR):
+            get_datumaro_cache_dir(fxt_writable_path)
+            assert len(caplog.records) == 0
+        with caplog.at_level(logging.ERROR):
+            get_datumaro_cache_dir(fxt_non_writable_path)
+            assert len(caplog.records) == 1


### PR DESCRIPTION
### Summary
 - This is because Geti containers have no write access.
 - Do not create Datumaro cache dir when just importing datumaro
 - Raise an error log and do not terminate it if it is not possible to create the cache directory.

### How to test
I added a test for this change.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
