### PR TITLE
Fix imagenet when importing a dataset with non-directory files

### DIFF
--- a/src/datumaro/plugins/data_formats/imagenet.py
+++ b/src/datumaro/plugins/data_formats/imagenet.py
@@ -6,8 +6,8 @@ import errno
 import logging as log
 import os
 import os.path as osp
-from typing import Optional
 import warnings
+from typing import Optional
 
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
@@ -44,7 +44,7 @@ class ImagenetBase(SubsetBase):
     def _load_categories(self, path):
         label_cat = LabelCategories()
         for dirname in sorted(os.listdir(path)):
-            if not os.path.isdir(os.path.join(path, dirname)):                
+            if not os.path.isdir(os.path.join(path, dirname)):
                 warnings.warn(
                     f"{dirname} is not a directory in the folder {path}, so this will"
                     "be skipped when declaring the cateogries of `imagenet` dataset."

--- a/src/datumaro/plugins/data_formats/imagenet.py
+++ b/src/datumaro/plugins/data_formats/imagenet.py
@@ -7,6 +7,7 @@ import logging as log
 import os
 import os.path as osp
 from typing import Optional
+import warnings
 
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
@@ -43,8 +44,12 @@ class ImagenetBase(SubsetBase):
     def _load_categories(self, path):
         label_cat = LabelCategories()
         for dirname in sorted(os.listdir(path)):
-            if not os.path.isdir(os.path.join(path, dirname)):
-                raise NotADirectoryError(errno.ENOTDIR, os.strerror(errno.ENOTDIR), path)
+            if not os.path.isdir(os.path.join(path, dirname)):                
+                warnings.warn(
+                    f"{dirname} is not a directory in the folder {path}, so this will"
+                    "be skipped when declaring the cateogries of `imagenet` dataset."
+                )
+                continue
             if dirname != ImagenetPath.IMAGE_DIR_NO_LABEL:
                 label_cat.add(dirname)
         return {AnnotationType.label: label_cat}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
