### PR TITLE
Enable image backend and color channel format to be selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1174>)
 - Add ImportError to catch GitPython import error
   (<https://github.com/openvinotoolkit/datumaro/pull/1174>)
+- Enable image backend and color channel format to be selectable
+  (<https://github.com/openvinotoolkit/datumaro/pull/1246>)
 
 ### Bug fixes
 - Modify the draw function in the visualizer not to raise an error for unsupported annotation types.

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -71,19 +71,9 @@ class ImageColorChannel(Enum):
         img = cv2.imdecode(image_buffer, cv2.IMREAD_COLOR)
 
         if self == ImageColorChannel.COLOR_BGR:
-            if len(img.shape) == 2:
-                return cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
-            if img.shape[-1] == 4:
-                return cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
-
             return img
 
         if self == ImageColorChannel.COLOR_RGB:
-            if len(img.shape) == 2:
-                return cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
-            if img.shape[-1] == 4:
-                return cv2.cvtColor(img, cv2.COLOR_BGRA2RGB)
-
             return cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
         raise ValueError

--- a/tests/unit/test_crypter.py
+++ b/tests/unit/test_crypter.py
@@ -9,7 +9,7 @@ import pytest
 
 from datumaro.components.crypter import NULL_CRYPTER, Crypter
 from datumaro.components.media import Image
-from datumaro.util.image import _IMAGE_BACKEND, _IMAGE_BACKENDS
+from datumaro.util.image import IMAGE_BACKEND, ImageBackend
 
 
 @pytest.fixture(scope="class")
@@ -36,12 +36,12 @@ def fxt_encrypted_image_file(test_dir, fxt_image_file, fxt_crypter):
 
 
 class CrypterTest:
-    @pytest.fixture(scope="class", params=[_IMAGE_BACKENDS.cv2, _IMAGE_BACKENDS.PIL], autouse=True)
+    @pytest.fixture(scope="class", params=[ImageBackend.cv2, ImageBackend.PIL], autouse=True)
     def fxt_image_backend(self, request):
-        curr_backend = _IMAGE_BACKEND.get()
-        _IMAGE_BACKEND.set(request.param)
+        curr_backend = IMAGE_BACKEND.get()
+        IMAGE_BACKEND.set(request.param)
         yield
-        _IMAGE_BACKEND.set(curr_backend)
+        IMAGE_BACKEND.set(curr_backend)
 
     def test_load_encrypted_image(self, fxt_image_file, fxt_encrypted_image_file, fxt_crypter):
         img = Image.from_file(path=fxt_image_file)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -40,6 +40,16 @@ class ImageOperationsTest(TestCase):
                 image_module.IMAGE_BACKEND.set(load_backend)
                 dst_image = image_module.load_image(path)
 
+                # If image_module.IMAGE_COLOR_CHANNEL.get() == image_module.ImageColorChannel.UNCHANGED
+                # OpenCV will read an image as BGR(A), but PIL will read an image as RGB(A).
+                if (
+                    c == 3
+                    and load_backend == image_module.ImageBackend.PIL
+                    and image_module.IMAGE_COLOR_CHANNEL.get()
+                    == image_module.ImageColorChannel.UNCHANGED
+                ):
+                    dst_image = np.flip(dst_image, -1)
+
                 self.assertTrue(
                     np.array_equal(src_image, dst_image),
                     "save: %s, load: %s" % (save_backend, load_backend),
@@ -59,6 +69,16 @@ class ImageOperationsTest(TestCase):
 
             image_module.IMAGE_BACKEND.set(load_backend)
             dst_image = image_module.decode_image(buffer)
+
+            # If image_module.IMAGE_COLOR_CHANNEL.get() == image_module.ImageColorChannel.UNCHANGED
+            # OpenCV will read an image as BGR(A), but PIL will read an image as RGB(A).
+            if (
+                c == 3
+                and load_backend == image_module.ImageBackend.PIL
+                and image_module.IMAGE_COLOR_CHANNEL.get()
+                == image_module.ImageColorChannel.UNCHANGED
+            ):
+                dst_image = np.flip(dst_image, -1)
 
             self.assertTrue(
                 np.array_equal(src_image, dst_image),

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2023 Intel Corporation
+# Copyright (C) 2019-2024 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -18,14 +18,14 @@ from tests.utils.test_utils import TestDir
 
 class ImageOperationsTest(TestCase):
     def setUp(self):
-        self.default_backend = image_module._IMAGE_BACKEND.get()
+        self.default_backend = image_module.IMAGE_BACKEND.get()
 
     def tearDown(self):
-        image_module._IMAGE_BACKEND.set(self.default_backend)
+        image_module.IMAGE_BACKEND.set(self.default_backend)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_save_and_load_backends(self):
-        backends = image_module._IMAGE_BACKENDS
+        backends = image_module.ImageBackend
         for save_backend, load_backend, c in product(backends, backends, [1, 3]):
             with TestDir() as test_dir:
                 if c == 1:
@@ -34,10 +34,10 @@ class ImageOperationsTest(TestCase):
                     src_image = np.random.randint(0, 255 + 1, (2, 4, c))
                 path = osp.join(test_dir, "img.png")  # lossless
 
-                image_module._IMAGE_BACKEND.set(save_backend)
+                image_module.IMAGE_BACKEND.set(save_backend)
                 image_module.save_image(path, src_image, jpeg_quality=100)
 
-                image_module._IMAGE_BACKEND.set(load_backend)
+                image_module.IMAGE_BACKEND.set(load_backend)
                 dst_image = image_module.load_image(path)
 
                 self.assertTrue(
@@ -47,17 +47,17 @@ class ImageOperationsTest(TestCase):
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_encode_and_decode_backends(self):
-        backends = image_module._IMAGE_BACKENDS
+        backends = image_module.ImageBackend
         for save_backend, load_backend, c in product(backends, backends, [1, 3]):
             if c == 1:
                 src_image = np.random.randint(0, 255 + 1, (2, 4))
             else:
                 src_image = np.random.randint(0, 255 + 1, (2, 4, c))
 
-            image_module._IMAGE_BACKEND.set(save_backend)
+            image_module.IMAGE_BACKEND.set(save_backend)
             buffer = image_module.encode_image(src_image, ".png", jpeg_quality=100)  # lossless
 
-            image_module._IMAGE_BACKEND.set(load_backend)
+            image_module.IMAGE_BACKEND.set(load_backend)
             dst_image = image_module.decode_image(buffer)
 
             self.assertTrue(
@@ -83,17 +83,45 @@ class ImageDecodeTest:
     def fxt_img_four_channels(self) -> np.ndarray:
         return np.random.randint(low=0, high=256, size=(5, 4, 4), dtype=np.uint8)
 
-    def test_decode_image_context(self, fxt_img_four_channels: np.ndarray):
+    @pytest.mark.parametrize(
+        "image_backend", [image_module.ImageBackend.cv2, image_module.ImageBackend.PIL]
+    )
+    def test_decode_image_context(
+        self, fxt_img_four_channels: np.ndarray, image_backend: image_module.ImageBackend
+    ):
         img_bytes = image_module.encode_image(fxt_img_four_channels, ".png")
 
-        # 3 channels from ImageColorScale.COLOR
-        with image_module.decode_image_context(image_module.ImageColorScale.COLOR):
+        # 3 channels from ImageColorScale.COLOR_BGR
+        with image_module.decode_image_context(
+            image_backend, image_module.ImageColorChannel.COLOR_BGR
+        ):
             img_decoded = image_module.decode_image(img_bytes)
             assert img_decoded.shape[-1] == 3
             assert np.allclose(fxt_img_four_channels[:, :, :3], img_decoded)
 
+        # 3 channels from ImageColorScale.COLOR_RGB
+        with image_module.decode_image_context(
+            image_backend, image_module.ImageColorChannel.COLOR_RGB
+        ):
+            img_decoded = image_module.decode_image(img_bytes)
+            assert img_decoded.shape[-1] == 3
+            assert np.allclose(
+                fxt_img_four_channels[:, :, :3][:, :, ::-1],  # Flip color channels of the fixture
+                img_decoded,
+            )
+
         # 4 channels from ImageColorScale.UNCHANGED
-        with image_module.decode_image_context(image_module.ImageColorScale.UNCHANGED):
+        with image_module.decode_image_context(
+            image_backend, image_module.ImageColorChannel.UNCHANGED
+        ):
             img_decoded = image_module.decode_image(img_bytes)
             assert img_decoded.shape[-1] == 4
-            assert np.allclose(fxt_img_four_channels, img_decoded)
+
+            if image_backend == image_module.ImageBackend.cv2:
+                assert np.allclose(fxt_img_four_channels, img_decoded)
+            else:
+                # PIL will return RGBA, thus we need to correct the fixture
+                to_rgb = fxt_img_four_channels[:, :, :3][:, :, ::-1]
+                fxt_img_four_channels[:, :, :3] = to_rgb
+
+                assert np.allclose(fxt_img_four_channels, img_decoded)


### PR DESCRIPTION
### Summary

- Previously we enabled the image decoding context managing only for both 3-channel colors or unchanged. However, we should extend it to image backend; and RGB or BGR color channel format selection for OTX use cases.

### How to test
I updated the existing unit tests to cover this change as well.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
