### PR TITLE
load CocoPageMapper once per process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1174>)
 
 ### Bug fixes
+- Import CocoPageMapper only once per process
+  (<https://github.com/openvinotoolkit/datumaro/pull/1184>)
 - Modify the draw function in the visualizer not to raise an error for unsupported annotation types.
   (<https://github.com/openvinotoolkit/datumaro/pull/1180>)
 - Correct explore path in the related document.

--- a/src/datumaro/plugins/data_formats/coco/page_mapper.py
+++ b/src/datumaro/plugins/data_formats/coco/page_mapper.py
@@ -5,7 +5,10 @@
 import logging as log
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
-from datumaro.rust_api import CocoPageMapper as CocoPageMapperImpl
+try:
+    from datumaro.rust_api import CocoPageMapper as CocoPageMapperImpl
+except ImportError:
+    pass
 
 __all__ = ["COCOPageMapper"]
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
When loading CocoPageMapper multiple times per interpreter or process, it would raise an ImportError as shown below.

![image](https://github.com/openvinotoolkit/datumaro/assets/75776702/318a9591-3c77-4d6e-9c9c-e33bf917305d)

So, I have modified it to import the module only once.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
