### PR TITLE
warning instead of raising an error for unsupported annotation types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1175>)
 
 ### Bug fixes
+- Modify the draw function in the visualizer not to raise an error for unsupported annotation types.
+  (<https://github.com/openvinotoolkit/datumaro/pull/1180>)
 - Correct explore path in the related document.
   (<https://github.com/openvinotoolkit/datumaro/pull/1176>)
 - Fix errata in the voc document. Color values in the labelmap.txt should be separated by commas, not colons.

--- a/src/datumaro/components/visualizer.py
+++ b/src/datumaro/components/visualizer.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
+import logging as log
 import math
 import random
 import warnings
@@ -182,7 +183,8 @@ class Visualizer:
         if ann.type == AnnotationType.ellipse:
             return self._draw_ellipse(ann, label_categories, fig, ax, context)
 
-        raise ValueError(f"Unknown ann.type={ann.type}")
+        # warning instead of raising an error for unsupported annotation types.
+        log.warning(f"Ignore unknown ann.type={ann.type}")
 
     def _get_color(self, ann: Annotation) -> str:
         color = self.color_cycles[ann.label % len(self.color_cycles)]

--- a/src/datumaro/components/visualizer.py
+++ b/src/datumaro/components/visualizer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 import logging as log

--- a/tests/unit/test_visualizer.py
+++ b/tests/unit/test_visualizer.py
@@ -89,7 +89,7 @@ class VisualizerTestBase:
             visualizer.vis_one_sample("unknown", self.subset)
 
         # Unknown subset
-        for idx, item in enumerate(self.items):
+        for item in self.items:
             with self.assertRaises(Exception):
                 visualizer.vis_one_sample(item.id, "unknown")
 

--- a/tests/unit/test_visualizer.py
+++ b/tests/unit/test_visualizer.py
@@ -14,12 +14,12 @@ from datumaro.components.annotation import (
     Caption,
     DepthAnnotation,
     Ellipse,
+    HashKey,
     Label,
     Mask,
     Points,
     Polygon,
     PolyLine,
-    HashKey,
     SuperResolutionAnnotation,
 )
 from datumaro.components.dataset import Dataset
@@ -127,6 +127,7 @@ class VisualizerTestBase:
 
         for test_case in test_cases:
             _check(test_case.infer_grid_size, test_case.expected_grid_size)
+
 
 class TestCaseClosePltFigure(TestCase):
     def tearDown(self) -> None:
@@ -466,15 +467,14 @@ class EllipseVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     def test_vis_gallery(self):
         self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
+
 class UnsupportedTypeTest(LabelVisualizerTest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
         for item in cls.dataset:
-            item.annotations.append(
-                HashKey(np.ones(64).astype(np.uint8))
-            )
+            item.annotations.append(HashKey(np.ones(64).astype(np.uint8)))
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_one_sample(self):

--- a/tests/unit/test_visualizer.py
+++ b/tests/unit/test_visualizer.py
@@ -19,6 +19,7 @@ from datumaro.components.annotation import (
     Points,
     Polygon,
     PolyLine,
+    HashKey,
     SuperResolutionAnnotation,
 )
 from datumaro.components.dataset import Dataset
@@ -88,7 +89,7 @@ class VisualizerTestBase:
             visualizer.vis_one_sample("unknown", self.subset)
 
         # Unknown subset
-        for item in self.items:
+        for idx, item in enumerate(self.items):
             with self.assertRaises(Exception):
                 visualizer.vis_one_sample(item.id, "unknown")
 
@@ -126,7 +127,6 @@ class VisualizerTestBase:
 
         for test_case in test_cases:
             _check(test_case.infer_grid_size, test_case.expected_grid_size)
-
 
 class TestCaseClosePltFigure(TestCase):
     def tearDown(self) -> None:
@@ -465,3 +465,17 @@ class EllipseVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_gallery(self):
         self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
+
+class UnsupportedTypeTest(LabelVisualizerTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        for item in cls.dataset:
+            item.annotations.append(
+                HashKey(np.ones(64).astype(np.uint8))
+            )
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_vis_one_sample(self):
+        self._test_vis_one_sample("_draw", check_z_order=False)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Modify the draw function in the visualizer to prevent it from raising an error for unsupported annotation types.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
