### PR TITLE
Fix: Dataset infos() can be broken if a transform not redefining infos() is stacked on the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 - Create cache dir under only writable filesystem
   (<https://github.com/openvinotoolkit/datumaro/pull/1088>)
+- Fix: Dataset infos() can be broken if a transform not redefining infos() is stacked on the top
+  (<https://github.com/openvinotoolkit/datumaro/pull/1101>)
 
 ## 07/07/2023 - Release 1.4.0rc1
 ### New features

--- a/src/datumaro/components/transformer.py
+++ b/src/datumaro/components/transformer.py
@@ -48,6 +48,9 @@ class Transform(DatasetBase, CliPlugin):
     def media_type(self):
         return self._extractor.media_type()
 
+    def infos(self):
+        return self._extractor.infos()
+
 
 class ItemTransform(Transform):
     def transform_item(self, item: DatasetItem) -> Optional[DatasetItem]:

--- a/tests/unit/components/test_dataset_storage.py
+++ b/tests/unit/components/test_dataset_storage.py
@@ -151,11 +151,11 @@ class StreamDatasetStorageTest:
         # Check extractor categories
         assert storage.categories() == fxt_categories
 
-        # Check extractor infos
         mapping = {"car": "apple", "cat": "banana", "dog": "cinnamon"}
         storage.transform(RemapLabels, mapping=mapping)
         assert fxt_stream_extractor.__iter__.call_count == 0
 
+        # Stack Rename (ItemTransform) on the top
         storage.transform(Rename, regex="|item_|rename_|")
         assert fxt_stream_extractor.__iter__.call_count == 0
 


### PR DESCRIPTION
### Summary
- Ticket no. 115725
- Fix: Dataset infos() can be broken if a transform not redefining infos() is stacked on the top
- Enhance the StreamDatasetStorage transform tests added in #1077.
- Test `call_count` as well in the tests to validate stacked transforms.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
