### PR TITLE
Replace xml.etree.ElementTree with defusedxml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements
 - Remove xfail marks from the convert integration tests
   (<https://github.com/openvinotoolkit/datumaro/pull/1115>)
+- Replace Roboflow `xml.etree` with `defusedxml`
+  (<https://github.com/openvinotoolkit/datumaro/pull/1117>)
 
 ### Bug fixes
 

--- a/src/datumaro/plugins/data_formats/roboflow/base.py
+++ b/src/datumaro/plugins/data_formats/roboflow/base.py
@@ -8,7 +8,8 @@ import os
 import os.path as osp
 import re
 from typing import Dict, List, Optional, Union
-from xml.etree import ElementTree
+
+from defusedxml import ElementTree
 
 from datumaro.components.annotation import (
     Annotation,

--- a/src/datumaro/plugins/data_formats/roboflow/importer.py
+++ b/src/datumaro/plugins/data_formats/roboflow/importer.py
@@ -8,7 +8,8 @@ from collections import defaultdict
 from glob import glob
 from io import TextIOWrapper
 from typing import Any, Dict, List, Type
-from xml.etree import ElementTree
+
+from defusedxml import ElementTree
 
 from datumaro.components.errors import DatasetImportError
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
