### PR TITLE
Implement dm.Dataset index access

### DIFF
--- a/src/datumaro/components/dataset.py
+++ b/src/datumaro/components/dataset.py
@@ -932,6 +932,9 @@ class Dataset(IDataset):
         """
         return deepcopy(self)
 
+    def __getitem__(self, idx: int) -> DatasetItem:
+        return self._data[idx]
+
 
 class StreamDataset(Dataset):
     _stream = True

--- a/src/datumaro/components/dataset_item_storage.py
+++ b/src/datumaro/components/dataset_item_storage.py
@@ -106,7 +106,7 @@ class DatasetItemStorage:
         copied._order = copy(self._order)
         copied.data = copy(self.data)
         return copied
-    
+
     def __getitem__(self, idx: int) -> DatasetItem:
         _id, subset = self._order[idx]
         item = self.data[subset][_id]

--- a/src/datumaro/components/dataset_storage.py
+++ b/src/datumaro/components/dataset_storage.py
@@ -557,6 +557,13 @@ class DatasetStorage(IDataset):
 
         self._transforms = safe_transforms
 
+    def __getitem__(self, idx: int) -> DatasetItem:
+        try:
+            return self._storage[idx]
+        except IndexError: # Data storage should be initialized
+            self.init_cache()
+            return self._storage[idx]
+
 
 class StreamSubset(IDataset):
     def __init__(self, source: IDataset, subset: str) -> None:

--- a/src/datumaro/components/dataset_storage.py
+++ b/src/datumaro/components/dataset_storage.py
@@ -560,7 +560,7 @@ class DatasetStorage(IDataset):
     def __getitem__(self, idx: int) -> DatasetItem:
         try:
             return self._storage[idx]
-        except IndexError: # Data storage should be initialized
+        except IndexError:  # Data storage should be initialized
             self.init_cache()
             return self._storage[idx]
 

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -2034,6 +2034,18 @@ class DatasetTest(TestCase):
         )
         self.assertEqual(dataset.get_label_cat_names(), ["a", "b", "c"])
 
+    def test_index_access(self):
+        dataset = Dataset.from_iterable([DatasetItem(id) for id in [1, 2, 3, 4]])
+        self.assertEqual(dataset[2].id, "3")
+
+        dataset.remove(3)
+        self.assertEqual(dataset[2].id, "4")
+
+        dataset.put(DatasetItem(3))
+        self.assertEqual(dataset[-1].id, "3")
+
+        self.assertRaises(IndexError, lambda: dataset[4])
+
 
 class DatasetItemTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -2049,7 +2049,7 @@ class DatasetTest(TestCase):
         dataset = Dataset.from_iterable(
             DatasetItem(
                 id,
-                media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                media=Image.from_numpy(data=np.ones((224, 224, 3))),
                 annotations=[
                     Bbox(1, 2, 3, 4, label=1),
                 ],
@@ -2057,15 +2057,20 @@ class DatasetTest(TestCase):
             for id in range(5)
         )
         length = len(dataset)
-        n_rows, n_cols = (1, 2)
+        n_rows, n_cols = (4, 4)
         dataset.transform("tile", grid_size=(n_rows, n_cols), overlap=(0, 0), threshold_drop_ann=0)
         tiled_length = length * n_rows * n_cols
-        for i in range(tiled_length):
-            dataset[i]
+        for i in range(length):
+            for row in range(n_rows):
+                for col in range(n_cols):
+                    idx = i * n_rows * n_cols + row * n_cols + col
+                    _id = f"{i}_tile_{row * n_cols + col}"
+                    self.assertEqual(dataset[idx].id, _id)
         self.assertRaises(IndexError, lambda: dataset[tiled_length])
+
         dataset.transform("merge_tile")
         for i in range(length):
-            dataset[i]
+            self.assertEqual(dataset[i].id, str(i))
         self.assertRaises(IndexError, lambda: dataset[length])
 
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->
Issue No: 126681
### Summary

This PR introduces dataset random index access for the easy conversion from `dm.Dataset` to `torch.Dataset`. The implementation requires an additional list property for `DatasetItemStorage` class, which would cost additional O(n) memory. It doesn't store items but references to them (subset and ID). 

Concern:
I wonder whether it is possible to store and manage this list for indexing, removal, addition, and iteration to reduce memory consumption. I tried to combine the following changes:
1) The `_traversal_order` dictionary seems unnecessary as all data is already stored and managed in the `data` property via `.put()` and `.remove()` methods. `__len__`, `__iter__`, and other methods can rely solely on `data`. Optionally, an `_order` property could enable O(1) `__len__` implementation.
2) Instead of overwriting `data` values with `None` to mark removal, deleting the entire dictionary entry accurately reflects the dataset state and eliminates ambiguity.

As a result, tests set `test_can_create_patch*` started to fail. It appears that items were not actually removed from the dataset, but merely marked as such. This suggests either the cache initialization or element remove operation needs adjusting for this scenario. Resolving this with assistance could significantly improve `dm.Dataset` interaction.


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
