### PR TITLE
Mark xfails on flaky and unavailable tests

### DIFF
--- a/tests/integration/cli/test_generator.py
+++ b/tests/integration/cli/test_generator.py
@@ -2,6 +2,8 @@ import os
 import os.path as osp
 from unittest import TestCase
 
+import pytest
+
 import datumaro.util.image as image_module
 
 from ...requirements import Requirements, mark_requirement
@@ -10,6 +12,7 @@ from tests.utils.test_utils import TestDir
 from tests.utils.test_utils import run_datum as run
 
 
+@pytest.mark.xfail(reason="Cannot download the model file from the source")
 class ImageGeneratorTest(TestCase):
     def check_images_shape(self, img_dir, expected_shape):
         exp_h, exp_w, exp_c = expected_shape

--- a/tests/integration/cli/test_utils.py
+++ b/tests/integration/cli/test_utils.py
@@ -2,6 +2,8 @@ import os
 import os.path as osp
 from unittest.case import TestCase
 
+import pytest
+
 from datumaro.components.media_manager import MediaManager
 from datumaro.util.scope import on_exit_do, scope_add, scoped
 
@@ -12,6 +14,7 @@ from tests.utils.test_utils import TestDir
 from tests.utils.test_utils import run_datum as run
 
 
+@pytest.mark.xfail(reason="This test is flaky so that can fail randomly")
 class VideoSplittingTest:
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @scoped

--- a/tests/unit/test_fractal_image_generator.py
+++ b/tests/unit/test_fractal_image_generator.py
@@ -3,6 +3,7 @@ import os.path as osp
 from unittest import TestCase
 
 import numpy as np
+import pytest
 
 from datumaro.plugins.synthetic_data import FractalImageGenerator
 from datumaro.util.image import load_image
@@ -13,6 +14,7 @@ from tests.utils.assets import get_test_asset_path
 from tests.utils.test_utils import TestDir
 
 
+@pytest.mark.xfail(reason="Cannot download the model file from the source")
 class FractalImageGeneratorTest(TestCase):
     @mark_requirement(Requirements.DATUM_677)
     def test_save_image_can_create_dir(self):


### PR DESCRIPTION
### Summary

- Same as title

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
