### PR TITLE
Fix broken YOLO ultralytics links

### DIFF
--- a/docs/source/docs/data-formats/formats/index.rst
+++ b/docs/source/docs/data-formats/formats/index.rst
@@ -224,8 +224,8 @@ Supported Data Formats
    * `Dataset example <https://github.com/openvinotoolkit/datumaro/tree/develop/tests/assets/yolo_dataset>`_
    * `Format documentation <yolo.md>`_
 * YOLO-Ultralytics (``bboxes``)
-   * `Format specification <https://github.com/ultralytics/ultralytics/blob/main/ultralytics/datasets/coco.yaml>`_
-   * `Dataset example <https://github.com/ultralytics/ultralytics/blob/main/ultralytics/datasets/coco.yaml>`_
+   * `Format specification <https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml>`_
+   * `Dataset example <https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml>`_
    * `Format documentation <yolo_ultralytics.md>`_
 
 Supported Annotation Types

--- a/docs/source/docs/data-formats/formats/yolo_ultralytics.md
+++ b/docs/source/docs/data-formats/formats/yolo_ultralytics.md
@@ -2,7 +2,7 @@
 
 ## Format specification
 
-The YOLO-Ultralytics dataset format is used for [Ultralytics YOLOv8](https://github.com/ultralytics/ultralytics), developed by [Ultralytics](https://ultralytics.com/). An example for this format is available [here](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/datasets/coco.yaml). This format shares the same annotation bounding box text file format with [YOLO](./yolo.md#bounding-box-annotation-text-file). However, it requires a YAML meta file where `train`, `val`, and `test` (optional) subsets are specified.
+The YOLO-Ultralytics dataset format is used for [Ultralytics YOLOv8](https://github.com/ultralytics/ultralytics), developed by [Ultralytics](https://ultralytics.com/). An example for this format is available [here](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml). This format shares the same annotation bounding box text file format with [YOLO](./yolo.md#bounding-box-annotation-text-file). However, it requires a YAML meta file where `train`, `val`, and `test` (optional) subsets are specified.
 
 Supported annotation types:
 - `Bounding boxes`


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

- Fixed broken YOLO-ultralytics links that were referring to the format specifications on GitHub. The source files were apparently changed, thus links became invalid. 

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [x] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
