### PR TITLE
[Bug fix] restore test for splitting video

### DIFF
--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -1084,7 +1084,7 @@ class MosaicImage(Image):
         raise DatumaroError(f"Please use a factory function '{cls.__name__}.from_image_roi_pairs'.")
 
 
-class MosiacImageFromData(FromDataMixin, MosaicImage):
+class MosaicImageFromData(FromDataMixin, MosaicImage):
     def save(
         self,
         fp: Union[str, io.IOBase],
@@ -1104,7 +1104,7 @@ class MosiacImageFromData(FromDataMixin, MosaicImage):
         save_image(fp, data, ext=new_ext, crypter=crypter)
 
 
-class MosaicImageFromImageRoIPairs(MosiacImageFromData):
+class MosaicImageFromImageRoIPairs(MosaicImageFromData):
     def __init__(self, data: List[ImageWithRoI], size: Tuple[int, int]) -> None:
         def _get_mosaic_img() -> np.ndarray:
             h, w = self.size

--- a/tests/integration/cli/test_utils.py
+++ b/tests/integration/cli/test_utils.py
@@ -1,7 +1,9 @@
 import os
 import os.path as osp
 from unittest.case import TestCase
+from unittest.mock import PropertyMock, patch
 
+import numpy as np
 import pytest
 
 from datumaro.components.media_manager import MediaManager
@@ -14,11 +16,12 @@ from tests.utils.test_utils import TestDir
 from tests.utils.test_utils import run_datum as run
 
 
-@pytest.mark.xfail(reason="This test is flaky so that can fail randomly")
 class VideoSplittingTest:
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @scoped
-    def test_can_split_video(self):
+    @patch("datumaro.components.media.VideoFrame.data", new_callable=PropertyMock)
+    def test_can_split_video(self, mock_video_frame_data):
+        mock_video_frame_data.return_value = np.full((32, 32, 3), fill_value=0, dtype=np.uint8)
         on_exit_do(MediaManager.get_instance().clear)
 
         test_dir = scope_add(TestDir())


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
