### PR TITLE
Add Rust API to optimize COCOPageMapper performance

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -27,6 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Installing Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
       - name: Installing python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/nightly_check.yml
+++ b/.github/workflows/nightly_check.yml
@@ -32,6 +32,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: Installing Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
       - name: Installing python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -40,6 +40,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: Installing Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
       - name: Installing python
         uses: actions/setup-python@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ src/**/*.so
 
 # Autosummary generated rst files
 docs/**/_autosummary/
+
+# Rust API
+rust/Cargo.lock
+rust/target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New features
 - Add tabular data import/export
   (<https://github.com/openvinotoolkit/datumaro/pull/1089>)
-- Add Rust API to optimize COCOPageMapper
+- Add Rust API to optimize COCOPageMapper performance
   (<https://github.com/openvinotoolkit/datumaro/pull/1120>)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New features
 - Add tabular data import/export
   (<https://github.com/openvinotoolkit/datumaro/pull/1089>)
+- Add Rust API to optimize COCOPageMapper
+  (<https://github.com/openvinotoolkit/datumaro/pull/1120>)
 
 ### Enhancements
 - Remove xfail marks from the convert integration tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New features
 - Add tabular data import/export
   (<https://github.com/openvinotoolkit/datumaro/pull/1089>)
-- Add Rust API to optimize COCOPageMapper performance
-  (<https://github.com/openvinotoolkit/datumaro/pull/1120>)
 
 ### Enhancements
 - Remove xfail marks from the convert integration tests
@@ -21,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1117>)
 - Define `GroupType` with `IntEnum` for, where `0` is `EXCLUSIVE`
   (<https://github.com/openvinotoolkit/datumaro/pull/1116>)
+- Add Rust API to optimize COCOPageMapper performance
+  (<https://github.com/openvinotoolkit/datumaro/pull/1120>)
 
 ### Bug fixes
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include 3rd-party.txt
 include src/datumaro/plugins/specs.json
 
 include rust/Cargo.toml
+recursive-include rust/src *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include requirements-core.txt
 include requirements-default.txt
 include 3rd-party.txt
 include src/datumaro/plugins/specs.json
+
+include rust/Cargo.toml

--- a/contributing.md
+++ b/contributing.md
@@ -15,6 +15,9 @@ For feature requests and issues, please feel free to create a GitHub Issue in th
 - Python (3.8+)
 
 To set up your development environment, please follow the steps below.
+
+0. Because Datumaro has some C++ and Rust implementations to improve Python performance, you should install C++ compiler (`apt-get install build-essential`) and a [Rust toolchain](https://www.rust-lang.org/tools/install) in your system to build the binary extensions.
+
 1. Fork the [repo](https://github.com/openvinotoolkit/datumaro).
 
 2. clone the forked repo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "pybind11"]
+requires = ["setuptools", "wheel", "pybind11", "setuptools-rust"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "datumaro-rust-api"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+derive_more = "0.99.17"
+pyo3 = "0.19.2"
+serde = { version = "1.0.180", features = ["derive"] }
+serde_json = "1.0.104"
+strum = { version = "0.25", features = ["derive"] }

--- a/rust/src/coco_page_mapper.rs
+++ b/rust/src/coco_page_mapper.rs
@@ -1,3 +1,7 @@
+//  Copyright (C) 2023 Intel Corporation
+//
+//  SPDX-License-Identifier: MIT
+
 use std::{
     io::{self, Read, Seek},
     str::FromStr,

--- a/rust/src/coco_page_mapper.rs
+++ b/rust/src/coco_page_mapper.rs
@@ -1,0 +1,292 @@
+use std::{
+    io::{self, Read, Seek},
+    str::FromStr,
+};
+use strum::EnumString;
+
+use crate::{
+    page_maps::{AnnPageMap, ImgPageMap, JsonDict},
+    utils::{invalid_data, parse_serde_json_value, read_skipping_ws},
+};
+
+#[derive(EnumString, Debug)]
+pub enum CocoJsonSection {
+    #[strum(ascii_case_insensitive)]
+    LICENSES(JsonDict),
+    #[strum(ascii_case_insensitive)]
+    INFO(JsonDict),
+    #[strum(ascii_case_insensitive)]
+    CATEGORIES(JsonDict),
+    #[strum(ascii_case_insensitive)]
+    IMAGES(ImgPageMap),
+    #[strum(ascii_case_insensitive)]
+    ANNOTATIONS(AnnPageMap),
+}
+
+#[derive(Debug)]
+pub struct CocoPageMapper {
+    licenses: JsonDict,
+    info: JsonDict,
+    categories: JsonDict,
+    images: ImgPageMap,
+    annotations: AnnPageMap,
+}
+
+impl CocoPageMapper {
+    pub fn licenses(&self) -> &JsonDict {
+        return &self.licenses;
+    }
+    pub fn info(&self) -> &JsonDict {
+        return &self.info;
+    }
+    pub fn categories(&self) -> &JsonDict {
+        return &self.categories;
+    }
+    pub fn get_img_ids(&self) -> &Vec<i64> {
+        self.images.ids()
+    }
+    pub fn get_item_dict(
+        &self,
+        img_id: i64,
+        mut reader: impl Read + Seek,
+    ) -> Result<JsonDict, io::Error> {
+        self.images.get_dict(&mut reader, img_id)
+    }
+    pub fn get_anns_dict(
+        &self,
+        img_id: i64,
+        mut reader: impl Read + Seek,
+    ) -> Result<Vec<JsonDict>, io::Error> {
+        self.annotations.get_anns(&mut reader, img_id)
+    }
+
+    pub fn new(mut reader: impl Read + Seek) -> Result<Self, io::Error> {
+        let sections = Self::parse_json(&mut reader)?;
+
+        let mut licenses = None;
+        let mut info = None;
+        let mut categories = None;
+        let mut images = None;
+        let mut annotations = None;
+
+        for section in sections {
+            match section {
+                CocoJsonSection::LICENSES(v) => {
+                    licenses = Some(v);
+                }
+                CocoJsonSection::INFO(v) => {
+                    info = Some(v);
+                }
+                CocoJsonSection::CATEGORIES(v) => {
+                    categories = Some(v);
+                }
+                CocoJsonSection::IMAGES(v) => {
+                    images = Some(v);
+                }
+                CocoJsonSection::ANNOTATIONS(v) => {
+                    annotations = Some(v);
+                }
+            }
+        }
+
+        let licenses = licenses.ok_or(invalid_data("Cannot find the licenses section."))?;
+        let info = info.ok_or(invalid_data("Cannot find the info section."))?;
+        let categories = categories.ok_or(invalid_data("Cannot find the categories section."))?;
+        let images = images.ok_or(invalid_data("Cannot find the images section."))?;
+        let annotations =
+            annotations.ok_or(invalid_data("Cannot find the annotations section."))?;
+
+        Ok(CocoPageMapper {
+            licenses,
+            info,
+            categories,
+            images,
+            annotations,
+        })
+    }
+
+    fn parse_json(mut reader: impl Read + Seek) -> Result<Vec<CocoJsonSection>, io::Error> {
+        let mut brace_level = 0;
+        let mut coco_json_sections = Vec::new();
+
+        while let Ok(c) = read_skipping_ws(&mut reader) {
+            match c {
+                b'{' => brace_level += 1,
+                b'"' => {
+                    let mut buf_key = Vec::new();
+                    while let Ok(c) = read_skipping_ws(&mut reader) {
+                        if c == b'"' {
+                            break;
+                        }
+                        buf_key.push(c);
+                    }
+                    match String::from_utf8(buf_key.clone()) {
+                        Ok(key) => {
+                            let section = Self::parse_section_from_key(key, &mut reader)?;
+                            coco_json_sections.push(section);
+                        }
+                        Err(e) => {
+                            let cur_pos = reader.stream_position()?;
+                            let msg = format!(
+                                "Section key buffer, {:?} is invalid at pos: {}. {}",
+                                buf_key, cur_pos, e
+                            );
+                            let err = invalid_data(msg.as_str());
+                            return Err(err);
+                        }
+                    }
+                }
+                b',' => {
+                    continue;
+                }
+                b'}' => {
+                    brace_level -= 1;
+                    if brace_level == 0 {
+                        break;
+                    }
+                }
+                _ => {
+                    let cur_pos = reader.stream_position()?;
+                    let msg = format!("{} is invalid character at pos: {}", c, cur_pos);
+                    let err = invalid_data(msg.as_str());
+                    return Err(err);
+                }
+            }
+        }
+        Ok(coco_json_sections)
+    }
+
+    fn parse_section_from_key(
+        buf_key: String,
+        mut reader: impl Read + Seek,
+    ) -> Result<CocoJsonSection, io::Error> {
+        match CocoJsonSection::from_str(buf_key.as_str()) {
+            Ok(curr_key) => {
+                while let Ok(c) = read_skipping_ws(&mut reader) {
+                    if c == b':' {
+                        break;
+                    }
+                }
+                match curr_key {
+                    CocoJsonSection::LICENSES(_) => {
+                        let v = parse_serde_json_value(reader)?;
+                        Ok(CocoJsonSection::LICENSES(v))
+                    }
+                    CocoJsonSection::INFO(_) => {
+                        let v = parse_serde_json_value(reader)?;
+                        Ok(CocoJsonSection::INFO(v))
+                    }
+                    CocoJsonSection::CATEGORIES(_) => {
+                        let v = parse_serde_json_value(reader)?;
+                        Ok(CocoJsonSection::CATEGORIES(v))
+                    }
+                    CocoJsonSection::IMAGES(_) => {
+                        let v = ImgPageMap::from_reader(reader)?;
+                        Ok(CocoJsonSection::IMAGES(v))
+                    }
+                    CocoJsonSection::ANNOTATIONS(_) => {
+                        let v = AnnPageMap::from_reader(reader)?;
+                        Ok(CocoJsonSection::ANNOTATIONS(v))
+                    }
+                }
+            }
+            Err(e) => {
+                let cur_pos = reader.stream_position()?;
+                let msg = format!("Unknown key: {} at pos: {}", e, cur_pos);
+                Err(invalid_data(msg.as_str()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        env::temp_dir,
+        fs::{File, OpenOptions},
+        io::{BufReader, Write},
+    };
+
+    use super::*;
+
+    fn prepare(example: &str) -> (BufReader<File>, CocoPageMapper) {
+        let filepath = temp_dir().join("tmp.json");
+
+        let mut f = OpenOptions::new()
+            .read(false)
+            .write(true)
+            .create(true)
+            .open(&filepath)
+            .expect("cannot open file");
+        let _ = f.write_all(example.as_bytes());
+        let f = File::open(&filepath).expect("cannot open file");
+        let mut reader = BufReader::new(f);
+        let coco_page_mapper = CocoPageMapper::new(&mut reader).unwrap();
+
+        (reader, coco_page_mapper)
+    }
+
+    #[test]
+    fn test_instance() {
+        const EXAMPLE: &str = r#"
+        {
+            "licenses":[{"name":"","id":0,"url":""}],
+            "info":{"contributor":"","date_created":"","description":"","url":"","version":"","year":""},
+            "categories":[
+                {"id":1,"name":"a","supercategory":""},
+                {"id":2,"name":"b","supercategory":""},
+                {"id":4,"name":"c","supercategory":""}
+            ],
+            "images":[
+                {"id":5,"width":10,"height":5,"file_name":"a.jpg","license":0,"flickr_url":"","coco_url":"","date_captured":0},
+                {"id":6,"width":10,"height":5,"file_name":"b.jpg","license":0,"flickr_url":"","coco_url":"","date_captured":0}
+            ],
+            "annotations":[
+                {"id":1,"image_id":5,"category_id":2,"segmentation":[],"area":3.0,"bbox":[2.0,2.0,3.0,1.0],"iscrowd":0},
+                {"id":2,"image_id":5,"category_id":2,"segmentation":[],"area":3.0,"bbox":[2.0,2.0,3.0,1.0],"iscrowd":0},
+                {"id":3,"image_id":5,"category_id":2,"segmentation":[],"area":3.0,"bbox":[2.0,2.0,3.0,1.0],"iscrowd":0},
+                {"id":4,"image_id":6,"category_id":2,"segmentation":[],"area":3.0,"bbox":[2.0,2.0,3.0,1.0],"iscrowd":0},
+                {"id":5,"image_id":6,"category_id":2,"segmentation":[],"area":3.0,"bbox":[2.0,2.0,3.0,1.0],"iscrowd":0}
+            ]
+        }"#;
+
+        let (mut reader, coco_page_mapper) = prepare(EXAMPLE);
+
+        println!("{:?}", coco_page_mapper);
+
+        for img_id in [5, 6] {
+            let item = coco_page_mapper.get_item_dict(img_id, &mut reader).unwrap();
+
+            assert_eq!(item["id"].as_i64(), Some(img_id));
+
+            let anns = coco_page_mapper.get_anns_dict(img_id, &mut reader).unwrap();
+            assert!(anns.len() > 0);
+
+            for ann in anns {
+                assert_eq!(ann["image_id"].as_i64(), Some(img_id));
+            }
+        }
+    }
+
+    #[test]
+    fn test_image_info_default() {
+        const EXAMPLE: &str = r#"
+        {"licenses": [{"name": "", "id": 0, "url": ""}], "info": {"contributor": "", "date_created": "", "description": "", "url": "", "version": "", "year": ""}, "categories": [], "images": [{"id": 1, "width": 2, "height": 4, "file_name": "1.jpg", "license": 0, "flickr_url": "", "coco_url": "", "date_captured": 0}], "annotations": []}
+        "#;
+
+        let (mut reader, coco_page_mapper) = prepare(EXAMPLE);
+
+        println!("{:?}", coco_page_mapper);
+    }
+
+    #[test]
+    fn test_panoptic_has_no_ann_id() {
+        const EXAMPLE: &str = r#"
+        {"licenses":[{"name":"","id":0,"url":""}],"info":{"contributor":"","date_created":"","description":"","url":"","version":"","year":""},"categories":[{"id":1,"name":"0","supercategory":"","isthing":0},{"id":2,"name":"1","supercategory":"","isthing":0},{"id":3,"name":"2","supercategory":"","isthing":0},{"id":4,"name":"3","supercategory":"","isthing":0},{"id":5,"name":"4","supercategory":"","isthing":0},{"id":6,"name":"5","supercategory":"","isthing":0},{"id":7,"name":"6","supercategory":"","isthing":0},{"id":8,"name":"7","supercategory":"","isthing":0},{"id":9,"name":"8","supercategory":"","isthing":0},{"id":10,"name":"9","supercategory":"","isthing":0}],"images":[{"id":1,"width":4,"height":4,"file_name":"1.jpg","license":0,"flickr_url":"","coco_url":"","date_captured":0}],"annotations":[{"image_id":1,"file_name":"1.png","segments_info":[{"id":3,"category_id":5,"area":5.0,"bbox":[1.0,0.0,2.0,2.0],"iscrowd":0}]}]}
+        "#;
+
+        let (mut reader, coco_page_mapper) = prepare(EXAMPLE);
+
+        println!("{:?}", coco_page_mapper);
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,7 @@
+//  Copyright (C) 2023 Intel Corporation
+//
+//  SPDX-License-Identifier: MIT
+
 mod coco_page_mapper;
 mod page_maps;
 mod utils;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,111 @@
+mod coco_page_mapper;
+mod page_maps;
+mod utils;
+
+use std::{fs::File, io::BufReader, path::Path};
+
+use crate::coco_page_mapper::CocoPageMapper as CocoPageMapperImpl;
+use pyo3::{
+    exceptions::PyValueError,
+    prelude::*,
+    types::{PyBool, PyDict, PyFloat, PyList, PyUnicode},
+};
+use serde_json;
+
+#[pyclass]
+struct CocoPageMapper {
+    reader: BufReader<File>,
+    mapper: CocoPageMapperImpl,
+}
+
+fn convert_to_py_object(value: &serde_json::Value, py: Python<'_>) -> PyResult<PyObject> {
+    if value.is_array() {
+        let list = PyList::empty(py);
+
+        for child in value.as_array().unwrap() {
+            list.append(convert_to_py_object(child, py)?)?;
+        }
+
+        return Ok(list.into());
+    } else if value.is_object() {
+        let dict = PyDict::new(py);
+
+        for (key, child) in value.as_object().unwrap().iter() {
+            let child = convert_to_py_object(child, py)?;
+            dict.set_item(key, child)?;
+        }
+
+        return Ok(dict.into());
+    } else if value.is_boolean() {
+        return Ok(PyBool::new(py, value.as_bool().unwrap()).into());
+    } else if value.is_f64() {
+        return Ok(PyFloat::new(py, value.as_f64().unwrap()).into());
+    } else if value.is_i64() {
+        return Ok(value.as_i64().unwrap().to_object(py));
+    } else if value.is_u64() {
+        return Ok(value.as_u64().unwrap().to_object(py));
+    } else if value.is_string() {
+        return Ok(PyUnicode::new(py, value.as_str().unwrap()).into());
+    } else if value.is_null() {
+        return Ok(PyUnicode::new(py, "null").into());
+    } else {
+        return Err(PyValueError::new_err("Unknown value type"));
+    }
+}
+
+#[pymethods]
+impl CocoPageMapper {
+    #[new]
+    fn py_new(path: String) -> PyResult<Self> {
+        let file = File::open(Path::new(&path))?;
+        let mut reader = BufReader::new(file);
+        let mapper = CocoPageMapperImpl::new(&mut reader)?;
+
+        Ok(CocoPageMapper { reader, mapper })
+    }
+
+    fn licenses(self_: PyRef<Self>) -> PyResult<PyObject> {
+        convert_to_py_object(self_.mapper.licenses(), self_.py())
+    }
+
+    fn info(self_: PyRef<Self>) -> PyResult<PyObject> {
+        convert_to_py_object(self_.mapper.info(), self_.py())
+    }
+
+    fn categories(self_: PyRef<Self>) -> PyResult<PyObject> {
+        convert_to_py_object(self_.mapper.categories(), self_.py())
+    }
+
+    fn get_item_dict(&mut self, py: Python<'_>, img_id: i64) -> PyResult<PyObject> {
+        let item_dict = self.mapper.get_item_dict(img_id, &mut self.reader)?;
+        Ok(convert_to_py_object(&item_dict, py)?)
+    }
+
+    fn get_anns_dict(&mut self, py: Python<'_>, img_id: i64) -> PyResult<PyObject> {
+        let anns_list = PyList::new(
+            py,
+            self.mapper
+                .get_anns_dict(img_id, &mut self.reader)?
+                .iter()
+                .map(|child| convert_to_py_object(child, py).unwrap()),
+        );
+        Ok(anns_list.into())
+    }
+
+    fn get_img_ids(&self) -> Vec<i64> {
+        self.mapper.get_img_ids().to_owned()
+    }
+
+    fn __len__(&self) -> PyResult<usize> {
+        Ok(self.mapper.get_img_ids().len())
+    }
+}
+
+/// Datumaro Rust API
+#[pymodule]
+#[pyo3(name = "rust_api")]
+fn rust_api(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_class::<CocoPageMapper>()?;
+
+    Ok(())
+}

--- a/rust/src/page_maps.rs
+++ b/rust/src/page_maps.rs
@@ -1,3 +1,7 @@
+//  Copyright (C) 2023 Intel Corporation
+//
+//  SPDX-License-Identifier: MIT
+
 use crate::utils::{
     invalid_data, parse_serde_json_value_from_page, read_skipping_ws, stream_error,
 };

--- a/rust/src/page_maps.rs
+++ b/rust/src/page_maps.rs
@@ -1,0 +1,252 @@
+use crate::utils::{
+    invalid_data, parse_serde_json_value_from_page, read_skipping_ws, stream_error,
+};
+use std::{
+    collections::HashMap,
+    io::{self},
+};
+
+fn is_empty_list(mut reader: impl io::Read + io::Seek) -> Result<(bool, u64), io::Error> {
+    let curr_pos = reader.stream_position()?;
+    let mut empty_list_str = [0u8; 2];
+    for i in 0..2 {
+        if let Ok(c) = read_skipping_ws(&mut reader) {
+            empty_list_str[i] = c;
+        }
+    }
+
+    if empty_list_str == "[]".as_bytes() {
+        Ok((true, curr_pos))
+    } else {
+        Ok((false, curr_pos))
+    }
+}
+
+pub type JsonDict = serde_json::Value;
+
+#[derive(Debug)]
+pub struct ImgPage {
+    pub offset: u64,
+    pub size: u32,
+}
+
+#[derive(Debug)]
+pub struct ImgPageMap {
+    ids: Vec<i64>,
+    pages: HashMap<i64, ImgPage>,
+}
+
+impl ImgPageMap {
+    pub fn get_dict<R>(&self, reader: &mut R, img_id: i64) -> Result<JsonDict, io::Error>
+    where
+        R: io::Read + io::Seek,
+    {
+        match self.pages.get(&img_id) {
+            Some(page) => parse_serde_json_value_from_page(reader, page.offset, page.size as u64),
+            None => Err(invalid_data(
+                format!("Image id: {} is not on the page map", img_id).as_str(),
+            )),
+        }
+    }
+
+    pub fn push(&mut self, img_id: i64, page: ImgPage) {
+        self.ids.push(img_id);
+        self.pages.insert(img_id, page);
+    }
+
+    pub fn from_reader(mut reader: impl io::Read + io::Seek) -> Result<ImgPageMap, io::Error> {
+        let mut page_map = ImgPageMap::default();
+
+        let (empty, rewind_pos) = is_empty_list(&mut reader)?;
+
+        if empty {
+            return Ok(page_map);
+        } else {
+            reader.seek(io::SeekFrom::Start(rewind_pos))?;
+        }
+
+        while let Ok(c) = read_skipping_ws(&mut reader) {
+            match c {
+                b'[' | b',' => {
+                    let curr_pos = reader.stream_position()?;
+                    let de = serde_json::Deserializer::from_reader(&mut reader);
+                    let mut stream = de.into_iter::<HashMap<String, serde_json::Value>>();
+                    let offset = curr_pos + stream.byte_offset() as u64;
+
+                    match stream.next().unwrap() {
+                        Ok(parsed_map) => {
+                            let id = parsed_map
+                                .get("id")
+                                .ok_or(stream_error("Cannot find an image id", offset))?
+                                .as_i64()
+                                .ok_or(stream_error("The image id is not an integer.", offset))?;
+
+                            let size = (curr_pos + stream.byte_offset() as u64 - offset) as u32;
+                            page_map.push(id, ImgPage { offset, size });
+                        }
+                        Err(e) => {
+                            return Err(stream_error(e.to_string().as_str(), offset));
+                        }
+                    }
+                }
+                b']' => break,
+                _ => {}
+            }
+        }
+        Ok(page_map)
+    }
+
+    pub fn ids(&self) -> &Vec<i64> {
+        return &self.ids;
+    }
+}
+
+impl IntoIterator for ImgPageMap {
+    type Item = (i64, ImgPage);
+
+    type IntoIter = <HashMap<i64, ImgPage> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.pages.into_iter()
+    }
+}
+
+impl Default for ImgPageMap {
+    fn default() -> Self {
+        Self {
+            ids: Vec::with_capacity(0),
+            pages: HashMap::with_capacity(0),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AnnPage {
+    pub id: i64,
+    pub offset: u64,
+    pub size: u32,
+    pub ptr: usize,
+}
+
+#[derive(Debug)]
+pub struct AnnPageMap {
+    pages: Vec<AnnPage>,
+    head_pointers: HashMap<i64, usize>,
+}
+
+impl AnnPageMap {
+    pub fn get_anns<R>(&self, reader: &mut R, img_id: i64) -> Result<Vec<JsonDict>, io::Error>
+    where
+        R: io::Read + io::Seek,
+    {
+        let curr_ptr = self.head_pointers.get(&img_id);
+
+        match curr_ptr {
+            Some(head) => {
+                let mut anns = vec![];
+                let mut ptr = *head;
+
+                loop {
+                    if ptr == usize::MAX {
+                        break;
+                    }
+                    let page = &self.pages[ptr];
+                    ptr = page.ptr;
+
+                    match parse_serde_json_value_from_page(reader, page.offset, page.size as u64) {
+                        Ok(v) => {
+                            anns.push(v);
+                        }
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    }
+                }
+
+                Ok(anns)
+            }
+            None => Ok(vec![]),
+        }
+    }
+
+    pub fn push(&mut self, ann_id: i64, img_id: i64, offset: u64, size: u32) {
+        let lookup = self.head_pointers.get(&img_id);
+
+        let mut ptr = usize::MAX;
+        if let Some(idx) = lookup {
+            ptr = *idx;
+        }
+        let new_head_idx = self.pages.len();
+        self.pages.push(AnnPage {
+            id: ann_id,
+            offset,
+            size,
+            ptr,
+        });
+        self.head_pointers.insert(img_id, new_head_idx);
+    }
+
+    pub fn from_reader(mut reader: impl io::Read + io::Seek) -> Result<AnnPageMap, io::Error> {
+        let mut page_map = AnnPageMap::default();
+
+        let (empty, rewind_pos) = is_empty_list(&mut reader)?;
+
+        if empty {
+            return Ok(page_map);
+        } else {
+            reader.seek(io::SeekFrom::Start(rewind_pos))?;
+        }
+
+        let mut missing_ann_id = 0;
+
+        while let Ok(c) = read_skipping_ws(&mut reader) {
+            match c {
+                b'[' | b',' => {
+                    let curr_pos = reader.stream_position()?;
+                    let de = serde_json::Deserializer::from_reader(&mut reader);
+                    let mut stream = de.into_iter::<HashMap<String, serde_json::Value>>();
+                    let offset = curr_pos + stream.byte_offset() as u64;
+
+                    match stream.next().unwrap() {
+                        Ok(parsed_map) => {
+                            let ann_id = if let Some(v) = parsed_map.get("id") {
+                                v.as_i64().ok_or(stream_error(
+                                    "The annotation id is not an integer.",
+                                    offset,
+                                ))?
+                            } else {
+                                let new_id = missing_ann_id;
+                                missing_ann_id += 1;
+                                new_id
+                            };
+
+                            let img_id = parsed_map
+                                .get("image_id")
+                                .ok_or(stream_error("Cannot find an image id", offset))?
+                                .as_i64()
+                                .ok_or(stream_error("The image id is not an integer.", offset))?;
+
+                            let size = (curr_pos + stream.byte_offset() as u64 - offset) as u32;
+                            page_map.push(ann_id, img_id, offset, size);
+                        }
+                        Err(e) => {
+                            return Err(stream_error(e.to_string().as_str(), offset));
+                        }
+                    }
+                }
+                b']' => break,
+                _ => {}
+            }
+        }
+        Ok(page_map)
+    }
+}
+
+impl Default for AnnPageMap {
+    fn default() -> Self {
+        Self {
+            pages: Vec::with_capacity(0),
+            head_pointers: HashMap::with_capacity(0),
+        }
+    }
+}

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,0 +1,59 @@
+use std::io::{self};
+
+pub fn read_skipping_ws(mut reader: impl io::Read) -> io::Result<u8> {
+    loop {
+        let mut byte = 0u8;
+        reader.read_exact(std::slice::from_mut(&mut byte))?;
+        if !byte.is_ascii_whitespace() {
+            return Ok(byte);
+        }
+    }
+}
+
+pub fn invalid_data(msg: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, msg)
+}
+
+pub fn stream_error(error: &str, offset: u64) -> io::Error {
+    let msg = format!("[Parse error, offset={}] {}", offset, error);
+    invalid_data(msg.as_str())
+}
+
+pub fn parse_serde_json_value_from_page<R>(
+    reader: &mut R,
+    offset: u64,
+    size: u64,
+) -> Result<serde_json::Value, io::Error>
+where
+    R: io::Read + io::Seek,
+{
+    reader.seek(io::SeekFrom::Start(offset))?;
+
+    let mut buf = vec![0u8; size as usize];
+    let _ = reader.read(buf.as_mut_slice())?;
+
+    let img_dict_str = String::from_utf8(buf).ok().ok_or(invalid_data(
+        format!("Cannot read offset: {} and size: {}", offset, size).as_str(),
+    ))?;
+
+    serde_json::from_str(img_dict_str.as_str())
+        .ok()
+        .ok_or(invalid_data(
+            format!("Cannot parse to dict offset: {} and size: {}", offset, size).as_str(),
+        ))
+}
+
+pub fn parse_serde_json_value(
+    reader: impl io::Read + io::Seek,
+) -> Result<serde_json::Value, io::Error> {
+    let de = serde_json::Deserializer::from_reader(reader);
+    let mut stream = de.into_iter::<serde_json::Value>();
+    match stream.next().unwrap() {
+        Ok(x) => Ok(x),
+        Err(e) => {
+            let cur_pos = stream.byte_offset();
+            let msg = format!("Parse error: {} at pos: {}", e, cur_pos);
+            Err(invalid_data(msg.as_str()))
+        }
+    }
+}

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,3 +1,7 @@
+//  Copyright (C) 2023 Intel Corporation
+//
+//  SPDX-License-Identifier: MIT
+
 use std::io::{self};
 
 pub fn read_skipping_ws(mut reader: impl io::Read) -> io::Result<u8> {

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from distutils.util import strtobool
 
 import setuptools
 from pybind11.setup_helpers import Pybind11Extension, build_ext
+from setuptools_rust import Binding, RustExtension
 
 
 def find_version(project_dir=None):
@@ -99,4 +100,14 @@ setuptools.setup(
         "datumaro.plugins.openvino_plugin.samples": ["coco.class", "imagenet.class"],
     },
     include_package_data=True,
+    rust_extensions=[
+        RustExtension(
+            "datumaro.rust_api",
+            path=osp.join("rust", "Cargo.toml"),
+            debug=False,
+            binding=Binding.PyO3,
+        ),
+    ],
+    # rust extensions are not zip safe, just like C-extensions.
+    zip_safe=False,
 )

--- a/src/datumaro/plugins/data_formats/coco/page_mapper.py
+++ b/src/datumaro/plugins/data_formats/coco/page_mapper.py
@@ -2,125 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
-import os
-import struct
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
+import logging as log
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
-import json_stream
-
-from datumaro.errors import DatasetImportError
-from datumaro.util import parse_json, to_dict_from_streaming_json
+from datumaro.rust_api import CocoPageMapper as CocoPageMapperImpl
 
 __all__ = ["COCOPageMapper"]
-
-
-@dataclass
-class AnnotationPageMap:
-    offsets: List[int] = field(default_factory=list)
-    sizes: List[int] = field(default_factory=list)
-    prev_pts: List[int] = field(default_factory=list)
-
-
-@dataclass
-class ItemPage:
-    offset: int
-    size: int
-    ann_last_pt: int
-
-
-@dataclass
-class BracketStatus:
-    """Struct to manage status for the brackets ([, ]) during constructing a page map
-
-    If `flush` is True, it means that we have extracted all items from the section.
-
-    "section": [        <- BracketStatus.flush = False and BracketStatus.level = 1
-        item_0,
-        item_1,
-        ...
-        item_n,
-    ]                   <- BracketStatus.flush = True and BracketStatus.level = 0
-    """
-
-    flush: bool = False
-    level: int = 0
-    get_started: bool = False
-
-
-@dataclass
-class BraceStatus:
-    """Struct to manage status for the braces ({, }) during constructing a page map
-
-    The braces set the bounds of the items to be extracted.
-    If `flush` is True, it flushes the bytes in its `buffer` which corresponds to the item.
-
-    {                               <- BraceStatus.flush = False and BraceStatus.level = 1
-        "attr1": 0,
-        "attr2": {                  <- BraceStatus.level = 2
-            "nested_attr": 1
-        }                           <- BraceStatus.level = 1
-    }                               <- BraceStatus.flush = True and BraceStatus.level = 0
-    """
-
-    flush: bool = False
-    level: int = 0
-    buffer: bytes = b""
-    start: int = -1
-    end: int = -1
-
-    def reset(self):
-        self.flush = False
-        self.level = 0
-        self.buffer = b""
-        self.start = -1
-        self.end = -1
-
-    def to_dict(self):
-        return parse_json(self.buffer)
-
-
-class COCOSection(Enum):
-    IMAGES = b'"images"'
-    ANNOTATIONS = b'"annotations"'
-    CATEGORIES = b'"categories"'
-
-    @property
-    def is_necessary(self) -> bool:
-        """Flat to indicate whether the section is necessary or not"""
-        if self in {COCOSection.IMAGES, COCOSection.ANNOTATIONS}:
-            return True
-
-        return False
-
-
-class FileReaderWithCache:
-    # _n_chars = 1024 * 1024 * 16  # 16MB
-    _n_chars = 1024 * 64  # 64KB
-
-    def __init__(self, path: str):
-        self.fp = open(path, "rb")
-        self.update_buffer(0, self._n_chars)
-
-    def close(self):
-        self.fp.close()
-
-    def __del__(self):
-        self.close()
-
-    def read(self, offset: int, size: int) -> str:
-        if offset < self.offset or self.offset + len(self.buffer) <= offset + size:
-            self.update_buffer(offset, size)
-
-        _from = offset - self.offset
-        _to = _from + size
-        return self.buffer[_from:_to]
-
-    def update_buffer(self, offset: int, size: int) -> None:
-        self.fp.seek(offset)
-        self.buffer = self.fp.read(max(size, self._n_chars))
-        self.offset = offset
 
 
 class COCOPageMapper:
@@ -131,232 +18,41 @@ class COCOPageMapper:
     in stream manner after constructing the page map.
     """
 
-    # _n_chars = 1024 * 1024 * 16  # 16MB
-    _n_chars = 1024 * 64  # 64KB
-    cnt = 0
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._impl = CocoPageMapperImpl(path)
 
-    def __init__(self, path: str):
-        self.path = path
-        self.section_offsets = {
-            section: self._find_section_offset(section)
-            for section in [COCOSection.IMAGES, COCOSection.ANNOTATIONS, COCOSection.CATEGORIES]
-        }
+    def __iter__(self) -> Iterator[Tuple[Dict, List[Dict]]]:
+        for item_key in self.iter_item_ids():
+            yield self._impl.get_item_dict(item_key), self._impl.get_anns_dict(item_key)
 
-        self.item_page_map = {}
-        self.ann_page_map = AnnotationPageMap()
+    def get_item_dict(self, item_key: int) -> Optional[Dict]:
+        try:
+            return self._impl.get_item_dict(item_key)
+        except Exception as e:
+            log.error(e)
+            return None
 
-        self._create_page_map(COCOSection.IMAGES, self._flush_item)
-        self._create_page_map(COCOSection.ANNOTATIONS, self._flush_ann)
+    def get_anns_dict(self, item_key: int) -> Optional[List[Dict]]:
+        try:
+            return self._impl.get_anns_dict(item_key)
+        except Exception as e:
+            log.error(e)
+            return None
 
-        # Since the item and annotations are in different sections,
-        # we have to maintain caches for both.
-        # If we use a single `FileReaderWithCache`, the caching will be useless
-        # because it reads the file and initialize the cache everytime,
-        # going back and forth between the item and annotation sections.
-        self.item_reader = FileReaderWithCache(self.path)
-        self.anns_reader = FileReaderWithCache(self.path)
+    def __len__(self) -> int:
+        return len(self._impl)
 
-    def __reduce__(self):
-        return COCOPageMapper, (self.path,)
+    def iter_item_ids(self) -> Iterator[int]:
+        for item_id in self._impl.get_img_ids():
+            yield item_id
 
     def __del__(self):
-        self.item_reader.close()
-        self.anns_reader.close()
+        pass
 
     def stream_parse_categories_data(self) -> Dict[str, Any]:
         """Parse "categories" section from the given JSON file using the stream json parser"""
-        section = COCOSection.CATEGORIES
-        offset = self.section_offsets[section]
-        if offset < 0:
-            return {}
+        return self._impl.categories()
 
-        with open(self.path, "rb") as fp:
-
-            def _gen():
-                fp.seek(offset)
-                not_started = True
-                while out := fp.read():
-                    # This is because we have to put "{" in front of '"categories": ... }'
-                    # to make the dictionary parsed properly as '{"categories": ... }'
-                    if not_started:
-                        not_started = False
-                        yield b"{" + out
-                    yield out
-
-            data = json_stream.load(_gen(), persistent=False)
-            categories = data.get("categories", None)
-
-            if categories is None:
-                raise DatasetImportError('Cannot parse "categories" section.')
-
-        return to_dict_from_streaming_json(categories)
-
-    @staticmethod
-    def _gen_char_and_cursor(fp, n_chars: int = 65536) -> Iterator[Tuple[bytes, int]]:
-        while out := fp.read(n_chars):
-            cursor = fp.tell() - len(out)
-            for idx, (c,) in enumerate(struct.iter_unpack("c", out)):
-                yield c, cursor + idx
-
-    def _find_section_offset(self, section: COCOSection) -> int:
-        pattern = section.value
-        len_pattern = len(pattern)
-        dst = -1
-        buffer = b""
-
-        with open(self.path, "rb") as fp:
-            while out_bytes := fp.read(self._n_chars):
-                cursor = fp.tell()
-
-                buffer = buffer + out_bytes
-                found = buffer.find(pattern)
-
-                if found >= 0:
-                    dst = cursor - len(buffer) + found
-                    break
-
-                buffer = buffer[-len_pattern:]
-
-        if dst < 0 and section.is_necessary:
-            raise DatasetImportError(
-                f"section={section} is necessary, but not in the input JSON file."
-            )
-
-        return dst
-
-    def _flush_item(self, brace: BraceStatus):
-        data = brace.to_dict()
-        img_id = data.get("id")
-
-        if img_id is None:
-            raise ValueError("Cannot find image id.")
-
-        self.item_page_map[img_id] = ItemPage(brace.start, brace.end - brace.start, -1)
-
-    def _flush_ann(self, brace: BraceStatus):
-        data = brace.to_dict()
-
-        img_id = data.get("image_id")
-        if img_id is None:
-            return
-        if img_id not in self.item_page_map:
-            return
-
-        self.ann_page_map.offsets.append(brace.start)
-        self.ann_page_map.sizes.append(brace.end - brace.start)
-
-        item_page = self.item_page_map[img_id]
-        curr_pt = len(self.ann_page_map.prev_pts)
-        prev_pt = item_page.ann_last_pt
-
-        self.ann_page_map.prev_pts.append(prev_pt)
-        item_page.ann_last_pt = curr_pt
-
-    def _create_page_map(
-        self, section: COCOSection, flush_callback: Callable[[BraceStatus], None]
-    ) -> None:
-        section_offset = self.section_offsets[section]
-        braket = BracketStatus()
-        brace = BraceStatus()
-
-        cnt = 0
-        with open(self.path, "rb") as fp:
-            fp.seek(section_offset, 0)
-
-            for c, cursor in self._gen_char_and_cursor(fp, self._n_chars):
-                # Continue to the root brace
-                if not braket.get_started and c != b"[":
-                    continue
-
-                # Start the root brace
-                braket.get_started = True
-
-                self.update(braket, brace, c, cursor)
-
-                if brace.flush:
-                    flush_callback(brace)
-                    brace.reset()
-                    cnt += 1
-                if braket.flush:
-                    break
-
-        if not braket.get_started:
-            raise ValueError(f"Cannot find the list from the section={section}.")
-        if (
-            brace.buffer.decode("utf-8").replace(os.linesep, "").replace("\t", "").replace(" ", "")
-            != ""
-        ):
-            raise ValueError(
-                f"The input has a dictionary with no terminating curly braces. Remaining buffer={brace.buffer}"
-            )
-
-    @staticmethod
-    def update(braket, brace, c, cursor):
-        if c == b"[":
-            if braket.level == 0:
-                braket.flush = False
-            else:
-                brace.buffer += b"["
-            braket.level += 1
-        elif c == b"{":
-            if brace.level == 0:
-                brace.flush = False
-                brace.buffer = b"{"
-                brace.start = cursor
-            else:
-                brace.buffer += b"{"
-            brace.level += 1
-        elif c == b"}":
-            brace.level -= 1
-            brace.buffer += b"}"
-            if brace.level == 0:
-                brace.flush = True
-                brace.end = cursor + 1
-        elif c == b"]":
-            braket.level -= 1
-            if braket.level == 0:
-                braket.flush = True
-            else:
-                brace.buffer += b"]"
-        else:
-            brace.buffer += c
-
-    def __iter__(self) -> Iterator[Tuple[Dict, List[Dict]]]:
-        for item_page in self.item_page_map.values():
-            yield self._gen_item_dict(item_page), self._gen_anns_dict(item_page)
-
-    def get_item_dict(self, item_key: int) -> Optional[Dict]:
-        item_page = self.item_page_map.get(item_key)
-        if item_page is None:
-            return None
-        return self._gen_item_dict(item_page)
-
-    def get_anns_dict(self, item_key: int) -> Optional[List[Dict]]:
-        item_page = self.item_page_map.get(item_key)
-        if item_page is None:
-            return None
-        return self._gen_anns_dict(item_page)
-
-    def _gen_item_dict(self, item_page: ItemPage) -> Dict:
-        data = self.item_reader.read(item_page.offset, item_page.size)
-        return parse_json(data)
-
-    def _gen_anns_dict(self, item_page: ItemPage) -> List[Dict]:
-        curr_pt = item_page.ann_last_pt
-        to_read = []
-        while curr_pt >= 0:
-            ann_offset = self.ann_page_map.offsets[curr_pt]
-            ann_size = self.ann_page_map.sizes[curr_pt]
-            curr_pt = self.ann_page_map.prev_pts[curr_pt]
-            to_read += [(ann_offset, ann_size)]
-
-        return [
-            parse_json(self.anns_reader.read(ann_offset, ann_size))
-            for ann_offset, ann_size in reversed(to_read)
-        ]
-
-    def __len__(self) -> int:
-        return len(self.item_page_map)
-
-    def iter_item_ids(self) -> Iterator[int]:
-        return self.item_page_map.keys()
+    def __reduce__(self):
+        return (self.__class__, (self._path,))


### PR DESCRIPTION
### Summary

 - Ticket no. 117181
 - Migrate COCOPageMapper algorithm from Python to Rust implementation

| Python impl. | Rust impl. |
| - | - |
| ![stream](https://github.com/openvinotoolkit/datumaro/assets/26541465/a79b6d47-2969-4be3-85f9-57c7b134b4d6) | ![coco-rust](https://github.com/openvinotoolkit/datumaro/assets/26541465/9d2f39a1-ac1e-43b2-8870-bbf6b9979382) |

This improvement shows that
1) The time from starting the Python script to creating the COCO page map is decreased from ~200 secs (Python impl.) to ~10 secs (Rust impl.).
2) Memory cost for constructing the COCO page map is decreased from ~350 Mb (Python impl.) to ~260 Mb (Rust impl.).

### How to test
Existing COCO tests with `stream=True` cover these changes.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
