### PR TITLE
Allow empty label on Ultralytics YOLO dataset

### DIFF
--- a/src/datumaro/plugins/data_formats/yolo/importer.py
+++ b/src/datumaro/plugins/data_formats/yolo/importer.py
@@ -160,6 +160,15 @@ class _YoloUltralyticsImporter(_YoloLooseImporter):
     META_FILE = YoloUltralyticsPath.META_FILE
     FORMAT = YoloFormatType.yolo_ultralytics.name
 
+    @classmethod
+    def _check_ann_file_impl(cls, fp: TextIOWrapper) -> bool:
+        try:
+            return _YoloLooseImporter._check_ann_file_impl(fp)
+        except DatasetImportError as e:
+            if e.args[0] == "Empty file is not allowed.":
+                return True
+            raise
+
 
 class YoloImporter(Importer):
     SUB_IMPORTERS: Dict[YoloFormatType, Importer] = {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

In [Ultralytics](https://docs.ultralytics.com/yolov5/tutorials/tips_for_best_training_results/#dataset:~:text=Background%20images.%20Background%20images%20are%20images%20with%20no%20objects%20that%20are%20added%20to%20a%20dataset%20to%20reduce%20False%20Positives%20(FP).%20We%20recommend%20about%200%2D10%25%20background%20images%20to%20help%20reduce%20FPs%20(COCO%20has%201000%20background%20images%20for%20reference%2C%201%25%20of%20the%20total).%20No%20labels%20are%20required%20for%20background%20images.) YOLO dataset, there is no label required for the background images. But in `datumaro`, the `_check_ann_file_impl` of the `_YoloLooseImporter` class will filter all empty label `.txt` and does not search for images without label `.txt`. This PR will not search for images without label `.txt` but will  add images with empty label `.txt` to the dataset.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
