### PR TITLE
Enhance visualizer to toggle plot title visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1182>)
 - Add ImageColorScale context manager
   (<https://github.com/openvinotoolkit/datumaro/pull/1194>)
+- Enhance visualizer to toggle plot title visibility
+  (<https://github.com/openvinotoolkit/datumaro/pull/1228>)
 
 ### Bug fixes
 - Fix wrong example of Datumaro dataset creation in document

--- a/src/datumaro/components/visualizer.py
+++ b/src/datumaro/components/visualizer.py
@@ -89,6 +89,7 @@ class Visualizer:
         bbox_linewidth: float = 1.0,
         text_y_offset: float = 1.5,
         alpha: float = 1.0,
+        show_plot_title: bool = True,
     ) -> None:
         """
         Visualizer for Datumaro annotations
@@ -114,6 +115,9 @@ class Visualizer:
         alpha:
             Transparency value when drawing annotations. It should be in [0, 1].
             If alpha=0, we do not draw any annotations.
+        show_plot_title:
+            If True, show the plot title formatted as "ID: {item_id}, Subset: {subset}".
+            Otherwise, hide the plot title.
         """
         self.dataset = dataset
         self.figsize = figsize
@@ -124,6 +128,7 @@ class Visualizer:
 
         assert 0.0 <= alpha <= 1.0, "alpha should be in [0, 1]."
         self.alpha = alpha
+        self.show_plot_title = show_plot_title
 
         self._items = [item for item in self.dataset]
 
@@ -430,17 +435,8 @@ class Visualizer:
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         ax.imshow(img)
 
-        width = ax.transAxes.transform_point((1, 0))[0] - ax.transAxes.transform_point((0, 0))[0]
-        text = ax.set_title(f"ID: {item_id}, Subset: {subset}", loc="center", wrap=True)
-        text.__get_wrapped_text = text._get_wrapped_text
-
-        def _get_wrapped_text():
-            wrapped_text = text.__get_wrapped_text()
-            text._text = wrapped_text
-            return wrapped_text
-
-        text._get_wrapped_text = _get_wrapped_text
-        text._get_wrap_line_width = lambda: width
+        if self.show_plot_title:
+            self._plot_title(ax, item_id, subset)
 
         ax.set_axis_off()
 
@@ -467,6 +463,19 @@ class Visualizer:
                 self._draw(ann, label_categories, fig, ax, context[ann.type])
 
         return fig
+
+    def _plot_title(self, ax: Axes, item_id: str, subset: str) -> None:
+        width = ax.transAxes.transform_point((1, 0))[0] - ax.transAxes.transform_point((0, 0))[0]
+        text = ax.set_title(f"ID: {item_id}, Subset: {subset}", loc="center", wrap=True)
+        text.__get_wrapped_text = text._get_wrapped_text
+
+        def _get_wrapped_text():
+            wrapped_text = text.__get_wrapped_text()
+            text._text = wrapped_text
+            return wrapped_text
+
+        text._get_wrapped_text = _get_wrapped_text
+        text._get_wrap_line_width = lambda: width
 
     def _draw_label(
         self,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

- Ticket no. 127587
- This option is needed for Datumaro GUI. See this comment, https://github.com/openvinotoolkit/datumaro/pull/1220#pullrequestreview-1776487817

### How to test
The existing unit test can cover `show_plot_title=True` option. `show_plot_title=False` is not covered, but manually tested. Please see this
![image](https://github.com/openvinotoolkit/datumaro/assets/26541465/be5f9c1f-d115-40a8-bac6-d91e16fc946f)
It might be addressed in the future when we transition the `Visualizer` unit tests from the `unittest` to the `pytest` framework.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
