### PR TITLE
Fix flaky test by setting the join timeout to infinite

### DIFF
--- a/src/datumaro/util/multi_procs_util.py
+++ b/src/datumaro/util/multi_procs_util.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from enum import IntEnum
 from queue import Full, Queue
 from threading import Condition, Thread
-from typing import Any, Generator, Iterator, TypeVar
+from typing import Any, Generator, Iterator, Optional, TypeVar
 
 __all__ = ["consumer_generator"]
 
@@ -25,7 +25,7 @@ def consumer_generator(
     producer_generator: Iterator[Item],
     queue_size: int = 100,
     enqueue_timeout: float = 5.0,
-    join_timeout: float = 10.0,
+    join_timeout: Optional[float] = 10.0,
 ) -> Generator[Iterator[Item], None, None]:
     """Context manager that creates a generator to consume items produced by another generator.
 
@@ -37,6 +37,7 @@ def consumer_generator(
         queue_size: The maximum size of the shared queue between the producer and consumer.
         enqueue_timeout: The maximum time to wait for enqueuing an item to the queue if it's full.
         join_timeout: The maximum time to wait for the producer thread to finish when exiting the context.
+            If None, wait until the producer thread terminates.
 
     Returns:
         Iterator: A context for iterating over the generated items.

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -271,7 +271,7 @@ class MultiProcUtilTest:
             with consumer_generator(
                 producer_generator=fxt_producer_generator(),
                 enqueue_timeout=0.05,
-                join_timeout=0.1,
+                join_timeout=None,
             ) as f:
                 for expect, actual in enumerate(f):
                     assert expect == actual.value


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

- One of the tests added in #1145 is flaky: https://github.com/openvinotoolkit/datumaro/actions/runs/6156803415/job/16706221640
```console
=========================== short test summary info ============================
FAILED tests/unit/test_util.py::MultiProcUtilTest::test_raise_exception_in_main_thread
= 1 failed, 1493 passed, 38 skipped, 2 xfailed, 48148 warnings in 407.34s (0:06:47) =
tests-py38-darwin: exit 1 (462.14 seconds) /Users/runner/work/datumaro/datumaro> python -m pytest -v --csv=/Users/runner/work/datumaro/datumaro/.tox/results-tests-py38-darwin.csv tests/unit --cov --cov-report=xml pid=4536
.pkg: _exit> python /Users/runner/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pyproject_api/_backend.py True setuptools.build_meta
  tests-py38-darwin: FAIL code 1 (793.18=setup[331.04]+cmd[462.14] seconds)
  evaluation failed :( (803.78 seconds)
```
- This is because `join_timeout` is too short, so that the main thread tries to assert the error logs before they are created.
- To fix it, set `join_timeout=None` to wait it infinitely until the producer thread terminates.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
