### PR TITLE
Remove unused imports from os_util.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1116>)
 - Add Rust API to optimize COCOPageMapper performance
   (<https://github.com/openvinotoolkit/datumaro/pull/1120>)
+- Remove unused imports from os_util.py
+  (<https://github.com/openvinotoolkit/datumaro/pull/1139>)
 
 ### Bug fixes
 - Fix bugs for Tile transform

--- a/src/datumaro/util/os_util.py
+++ b/src/datumaro/util/os_util.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/datumaro/util/os_util.py
+++ b/src/datumaro/util/os_util.py
@@ -14,17 +14,6 @@ from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdo
 from io import StringIO
 from typing import Iterable, Iterator, Optional, Union
 
-try:
-    # Declare functions to remove files and directories.
-    #
-    # Use rmtree from GitPython to avoid the problem with removal of
-    # readonly files on Windows, which Git uses extensively
-    # It double checks if a file cannot be removed because of readonly flag
-    from git.util import rmfile, rmtree  # noqa: F401
-except ModuleNotFoundError:
-    from os import remove as rmfile  # noqa: F401
-    from shutil import rmtree as rmtree  # noqa: F401
-
 from . import cast
 from .definitions import DEFAULT_SUBSET_NAME
 


### PR DESCRIPTION
### Summary

- `rmfile` and `rmtree` are not used in `src/datumaro/util/os_util.py` anymore. We can remove them.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
