### PR TITLE
Bugfix for explore cli test to get datasetitem through path

### DIFF
--- a/docs/source/docs/command-reference/context_free/explorer.md
+++ b/docs/source/docs/command-reference/context_free/explorer.md
@@ -12,14 +12,18 @@ The command can be applied to a dataset. And if you want to use multiple dataset
 
 Usage:
 ```console
-datum explore [target] -q <path/to/image> or <text_query>
-              [-topk TOPK] [-p PROJECT_DIR] [-s SAVE] [--stage STAGE]
+datum explore [target] [--query-img-path <path/to/image>]
+              [--query-item-id </id/of/image/datasetitem> --query-item-subset <subset/of/image>]
+              [--query-str <text_query>] [-topk TOPK] [-p PROJECT_DIR] [-s SAVE] [--stage STAGE]
 ```
 
 Parameters:
 - `<target>` (string) - Target [dataset revpath](../../user-manual/how_to_use_datumaro.md#dataset-path-concepts).
   By default, prints info about the joined `project` dataset.
-- `-q, --query` (string) - Image path or text to use as query.
+- `--query-img-path` (string) - Image path to use as query or list of it.
+- `--query-item-id` (string) - Datasetitem id of Image to use as query or list of it.
+- `--query-item-subset` (string) - Datasetitem subset of Image to use as query or list of it. (default: None)
+- `--query-str` (string) - Test to use as query or list of it.
 - `-topk` (int) - Number how much you want to find similar data.
 - `-p, --project` (string) - Directory of the project to operate on (default: current directory).
 - `-s, --save` (bool) - Save explorer result files on explore_result folder.
@@ -30,29 +34,39 @@ Parameters:
   and the `project` target, but not intermediate stages). Enabled by default.
 
 Examples:
-- Explore top10 similar images of image query
+- Explore top10 similar images of image path query.
   ```console
-  datum search -q <path/to/image> -topk 10 <path/to/dataset/>
+  datum explore -query-img-path <path/to/image> -topk 10 <path/to/dataset/>
   ```
 
-- Explore top10 similar images of image query within project
+- Explore top10 similar images using image datasetitem id query. Setting the subset of a DatasetItem is not mandatory.
+  ```console
+  datum explore --query-item-id <id/of/image/datasetitem> -topk 10 <path/to/dataset/>
+  ```
+
+- Explore top10 similar images using image datasetitem id and subset query.
+  ```console
+  datum explore --query-item-id <id/of/image/datasetitem> --query-item-subset <subset/of/image/datasetitem> -topk 10 <path/to/dataset/>
+  ```
+
+- Explore top10 similar images of image query within project.
   ```console
   datum project create <...>
   datum project import -f <format> <path/to/dataset/>
-  datum explore -q <path/to/image> -topk 10
+  datum explore -query-img-path <path/to/image> -topk 10
   ```
 
 - Explore top10 similar images of text query, elephant
   ```console
-  datum search -q elephant -topk 10 <path/to/dataset/>
+  datum explore --query-str elephant -topk 10 <path/to/dataset/>
   ```
 
 - Explore top50 similar images of image query list
   ```console
-  datum search -q <path/to/image1> <path/to/image2> <path/to/image3> -topk 50 <path/to/dataset/>
+  datum explore --query-img-path <path/to/image1> <path/to/image2> <path/to/image3> -topk 50 <path/to/dataset/>
   ```
 
 - Explore top50 similar images of text query list
   ```console
-  datum search -q motorcycle bus train -topk 50 <path/to/dataset/>
+  datum explore --query-str motorcycle bus train -topk 50 <path/to/dataset/>
   ```

