### PR TITLE
Fix a bug in the previous behavior when importing nested datasets in the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1232>)
 - Add unit test for item rename
   (<https://github.com/openvinotoolkit/datumaro/pull/1237>)
+- Fix a bug in the previous behavior when importing nested datasets in the project
+  (<https://github.com/openvinotoolkit/datumaro/pull/1243>)
 
 ## 16/11/2023 - Release 1.5.1
 ### Enhancements

--- a/src/datumaro/cli/commands/convert.py
+++ b/src/datumaro/cli/commands/convert.py
@@ -135,7 +135,7 @@ def convert_command(args):
         log.info(f"Source dataset format detected as {fmt}")
 
     if fmt == args.output_format:
-        log.error("The source data format and the output data format is same as {fmt}.")
+        log.error(f"The source data format and the output data format is same as {fmt}.")
         return 3
 
     source = osp.abspath(args.source)

--- a/src/datumaro/plugins/data_formats/coco/extractor_merger.py
+++ b/src/datumaro/plugins/data_formats/coco/extractor_merger.py
@@ -85,6 +85,6 @@ class COCOExtractorMerger(ExtractorMerger):
             grouped_by_subset[s.subset] += [s]
 
         self._subsets = {
-            subset: COCOTaskMergedBase(sources, subset)
+            subset: [COCOTaskMergedBase(sources, subset)]
             for subset, sources in grouped_by_subset.items()
         }

--- a/tests/integration/cli/test_yolo_format.py
+++ b/tests/integration/cli/test_yolo_format.py
@@ -215,7 +215,7 @@ class YoloIntegrationScenariosTest:
     def fxt_yolo_dir(self, request) -> str:
         return get_test_asset_path("yolo_dataset", request.param)
 
-    @mark_requirement(Requirements.DATUM_BUG_1204)
+    @mark_requirement(Requirements.DATUM_BUG_1214)
     def test_can_import_nested_datasets_in_project(self, fxt_yolo_dir, test_dir, helper_tc):
         run(helper_tc, "project", "create", "-o", test_dir)
 

--- a/tests/integration/cli/test_yolo_format.py
+++ b/tests/integration/cli/test_yolo_format.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2023-2024 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import os.path as osp
 from unittest import TestCase
 

--- a/tests/requirements.py
+++ b/tests/requirements.py
@@ -64,6 +64,9 @@ class Requirements:
     DATUM_BUG_1204 = (
         "Statistics raise an error when there is a label annotation not in the category"
     )
+    DATUM_BUG_1214 = (
+        "Dataset.import_from() can import nested datasets that exist in the given path."
+    )
 
 
 class SkipMessages:

--- a/tests/unit/operations/test_statistics.py
+++ b/tests/unit/operations/test_statistics.py
@@ -334,7 +334,7 @@ class AnnStatisticsTest:
         actual = compute_ann_statistics(dataset)
         assert actual == expected
 
-    @mark_requirement(Requirements.DATUM_BUG_1204)
+    @mark_requirement(Requirements.DATUM_BUG_1214)
     def test_stats_with_invalid_label(self):
         label_names = ["label_%s" % i for i in range(3)]
         dataset = Dataset.from_iterable(


### PR DESCRIPTION
### Summary

- Ticket no. 127589
- Fix a bug found in #1214
- In the previous Datumaro version, we could import the nested datasets in the given path. For example, if we `Dataset.import_from(./some_project)` for the following directory structure
``` console
./some_project/
├── dataset_1
└── dataset_2
```
, the imported dataset include `dataset_1` and `dataset_2`.
- This is common pattern for the Datumaro project, so that we have to fix this.

### How to test
Added an integration test for this scenario.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
