### PR TITLE
Raise VcsAlreadyExists error if vcs directory exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1123>)
 - Disable Roboflow Tfrecord format when Tensorflow is not installed
   (<https://github.com/openvinotoolkit/datumaro/pull/1130>)
+- Raise VcsAlreadyExists error if vcs directory exists
+  (<https://github.com/openvinotoolkit/datumaro/pull/1138>)
 
 ## 27/07/2023 - Release 1.4.1
 ### Bug fixes

--- a/src/datumaro/components/errors.py
+++ b/src/datumaro/components/errors.py
@@ -143,6 +143,14 @@ class ProjectAlreadyExists(DatumaroError):
 
 
 @define(auto_exc=False)
+class VcsAlreadyExists(DatumaroError):
+    path = field()
+
+    def __str__(self):
+        return f"Can't create project: a version control system already exists " f"at '{self.path}'"
+
+
+@define(auto_exc=False)
 class UnknownSourceError(DatumaroError):
     name = field()
 

--- a/src/datumaro/components/project.py
+++ b/src/datumaro/components/project.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2022 Intel Corporation
+# Copyright (C) 2019-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/datumaro/components/project.py
+++ b/src/datumaro/components/project.py
@@ -70,6 +70,7 @@ from datumaro.components.errors import (
     UnknownStageError,
     UnknownTargetError,
     UnsavedChangesError,
+    VcsAlreadyExists,
     VcsError,
 )
 from datumaro.components.launcher import Launcher
@@ -1787,8 +1788,16 @@ class Project:
         os.makedirs(osp.join(path, ProjectLayout.cache_dir))
         os.makedirs(osp.join(path, ProjectLayout.tmp_dir))
 
-        on_error_do(rmtree, osp.join(project_dir, ".git"), ignore_errors=True)
-        on_error_do(rmtree, osp.join(project_dir, ".dvc"), ignore_errors=True)
+        git_dir, dvc_dir = osp.join(project_dir, ".git"), osp.join(project_dir, ".dvc")
+
+        if osp.exists(git_dir):
+            raise VcsAlreadyExists(git_dir)
+        if osp.exists(dvc_dir):
+            raise VcsAlreadyExists(dvc_dir)
+
+        on_error_do(rmtree, git_dir, ignore_errors=True)
+        on_error_do(rmtree, dvc_dir, ignore_errors=True)
+
         project = Project(path)
         project._init_vcs()
 

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2019-2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import os
 import os.path as osp
 import shutil

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -6,6 +6,7 @@ from typing import List, Sequence
 from unittest import TestCase
 
 import numpy as np
+import pytest
 
 from datumaro.components.annotation import Annotation, Bbox, Label
 from datumaro.components.config_model import Model, Source
@@ -26,17 +27,37 @@ from datumaro.components.errors import (
     SourceUrlInsideProjectError,
     UnexpectedUrlError,
     UnknownTargetError,
+    VcsAlreadyExists,
 )
 from datumaro.components.launcher import Launcher
 from datumaro.components.media import Image
 from datumaro.components.project import DiffStatus, Project
 from datumaro.components.transformer import ItemTransform
+from datumaro.util.os_util import find_files
 from datumaro.util.scope import scope_add, scoped
 
 from ..requirements import Requirements, mark_requirement
 
 from tests.utils.assets import get_test_asset_path
 from tests.utils.test_utils import TestDir, compare_datasets, compare_dirs
+
+
+class ProjectNewTest:
+    @pytest.fixture(params=[".git", ".dvc"])
+    def fxt_vcs_exist_dir(self, test_dir, request):
+        vcs_dir = osp.join(test_dir, request.param)
+        os.makedirs(vcs_dir)
+        with open(osp.join(vcs_dir, "dummy.file"), "w") as fp:
+            fp.write("dummy")
+        yield test_dir
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_project_init_failed_by_vcs_already_exist(self, fxt_vcs_exist_dir):
+        with pytest.raises(VcsAlreadyExists):
+            Project.init(fxt_vcs_exist_dir)
+
+        # Assert Project.init() do not the existing vcs directory
+        assert len(list(find_files(fxt_vcs_exist_dir, ".file", recursive=True))) > 0
 
 
 class ProjectTest(TestCase):


### PR DESCRIPTION
### Summary
 - Resolve #1136
 - Currently, the `datum project create` command can remove the vcs directory such as Git which is already existed. This patch will prevent it from removing it.

### How to test
Updated unit tests for it.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