--- a/docs/source/docs/level-up/intermediate_skills/10_data_exploration.rst
+++ b/docs/source/docs/level-up/intermediate_skills/10_data_exploration.rst
@@ -39,17 +39,31 @@ The Python example for the usage of explorer is described in :doc:`here <../../j
 
     .. tab-item:: CLI
 
-        Without the project declaration, we can simply ``explore`` dataset by
+        Without the project declaration, we can simply ``explore`` dataset like below.
+
+        You can set the query using one of the following options: ``QUERY_PATH``, ``QUERY_ID``, or ``QUERY_STR``
 
         .. code-block:: bash
 
-            datum explore <target> --query QUERY -topk TOPK_NUM
+            datum explore <target> --query-img-path QUERY_PATH -topk TOPK_NUM
 
-        ``QUERY`` could be image file path, text description, list of both of them
+        ``QUERY_PATH`` could be image file path or list of them
 
         ``TOPK_NUM`` is an integer that you want to find the number of similar results for query
 
-        Exploration result would be printed by log and result files would be copied into ``explore_result`` folder
+        Exploration result would be printed by log and result files would be copied into ``explore_result`` folder.
+
+        .. code-block:: bash
+
+            datum explore <target> --query-item-id QUERY_ID -topk TOPK_NUM
+
+        ``QUERY_ID`` could be datasetitem id or list of them
+
+        .. code-block:: bash
+
+            datum explore <target> --query-str QUERY_STR -topk TOPK_NUM
+
+        ``QUERY_STR`` could be text description or list of them
 
     .. tab-item:: ProjectCLI
 
@@ -65,14 +79,28 @@ The Python example for the usage of explorer is described in :doc:`here <../../j
 
             datum project import --project <path/to/project> <path/to/data>
 
-        We can ``explore`` similar items for the query
+        We can ``explore`` similar items for the query.
+
+        You can set the query using one of the following options: ``QUERY_PATH``, ``QUERY_ID``, or ``QUERY_STR``
 
         .. code-block:: bash
 
-            datum explore --query QUERY -topk TOPK_NUM -p <path/to/project>
+            datum explore --query-img-path QUERY_PATH -topk TOPK_NUM -p <path/to/project>
 
-        ``QUERY`` could be image file path, text description, list of both of them
+        ``QUERY_PATH`` could be image file path or list of them
 
         ``TOPK_NUM`` is an integer that you want to find the number of similar results for query
 
-        Exploration result would be printed by log and result files would be copied into ``explore_result`` folder
+        Exploration result would be printed by log and result files would be copied into ``explore_result`` folder.
+
+        .. code-block:: bash
+
+            datum explore <target> --query-item-id QUERY_ID -topk TOPK_NUM -p <path/to/project>
+
+        ``QUERY_ID`` could be datasetitem id or list of them
+
+        .. code-block:: bash
+
+            datum explore <target> --query-str QUERY_STR -topk TOPK_NUM -p <path/to/project>
+
+        ``QUERY_STR`` could be text description or list of them

--- a/src/datumaro/cli/commands/explore.py
+++ b/src/datumaro/cli/commands/explore.py
@@ -10,7 +10,10 @@ import random
 import shutil
 
 from datumaro.components.algorithms.hash_key_inference.explorer import Explorer
-from datumaro.components.algorithms.hash_key_inference.hashkey_util import match_query_subset
+from datumaro.components.algorithms.hash_key_inference.hashkey_util import (
+    check_and_convert_to_list,
+    match_query_subset,
+)
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.errors import ProjectNotFoundError
 from datumaro.components.media import Image
@@ -58,6 +61,12 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         default=None,
         type=str,
         help="Datasetitem id of query to explore similar data",
