### PR TITLE
Change RoIImage and MosaicImage to have np.uint8 dtype as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1228>)
 - Enhance Datumaro data format detect() to be memory-bounded and performant
   (<https://github.com/openvinotoolkit/datumaro/pull/1229>)
+- Change RoIImage and MosaicImage to have np.uint8 dtype as default
+  (<https://github.com/openvinotoolkit/datumaro/pull/1245>)
 
 ### Bug fixes
 - Fix wrong example of Datumaro dataset creation in document

--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -971,8 +971,6 @@ class RoIImage(Image):
 
     def _get_roi_data(self, data: np.ndarray) -> np.ndarray:
         x, y, w, h = self._roi
-        if isinstance(data, np.ndarray):
-            data = data.astype(np.float32)
         return data[y : y + h, x : x + w]
 
     def save(
@@ -1007,7 +1005,7 @@ class RoIImageFromFile(FromFileMixin, RoIImage):
 
     @property
     def data(self) -> Optional[np.ndarray]:
-        """Image data in BGRA HWC [0; 255] (float) format"""
+        """Image data in BGRA HWC [0; 255] (uint8) format"""
         if not self.has_data:
             return None
         data = self.__data()
@@ -1030,7 +1028,7 @@ class RoIImageFromBytes(RoIImageFromData):
 
     @property
     def data(self) -> Optional[np.ndarray]:
-        """Image data in BGRA HWC [0; 255] (float) format"""
+        """Image data in BGRA HWC [0; 255] (uint8) format"""
         data = super().data
         if data is None:
             return None
@@ -1051,7 +1049,7 @@ class RoIImageFromNumpy(RoIImageFromData):
 
     @property
     def data(self) -> Optional[np.ndarray]:
-        """Image data in BGRA HWC [0; 255] (float) format"""
+        """Image data in BGRA HWC [0; 255] (uint8) format"""
         data = super().data
         if data is None:
             return None
@@ -1116,7 +1114,7 @@ class MosaicImageFromImageRoIPairs(MosaicImageFromData):
     def __init__(self, data: List[ImageWithRoI], size: Tuple[int, int]) -> None:
         def _get_mosaic_img() -> np.ndarray:
             h, w = self.size
-            mosaic_img = np.zeros(shape=(h, w, 3), dtype=np.float32)
+            mosaic_img = np.zeros(shape=(h, w, 3), dtype=np.uint8)
             for img, roi in data:
                 assert isinstance(img, Image), "MosaicImage can only take a list of Images."
                 x, y, w, h = roi


### PR DESCRIPTION
### Summary

- This is something missed in https://github.com/openvinotoolkit/datumaro/pull/1175

### How to test
I believe the existing tests (`tests/unit/test_images.py`) can cover it. 

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
