### PR TITLE
Update CVAT format doc to bypass warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1159>, <https://github.com/openvinotoolkit/datumaro/pull/1161>)
 - Fix memory unbounded Arrow data format export/import
   (<https://github.com/openvinotoolkit/datumaro/pull/1169>)
+- Update CVAT format doc to bypass warning
+  (<https://github.com/openvinotoolkit/datumaro/pull/1183>)
 
 ## 15/09/2023 - Release 1.5.0
 ### New features

--- a/docs/source/docs/data-formats/formats/cvat.md
+++ b/docs/source/docs/data-formats/formats/cvat.md
@@ -129,8 +129,20 @@ Extra options for exporting to CVAT format:
   (by default `False`)
 - `--image-ext IMAGE_EXT` allow to specify image extension
   for exporting dataset (by default - keep original or use `.jpg`, if none)
-- `--save-dataset-meta` - allow to export dataset with saving dataset meta
+- `--save-dataset-meta` allow to export dataset with saving dataset meta
   file (by default `False`)
+- `--reindex` assign new indices to frames
+- `--allow-undeclared-attrs` write annotation attributes even if they are not present in the input dataset metainfo
+
+When performing `convert` to CVAT format, you may encounter a warning message like the following:
+```bash
+skipping undeclared attribute 'is_crowd' for label '<label>' (allow with --allow-undeclared-attrs option)
+```
+In such cases, you can bypass this warning by using the `export` command as follows:
+```bash
+datum project export -o <output/dir> -p <path/to/project> -f cvat -- --allow-undeclared-attrs
+```
+This allows you to proceed with the export while bypassing the warning.
 
 ## Examples
 

--- a/docs/source/docs/data-formats/formats/index.rst
+++ b/docs/source/docs/data-formats/formats/index.rst
@@ -101,6 +101,7 @@ Supported Data Formats
 * CVAT (`for images`, `for video` (import-only))
    * `Format specification <https://opencv.github.io/cvat/docs/manual/advanced/xml_format>`_
    * `Dataset example <https://github.com/openvinotoolkit/datumaro/tree/develop/tests/assets/cvat_dataset>`_
+   * `Format documentation <cvat.md>`_
 * ICDAR13/15 (``word recognition``, ``text localization``, ``text segmentation``)
    * `Format specification <https://rrc.cvc.uab.es/?ch=2>`_
    * `Dataset example <https://github.com/openvinotoolkit/datumaro/tree/develop/tests/assets/icdar_dataset>`_


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Introduce how to bypass warning during converting dataset into `cvat` format

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [X] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [X] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