+    )
+    query_parser.add_argument(
+        "--query-item-subset",
+        default=None,
+        type=str,
+        help="Datasetitem subset of query to explore similar data",
     )
     query_parser.add_argument(
         "--query-str",
@@ -141,11 +150,7 @@ def explore_command(args):
         project.working_tree.save()
 
     if args.query_img_path:
-        querys = (
-            [args.query_img_path]
-            if not isinstance(args.query_img_path, list)
-            else args.query_img_path
-        )
+        querys = check_and_convert_to_list(args.query_img_path)
         query_datasetitems = []
         for query_ in querys:
             query_datasetitem = DatasetItem(
@@ -159,12 +164,12 @@ def explore_command(args):
         query_datasetitems = []
         for query in querys:
             for dataset in source_datasets:
-                query_datasetitem = match_query_subset(query, dataset)
+                query_datasetitem = match_query_subset(
+                    query, dataset, subset=args.query_item_subset
+                )
             query_datasetitems.append(query_datasetitem)
     elif args.query_str:
         query_datasetitems = args.query_str
-    else:
-        raise
 
     results = explorer.explore_topk(query_datasetitems, args.topk)
 

--- a/src/datumaro/cli/commands/explore.py
+++ b/src/datumaro/cli/commands/explore.py
@@ -133,7 +133,7 @@ def explore_command(args):
                 query_datasetitem = dataset.get_datasetitem_by_path(args.query)
             except Exception:
                 continue
-            if not query_datasetitem:
+            if query_datasetitem:
                 break
     else:
         query_datasetitem = args.query

--- a/src/datumaro/cli/commands/explore.py
+++ b/src/datumaro/cli/commands/explore.py
@@ -6,14 +6,14 @@ import argparse
 import logging as log
 import os
 import os.path as osp
+import random
 import shutil
 
 from datumaro.components.algorithms.hash_key_inference.explorer import Explorer
-from datumaro.components.algorithms.hash_key_inference.hashkey_util import (
-    match_query_path,
-    match_query_subset,
-)
+from datumaro.components.algorithms.hash_key_inference.hashkey_util import match_query_subset
+from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.errors import ProjectNotFoundError
+from datumaro.components.media import Image
 from datumaro.util import str_to_bool
 from datumaro.util.scope import scope_add, scoped
 
@@ -141,18 +141,16 @@ def explore_command(args):
         project.working_tree.save()
 
     if args.query_img_path:
-        querys = [args.query_img_path]
+        querys = (
+            [args.query_img_path]
+            if not isinstance(args.query_img_path, list)
+            else args.query_img_path
+        )
         query_datasetitems = []
         for query_ in querys:
-            query_datasetitem = None
-            for dataset in source_datasets:
-                query = match_query_path(query_, dataset)
-                try:
-                    query_datasetitem = dataset.get_datasetitem_by_path(query)
-                except Exception:
-                    continue
-                if query_datasetitem:
-                    break
+            query_datasetitem = DatasetItem(
+                id=random.randrange(100, 1000), media=Image.from_file(query_)
+            )
             query_datasetitems.append(query_datasetitem)
     elif args.query_item_id:
         querys = (

--- a/src/datumaro/cli/commands/explore.py
+++ b/src/datumaro/cli/commands/explore.py
@@ -155,7 +155,9 @@ def explore_command(args):
                     break
             query_datasetitems.append(query_datasetitem)
     elif args.query_item_id:
-        querys = [args.query_item_id] if not type(args.query_item_id, list) else args.query_item_id
+        querys = (
+            [args.query_item_id] if not isinstance(args.query_item_id, list) else args.query_item_id
+        )
         query_datasetitems = []
         for query in querys:
             for dataset in source_datasets:

--- a/src/datumaro/cli/commands/explore.py
+++ b/src/datumaro/cli/commands/explore.py
@@ -140,10 +140,6 @@ def explore_command(args):
         project.working_tree.config.update(build_tree.config)
         project.working_tree.save()
 
-    # Get query datasetitem through query path
-    input_query = args.query_img_path or args.query_item_id or args.query_str
-
-    # input_query is one img path
     if args.query_img_path:
         querys = [args.query_img_path]
         query_datasetitems = []

--- a/src/datumaro/cli/commands/explore.py
+++ b/src/datumaro/cli/commands/explore.py
@@ -153,7 +153,7 @@ def explore_command(args):
         querys = check_and_convert_to_list(args.query_img_path)
         query_datasetitems = []
         for query_ in querys:
-            query_datasetitem = DatasetItem(id=uuid.uuid4(), media=Image.from_file(query_))
+            query_datasetitem = DatasetItem(id=str(uuid.uuid4()), media=Image.from_file(query_))
             query_datasetitems.append(query_datasetitem)
     elif args.query_item_id:
         querys = (

--- a/src/datumaro/cli/commands/explore.py
+++ b/src/datumaro/cli/commands/explore.py
@@ -6,8 +6,8 @@ import argparse
 import logging as log
 import os
 import os.path as osp
-import random
 import shutil
+import uuid
 
 from datumaro.components.algorithms.hash_key_inference.explorer import Explorer
 from datumaro.components.algorithms.hash_key_inference.hashkey_util import (
@@ -153,9 +153,7 @@ def explore_command(args):
         querys = check_and_convert_to_list(args.query_img_path)
         query_datasetitems = []
         for query_ in querys:
-            query_datasetitem = DatasetItem(
-                id=random.randrange(100, 1000), media=Image.from_file(query_)
-            )
+            query_datasetitem = DatasetItem(id=uuid.uuid4(), media=Image.from_file(query_))
             query_datasetitems.append(query_datasetitem)
     elif args.query_item_id:
         querys = (

--- a/src/datumaro/cli/commands/explore.py
+++ b/src/datumaro/cli/commands/explore.py
@@ -34,36 +34,36 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         |n
         Examples:|n
         - Explore top50 similar images of image query in COCO dataset:|n
-        |s|s%(prog)s -q path/to/image.jpg -topk 50|n
+        |s|s%(prog)s --query-img-path path/to/image.jpg -topk 50|n
         - Explore top50 similar images of text query, elephant, in COCO dataset:|n
-        |s|s%(prog)s -q elephant -topk 50|n
+        |s|s%(prog)s --query-str elephant -topk 50|n
         - Explore top50 similar images of image query list in COCO dataset:|n
-        |s|s%(prog)s -q path/to/image1.jpg/ path/to/image2.jpg/ path/to/image3.jpg/ -topk 50|n
+        |s|s%(prog)s --query-img-path path/to/image1.jpg/ path/to/image2.jpg/ path/to/image3.jpg/ -topk 50|n
         - Explore top50 similar images of text query list in COCO dataset:|n
-        |s|s%(prog)s -q motorcycle/ bus/ train/ -topk 50
+        |s|s%(prog)s --query-str motorcycle/ bus/ train/ -topk 50
         """,
         formatter_class=MultilineFormatter,
     )
 
     parser.add_argument("target", nargs="?", help="Target dataset")
-    query_parser = parser.add_argument_group("Query options")
-    query_parser.add_argument(
-        "--query-item-id",
-        default=None,
-        type=str,
-        help="",
-    )
+    query_parser = parser.add_mutually_exclusive_group(required=True)
     query_parser.add_argument(
         "--query-img-path",
         default=None,
         type=str,
-        help="",
+        help="Image path of query to explore similar data",
+    )
+    query_parser.add_argument(
+        "--query-item-id",
+        default=None,
+        type=str,
+        help="Datasetitem id of query to explore similar data",
     )
     query_parser.add_argument(
         "--query-str",
         default=None,
         type=str,
-        help="",
+        help="Text to explore similar data",
     )
     parser.add_argument("-topk", type=int, dest="topk", help="Number of similar results")
     parser.add_argument(
@@ -155,7 +155,7 @@ def explore_command(args):
                     break
             query_datasetitems.append(query_datasetitem)
     elif args.query_item_id:
-        querys = [args.query_item_id]
+        querys = [args.query_item_id] if not type(args.query_item_id, list) else args.query_item_id
         query_datasetitems = []
         for query in querys:
             for dataset in source_datasets:

--- a/src/datumaro/components/algorithms/hash_key_inference/hashkey_util.py
+++ b/src/datumaro/components/algorithms/hash_key_inference/hashkey_util.py
@@ -176,21 +176,6 @@ def calculate_hamming(B1, B2):
     return np.count_nonzero(B1 != B2, axis=1)
 
 
-def match_query_path(query_path, dataset):
-    query_path = os.path.expanduser(query_path)
-    common_base = os.path.commonpath([query_path, dataset.data_path])
-    result_path = None
-
-    for item in dataset:
-        query_rel = os.path.relpath(query_path, common_base)
-        item_rel = os.path.relpath(item.media.path, common_base)
-
-        for q, i in zip(query_rel.split(os.sep)[::-1], item_rel.split(os.sep)[::-1]):
-            if q == i:
-                result_path = item.media.path
-    return result_path
-
-
 def match_query_subset(query_id, dataset):
     subset_names = list(dataset.subsets().keys())
     for subset_name in subset_names:

--- a/src/datumaro/components/algorithms/hash_key_inference/hashkey_util.py
+++ b/src/datumaro/components/algorithms/hash_key_inference/hashkey_util.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+import os
+
 import numpy as np
 
 from datumaro.components.annotation import HashKey
@@ -172,3 +174,30 @@ def calculate_hamming(B1, B2):
     :return: hamming distance [r]
     """
     return np.count_nonzero(B1 != B2, axis=1)
+
+
+def match_query_path(query_path, dataset):
+    query_path = os.path.expanduser(query_path)
+    common_base = os.path.commonpath([query_path, dataset.data_path])
+    result_path = None
+
+    for item in dataset:
+        query_rel = os.path.relpath(query_path, common_base)
+        item_rel = os.path.relpath(item.media.path, common_base)
+
+        for q, i in zip(query_rel.split(os.sep)[::-1], item_rel.split(os.sep)[::-1]):
+            if q == i:
+                result_path = item.media.path
+    return result_path
+
+
+def match_query_subset(query_id, dataset):
+    subset_names = list(dataset.subsets().keys())
+    for subset_name in subset_names:
+        try:
+            query_datasetitem = dataset.get(query_id, subset_name)
+        except Exception:
+            continue
+        if query_datasetitem:
+            break
+    return query_datasetitem

--- a/src/datumaro/components/algorithms/hash_key_inference/hashkey_util.py
+++ b/src/datumaro/components/algorithms/hash_key_inference/hashkey_util.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import os
-
 import numpy as np
 
 from datumaro.components.annotation import HashKey

--- a/src/datumaro/components/algorithms/hash_key_inference/hashkey_util.py
+++ b/src/datumaro/components/algorithms/hash_key_inference/hashkey_util.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+import os
+
 import numpy as np
 
 from datumaro.components.annotation import HashKey
@@ -174,13 +176,33 @@ def calculate_hamming(B1, B2):
     return np.count_nonzero(B1 != B2, axis=1)
 
 
-def match_query_subset(query_id, dataset):
-    subset_names = list(dataset.subsets().keys())
+def match_query_subset(query_id, dataset, subset=None):
+    if subset:
+        return dataset.get(query_id, subset)
+
+    subset_names = dataset.subsets().keys()
     for subset_name in subset_names:
         try:
             query_datasetitem = dataset.get(query_id, subset_name)
+            if query_datasetitem:
+                return query_datasetitem
         except Exception:
-            continue
-        if query_datasetitem:
-            break
-    return query_datasetitem
+            pass
+
+    return None
+
+
+def check_and_convert_to_list(paths):
+    if isinstance(paths, str):
+        paths = [paths]
+    elif not isinstance(paths, list):
+        raise ValueError("Invalid value type. Expected str or list.")
+
+    valid_paths = []
+    for path in paths:
+        if os.path.exists(path):
+            valid_paths.append(path)
+        else:
+            raise ValueError(f"Invalid path: {path}")
+
+    return valid_paths

--- a/src/datumaro/components/dataset_item_storage.py
+++ b/src/datumaro/components/dataset_item_storage.py
@@ -86,7 +86,7 @@ class DatasetItemStorage:
 
     def get_datasetitem_by_path(self, path):
         for s in self._traversal_order.values():
-            if getattr(s.media, "path", None) == path or getattr(s.media, "_path", None) == path:
+            if getattr(s.media, "path", None) == path:
                 return s
 
     def get_annotations(self):

--- a/src/datumaro/components/dataset_item_storage.py
+++ b/src/datumaro/components/dataset_item_storage.py
@@ -86,7 +86,7 @@ class DatasetItemStorage:
 
     def get_datasetitem_by_path(self, path):
         for s in self._traversal_order.values():
-            if getattr(s.media, "path", None) == path:
+            if getattr(s.media, "path", None) == path or getattr(s.media, "_path", None) == path:
                 return s
 
     def get_annotations(self):

--- a/tests/integration/cli/test_explore.py
+++ b/tests/integration/cli/test_explore.py
@@ -162,7 +162,6 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset_url = osp.join(test_dir, "dataset")
-        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset_url, "datumaro", save_media=True)
 
@@ -172,8 +171,8 @@ class ExploreTest(TestCase):
             self,
             "explore",
             "source-1",
-            "--query-img-path",
-            train_image_path,
+            "--query-str",
+            "a photo of a upper white and bottom black background",
             "-topk",
             "2",
             "-p",

--- a/tests/integration/cli/test_explore.py
+++ b/tests/integration/cli/test_explore.py
@@ -115,7 +115,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skipIf(
         platform.system() == "Darwin",
@@ -139,7 +139,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skipIf(
         platform.system() == "Darwin",
@@ -189,7 +189,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skipIf(
         platform.system() == "Darwin",
@@ -237,7 +237,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skipIf(
         platform.system() == "Darwin",
@@ -292,7 +292,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skipIf(
         platform.system() == "Darwin",
@@ -342,7 +342,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skipIf(
         platform.system() == "Darwin",

--- a/tests/integration/cli/test_explore.py
+++ b/tests/integration/cli/test_explore.py
@@ -89,7 +89,7 @@ class ExploreTest(TestCase):
     )
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @scoped
-    def test_can_explore_dataset_w_target(self):
+    def test_can_explore_dataset_w_query_img_path(self):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset_url = osp.join(test_dir, "dataset")
@@ -103,7 +103,76 @@ class ExploreTest(TestCase):
             self,
             "explore",
             "source-1",
-            "-q",
+            "--query-img-path",
+            train_image_path,
+            "-topk",
+            "2",
+            "-p",
+            proj_dir,
+            "-s",
+        )
+
+        saved_result_path = osp.join(proj_dir, "explore_result")
+        results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
+
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+
+    @skipIf(
+        platform.system() == "Darwin",
+        "Segmentation fault only occurs on MacOS: "
+        "https://github.com/openvinotoolkit/datumaro/actions/runs/4202399957/jobs/7324077250",
+    )
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    @scoped
+    def test_can_explore_dataset_w_query_item_id(self):
+        test_dir = scope_add(TestDir())
+        proj_dir = osp.join(test_dir, "proj")
+        dataset_url = osp.join(test_dir, "dataset")
+
+        self.test_dataset.export(dataset_url, "datumaro", save_media=True)
+
+        run(self, "project", "create", "-o", proj_dir)
+        run(self, "project", "import", "-p", proj_dir, "-f", "datumaro", dataset_url)
+        run(
+            self,
+            "explore",
+            "source-1",
+            "--query-item-id",
+            "1",
+            "-topk",
+            "2",
+            "-p",
+            proj_dir,
+            "-s",
+        )
+
+        saved_result_path = osp.join(proj_dir, "explore_result")
+        results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
+
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+
+    @skipIf(
+        platform.system() == "Darwin",
+        "Segmentation fault only occurs on MacOS: "
+        "https://github.com/openvinotoolkit/datumaro/actions/runs/4202399957/jobs/7324077250",
+    )
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    @scoped
+    def test_can_explore_dataset_w_query_str(self):
+        test_dir = scope_add(TestDir())
+        proj_dir = osp.join(test_dir, "proj")
+        dataset_url = osp.join(test_dir, "dataset")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
+
+        self.test_dataset.export(dataset_url, "datumaro", save_media=True)
+
+        run(self, "project", "create", "-o", proj_dir)
+        run(self, "project", "import", "-p", proj_dir, "-f", "datumaro", dataset_url)
+        run(
+            self,
+            "explore",
+            "source-1",
+            "--query-img-path",
             train_image_path,
             "-topk",
             "2",
@@ -134,7 +203,17 @@ class ExploreTest(TestCase):
 
         run(self, "project", "create", "-o", proj_dir)
         run(self, "project", "import", "-p", proj_dir, "-f", "datumaro", dataset_url)
-        run(self, "explore", "-q", train_image_path, "-topk", "2", "-p", proj_dir, "-s")
+        run(
+            self,
+            "explore",
+            "--query-img-path",
+            train_image_path,
+            "-topk",
+            "2",
+            "-p",
+            proj_dir,
+            "-s",
+        )
 
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
@@ -162,7 +241,7 @@ class ExploreTest(TestCase):
             self,
             "explore",
             "source-1",
-            "-q",
+            "--query-img-path",
             train_image_path,
             "-topk",
             "2",
@@ -177,7 +256,7 @@ class ExploreTest(TestCase):
             self,
             "explore",
             "source-1",
-            "-q",
+            "--query-img-path",
             train_image_path,
             "-topk",
             "2",
@@ -211,7 +290,7 @@ class ExploreTest(TestCase):
         run(
             self,
             "explore",
-            "-q",
+            "--query-img-path",
             train_image_path,
             "-topk",
             "2",
@@ -225,7 +304,7 @@ class ExploreTest(TestCase):
         run(
             self,
             "explore",
-            "-q",
+            "--query-img-path",
             train_image_path,
             "-topk",
             "4",
@@ -256,7 +335,17 @@ class ExploreTest(TestCase):
 
         run(self, "project", "create", "-o", proj_dir)
         run(self, "project", "import", "-p", proj_dir, "-f", "datumaro", dataset1_url)
-        run(self, "explore", "-q", train_image_path, "-topk", "2", "-p", proj_dir, "source-1")
+        run(
+            self,
+            "explore",
+            "--query-img-path",
+            train_image_path,
+            "-topk",
+            "2",
+            "-p",
+            proj_dir,
+            "source-1",
+        )
 
         dataset2_url = osp.join(test_dir, "dataset2")
         self.test_dataset2.save(dataset2_url, save_media=True)
@@ -280,7 +369,7 @@ class ExploreTest(TestCase):
             self,
             "explore",
             "result",
-            "-q",
+            "--query-img-path",
             train_image_path,
             "-topk",
             "4",
@@ -310,7 +399,7 @@ class ExploreTest(TestCase):
         train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
         run(self, "project", "create", "-o", proj_dir)
         run(self, "project", "import", "-p", proj_dir, "-f", "datumaro", dataset1_url)
-        run(self, "explore", "-q", train_image_path, "-topk", "2", "-p", proj_dir)
+        run(self, "explore", "--query-img-path", train_image_path, "-topk", "2", "-p", proj_dir)
 
         dataset2_url = osp.join(test_dir, "dataset2")
         self.test_dataset2.save(dataset2_url, save_media=True)
@@ -330,7 +419,7 @@ class ExploreTest(TestCase):
         run(
             self,
             "explore",
-            "-q",
+            "--query-img-path",
             train_image_path,
             "-topk",
             "4",
@@ -355,12 +444,22 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset1_url = osp.join(test_dir, "dataset1")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(dataset1_url, "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset1_url, "datumaro", save_media=True)
         run(self, "project", "create", "-o", proj_dir)
         run(self, "project", "import", "-p", proj_dir, "-f", "datumaro", dataset1_url)
-        run(self, "explore", "source-1", "-q", train_image_path, "-topk", "2", "-p", proj_dir)
+        run(
+            self,
+            "explore",
+            "source-1",
+            "--query-img-path",
+            train_image_path,
+            "-topk",
+            "2",
+            "-p",
+            proj_dir,
+        )
         run(self, "project", "commit", "-p", proj_dir, "-m", "commit1")
 
         commit1_proj = load_project(proj_dir)
@@ -395,7 +494,7 @@ class ExploreTest(TestCase):
             self,
             "explore",
             "result",
-            "-q",
+            "--query-img-path",
             train_image_path,
             "-topk",
             "2",
@@ -442,7 +541,7 @@ class ExploreTest(TestCase):
         self.test_dataset.export(dataset1_url, "datumaro", save_media=True)
         run(self, "project", "create", "-o", proj_dir)
         run(self, "project", "import", "-p", proj_dir, "-f", "datumaro", dataset1_url)
-        run(self, "explore", "-q", train_image_path, "-topk", "2", "-p", proj_dir)
+        run(self, "explore", "--query-img-path", train_image_path, "-topk", "2", "-p", proj_dir)
 
         proj = load_project(proj_dir)
         srcs = list(proj.working_tree.config.sources.keys())

--- a/tests/integration/cli/test_explore.py
+++ b/tests/integration/cli/test_explore.py
@@ -535,7 +535,7 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset1_url = osp.join(test_dir, "dataset1")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(dataset1_url, "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset1_url, "datumaro", save_media=True)
         run(self, "project", "create", "-o", proj_dir)

--- a/tests/integration/cli/test_explore.py
+++ b/tests/integration/cli/test_explore.py
@@ -115,7 +115,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skipIf(
         platform.system() == "Darwin",
@@ -139,7 +139,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skipIf(
         platform.system() == "Darwin",
@@ -189,7 +189,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skipIf(
         platform.system() == "Darwin",
@@ -237,7 +237,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skipIf(
         platform.system() == "Darwin",
@@ -292,7 +292,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skipIf(
         platform.system() == "Darwin",
@@ -342,7 +342,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skipIf(
         platform.system() == "Darwin",

--- a/tests/integration/cli/test_explore.py
+++ b/tests/integration/cli/test_explore.py
@@ -1,7 +1,7 @@
 import os.path as osp
 import platform
 from glob import glob
-from unittest import TestCase, skip, skipIf
+from unittest import TestCase, skipIf
 
 import numpy as np
 
@@ -82,7 +82,6 @@ class ExploreTest(TestCase):
         )
         return dataset
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "
@@ -118,7 +117,6 @@ class ExploreTest(TestCase):
 
         self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "
@@ -143,7 +141,6 @@ class ExploreTest(TestCase):
 
         self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "
@@ -194,7 +191,6 @@ class ExploreTest(TestCase):
 
         self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "
@@ -243,7 +239,6 @@ class ExploreTest(TestCase):
 
         self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "
@@ -276,8 +271,11 @@ class ExploreTest(TestCase):
             result_dir,
             dataset1_url,
             dataset2_url,
+            "--",
+            "--save-media",
         )
         run(self, "project", "import", "-n", "result", "-p", proj_dir, "-f", "datumaro", result_dir)
+        train_image_path = osp.join(proj_dir, "result", "images", "train", "1.jpg")
         run(
             self,
             "explore",
@@ -296,7 +294,6 @@ class ExploreTest(TestCase):
 
         self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
-    @skip("Skip tests for explorer CLI")
     @skipIf(
         platform.system() == "Darwin",
         "Segmentation fault only occurs on MacOS: "

--- a/tests/integration/cli/test_explore.py
+++ b/tests/integration/cli/test_explore.py
@@ -94,7 +94,7 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset_url = osp.join(test_dir, "dataset")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset_url, "datumaro", save_media=True)
 
@@ -116,7 +116,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -130,7 +130,7 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset_url = osp.join(test_dir, "dataset")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset_url, "datumaro", save_media=True)
 
@@ -141,7 +141,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -155,7 +155,7 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset1_url = osp.join(test_dir, "dataset1")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset1_url, "datumaro", save_media=True)
         run(self, "project", "create", "-o", proj_dir)
@@ -192,7 +192,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -206,7 +206,7 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset1_url = osp.join(test_dir, "dataset1")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset1_url, "datumaro", save_media=True)
         run(self, "project", "create", "-o", proj_dir)
@@ -241,7 +241,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -255,7 +255,7 @@ class ExploreTest(TestCase):
         test_dir = scope_add(TestDir())
         proj_dir = osp.join(test_dir, "proj")
         dataset1_url = osp.join(test_dir, "dataset1")
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
 
         self.test_dataset.export(dataset1_url, "datumaro", save_media=True)
 
@@ -294,7 +294,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -310,7 +310,7 @@ class ExploreTest(TestCase):
         dataset1_url = osp.join(test_dir, "dataset1")
         self.test_dataset.export(dataset1_url, "datumaro", save_media=True)
 
-        train_image_path = osp.join(test_dir, "train", "1.jpg")
+        train_image_path = osp.join(proj_dir, "source-1", "images", "train", "1.jpg")
         run(self, "project", "create", "-o", proj_dir)
         run(self, "project", "import", "-p", proj_dir, "-f", "datumaro", dataset1_url)
         run(self, "explore", "-q", train_image_path, "-topk", "2", "-p", proj_dir)
@@ -345,7 +345,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train"), results)
+        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
 
     @skipIf(
         platform.system() == "Darwin",

--- a/tests/integration/cli/test_explore.py
+++ b/tests/integration/cli/test_explore.py
@@ -116,7 +116,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -141,7 +141,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -192,7 +192,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -241,7 +241,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -294,7 +294,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skip("Skip tests for explorer CLI")
     @skipIf(
@@ -345,7 +345,7 @@ class ExploreTest(TestCase):
         saved_result_path = osp.join(proj_dir, "explore_result")
         results = glob(osp.join(saved_result_path, "**", "*"), recursive=True)
 
-        self.assertIn(osp.join(saved_result_path, "train", "1.jpg"), results)
+        self.assertIn(osp.join(saved_result_path, "train"), results)
 
     @skipIf(
         platform.system() == "Darwin",


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Due to `train_path` not matched with `dataset._source_path`, `query` is considered as `string` input, not coverted to `Datasetitem` or could not bring the proper `Datasetitem` which is matched with `path` through `dataset.get_datasetitem_by_path(args.query)`. 
- Match `train_path` of CLI path as `project/source-1/images/train/1.jpg'.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
- I fixed the path in integration test.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [X] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [X] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
