### PR TITLE
Hotfix some mis-implements making datum stream importer slow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate DVC v3.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1072>)
 - Stream dataset import/export
-  (<https://github.com/openvinotoolkit/datumaro/pull/1077>, <https://github.com/openvinotoolkit/datumaro/pull/1081>, <https://github.com/openvinotoolkit/datumaro/pull/1082>, <https://github.com/openvinotoolkit/datumaro/pull/1091>, <https://github.com/openvinotoolkit/datumaro/pull/1093>)
+  (<https://github.com/openvinotoolkit/datumaro/pull/1077>, <https://github.com/openvinotoolkit/datumaro/pull/1081>, <https://github.com/openvinotoolkit/datumaro/pull/1082>, <https://github.com/openvinotoolkit/datumaro/pull/1091>, <https://github.com/openvinotoolkit/datumaro/pull/1093>, <https://github.com/openvinotoolkit/datumaro/pull/1098>)
 - Support mask annotations for CVAT data format
   (<https://github.com/openvinotoolkit/datumaro/pull/1078>)
 

--- a/src/datumaro/components/progress_reporting.py
+++ b/src/datumaro/components/progress_reporting.py
@@ -186,6 +186,8 @@ class TQDMProgressReporter(ProgressReporter):
         self._cur = progress
 
     def finish(self):
+        if self._total is None:
+            self._total = self._cur  # Total can be None
         self._pbar.update(self._total - self._cur)
         self._pbar.close()
 

--- a/src/datumaro/plugins/data_formats/datumaro/base.py
+++ b/src/datumaro/plugins/data_formats/datumaro/base.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
+import re
 from typing import Dict, List, Optional, Type
 
 import json_stream
@@ -37,12 +38,19 @@ __all__ = ["DatumaroBase"]
 
 class JsonReader:
     def __init__(
-        self, path: str, subset: str, rootpath: str, images_dir: str, pcd_dir: str
+        self,
+        path: str,
+        subset: str,
+        rootpath: str,
+        images_dir: str,
+        pcd_dir: str,
+        ctx: ImportContext,
     ) -> None:
         self._subset = subset
         self._rootpath = rootpath
         self._images_dir = images_dir
         self._pcd_dir = pcd_dir
+        self._ctx = ctx
 
         self._reader = self._init_reader(path)
         self.media_type = self._load_media_type(self._reader)
@@ -106,8 +114,13 @@ class JsonReader:
         items = []
 
         item_descs = parsed["items"]
-        while item_descs:
-            item_desc = item_descs.pop()
+        pbar = self._ctx.progress_reporter
+
+        def _gen():
+            while item_descs:
+                yield item_descs.pop()
+
+        for item_desc in pbar.iter(_gen(), total=len(item_descs)):
             item = self._parse_item(item_desc)
             items.append(item)
 
@@ -298,9 +311,15 @@ class JsonReader:
 
 class StreamJsonReader(JsonReader):
     def __init__(
-        self, path: str, subset: str, rootpath: str, images_dir: str, pcd_dir: str
+        self,
+        path: str,
+        subset: str,
+        rootpath: str,
+        images_dir: str,
+        pcd_dir: str,
+        ctx: ImportContext,
     ) -> None:
-        super().__init__(path, subset, rootpath, images_dir, pcd_dir)
+        super().__init__(path, subset, rootpath, images_dir, pcd_dir, ctx)
         self._length = None
 
     def __len__(self):
@@ -309,14 +328,15 @@ class StreamJsonReader(JsonReader):
         return self._length
 
     def __iter__(self):
-        with open(self._reader, encoding="utf-8") as fp:
+        pbar = self._ctx.progress_reporter
+        with open(self._reader, "rb") as fp:
             data = json_stream.load(fp)
             items = data.get("items", None)
             if items is None:
                 raise DatasetImportError('Annotation JSON file should have "items" entity.')
 
             length = 0
-            for item in items:
+            for item in pbar.iter(items):
                 item_desc = to_dict_from_streaming_json(item)
                 length += 1
                 yield self._parse_item(item_desc)
@@ -329,10 +349,21 @@ class StreamJsonReader(JsonReader):
 
     @staticmethod
     def _load_media_type(path) -> Type[MediaElement]:
+        # We can assume that the media_type information will be within the first 1 KB of the file.
+        # This is because we are the producer of Datumaro format.
+        search_size = 1024  # 1 KB
+
+        pattern = '"media_type"\s*:\s*(\d+)'
+
         with open(path, "r", encoding="utf-8") as fp:
-            data = json_stream.load(fp)
-            media_type = data.get("media_type", MediaType.IMAGE)
-            return MediaType(media_type).media
+            out = fp.read(search_size)
+            found = re.search(pattern, out)
+
+            if found:
+                int_type = int(found.group(1))
+                return MediaType(int_type).IMAGE.media
+
+        return MediaType.IMAGE.media
 
     @staticmethod
     def _load_infos(path) -> Dict:
@@ -426,10 +457,22 @@ class DatumaroBase(SubsetBase):
     def _load_impl(self, path: str) -> None:
         """Actual implementation of loading Datumaro format."""
         self._reader = (
-            JsonReader(path, self._subset, self._rootpath, self._images_dir, self._pcd_dir)
+            JsonReader(
+                path,
+                self._subset,
+                self._rootpath,
+                self._images_dir,
+                self._pcd_dir,
+                self._ctx,
+            )
             if not self._stream
             else StreamJsonReader(
-                path, self._subset, self._rootpath, self._images_dir, self._pcd_dir
+                path,
+                self._subset,
+                self._rootpath,
+                self._images_dir,
+                self._pcd_dir,
+                self._ctx,
             )
         )
         return self._reader
@@ -441,9 +484,25 @@ class DatumaroBase(SubsetBase):
         Note that the legacy Datumaro doesn't store the version into exported dataset.
         Thus it returns DatumaroBase.LEGACY_VERSION
         """
+        # We can assume that the version information will be within the first 1 KB of the file.
+        # This is because we are the producer of Datumaro format.
+        search_size = 1024  # 1 KB
+
+        pattern = '"dm_format_version"\s*:\s*"(\w+)"'
+
         with open(path, "r", encoding="utf-8") as fp:
-            version = json_stream.load(fp).get("dm_format_version", self.LEGACY_VERSION)
-        return version
+            out = fp.read(search_size)
+            found = re.search(pattern, out)
+
+            if not found:
+                return self.LEGACY_VERSION
+
+        version_str = found.group(1)
+
+        if re.match("\d+\.d+", version_str) is None:
+            raise DatasetImportError(f"Invalid version string: {version_str} ")
+
+        return version_str
 
     def __len__(self) -> int:
         return len(self._reader)


### PR DESCRIPTION
### Summary
- Fix `_get_dm_format_version()` faster when there is no `dm_format_version` field in the file.
- Fix `_load_media_type()` faster when there is no `media_type` field in the file.
- Fix `TQDMProgressReporter` when `total` is not given (`total = None`)

### How to test
I manually tested the following code on the real-life COCO2017 object detection dataset which is converted to Datumaro (JSON) data format.

```python
from datumaro.components.dataset_base import DatasetItem
from datumaro.components.dataset import StreamDataset, Dataset
from time import time
from datumaro.components.progress_reporting import TQDMProgressReporter
import argparse

parser = argparse.ArgumentParser()
parser.add_argument("-f", "--format", choices=["coco", "datumaro", "yolo", "voc"], help="Choose format")
parser.add_argument("--stream", action="store_true", help="Use stream importer")


def upload_to_geti_db(item: DatasetItem) -> None:
    # Hi, I'm mock!
    pass


if __name__ == "__main__":
    args = parser.parse_args()
    path, format = args.format, args.format
    if format == "coco":
        format = "coco_instances"  # Set specific format
    start = time()

    dataset = (
        StreamDataset.import_from(path, format=format, progress_reporter=TQDMProgressReporter())
        if args.stream
        else Dataset.import_from(path, format=format, progress_reporter=TQDMProgressReporter())
    )

    for item in dataset:
        upload_to_geti_db(item)

    print(f"Done. Elapsed time: {time() - start:.2f}s")
```

**Results:**

- No stream

![no_stream](https://github.com/openvinotoolkit/datumaro/assets/26541465/8777f340-9ccf-47f4-8bde-0e36efb5c389)

```
(datumaro-basic) vinnamki@vinnamki:~/datumaro/ws_datum/coco$ mprof run --python python test_perf.py -f datumaro
mprof: Sampling memory every 0.1s
running new process
running as a Python program...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 5000/5000 [00:01<00:00, 4728.92it/s]
100%|███████████████████████████████████████████████████████████████████████████████████████████████| 118287/118287 [00:30<00:00, 3919.85it/s]
Done. Elapsed time: 42.14s
```
- Stream

![stream](https://github.com/openvinotoolkit/datumaro/assets/26541465/eca19caa-73d5-45c3-81a1-1fae17c85e34)

```
(datumaro-basic) vinnamki@vinnamki:~/datumaro/ws_datum/coco$ mprof run --python python test_perf.py -f datumaro --stream
mprof: Sampling memory every 0.1s
running new process
running as a Python program...
4999it [00:06, 732.11it/s]
118286it [02:41, 731.49it/s]
Done. Elapsed time: 168.55s
```
### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
