### PR TITLE
hotfix indent of installation document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix wrong example of Datumaro dataset creation in document
   (<https://github.com/openvinotoolkit/datumaro/pull/1195>)
 - Fix wrong command to install datumaro from github
-  (<https://github.com/openvinotoolkit/datumaro/pull/1202>)
+  (<https://github.com/openvinotoolkit/datumaro/pull/1202>, <https://github.com/openvinotoolkit/datumaro/pull/1207>)
 
 ## 16/11/2023 - Release 1.5.1
 ### Enhancements

--- a/docs/source/docs/get-started/quick-start-guide/installation.rst
+++ b/docs/source/docs/get-started/quick-start-guide/installation.rst
@@ -22,33 +22,34 @@ Install:
 
 1. From PyPI (**recommended**)
 
-   .. code-block::
+    .. code-block::
 
-       pip install datumaro[default]
+        pip install datumaro[default]
+
 
     Alternatively, for zsh users:
 
-   .. code-block::
+    .. code-block::
 
-       pip install 'datumaro[default]'
+        pip install 'datumaro[default]'
 
 
 2. From the GitHub repository (**not recommended, for advanced users**)
 
-   Installation from the repository source is not recommended.
-   This is because it requires that C++ and Rust build systems are prepared in your local environment before installation.
-   Datumaro includes C++ and Rust implementations to accelerate some workloads to overcome Python's innate slowness.
+    Installation from the repository source is not recommended.
+    This is because it requires that C++ and Rust build systems are prepared in your local environment before installation.
+    Datumaro includes C++ and Rust implementations to accelerate some workloads to overcome Python's innate slowness.
 
-   .. code-block::
+    .. code-block::
 
-       # Prerequisite (For Unix-like systems)
-       # Install C++ build system
-       sudo apt-get install build-essential
-       # Install Rust build system
-       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        # Prerequisite (For Unix-like systems)
+        # Install C++ build system
+        sudo apt-get install build-essential
+        # Install Rust build system
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
-       # Install from the GitHub repository
-       pip install 'datumaro[default] @ git+https://github.com/openvinotoolkit/datumaro'
+        # Install from the GitHub repository
+        pip install 'datumaro[default] @ git+https://github.com/openvinotoolkit/datumaro'
 
 
 Plugins


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
The installation document was incorrect due to the indentation like below:
![image](https://github.com/openvinotoolkit/datumaro/assets/75776702/cb8f0ee9-f81b-4a78-9948-36c55d972d22)

So, I corrected the indentation of the document.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [x] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
