### PR TITLE
Remove xfail marks from the convert integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## \[Unreleased\]
+### New features
 - Add tabular data import/export
   (<https://github.com/openvinotoolkit/datumaro/pull/1089>)
+
+### Enhancements
+- Remove xfail marks from the convert integration tests
+  (<https://github.com/openvinotoolkit/datumaro/pull/1115>)
+
+### Bug fixes
 
 ## 27/07/2023 - Release 1.4.1
 ### Bug fixes

--- a/src/datumaro/plugins/data_formats/datumaro/base.py
+++ b/src/datumaro/plugins/data_formats/datumaro/base.py
@@ -111,10 +111,12 @@ class JsonReader:
         return categories
 
     def _load_items(self, parsed) -> List:
-        item_descs = parsed["items"]
+        item_descs: List = parsed["items"]
         pbar = self._ctx.progress_reporter
 
         def _gen():
+            # Reverse the list to pop from the front of it
+            item_descs.reverse()
             while item_descs:
                 yield item_descs.pop()
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -138,7 +138,7 @@ def _compare_annotations(
         setattr(expected, "group", 0)
         setattr(actual, "group", 0)
 
-    if ignored_attrs == None:
+    if ignored_attrs is None:
         pass
     elif ignored_attrs == IGNORE_ALL:
         expected.attributes = {}
@@ -157,7 +157,7 @@ def _compare_annotations(
         setattr(expected, "group", a_group)
         setattr(actual, "group", b_group)
 
-    if ignored_attrs != None:
+    if ignored_attrs is not None:
         expected.attributes = a_attr
         actual.attributes = b_attr
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2022 Intel Corporation
+# Copyright (C) 2019-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
### Summary

- Ticket no. 115954
- Remove xfail marks from the convert integration tests
- This is because some data format should require annotation's `id` and `group` to be re-indexed, which should be taken into account when comparing the two datasets for equality.
- It means that there is no functional failures, so this PR just change the testing.

### How to test
I updated the target tests.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
