### PR TITLE
Add ImageColorScale context manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements
 - Optimize Python import to make CLI entrypoint faster
   (<https://github.com/openvinotoolkit/datumaro/pull/1182>)
+- Add ImageColorScale context manager
+  (<https://github.com/openvinotoolkit/datumaro/pull/1194>)
 
 ## 16/11/2023 - Release 1.5.1
 ### Enhancements

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2019-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
+from __future__ import annotations
 
 import importlib
 import os
@@ -8,9 +9,10 @@ import os.path as osp
 import shlex
 import weakref
 from contextlib import contextmanager
+from contextvars import ContextVar
 from enum import Enum, auto
 from io import BytesIO, IOBase
-from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Iterator, Optional, Tuple, Union
 
 import numpy as np
 
@@ -29,19 +31,73 @@ class _IMAGE_BACKENDS(Enum):
     PIL = auto()
 
 
-_IMAGE_BACKEND = None
+_IMAGE_BACKEND: ContextVar[_IMAGE_BACKENDS] = ContextVar("_IMAGE_BACKENDS")
 _image_loading_errors = (FileNotFoundError,)
 try:
     importlib.import_module("cv2")
-    _IMAGE_BACKEND = _IMAGE_BACKENDS.cv2
+    _IMAGE_BACKEND.set(_IMAGE_BACKENDS.cv2)
 except ModuleNotFoundError:
     import PIL
 
-    _IMAGE_BACKEND = _IMAGE_BACKENDS.PIL
+    _IMAGE_BACKEND.set(_IMAGE_BACKENDS.PIL)
     _image_loading_errors = (*_image_loading_errors, PIL.UnidentifiedImageError)
 
 from datumaro.util.image_cache import ImageCache
 from datumaro.util.os_util import find_files
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImage
+
+
+class ImageColorScale(Enum):
+    """Image color scale
+
+    - UNCHANGED: Use the original image's scale (default)
+    - COLOR: Use 3 channels (it can ignore the alpha channel or convert the gray scale image to BGR)
+    """
+
+    UNCHANGED = 0
+    COLOR = 1
+
+    def convert_cv2(self, img: np.ndarray) -> np.ndarray:
+        import cv2
+
+        if self == ImageColorScale.COLOR:
+            return cv2.imdecode(img, cv2.IMREAD_COLOR)
+
+        return cv2.imdecode(img, cv2.IMREAD_UNCHANGED)
+
+    def convert_pil(self, img: PILImage) -> PILImage:
+        if self == ImageColorScale.COLOR:
+            return img.convert("RGB")
+
+        return img
+
+
+IMAGE_COLOR_SCALE: ContextVar[ImageColorScale] = ContextVar(
+    "IMAGE_COLOR_SCALE", default=ImageColorScale.UNCHANGED
+)
+
+
+@contextmanager
+def decode_image_context(color_scale: ImageColorScale):
+    """Change Datumaro image decoding color scale.
+
+    For model training, it is recommended to use this context manager
+    to load images in the BGR 3-channel format. For example,
+
+    .. code-block:: python
+
+        import datumaro as dm
+        with decode_image_context(ImageColorScale.COLOR):
+            item: dm.DatasetItem
+            img_data = item.media_as(dm.Image).data
+            assert img_data.shape[-1] == 3  # It should be a 3-channel image
+    """
+    curr_ctx = IMAGE_COLOR_SCALE.get()
+    IMAGE_COLOR_SCALE.set(color_scale)
+    yield
+    IMAGE_COLOR_SCALE.set(curr_ctx)
 
 
 def load_image(path: str, dtype: DTypeLike = np.uint8, crypter: Crypter = NULL_CRYPTER):
@@ -49,7 +105,7 @@ def load_image(path: str, dtype: DTypeLike = np.uint8, crypter: Crypter = NULL_C
     Reads an image in the HWC Grayscale/BGR(A) [0; 255] format (default dtype is uint8).
     """
 
-    if _IMAGE_BACKEND == _IMAGE_BACKENDS.cv2:
+    if _IMAGE_BACKEND.get() == _IMAGE_BACKENDS.cv2:
         # cv2.imread does not support paths that are not representable
         # in the locale encoding on Windows, so we read the image bytes
         # ourselves.
@@ -58,24 +114,13 @@ def load_image(path: str, dtype: DTypeLike = np.uint8, crypter: Crypter = NULL_C
             image_bytes = crypter.decrypt(f.read())
 
         return decode_image(image_bytes, dtype=dtype)
-    elif _IMAGE_BACKEND == _IMAGE_BACKENDS.PIL:
-        from PIL import Image
+    elif _IMAGE_BACKEND.get() == _IMAGE_BACKENDS.PIL:
+        with open(path, "rb") as f:
+            image_bytes = crypter.decrypt(f.read())
 
-        if not crypter.is_null_crypter:
-            raise DatumaroError("PIL backend should have crypter=NullCrypter.")
+        return decode_image(image_bytes, dtype=dtype)
 
-        image = Image.open(path)
-        image = np.asarray(image, dtype=dtype)
-        if len(image.shape) == 3 and image.shape[2] in {3, 4}:
-            image = np.array(image)  # Release read-only
-            image[:, :, :3] = image[:, :, 2::-1]  # RGB to BGR
-    else:
-        raise NotImplementedError()
-
-    assert len(image.shape) in {2, 3}
-    if len(image.shape) == 3:
-        assert image.shape[2] in {3, 4}
-    return image
+    raise NotImplementedError(_IMAGE_BACKEND)
 
 
 def copyto_image(
@@ -130,7 +175,7 @@ def save_image(
     # NOTE: OpenCV documentation says "If the image format is not supported,
     # the image will be converted to 8-bit unsigned and saved that way".
     # Conversion from np.int32 to np.uint8 is not working properly
-    backend = _IMAGE_BACKEND
+    backend = _IMAGE_BACKEND.get()
     if dtype == np.int32:
         backend = _IMAGE_BACKENDS.PIL
     if backend == _IMAGE_BACKENDS.cv2:
@@ -172,7 +217,7 @@ def encode_image(image: np.ndarray, ext: str, dtype: DTypeLike = np.uint8, **kwa
     if not kwargs:
         kwargs = {}
 
-    if _IMAGE_BACKEND == _IMAGE_BACKENDS.cv2:
+    if _IMAGE_BACKEND.get() == _IMAGE_BACKENDS.cv2:
         import cv2
 
         params = []
@@ -188,7 +233,7 @@ def encode_image(image: np.ndarray, ext: str, dtype: DTypeLike = np.uint8, **kwa
         if not success:
             raise Exception("Failed to encode image to '%s' format" % (ext))
         return result.tobytes()
-    elif _IMAGE_BACKEND == _IMAGE_BACKENDS.PIL:
+    elif _IMAGE_BACKEND.get() == _IMAGE_BACKENDS.PIL:
         from PIL import Image
 
         if ext.startswith("."):
@@ -211,16 +256,17 @@ def encode_image(image: np.ndarray, ext: str, dtype: DTypeLike = np.uint8, **kwa
 
 
 def decode_image(image_bytes: bytes, dtype: DTypeLike = np.uint8) -> np.ndarray:
-    if _IMAGE_BACKEND == _IMAGE_BACKENDS.cv2:
-        import cv2
+    ctx_color_scale = IMAGE_COLOR_SCALE.get()
 
+    if _IMAGE_BACKEND.get() == _IMAGE_BACKENDS.cv2:
         image = np.frombuffer(image_bytes, dtype=np.uint8)
-        image = cv2.imdecode(image, cv2.IMREAD_UNCHANGED)
+        image = ctx_color_scale.convert_cv2(image)
         image = image.astype(dtype)
-    elif _IMAGE_BACKEND == _IMAGE_BACKENDS.PIL:
+    elif _IMAGE_BACKEND.get() == _IMAGE_BACKENDS.PIL:
         from PIL import Image
 
         image = Image.open(BytesIO(image_bytes))
+        image = ctx_color_scale.convert_pil(image)
         image = np.asarray(image, dtype=dtype)
         if len(image.shape) == 3 and image.shape[2] in {3, 4}:
             image = np.array(image)  # Release read-only

--- a/tests/unit/test_crypter.py
+++ b/tests/unit/test_crypter.py
@@ -9,6 +9,7 @@ import pytest
 
 from datumaro.components.crypter import NULL_CRYPTER, Crypter
 from datumaro.components.media import Image
+from datumaro.util.image import _IMAGE_BACKEND, _IMAGE_BACKENDS
 
 
 @pytest.fixture(scope="class")
@@ -35,6 +36,13 @@ def fxt_encrypted_image_file(test_dir, fxt_image_file, fxt_crypter):
 
 
 class CrypterTest:
+    @pytest.fixture(scope="class", params=[_IMAGE_BACKENDS.cv2, _IMAGE_BACKENDS.PIL], autouse=True)
+    def fxt_image_backend(self, request):
+        curr_backend = _IMAGE_BACKEND.get()
+        _IMAGE_BACKEND.set(request.param)
+        yield
+        _IMAGE_BACKEND.set(curr_backend)
+
     def test_load_encrypted_image(self, fxt_image_file, fxt_encrypted_image_file, fxt_crypter):
         img = Image.from_file(path=fxt_image_file)
         encrypted_img = Image.from_file(path=fxt_encrypted_image_file, crypter=fxt_crypter)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -1,8 +1,13 @@
+# Copyright (C) 2019-2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import os.path as osp
 from itertools import product
 from unittest import TestCase
 
 import numpy as np
+import pytest
 
 import datumaro.util.image as image_module
 
@@ -13,10 +18,10 @@ from tests.utils.test_utils import TestDir
 
 class ImageOperationsTest(TestCase):
     def setUp(self):
-        self.default_backend = image_module._IMAGE_BACKEND
+        self.default_backend = image_module._IMAGE_BACKEND.get()
 
     def tearDown(self):
-        image_module._IMAGE_BACKEND = self.default_backend
+        image_module._IMAGE_BACKEND.set(self.default_backend)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_save_and_load_backends(self):
@@ -29,10 +34,10 @@ class ImageOperationsTest(TestCase):
                     src_image = np.random.randint(0, 255 + 1, (2, 4, c))
                 path = osp.join(test_dir, "img.png")  # lossless
 
-                image_module._IMAGE_BACKEND = save_backend
+                image_module._IMAGE_BACKEND.set(save_backend)
                 image_module.save_image(path, src_image, jpeg_quality=100)
 
-                image_module._IMAGE_BACKEND = load_backend
+                image_module._IMAGE_BACKEND.set(load_backend)
                 dst_image = image_module.load_image(path)
 
                 self.assertTrue(
@@ -49,10 +54,10 @@ class ImageOperationsTest(TestCase):
             else:
                 src_image = np.random.randint(0, 255 + 1, (2, 4, c))
 
-            image_module._IMAGE_BACKEND = save_backend
+            image_module._IMAGE_BACKEND.set(save_backend)
             buffer = image_module.encode_image(src_image, ".png", jpeg_quality=100)  # lossless
 
-            image_module._IMAGE_BACKEND = load_backend
+            image_module._IMAGE_BACKEND.set(load_backend)
             dst_image = image_module.decode_image(buffer)
 
             self.assertTrue(
@@ -71,3 +76,24 @@ class ImageOperationsTest(TestCase):
             path = osp.join(test_dir, "some", "path.jpg")
             image_module.save_image(path, np.ones((5, 4, 3)), create_dir=True)
             self.assertTrue(osp.isfile(path))
+
+
+class ImageDecodeTest:
+    @pytest.fixture
+    def fxt_img_four_channels(self) -> np.ndarray:
+        return np.random.randint(low=0, high=256, size=(5, 4, 4), dtype=np.uint8)
+
+    def test_decode_image_context(self, fxt_img_four_channels: np.ndarray):
+        img_bytes = image_module.encode_image(fxt_img_four_channels, ".png")
+
+        # 3 channels from ImageColorScale.COLOR
+        with image_module.decode_image_context(image_module.ImageColorScale.COLOR):
+            img_decoded = image_module.decode_image(img_bytes)
+            assert img_decoded.shape[-1] == 3
+            assert np.allclose(fxt_img_four_channels[:, :, :3], img_decoded)
+
+        # 4 channels from ImageColorScale.UNCHANGED
+        with image_module.decode_image_context(image_module.ImageColorScale.UNCHANGED):
+            img_decoded = image_module.decode_image(img_bytes)
+            assert img_decoded.shape[-1] == 4
+            assert np.allclose(fxt_img_four_channels, img_decoded)


### PR DESCRIPTION
### Summary

- To utilize Datumaro as the data pipeline frontend for model training, it is crucial to ensure that the input image's color format consistently adheres to the 3-channel requirement. This is a common practice for many model training frameworks. This pull request introduces a context manager designed to enforce the acquisition of raw images in Datumaro (e.g., data.media_as(Image).data) in the 3-channel.

### How to test
I added some tests for this change.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
