### PR TITLE
Fix label compare of distance method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1202>, <https://github.com/openvinotoolkit/datumaro/pull/1207>)
 - Update document to correct wrong `datum project import` command and add filtering example to filter out items containing annotations.
   (<https://github.com/openvinotoolkit/datumaro/pull/1210>)
+- Fix label compare of distance method
+  (<https://github.com/openvinotoolkit/datumaro/pull/1205>)
 
 ## 16/11/2023 - Release 1.5.1
 ### Enhancements

--- a/src/datumaro/cli/util/compare.py
+++ b/src/datumaro/cli/util/compare.py
@@ -8,7 +8,6 @@ import os.path as osp
 import warnings
 from collections import Counter
 from enum import Enum, auto
-from itertools import zip_longest
 from typing import TYPE_CHECKING, Union
 
 import cv2
@@ -83,22 +82,24 @@ class DistanceCompareVisualizer:
         if len(a) != len(b):
             print("Datasets have different lengths: %s vs %s" % (len(a), len(b)))
 
-        a_classes = a.categories().get(AnnotationType.label, LabelCategories())
-        b_classes = b.categories().get(AnnotationType.label, LabelCategories())
-        class_mismatch = [
-            (idx, a_cls, b_cls)
-            for idx, (a_cls, b_cls) in enumerate(zip_longest(a_classes, b_classes))
-            if getattr(a_cls, "name", None) != getattr(b_cls, "name", None)
+        a_classes = set(
+            a_cls.name for a_cls in a.categories().get(AnnotationType.label, LabelCategories())
+        )
+        b_classes = set(
+            b_cls.name for b_cls in b.categories().get(AnnotationType.label, LabelCategories())
+        )
+
+        class_mismatch = [(diff, None) for diff in a_classes - b_classes] + [
+            (None, diff) for diff in b_classes - a_classes
         ]
+
         if class_mismatch:
             print("Datasets have mismatching labels:")
-            for idx, a_class, b_class in class_mismatch:
-                if a_class and b_class:
-                    print("  #%s: %s != %s" % (idx, a_class.name, b_class.name))
-                elif a_class:
-                    print("  #%s:  > %s" % (idx, a_class.name))
+            for idx, (a_class, b_class) in enumerate(class_mismatch):
+                if a_class:
+                    print("  #%s:  > %s" % (idx, a_class))
                 else:
-                    print("  #%s:  < %s" % (idx, b_class.name))
+                    print("  #%s:  < %s" % (idx, b_class))
         self._a_classes = a.categories().get(AnnotationType.label)
         self._b_classes = b.categories().get(AnnotationType.label)
 

--- a/src/datumaro/cli/util/compare.py
+++ b/src/datumaro/cli/util/compare.py
@@ -91,7 +91,7 @@ class DistanceCompareVisualizer:
         for idx, diff in enumerate(a_classes - b_classes):
             print(" #%s: > %s" % (idx, diff))
 
-        for idx, diff in enumerate(b_classes - a_classes, start=len(a_classes)):
+        for idx, diff in enumerate(b_classes - a_classes, start=len((a_classes - b_classes))):
             print(" #%s: < %s" % (idx, diff))
 
         self._a_classes = a.categories().get(AnnotationType.label)

--- a/src/datumaro/cli/util/compare.py
+++ b/src/datumaro/cli/util/compare.py
@@ -82,24 +82,18 @@ class DistanceCompareVisualizer:
         if len(a) != len(b):
             print("Datasets have different lengths: %s vs %s" % (len(a), len(b)))
 
-        a_classes = set(
-            a_cls.name for a_cls in a.categories().get(AnnotationType.label, LabelCategories())
-        )
-        b_classes = set(
-            b_cls.name for b_cls in b.categories().get(AnnotationType.label, LabelCategories())
-        )
+        a_classes = set(a.get_label_cat_names())
+        b_classes = set(b.get_label_cat_names())
 
-        class_mismatch = [(diff, None) for diff in a_classes - b_classes] + [
-            (None, diff) for diff in b_classes - a_classes
-        ]
-
-        if class_mismatch:
+        if a_classes ^ b_classes:
             print("Datasets have mismatching labels:")
-            for idx, (a_class, b_class) in enumerate(class_mismatch):
-                if a_class:
-                    print("  #%s:  > %s" % (idx, a_class))
-                else:
-                    print("  #%s:  < %s" % (idx, b_class))
+
+        for idx, diff in enumerate(a_classes - b_classes):
+            print(" #%s: > %s" % (idx, diff))
+
+        for idx, diff in enumerate(b_classes - a_classes, start=len(a_classes)):
+            print(" #%s: < %s" % (idx, diff))
+
         self._a_classes = a.categories().get(AnnotationType.label)
         self._b_classes = b.categories().get(AnnotationType.label)
 

--- a/src/datumaro/components/dataset.py
+++ b/src/datumaro/components/dataset.py
@@ -315,6 +315,12 @@ class Dataset(IDataset):
             path = osp.join(self._source_path, path)
         return self._data.get_datasetitem_by_path(path)
 
+    def get_label_cat_names(self):
+        return [
+            label.name
+            for label in self._data.categories().get(AnnotationType.label, LabelCategories())
+        ]
+
     def get_subset_info(self) -> str:
         return (
             f"{subset_name}: # of items={len(self.get_subset(subset_name))}, "

--- a/tests/integration/cli/test_compare.py
+++ b/tests/integration/cli/test_compare.py
@@ -1,9 +1,10 @@
+# Copyright (C) 2021-2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
 import os
 import os.path as osp
-from unittest import TestCase
 
 import numpy as np
-import pytest
 
 from datumaro.cli.util.compare import DistanceCompareVisualizer
 from datumaro.components.annotation import (
@@ -30,13 +31,9 @@ from tests.utils.test_utils import TestDir
 from tests.utils.test_utils import run_datum as run
 
 
-class CompareTest(TestCase):
-    @pytest.fixture(autouse=True)
-    def capsys(self, capsys):
-        self.capsys = capsys
-
+class CompareTest:
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_can_compare_projects(self):  # just a smoke test
+    def test_can_compare_projects(self, capsys):  # just a smoke test
         label_categories1 = LabelCategories.from_iterable(["x", "a", "b", "y", "z"])
         mask_categories1 = MaskCategories.generate(len(label_categories1))
 
@@ -184,13 +181,13 @@ class CompareTest(TestCase):
 
             expected_output1 = "> z"
             expected_output2 = "< c"
-            captured = self.capsys.readouterr()
-            self.assertIn(expected_output1, captured.out)
-            self.assertIn(expected_output2, captured.out)
-            self.assertNotEqual(0, os.listdir(osp.join(test_dir)))
+            captured = capsys.readouterr()
+            assert expected_output1 in captured.out
+            assert expected_output2 in captured.out
+            assert 0 != os.listdir(osp.join(test_dir))
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_can_run_distance_diff(self):
+    def test_can_run_distance_diff(self, helper_tc):
         dataset1 = Dataset.from_iterable(
             [
                 DatasetItem(
@@ -229,7 +226,7 @@ class CompareTest(TestCase):
 
             result_dir = osp.join(test_dir, "cmp_result")
             run(
-                self,
+                helper_tc,
                 "compare",
                 dataset1_url + ":coco",
                 dataset2_url + ":voc",
@@ -238,10 +235,10 @@ class CompareTest(TestCase):
                 "-o",
                 result_dir,
             )
-            self.assertEqual({"bbox_confusion.png", "train"}, set(os.listdir(result_dir)))
+            assert {"bbox_confusion.png", "train"} == set(os.listdir(result_dir))
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_can_run_equality_diff(self):
+    def test_can_run_equality_diff(self, helper_tc):
         dataset1 = Dataset.from_iterable(
             [
                 DatasetItem(
@@ -280,7 +277,7 @@ class CompareTest(TestCase):
 
             result_dir = osp.join(test_dir, "cmp_result")
             run(
-                self,
+                helper_tc,
                 "compare",
                 dataset1_url + ":coco",
                 dataset2_url + ":voc",
@@ -290,4 +287,4 @@ class CompareTest(TestCase):
                 result_dir,
             )
 
-            self.assertEqual({"equality_compare.json"}, set(os.listdir(result_dir)))
+            assert {"equality_compare.json"} == set(os.listdir(result_dir))

--- a/tests/integration/cli/test_compare.py
+++ b/tests/integration/cli/test_compare.py
@@ -1,6 +1,8 @@
+import io
 import os
 import os.path as osp
 from unittest import TestCase
+from unittest.mock import patch
 
 import numpy as np
 
@@ -179,8 +181,9 @@ class CompareTest(TestCase):
 
             self.assertNotEqual(0, os.listdir(osp.join(test_dir)))
 
+    @patch("sys.stdout", new_callable=io.StringIO)
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_can_run_distance_diff(self):
+    def test_can_run_distance_diff(self, mock_stdout):
         dataset1 = Dataset.from_iterable(
             [
                 DatasetItem(
@@ -229,6 +232,10 @@ class CompareTest(TestCase):
                 result_dir,
             )
 
+            expected_output1 = "< c"
+            expected_output2 = "< background"
+            self.assertIn(expected_output1, mock_stdout.getvalue())
+            self.assertIn(expected_output2, mock_stdout.getvalue())
             self.assertEqual({"bbox_confusion.png", "train"}, set(os.listdir(result_dir)))
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -2017,6 +2017,23 @@ class DatasetTest(TestCase):
         with self.assertRaises(MediaTypeError):
             dataset.init_cache()
 
+    @mark_requirement(Requirements.DATUM_GENERIC_MEDIA)
+    def test_get_label_cat_names(self):
+        dataset = Dataset.from_iterable(
+            [
+                DatasetItem(
+                    id=100,
+                    subset="train",
+                    media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                    annotations=[
+                        Bbox(1, 2, 3, 4, label=1),
+                    ],
+                ),
+            ],
+            categories=["a", "b", "c"],
+        )
+        self.assertEqual(dataset.get_label_cat_names(), ["a", "b", "c"])
+
 
 class DatasetItemTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Fix label comparison result of distance method
- Example: dataset1 included label ['a', 'b] and dataset2 included label ['background', 'a', 'b', 'c']
  - Expected Result :
    < c
    < background
  - Actual Result:
    a != background
    b != a
    < b
    < c
- Ticket no. 124879


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [X] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
