### PR TITLE
Prioritize using imagesize library to get image size for ImageFromFile

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,6 +1,7 @@
 attrs>=21.3.0
 defusedxml>=0.7.0
 h5py>=2.10.0
+imagesize>=1.4.1
 lxml>=4.4.1
 matplotlib>=3.3.1
 networkx>=2.6
@@ -12,7 +13,6 @@ ruamel.yaml>=0.17.0
 shapely>=1.7
 typing_extensions>=3.7.4.3
 tqdm
-imagesize>=1.4.1
 
 pycocotools>=2.0.4; platform_system != "Windows" or python_version >= '3.9'
 

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -12,6 +12,7 @@ ruamel.yaml>=0.17.0
 shapely>=1.7
 typing_extensions>=3.7.4.3
 tqdm
+imagesize>=1.4.1
 
 pycocotools>=2.0.4; platform_system != "Windows" or python_version >= '3.9'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@
 -r requirements-default.txt
 
 opencv-python-headless>=4.1.0.25
-imagesize>=1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 -r requirements-default.txt
 
 opencv-python-headless>=4.1.0.25
+imagesize>=1.4.1

--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -337,14 +337,18 @@ class ImageFromFile(FromFileMixin, Image):
         return data
 
     @property
+import imagesize
+
+...
+
     def size(self) -> Optional[Tuple[int, int]]:
         """Returns (H, W)"""
 
         if self._size is None:
-            if _HAS_PIL:
-                w, h = PILImage.open(self.path).size
-                self._size = (h, w)
-            else:
+            try:
+                width, height = imagesize.get(self.path)
+                self._size = (height, width)
+            except Exception:
                 _ = super().size
         return self._size
 

--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -49,6 +49,12 @@ else:
 
     pd = lazy_import("pandas")
 
+try:
+    from PIL import Image as PILImage
+
+    _HAS_PIL = True
+except (ModuleNotFoundError, ImportError):
+    _HAS_PIL = False
 
 AnyData = TypeVar("AnyData", bytes, np.ndarray)
 
@@ -329,6 +335,18 @@ class ImageFromFile(FromFileMixin, Image):
                 raise MediaShapeError("An image should have 2 (gray) or 3 (bgra) dims.")
             self._size = tuple(map(int, data.shape[:2]))
         return data
+
+    @property
+    def size(self) -> Optional[Tuple[int, int]]:
+        """Returns (H, W)"""
+
+        if self._size is None:
+            if _HAS_PIL:
+                w, h = PILImage.open(self.path).size
+                self._size = (h, w)
+            else:
+                _ = super().size
+        return self._size
 
     def save(
         self,

--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -29,6 +29,7 @@ from typing import (
 )
 
 import cv2
+import imagesize
 import numpy as np
 
 from datumaro.components.crypter import NULL_CRYPTER, Crypter
@@ -49,12 +50,6 @@ else:
 
     pd = lazy_import("pandas")
 
-try:
-    from PIL import Image as PILImage
-
-    _HAS_PIL = True
-except (ModuleNotFoundError, ImportError):
-    _HAS_PIL = False
 
 AnyData = TypeVar("AnyData", bytes, np.ndarray)
 
@@ -337,16 +332,13 @@ class ImageFromFile(FromFileMixin, Image):
         return data
 
     @property
-import imagesize
-
-...
-
     def size(self) -> Optional[Tuple[int, int]]:
         """Returns (H, W)"""
 
         if self._size is None:
             try:
                 width, height = imagesize.get(self.path)
+                assert width != -1 and height != -1
                 self._size = (height, width)
             except Exception:
                 _ = super().size


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

Accelerate loading of image file-based datasets.

I found that printing out the YOLO dataset information for the first time was slow. After some digging I found that `datamaro` was reading the entire dataset through to get the size of each image.

```python
ds = Dataset.import_from("/yolo-ultralytics", "yolo")
print(ds)  # <-- wait a long time
```

```python
    # from class Image
    @property
    def size(self) -> Optional[Tuple[int, int]]:
        """Returns (H, W)"""

        if self._size is None:
            try:
                data = self.data  # <-- load the whole media into memory
            except _image_loading_errors:
                return None
            if data is not None:
                self._size = tuple(map(int, data.shape[:2]))
        return self._size
```

Interactive encoding with datasets on HDD is slow. So I added an override `size()` property in the `ImageFromFile` class which first tries to get the image size using `PIL`. The `PIL` library is about 8 times faster than `OpenCV` in getting the image size.

All dataset classes that use the `size` property of `ImageFromFile` can benefit from this modification.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
