### PR TITLE
Fix bugs for Tile transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1120>)
 
 ### Bug fixes
+- Fix bugs for Tile transform
+  (<https://github.com/openvinotoolkit/datumaro/pull/1123>)
 
 ## 27/07/2023 - Release 1.4.1
 ### Bug fixes

--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -1045,6 +1045,24 @@ class RoIImage(Image):
             data = data.astype(np.float32)
         return data[y : y + h, x : x + w]
 
+    def save(
+        self,
+        fp: Union[str, io.IOBase],
+        ext: Optional[str] = None,
+        crypter: Crypter = NULL_CRYPTER,
+    ):
+        if not crypter.is_null_crypter:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} does not implement save() with non NullCrypter."
+            )
+        data = self.data
+        if data is None:
+            raise ValueError(f"{self.__class__.__name__} is empty.")
+        new_ext = self._get_ext_to_save(fp, ext)
+        if isinstance(fp, str):
+            os.makedirs(osp.dirname(fp), exist_ok=True)
+        save_image(fp, data, ext=new_ext, crypter=crypter)
+
 
 class RoIImageFromFile(FromFileMixin, RoIImage):
     def __init__(
@@ -1067,23 +1085,7 @@ class RoIImageFromFile(FromFileMixin, RoIImage):
 
 
 class RoIImageFromData(FromDataMixin, RoIImage):
-    def save(
-        self,
-        fp: Union[str, io.IOBase],
-        ext: Optional[str] = None,
-        crypter: Crypter = NULL_CRYPTER,
-    ):
-        if not crypter.is_null_crypter:
-            raise NotImplementedError(
-                f"{self.__class__.__name__} does not implement save() with non NullCrypter."
-            )
-        data = self.data
-        if data is None:
-            raise ValueError(f"{self.__class__.__name__} is empty.")
-        new_ext = self._get_ext_to_save(fp, ext)
-        if isinstance(fp, str):
-            os.makedirs(osp.dirname(fp), exist_ok=True)
-        save_image(fp, data, ext=new_ext, crypter=crypter)
+    pass
 
 
 class RoIImageFromBytes(RoIImageFromData):

--- a/src/datumaro/plugins/tiling/tile.py
+++ b/src/datumaro/plugins/tiling/tile.py
@@ -147,7 +147,7 @@ class Tile(Transform, CliPlugin):
     --------
     The following example is the CLI command for a 3x2 tiling with a width and height overlap of 10%::
 
-        $ datum transform -t tile --grid-size 3 2 --overlap 0.1 0.1 --threshold-drop-ann 0.1
+        $ datum transform -t tile -- --grid-size 3 2 --overlap 0.1 0.1 --threshold-drop-ann 0.1
 
     :obj:`--threshold-drop-ann` means an area threshold to remove bboxes and polygons
     when they are in the boundary of the tiled image and cropped by tiling. In this example,

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -263,7 +263,7 @@ class BytesImageTest(TestCase):
 
 
 class RoIImageTest(TestCase):
-    def _test_ctors(self, img_ctor, args_list, is_bytes=False):
+    def _test_ctors(self, img_ctor, args_list, test_dir, is_bytes=False):
         for args in args_list:
             # Case 1. Retrieve roi_img.data without retrieving the original image
             with self.subTest(**args):
@@ -303,12 +303,18 @@ class RoIImageTest(TestCase):
                 self.assertEqual(roi_img.size, (new_h, new_w))
                 self.assertEqual(roi_img.data.shape[:2], (new_h, new_w))
 
+            with self.subTest(**args):
+                try:
+                    roi_img.save(osp.join(test_dir, "test.png"))
+                except:
+                    self.fail("Cannot save RoIImage")
+
     def test_ctors_from_image(self):
         with TestDir() as test_dir:
             _, args_list = ImageTest._gen_image_and_args_list(test_dir)
-            self._test_ctors(Image, args_list)
+            self._test_ctors(Image, args_list, test_dir, False)
             _, _, args_list = ImageTest._gen_bytes_image_and_args_list()
-            self._test_ctors(Image, args_list, True)
+            self._test_ctors(Image, args_list, test_dir, True)
 
 
 class ImageMetaTest(TestCase):


### PR DESCRIPTION
### Summary
 - Resolve this issue, https://github.com/openvinotoolkit/datumaro/issues/1118
 - Fix documentation error on CLI guide for Tile transform
 - Fix a problem that RoIImageFromFile cannot be saved properly

### How to test
I updated the existing test to test saving `RoIImage` as well.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [x] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
