### PR TITLE
Update our CI OS from `windows-2019` to `windows-2022`

### DIFF
--- a/.github/workflows/nightly_check.yml
+++ b/.github/workflows/nightly_check.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-11', 'ubuntu-20.04', 'windows-2019']
+        os: ['macos-11', 'ubuntu-20.04', 'windows-2022']
         python-version: ['3.8', '3.9', '3.10','3.11']
         include:
           - os: "macos-11"
             tox-env-os: "darwin"
           - os: "ubuntu-20.04"
             tox-env-os: "lin"
-          - os: "windows-2019"
+          - os: "windows-2022"
             tox-env-os: "win"
           - python-version: "3.8"
             tox-env-py: "38"

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-11', 'ubuntu-20.04', 'windows-2019']
+        os: ['macos-11', 'ubuntu-20.04', 'windows-2022']
         python-version: ['3.8']
         include:
           - python-version: "3.8"
@@ -34,7 +34,7 @@ jobs:
             tox-env-os: "darwin"
           - os: "ubuntu-20.04"
             tox-env-os: "lin"
-          - os: "windows-2019"
+          - os: "windows-2022"
             tox-env-os: "win"
     name: pr test (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish_sdist_to_pypi.yml
+++ b/.github/workflows/publish_sdist_to_pypi.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-11', 'ubuntu-20.04', 'windows-2019']
+        os: ['macos-11', 'ubuntu-20.04', 'windows-2022']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/weekly_check.yml
+++ b/.github/workflows/weekly_check.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-11', 'ubuntu-20.04', 'windows-2019']
+        os: ['macos-11', 'ubuntu-20.04', 'windows-2022']
         python-version: ['3.8']
         include:
           - python-version: "3.8"
@@ -28,7 +28,7 @@ jobs:
             tox-env-os: "darwin"
           - os: "ubuntu-20.04"
             tox-env-os: "lin"
-          - os: "windows-2019"
+          - os: "windows-2022"
             tox-env-os: "win"
     name: stability test (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Summary

- Update our CI OS from `windows-2019` to `windows-2022`
- This is because our CI has problem only on `windows-2019` while cleaning up test directory: https://github.com/openvinotoolkit/datumaro/actions/runs/6549100531/job/17785292362 and https://github.com/openvinotoolkit/datumaro/actions/runs/6557126906/job/17808184193?pr=1169

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
