### PR TITLE
Add importers grouping by file extensions

### DIFF
--- a/src/datumaro/__init__.py
+++ b/src/datumaro/__init__.py
@@ -51,7 +51,7 @@ from .components.dataset_base import (
     SubsetBase,
 )
 from .components.dataset_item_storage import ItemStatus
-from .components.environment import Environment, PluginRegistry
+from .components.environment import Environment
 from .components.exporter import Exporter, ExportErrorPolicy, FailingExportErrorPolicy
 from .components.hl_ops import HLOps
 from .components.importer import FailingImportErrorPolicy, Importer, ImportErrorPolicy
@@ -64,6 +64,7 @@ from .components.progress_reporting import (
     SimpleProgressReporter,
     TQDMProgressReporter,
 )
+from .components.registry import PluginRegistry
 from .components.transformer import ItemTransform, ModelTransform, Transform
 from .components.validator import Validator
 from .components.visualizer import Visualizer

--- a/src/datumaro/components/environment.py
+++ b/src/datumaro/components/environment.py
@@ -8,127 +8,39 @@ import logging as log
 import os.path as osp
 from functools import partial
 from inspect import getmodule, isclass
-from typing import (
-    Callable,
-    Dict,
-    Generator,
-    Generic,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-)
+from typing import Callable, List, Optional, Sequence, Set
 
-from datumaro.components.cli_plugin import CliPlugin, plugin_types
+from datumaro.components.cli_plugin import plugin_types
 from datumaro.components.format_detection import (
     DetectedFormat,
     FormatDetectionConfidence,
     RejectionReason,
     detect_dataset_format,
 )
-from datumaro.components.lazy_plugin import PLUGIN_TYPES, LazyPlugin
-from datumaro.util.os_util import import_foreign_module, split_path
-
-T = TypeVar("T")
-
-
-class Registry(Generic[T]):
-    def __init__(self):
-        self._items: Dict[str, T] = {}
-
-    def register(self, name: str, value: T) -> T:
-        self._items[name] = value
-        return value
-
-    def unregister(self, name: str) -> Optional[T]:
-        return self._items.pop(name, None)
-
-    def get(self, key: str):
-        """Returns a class or a factory function"""
-        return self._items[key]
-
-    def __getitem__(self, key: str) -> T:
-        return self.get(key)
-
-    def __contains__(self, key) -> bool:
-        return key in self._items
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self._items)
-
-    def items(self) -> Generator[Tuple[str, T], None, None]:
-        for key in self:
-            yield key, self.get(key)
-
-
-class PluginRegistry(Registry[Type[CliPlugin]]):
-    def __init__(
-        self, filter: Callable[[Type[CliPlugin]], bool] = None
-    ):  # pylint: disable=redefined-builtin
-        super().__init__()
-        self._filter = filter
-
-    def get(self, key: str) -> PLUGIN_TYPES:
-        """Returns a class or a factory function"""
-        item = self._items[key]
-        if issubclass(item, LazyPlugin):
-            return item.get_plugin_cls()
-        return item
-
-    def batch_register(self, values: Iterable[CliPlugin]):
-        for v in values:
-            if self._filter and not self._filter(v):
-                continue
-
-            self.register(v.NAME, v)
+from datumaro.components.registry import (
+    DatasetBaseRegistry,
+    ExporterRegistry,
+    GeneratorRegistry,
+    ImporterRegistry,
+    LauncherRegistry,
+    PluginRegistry,
+    TransformRegistry,
+    ValidatorRegistry,
+)
+from datumaro.util.os_util import get_all_file_extensions, import_foreign_module, split_path
 
 
 class Environment:
     _builtin_plugins = None
 
-    @classmethod
-    def _make_filter(cls, accept, decline=None, skip=None):
-        accept = (accept,) if isclass(accept) else tuple(accept)
-        skip = {skip} if isclass(skip) else set(skip or [])
-        skip = tuple(skip | set(accept))
-        return partial(cls._check_type, accept=accept, decline=decline, skip=skip)
-
-    @staticmethod
-    def _check_type(t, *, accept, decline, skip):
-        if not issubclass(t, accept) or t in skip or (decline and issubclass(t, decline)):
-            return False
-        if getattr(t, "__not_plugin__", None):
-            return False
-        return True
-
     def __init__(self, use_lazy_import: bool = True):
-        from datumaro.components.dataset_base import DatasetBase, SubsetBase
-        from datumaro.components.exporter import Exporter
-        from datumaro.components.generator import DatasetGenerator
-        from datumaro.components.importer import Importer
-        from datumaro.components.launcher import Launcher
-        from datumaro.components.transformer import ItemTransform, Transform
-        from datumaro.components.validator import Validator
-
-        _filter = self._make_filter
-        self._extractors = PluginRegistry(
-            _filter(
-                DatasetBase,
-                decline=Transform,
-                skip=(SubsetBase, Transform, ItemTransform),
-            )
-        )
-        self._importers = PluginRegistry(_filter(Importer))
-        self._launchers = PluginRegistry(_filter(Launcher))
-        self._exporters = PluginRegistry(_filter(Exporter))
-        self._generators = PluginRegistry(_filter(DatasetGenerator))
-        self._transforms = PluginRegistry(_filter(Transform, skip=ItemTransform))
-        self._validators = PluginRegistry(_filter(Validator))
+        self._extractors = DatasetBaseRegistry()
+        self._importers = ImporterRegistry()
+        self._launchers = LauncherRegistry()
+        self._exporters = ExporterRegistry()
+        self._generators = GeneratorRegistry()
+        self._transforms = TransformRegistry()
+        self._validators = ValidatorRegistry()
         self._builtins_initialized = False
         self._use_lazy_import = use_lazy_import
 
@@ -139,31 +51,31 @@ class Environment:
         return getattr(self, name)
 
     @property
-    def extractors(self) -> PluginRegistry:
+    def extractors(self) -> DatasetBaseRegistry:
         return self._get_plugin_registry("_extractors")
 
     @property
-    def importers(self) -> PluginRegistry:
+    def importers(self) -> ImporterRegistry:
         return self._get_plugin_registry("_importers")
 
     @property
-    def launchers(self) -> PluginRegistry:
+    def launchers(self) -> LauncherRegistry:
         return self._get_plugin_registry("_launchers")
 
     @property
-    def exporters(self) -> PluginRegistry:
+    def exporters(self) -> ExporterRegistry:
         return self._get_plugin_registry("_exporters")
 
     @property
-    def generators(self) -> PluginRegistry:
+    def generators(self) -> GeneratorRegistry:
         return self._get_plugin_registry("_generators")
 
     @property
-    def transforms(self) -> PluginRegistry:
+    def transforms(self) -> TransformRegistry:
         return self._get_plugin_registry("_transforms")
 
     @property
-    def validators(self) -> PluginRegistry:
+    def validators(self) -> ValidatorRegistry:
         return self._get_plugin_registry("_validators")
 
     @staticmethod
@@ -320,12 +232,16 @@ class Environment:
         ignore_dirs = {"__MSOSX", "__MACOSX"}
         all_matched_formats: Set[DetectedFormat] = set()
 
+        extensions = get_all_file_extensions(path, ignore_dirs)
+
+        importers = {
+            importer
+            for extension in extensions
+            for importer in self.importers.extension_groups.get(extension, [])
+        }
         for _ in range(depth + 1):
             detected_formats = detect_dataset_format(
-                (
-                    (format_name, importer.detect)
-                    for format_name, importer in self.importers.items()
-                ),
+                ((format_name, importer.detect) for format_name, importer in importers),
                 path,
                 rejection_callback=rejection_callback,
             )

--- a/src/datumaro/components/environment.py
+++ b/src/datumaro/components/environment.py
@@ -235,9 +235,9 @@ class Environment:
         extensions = get_all_file_extensions(path, ignore_dirs) or [""]
 
         importers = {
-            importer
+            (name, importer.get_plugin_cls() if self._use_lazy_import else importer)
             for extension in extensions
-            for importer in self.importers.extension_groups.get(extension, [])
+            for name, importer in self.importers.extension_groups.get(extension, [])
         }
         for _ in range(depth + 1):
             detected_formats = detect_dataset_format(

--- a/src/datumaro/components/environment.py
+++ b/src/datumaro/components/environment.py
@@ -232,7 +232,7 @@ class Environment:
         ignore_dirs = {"__MSOSX", "__MACOSX"}
         all_matched_formats: Set[DetectedFormat] = set()
 
-        extensions = get_all_file_extensions(path, ignore_dirs)
+        extensions = get_all_file_extensions(path, ignore_dirs) or [""]
 
         importers = {
             importer

--- a/src/datumaro/components/importer.py
+++ b/src/datumaro/components/importer.py
@@ -51,6 +51,10 @@ class Importer(CliPlugin):
         return cls.DETECT_CONFIDENCE
 
     @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        raise NotImplementedError()
+
+    @classmethod
     def find_sources(cls, path: str) -> List[Dict]:
         raise NotImplementedError()
 

--- a/src/datumaro/components/lazy_plugin.py
+++ b/src/datumaro/components/lazy_plugin.py
@@ -6,7 +6,7 @@ import logging as log
 from abc import ABC, abstractclassmethod
 from importlib import import_module
 from importlib.util import find_spec
-from typing import List, Optional, Sequence, Type, Union
+from typing import Dict, List, Optional, Sequence, Type, Union
 
 from datumaro.components.dataset_base import DatasetBase
 from datumaro.components.errors import DatumaroError
@@ -57,6 +57,7 @@ def get_lazy_plugin(
     plugin_name: str,
     plugin_type: str,
     extra_deps: List[str] = [],
+    metadata: Dict = {},
 ) -> Optional[LazyPlugin]:
     for extra_dep in extra_deps:
         spec = find_spec(extra_dep)
@@ -68,6 +69,7 @@ def get_lazy_plugin(
 
     class LazyPluginImpl(LazyPlugin, plugin_type_cls):
         NAME = plugin_name
+        METADATA = metadata
 
         @classmethod
         def get_plugin_cls(cls) -> PLUGIN_TYPES:

--- a/src/datumaro/components/registry.py
+++ b/src/datumaro/components/registry.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Intel Corporation
+# Copyright (C) 2024 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/datumaro/components/registry.py
+++ b/src/datumaro/components/registry.py
@@ -102,11 +102,16 @@ class ImporterRegistry(PluginRegistry):
         super().__init__()
         self.extension_groups = defaultdict(list)
 
-    def register(self, name: str, value: Type[Importer]) -> Type[Importer]:
+    def register(
+        self, name: str, value: Type[Importer] | LazyPlugin
+    ) -> Type[Importer] | LazyPlugin:
         super().register(name, value)
-        importer = self.get(name)
-        for extension in importer.get_file_extensions():
-            self.extension_groups[extension].append((name, importer))
+        if issubclass(value, LazyPlugin):
+            file_extensions = value.METADATA["file_extensions"]
+        else:
+            file_extensions = value.get_file_extensions()
+        for extension in file_extensions:
+            self.extension_groups[extension].append((name, value))
         return value
 
 

--- a/src/datumaro/components/registry.py
+++ b/src/datumaro/components/registry.py
@@ -1,0 +1,127 @@
+from collections import defaultdict
+from inspect import isclass
+from typing import Dict, Generator, Generic, Iterable, Iterator, Optional, Tuple, Type, TypeVar
+
+from datumaro.components.cli_plugin import CliPlugin
+from datumaro.components.dataset_base import DatasetBase, SubsetBase
+from datumaro.components.exporter import Exporter
+from datumaro.components.generator import DatasetGenerator
+from datumaro.components.importer import Importer
+from datumaro.components.launcher import Launcher
+from datumaro.components.lazy_plugin import LazyPlugin
+from datumaro.components.transformer import ItemTransform, Transform
+from datumaro.components.validator import Validator
+
+T = TypeVar("T")
+
+
+class Registry(Generic[T]):
+    def __init__(self):
+        self._items: Dict[str, T] = {}
+
+    def register(self, name: str, value: T) -> T:
+        self._items[name] = value
+        return value
+
+    def unregister(self, name: str) -> Optional[T]:
+        return self._items.pop(name, None)
+
+    def get(self, key: str) -> T:
+        """Returns a class or a factory function"""
+        return self._items[key]
+
+    def __getitem__(self, key: str) -> T:
+        return self.get(key)
+
+    def __contains__(self, key) -> bool:
+        return key in self._items
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._items)
+
+    def items(self) -> Generator[Tuple[str, T], None, None]:
+        for key in self:
+            yield key, self.get(key)
+
+
+class PluginRegistry(Registry[Type[CliPlugin]]):
+    _ACCEPT: Type[CliPlugin] = None
+    _SKIP: Optional[Iterable[Type[CliPlugin]]] = None
+    _DECLINE: Optional[Type[CliPlugin]] = None
+
+    def __init__(self):
+        super().__init__()
+        if self._ACCEPT is None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} requires an _ACCEPT class attribute"
+                " to specify the accepted type of stored instances."
+            )
+
+    def _filter(self, t):
+        skip = {self.skip} if isclass(self.skip) else set(self.skip or [])
+        skip = tuple(skip | set((self.accept,)))
+        if (
+            not issubclass(t, self.accept)
+            or t in skip
+            or (self.decline and issubclass(t, self.decline))
+        ):
+            return False
+        if getattr(t, "__not_plugin__", None):
+            return False
+        return True
+
+    def get(self, key: str) -> Type[CliPlugin]:
+        """Returns a class or a factory function"""
+        item = self._items[key]
+        if issubclass(item, LazyPlugin):
+            return item.get_plugin_cls()
+        return item
+
+    def batch_register(self, values: Iterable[Type[CliPlugin]]):
+        for v in values:
+            if not self._filter(v):
+                continue
+
+            self.register(v.NAME, v)
+
+
+class DatasetBaseRegistry(PluginRegistry):
+    _ACCEPT = DatasetBase
+    _SKIP = (SubsetBase, Transform, ItemTransform)
+    _DECLINE = Transform
+
+
+class ImporterRegistry(PluginRegistry):
+    _ACCEPT = Importer
+
+    def __init__(self):
+        super().__init__()
+        self.extension_groups = defaultdict(list)
+
+    def register(self, name: str, value: Type[Importer]) -> Type[Importer]:
+        super().register(name, value)
+        importer = self.get(name)
+        for extension in importer.get_file_extensions():
+            self.extension_groups[extension].append((name, importer))
+        return value
+
+
+class LauncherRegistry(PluginRegistry):
+    _ACCEPT = Launcher
+
+
+class ExporterRegistry(PluginRegistry):
+    _ACCEPT = Exporter
+
+
+class GeneratorRegistry(PluginRegistry):
+    _ACCEPT = DatasetGenerator
+
+
+class TransformRegistry(PluginRegistry):
+    _ACCEPT = Transform
+    _SKIP = ItemTransform
+
+
+class ValidatorRegistry(PluginRegistry):
+    _ACCEPT = Validator

--- a/src/datumaro/components/registry.py
+++ b/src/datumaro/components/registry.py
@@ -4,7 +4,18 @@
 
 from collections import defaultdict
 from inspect import isclass
-from typing import Dict, Generator, Generic, Iterable, Iterator, Optional, Tuple, Type, TypeVar
+from typing import (
+    Dict,
+    Generator,
+    Generic,
+    Iterable,
+    Iterator,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from datumaro.components.cli_plugin import CliPlugin
 from datumaro.components.dataset_base import DatasetBase, SubsetBase
@@ -103,8 +114,8 @@ class ImporterRegistry(PluginRegistry):
         self.extension_groups = defaultdict(list)
 
     def register(
-        self, name: str, value: Type[Importer] | LazyPlugin
-    ) -> Type[Importer] | LazyPlugin:
+        self, name: str, value: Union[Type[Importer], LazyPlugin]
+    ) -> Union[Type[Importer], LazyPlugin]:
         super().register(name, value)
         if issubclass(value, LazyPlugin):
             file_extensions = value.METADATA["file_extensions"]

--- a/src/datumaro/components/registry.py
+++ b/src/datumaro/components/registry.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 from collections import defaultdict
 from inspect import isclass
 from typing import Dict, Generator, Generic, Iterable, Iterator, Optional, Tuple, Type, TypeVar

--- a/src/datumaro/components/registry.py
+++ b/src/datumaro/components/registry.py
@@ -62,12 +62,12 @@ class PluginRegistry(Registry[Type[CliPlugin]]):
             )
 
     def _filter(self, t):
-        skip = {self.skip} if isclass(self.skip) else set(self.skip or [])
-        skip = tuple(skip | set((self.accept,)))
+        skip = {self._SKIP} if isclass(self._SKIP) else set(self._SKIP or [])
+        skip = tuple(skip | set((self._ACCEPT,)))
         if (
-            not issubclass(t, self.accept)
+            not issubclass(t, self._ACCEPT)
             or t in skip
-            or (self.decline and issubclass(t, self.decline))
+            or (self._DECLINE and issubclass(t, self._DECLINE))
         ):
             return False
         if getattr(t, "__not_plugin__", None):

--- a/src/datumaro/plugins/data_formats/ade20k2017.py
+++ b/src/datumaro/plugins/data_formats/ade20k2017.py
@@ -8,7 +8,7 @@ import logging as log
 import os
 import os.path as osp
 import re
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -169,9 +169,11 @@ class Ade20k2017Base(DatasetBase):
 
 
 class Ade20k2017Importer(Importer):
+    _ANNO_EXT = ".txt"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        context.require_file("*/**/*_atr.txt")
+        context.require_file(f"*/**/*_atr{cls._ANNO_EXT}")
 
     @classmethod
     def find_sources(cls, path):
@@ -185,3 +187,7 @@ class Ade20k2017Importer(Importer):
                         }
                     ]
         return []
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]

--- a/src/datumaro/plugins/data_formats/ade20k2020.py
+++ b/src/datumaro/plugins/data_formats/ade20k2020.py
@@ -8,7 +8,7 @@ import logging as log
 import os
 import os.path as osp
 import re
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -217,9 +217,11 @@ class Ade20k2020Base(DatasetBase):
 
 
 class Ade20k2020Importer(Importer):
+    _ANNO_EXT = ".json"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        annot_path = context.require_file("*/**/*.json")
+        annot_path = context.require_file(f"*/**/*{cls._ANNO_EXT}")
 
         with context.probe_text_file(
             annot_path,
@@ -244,3 +246,7 @@ class Ade20k2020Importer(Importer):
                         }
                     ]
         return []
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]

--- a/src/datumaro/plugins/data_formats/arrow/importer.py
+++ b/src/datumaro/plugins/data_formats/arrow/importer.py
@@ -17,6 +17,8 @@ __all__ = ["ArrowImporter"]
 
 
 class ArrowImporter(Importer):
+    _FORMAT_EXT = ".arrow"
+
     @classmethod
     def detect(
         cls,
@@ -45,7 +47,7 @@ class ArrowImporter(Importer):
 
         return cls._find_sources_recursive(
             path=path,
-            ext=".arrow",
+            ext=cls._FORMAT_EXT,
             extractor_name=cls.NAME,
             file_filter=_filter,
             max_depth=0,
@@ -71,3 +73,7 @@ class ArrowImporter(Importer):
         DatumaroArrow.check_signature(schema.metadata.get(b"signature", b"").decode())
         DatumaroArrow.check_version(schema.metadata.get(b"version", b"").decode())
         DatumaroArrow.check_schema(schema)
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._FORMAT_EXT]

--- a/src/datumaro/plugins/data_formats/ava/ava.py
+++ b/src/datumaro/plugins/data_formats/ava/ava.py
@@ -6,7 +6,7 @@ import csv
 import errno
 import os
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 import google.protobuf.text_format as text_format
 
@@ -157,10 +157,12 @@ class AvaBase(SubsetBase):
 
 
 class AvaImporter(Importer):
+    _ANNO_EXT = "csv"
+
     @classmethod
     def find_sources(cls, path):
         ann_files = find_files(
-            osp.join(path, AvaPath.ANNOTATION_DIR), exts="csv", recursive=True, max_depth=1
+            osp.join(path, AvaPath.ANNOTATION_DIR), exts=cls._ANNO_EXT, recursive=True, max_depth=1
         )
 
         sources = []
@@ -174,6 +176,10 @@ class AvaImporter(Importer):
     def detect(cls, context: FormatDetectionContext) -> FormatDetectionConfidence:
         super().detect(context)
         return FormatDetectionConfidence.MEDIUM
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [f".{cls._ANNO_EXT}"]
 
 
 class AvaExporter(Exporter):

--- a/src/datumaro/plugins/data_formats/brats.py
+++ b/src/datumaro/plugins/data_formats/brats.py
@@ -5,7 +5,7 @@
 import errno
 import glob
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 import nibabel as nib
 import numpy as np
@@ -107,3 +107,7 @@ class BratsImporter(Importer):
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(path, "", "brats", filename=f"{BratsPath.IMAGES_DIR}*")
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [osp.splitext(BratsPath.DATA_EXT)[-1]]

--- a/src/datumaro/plugins/data_formats/brats_numpy.py
+++ b/src/datumaro/plugins/data_formats/brats_numpy.py
@@ -4,7 +4,7 @@
 
 import errno
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -113,3 +113,7 @@ class BratsNumpyImporter(Importer):
         return cls._find_sources_recursive(
             path, "", "brats_numpy", filename=BratsNumpyPath.IDS_FILE
         )
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [osp.splitext(BratsNumpyPath.IDS_FILE)[1]]

--- a/src/datumaro/plugins/data_formats/camvid.py
+++ b/src/datumaro/plugins/data_formats/camvid.py
@@ -8,7 +8,7 @@ import os
 import os.path as osp
 from collections import OrderedDict
 from enum import Enum, auto
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -246,9 +246,13 @@ class CamvidBase(SubsetBase):
 
 
 class CamvidImporter(Importer):
+    _ANNO_EXT = ".txt"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        annot_path = context.require_file("*.txt", exclude_fnames=CamvidPath.LABELMAP_FILE)
+        annot_path = context.require_file(
+            f"*{cls._ANNO_EXT}", exclude_fnames=CamvidPath.LABELMAP_FILE
+        )
 
         with context.probe_text_file(
             annot_path,
@@ -273,6 +277,10 @@ class CamvidImporter(Importer):
             "camvid",
             file_filter=lambda p: osp.basename(p) != CamvidPath.LABELMAP_FILE,
         )
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
 
 
 class LabelmapType(Enum):

--- a/src/datumaro/plugins/data_formats/celeba/celeba.py
+++ b/src/datumaro/plugins/data_formats/celeba/celeba.py
@@ -5,7 +5,7 @@
 import errno
 import os
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.annotation import (
     AnnotationType,
@@ -273,3 +273,7 @@ class CelebaImporter(Importer):
             source["url"] = root_dir
 
         return sources
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [osp.splitext(cls.PATH_CLS.LABELS_FILE)[1]]

--- a/src/datumaro/plugins/data_formats/cifar.py
+++ b/src/datumaro/plugins/data_formats/cifar.py
@@ -215,6 +215,10 @@ class CifarImporter(Importer):
 
         return sources
 
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return list({osp.splitext(p)[1] for p in (CifarPath.META_10_FILE, CifarPath.META_100_FILE)})
+
 
 class CifarExporter(Exporter):
     DEFAULT_IMAGE_EXT = ".png"

--- a/src/datumaro/plugins/data_formats/cityscapes.py
+++ b/src/datumaro/plugins/data_formats/cityscapes.py
@@ -9,7 +9,7 @@ import os
 import os.path as osp
 from collections import OrderedDict
 from enum import Enum, auto
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -351,6 +351,18 @@ class CityscapesImporter(Importer):
             )
 
         return sources
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return list(
+            {
+                osp.splitext(p)[1]
+                for p in (
+                    CityscapesPath.GT_INSTANCE_MASK_SUFFIX,
+                    CityscapesPath.LABEL_TRAIN_IDS_SUFFIX,
+                )
+            }
+        )
 
 
 class LabelmapType(Enum):

--- a/src/datumaro/plugins/data_formats/coco/importer.py
+++ b/src/datumaro/plugins/data_formats/coco/importer.py
@@ -5,7 +5,7 @@
 import logging as log
 import os.path as osp
 from glob import glob
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.dataset_base import DEFAULT_SUBSET_NAME
 from datumaro.components.errors import DatasetNotFoundError
@@ -37,6 +37,7 @@ class CocoImporter(Importer):
         CocoTask.stuff: CocoStuffBase,
     }
     _IMPORTER_TYPE = CocoImporterType.default
+    _ANNO_EXT = ".json"
 
     @classmethod
     def build_cmdline_parser(cls, **kwargs):
@@ -65,7 +66,7 @@ class CocoImporter(Importer):
         with context.require_any():
             for task in cls._TASKS.keys():
                 with context.alternative():
-                    context.require_file(f"annotations/{task.name}_*.json")
+                    context.require_file(f"annotations/{task.name}_*{cls._ANNO_EXT}")
 
     def __call__(self, path, stream: bool = False, **extra_params):
         subsets = self.find_sources(path)
@@ -157,6 +158,10 @@ class CocoImporter(Importer):
             subsets.setdefault(subset_name, {})[ann_type] = subset_path
 
         return subsets
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
 
     @property
     def can_stream(self) -> bool:

--- a/src/datumaro/plugins/data_formats/common_semantic_segmentation.py
+++ b/src/datumaro/plugins/data_formats/common_semantic_segmentation.py
@@ -5,7 +5,7 @@
 import errno
 import glob
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -162,6 +162,10 @@ class CommonSemanticSegmentationImporter(Importer):
     @classmethod
     def find_sources(cls, path):
         return [{"url": path, "format": "common_semantic_segmentation"}]
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [osp.splitext(DATASET_META_FILE)[1]]
 
 
 @with_subset_dirs

--- a/src/datumaro/plugins/data_formats/common_super_resolution.py
+++ b/src/datumaro/plugins/data_formats/common_super_resolution.py
@@ -4,7 +4,7 @@
 
 import errno
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.annotation import SuperResolutionAnnotation
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
@@ -80,11 +80,21 @@ class CommonSuperResolutionBase(SubsetBase):
 
 
 class CommonSuperResolutionImporter(Importer):
+    _FORMAT_EXT = ".jpg"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        context.require_file(osp.join(CommonSuperResolutionPath.HR_IMAGES_DIR, "**", "*"))
-        context.require_file(osp.join(CommonSuperResolutionPath.LR_IMAGES_DIR, "**", "*"))
+        context.require_file(
+            osp.join(CommonSuperResolutionPath.HR_IMAGES_DIR, "**", f"*{cls._FORMAT_EXT}")
+        )
+        context.require_file(
+            osp.join(CommonSuperResolutionPath.LR_IMAGES_DIR, "**", f"*{cls._FORMAT_EXT}")
+        )
 
     @classmethod
     def find_sources(cls, path):
         return [{"url": path, "format": "common_super_resolution"}]
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._FORMAT_EXT]

--- a/src/datumaro/plugins/data_formats/cvat/base.py
+++ b/src/datumaro/plugins/data_formats/cvat/base.py
@@ -5,7 +5,7 @@
 import os.path as osp
 from collections import OrderedDict
 from copy import deepcopy
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 from defusedxml import ElementTree
@@ -392,9 +392,11 @@ class CvatBase(SubsetBase):
 
 
 class CvatImporter(Importer):
+    _ANNO_EXT = ".xml"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        annot_file = context.require_file("*.xml")
+        annot_file = context.require_file(f"*{cls._ANNO_EXT}")
 
         with context.probe_text_file(
             annot_file,
@@ -433,3 +435,7 @@ class CvatImporter(Importer):
                 )
 
         return sources
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]

--- a/src/datumaro/plugins/data_formats/datumaro/importer.py
+++ b/src/datumaro/plugins/data_formats/datumaro/importer.py
@@ -44,6 +44,10 @@ class DatumaroImporter(Importer):
             dirname=cls.PATH_CLS.ANNOTATIONS_DIR,
         )
 
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls.PATH_CLS.ANNOTATION_EXT]
+
     @property
     def can_stream(self) -> bool:
         return True

--- a/src/datumaro/plugins/data_formats/icdar/base.py
+++ b/src/datumaro/plugins/data_formats/icdar/base.py
@@ -7,7 +7,7 @@ import errno
 import glob
 import logging as log
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -284,9 +284,11 @@ class IcdarTextSegmentationBase(_IcdarBase):
 
 
 class IcdarWordRecognitionImporter(Importer):
+    _ANNO_EXT = ".txt"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        annot_path = context.require_file("*/gt.txt")
+        annot_path = context.require_file(f"*/gt{cls._ANNO_EXT}")
 
         with context.probe_text_file(
             annot_path,
@@ -303,24 +305,40 @@ class IcdarWordRecognitionImporter(Importer):
     def find_sources(cls, path):
         return cls._find_sources_recursive(path, ".txt", "icdar_word_recognition")
 
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
+
 
 class IcdarTextLocalizationImporter(Importer):
+    _ANNO_EXT = ".txt"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        context.require_file("**/gt_*.txt")
+        context.require_file(f"**/gt_*{cls._ANNO_EXT}")
 
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(path, "", "icdar_text_localization")
 
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
+
 
 class IcdarTextSegmentationImporter(Importer):
+    _ANNO_EXT = ".txt"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        gt_txt_path = context.require_file("**/*_GT.txt")
+        gt_txt_path = context.require_file(f"**/*_GT{cls._ANNO_EXT}")
         gt_bmp_path = osp.splitext(gt_txt_path)[0] + ".bmp"
         context.require_file(glob.escape(gt_bmp_path))
 
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(path, "", "icdar_text_segmentation")
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]

--- a/src/datumaro/plugins/data_formats/image_dir.py
+++ b/src/datumaro/plugins/data_formats/image_dir.py
@@ -5,14 +5,14 @@
 import logging as log
 import os
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionConfidence
 from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
-from datumaro.util.image import find_images
+from datumaro.util.image import IMAGE_EXTENSIONS, find_images
 
 
 class ImageDirImporter(Importer):
@@ -36,6 +36,10 @@ class ImageDirImporter(Importer):
         if not osp.isdir(path):
             return []
         return [{"url": path, "format": ImageDirBase.NAME}]
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return list(IMAGE_EXTENSIONS)
 
 
 class ImageDirBase(SubsetBase):

--- a/src/datumaro/plugins/data_formats/image_zip.py
+++ b/src/datumaro/plugins/data_formats/image_zip.py
@@ -6,7 +6,7 @@ import logging as log
 import os
 import os.path as osp
 from enum import Enum
-from typing import Optional
+from typing import List, Optional
 from zipfile import ZIP_BZIP2, ZIP_DEFLATED, ZIP_LZMA, ZIP_STORED, ZipFile
 
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
@@ -51,9 +51,15 @@ class ImageZipBase(SubsetBase):
 
 
 class ImageZipImporter(Importer):
+    _FORMAT_EXT = ".zip"
+
     @classmethod
     def find_sources(cls, path):
-        return cls._find_sources_recursive(path, ".zip", "image_zip")
+        return cls._find_sources_recursive(path, cls._FORMAT_EXT, "image_zip")
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._FORMAT_EXT]
 
 
 class ImageZipExporter(Exporter):

--- a/src/datumaro/plugins/data_formats/imagenet.py
+++ b/src/datumaro/plugins/data_formats/imagenet.py
@@ -7,7 +7,7 @@ import logging as log
 import os
 import os.path as osp
 import warnings
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
@@ -17,7 +17,7 @@ from datumaro.components.format_detection import FormatDetectionConfidence, Form
 from datumaro.components.importer import ImportContext, Importer, with_subset_dirs
 from datumaro.components.media import Image
 from datumaro.util.definitions import SUBSET_NAME_BLACKLIST
-from datumaro.util.image import find_images
+from datumaro.util.image import IMAGE_EXTENSIONS, find_images
 
 
 class ImagenetPath:
@@ -127,6 +127,10 @@ class ImagenetImporter(Importer):
             return [{"url": path, "format": ImagenetBase.NAME}]
 
         return []
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return list(IMAGE_EXTENSIONS)
 
 
 @with_subset_dirs

--- a/src/datumaro/plugins/data_formats/imagenet_txt.py
+++ b/src/datumaro/plugins/data_formats/imagenet_txt.py
@@ -6,7 +6,7 @@ import errno
 import os
 import os.path as osp
 from enum import Enum, auto
-from typing import Iterable, Optional, Sequence, Tuple, Union
+from typing import Iterable, List, Optional, Sequence, Tuple, Union
 
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.cli_plugin import CliPlugin
@@ -139,9 +139,13 @@ class ImagenetTxtBase(SubsetBase):
 
 
 class ImagenetTxtImporter(Importer, CliPlugin):
+    _ANNO_EXT = ".txt"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        annot_path = context.require_file("*.txt", exclude_fnames=ImagenetTxtPath.LABELS_FILE)
+        annot_path = context.require_file(
+            f"*{cls._ANNO_EXT}", exclude_fnames=ImagenetTxtPath.LABELS_FILE
+        )
 
         with context.probe_text_file(
             annot_path,
@@ -188,6 +192,10 @@ class ImagenetTxtImporter(Importer, CliPlugin):
             file_filter = None
 
         return cls._find_sources_recursive(path, ".txt", "imagenet_txt", file_filter=file_filter)
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
 
 
 class ImagenetTxtExporter(Exporter):

--- a/src/datumaro/plugins/data_formats/kinetics.py
+++ b/src/datumaro/plugins/data_formats/kinetics.py
@@ -6,7 +6,7 @@ import csv
 import errno
 import os
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.dataset_base import DatasetBase, DatasetItem
@@ -134,11 +134,13 @@ class KineticsBase(DatasetBase):
 
 
 class KineticsImporter(Importer):
+    _ANNO_EXTS = [".json", ".csv"]
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
         with context.require_any():
             with context.alternative():
-                ann_file = context.require_file("*.json")
+                ann_file = context.require_file(f"*{cls._ANNO_EXTS[0]}")
 
                 with context.probe_text_file(
                     ann_file,
@@ -159,7 +161,7 @@ class KineticsImporter(Importer):
                         raise Exception
 
             with context.alternative():
-                ann_file = context.require_file("*.csv")
+                ann_file = context.require_file(f"*{cls._ANNO_EXTS[1]}")
 
                 with context.probe_text_file(
                     ann_file,
@@ -174,3 +176,7 @@ class KineticsImporter(Importer):
         if find_files(path, ["csv", "json"]):
             return [{"url": path, "format": KineticsBase.NAME}]
         return []
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return cls._ANNO_EXTS

--- a/src/datumaro/plugins/data_formats/kitti_raw/base.py
+++ b/src/datumaro/plugins/data_formats/kitti_raw/base.py
@@ -4,7 +4,7 @@
 
 import os
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 from defusedxml import ElementTree as ET
 
@@ -279,9 +279,11 @@ class KittiRawBase(SubsetBase):
 
 
 class KittiRawImporter(Importer):
+    _ANNO_EXT = ".xml"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        annot_file = context.require_file("*.xml")
+        annot_file = context.require_file(f"*{cls._ANNO_EXT}")
 
         with context.probe_text_file(
             annot_file,
@@ -300,3 +302,7 @@ class KittiRawImporter(Importer):
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(path, ".xml", "kitti_raw")
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]

--- a/src/datumaro/plugins/data_formats/labelme.py
+++ b/src/datumaro/plugins/data_formats/labelme.py
@@ -8,7 +8,7 @@ import os
 import os.path as osp
 from collections import defaultdict
 from glob import glob, iglob
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 from defusedxml import ElementTree
@@ -295,9 +295,11 @@ class LabelMeBase(DatasetBase):
 
 
 class LabelMeImporter(Importer):
+    _ANNO_EXT = ".xml"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        annot_paths = context.require_files("**/*.xml")
+        annot_paths = context.require_files(f"**/*{cls._ANNO_EXT}")
 
         for annot_path in annot_paths:
             with context.probe_text_file(
@@ -351,6 +353,10 @@ class LabelMeImporter(Importer):
         except StopIteration:
             pass
         return subsets
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
 
 
 class LabelMeExporter(Exporter):

--- a/src/datumaro/plugins/data_formats/lfw.py
+++ b/src/datumaro/plugins/data_formats/lfw.py
@@ -6,7 +6,7 @@ import errno
 import os
 import os.path as osp
 import re
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories, Points
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
@@ -234,6 +234,10 @@ class LfwImporter(Importer):
         return cls._find_sources_recursive(
             path, ext, "lfw", filename=base, dirname=LfwPath.ANNOTATION_DIR
         )
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [osp.splitext(LfwPath.PAIRS_FILE)[1]]
 
 
 class LfwExporter(Exporter):

--- a/src/datumaro/plugins/data_formats/mapillary_vistas/importer.py
+++ b/src/datumaro/plugins/data_formats/mapillary_vistas/importer.py
@@ -4,6 +4,7 @@
 import glob
 import logging as log
 import os.path as osp
+from typing import List
 
 from datumaro.components.dataset_base import DEFAULT_SUBSET_NAME
 from datumaro.components.errors import DatasetNotFoundError
@@ -112,6 +113,10 @@ class MapillaryVistasImporter(Importer):
                 subsets.setdefault(subset, {})[task] = osp.join(path, subset)
 
         return subsets
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [".jpg", ".png", ".json"]
 
 
 class MapillaryVistasInstancesImporter(MapillaryVistasImporter):

--- a/src/datumaro/plugins/data_formats/market1501.py
+++ b/src/datumaro/plugins/data_formats/market1501.py
@@ -6,7 +6,7 @@ import errno
 import os
 import os.path as osp
 import re
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.dataset_base import DatasetBase, DatasetItem
 from datumaro.components.errors import MediaTypeError
@@ -117,6 +117,10 @@ class Market1501Importer(Importer):
                 (Market1501Path.BBOX_DIR, Market1501Path.QUERY_DIR, Market1501Path.LIST_PREFIX)
             ):
                 return [{"url": path, "format": Market1501Base.NAME}]
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [".jpg"]
 
 
 class Market1501Exporter(Exporter):

--- a/src/datumaro/plugins/data_formats/mars.py
+++ b/src/datumaro/plugins/data_formats/mars.py
@@ -7,7 +7,7 @@ import glob
 import logging as log
 import os
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.annotation import AnnotationType, Label, LabelCategories
 from datumaro.components.dataset import DatasetItem
@@ -21,7 +21,7 @@ from datumaro.util.image import find_images
 class MarsPath:
     SUBSET_DIR_PATTERN = "bbox_*"
     IMAGE_DIR_PATTERNS = ["[0-9]" * 4, "00-1"]
-    IMAGE_NAME_POSTFIX = "C[0-9]" + "T" + "[0-9]" * 4 + "F" + "[0-9]" * 3 + ".*"
+    IMAGE_NAME_POSTFIX = "C[0-9]" + "T" + "[0-9]" * 4 + "F" + "[0-9]" * 3 + ".jpg"
 
 
 class MarsBase(DatasetBase):
@@ -141,3 +141,7 @@ class MarsImporter(Importer):
                 return [{"url": path, "format": "mars"}]
             except StopIteration:
                 continue
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [osp.splitext(MarsPath.IMAGE_NAME_POSTFIX)[1]]

--- a/src/datumaro/plugins/data_formats/mnist.py
+++ b/src/datumaro/plugins/data_formats/mnist.py
@@ -6,7 +6,7 @@ import errno
 import gzip
 import os
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -126,15 +126,21 @@ class MnistBase(SubsetBase):
 
 
 class MnistImporter(Importer):
+    _FORMAT_EXT = ".gz"
+
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(
             path,
-            ".gz",
+            cls._FORMAT_EXT,
             "mnist",
             file_filter=lambda p: 1 < len(osp.basename(p).split("-"))
             and osp.basename(p).split("-")[1] == "labels",
         )
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._FORMAT_EXT]
 
 
 class MnistExporter(Exporter):

--- a/src/datumaro/plugins/data_formats/mnist_csv.py
+++ b/src/datumaro/plugins/data_formats/mnist_csv.py
@@ -5,7 +5,7 @@
 import errno
 import os
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -116,12 +116,20 @@ class MnistCsvBase(SubsetBase):
 
 class MnistCsvImporter(Importer):
     DETECT_CONFIDENCE = FormatDetectionConfidence.MEDIUM
+    _ANNO_EXT = ".csv"
 
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(
-            path, ".csv", "mnist_csv", file_filter=lambda p: osp.basename(p).find("mnist_") != -1
+            path,
+            cls._ANNO_EXT,
+            "mnist_csv",
+            file_filter=lambda p: osp.basename(p).find("mnist_") != -1,
         )
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
 
 
 class MnistCsvExporter(Exporter):

--- a/src/datumaro/plugins/data_formats/mot.py
+++ b/src/datumaro/plugins/data_formats/mot.py
@@ -227,15 +227,25 @@ class MotSeqBase(SubsetBase):
 
 
 class MotSeqImporter(Importer):
+    _ANNO_EXT = ".txt"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        context.require_file("gt/gt.txt")
+        context.require_file(f"gt/gt{cls._ANNO_EXT}")
 
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(
-            path, ".txt", "mot_seq", dirname="gt", filename=osp.splitext(MotPath.GT_FILENAME)[0]
+            path,
+            cls._ANNO_EXT,
+            "mot_seq",
+            dirname="gt",
+            filename=osp.splitext(MotPath.GT_FILENAME)[0],
         )
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
 
 
 class MotSeqGtExporter(Exporter):

--- a/src/datumaro/plugins/data_formats/mots.py
+++ b/src/datumaro/plugins/data_formats/mots.py
@@ -9,7 +9,7 @@ import os
 import os.path as osp
 from enum import Enum
 from glob import iglob
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -148,6 +148,10 @@ class MotsImporter(Importer):
                     s.setdefault("options", {})["subset"] = p
                 subsets.extend(detected)
         return subsets
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [".png", ".txt"]
 
 
 class MotsPngExporter(Exporter):

--- a/src/datumaro/plugins/data_formats/mpii/mpii_json.py
+++ b/src/datumaro/plugins/data_formats/mpii/mpii_json.py
@@ -4,7 +4,7 @@
 
 import errno
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -173,3 +173,7 @@ class MpiiJsonImporter(Importer):
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
         context.require_file(MpiiJsonPath.ANNOTATION_FILE)
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [osp.splitext(MpiiJsonPath.ANNOTATION_FILE)[1]]

--- a/src/datumaro/plugins/data_formats/mpii/mpii_mat.py
+++ b/src/datumaro/plugins/data_formats/mpii/mpii_mat.py
@@ -4,7 +4,7 @@
 
 import errno
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 import scipy.io as spio
 
@@ -142,10 +142,16 @@ class MpiiBase(SubsetBase):
 
 
 class MpiiImporter(Importer):
+    _FORMAT_EXT = ".mat"
+
     @classmethod
     def find_sources(cls, path):
-        return cls._find_sources_recursive(path, ".mat", "mpii")
+        return cls._find_sources_recursive(path, cls._FORMAT_EXT, "mpii")
 
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        context.require_file("*.mat")
+        context.require_file(f"*{cls._FORMAT_EXT}")
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._FORMAT_EXT]

--- a/src/datumaro/plugins/data_formats/mvtec/importer.py
+++ b/src/datumaro/plugins/data_formats/mvtec/importer.py
@@ -4,6 +4,7 @@
 
 import os.path as osp
 from glob import glob
+from typing import List
 
 from datumaro.components.format_detection import FormatDetectionConfidence
 from datumaro.components.importer import Importer
@@ -39,6 +40,10 @@ class MvtecImporter(Importer):
                     )
 
         return sources
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [".png"]
 
 
 class MvtecClassificationImporter(MvtecImporter):

--- a/src/datumaro/plugins/data_formats/nyu_depth_v2.py
+++ b/src/datumaro/plugins/data_formats/nyu_depth_v2.py
@@ -5,7 +5,7 @@
 import errno
 import glob
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 import h5py
 import numpy as np
@@ -52,10 +52,16 @@ class NyuDepthV2Base(SubsetBase):
 
 
 class NyuDepthV2Importer(Importer):
+    _FORMAT_EXT = ".h5"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        context.require_file("*.h5")
+        context.require_file(f"*{cls._FORMAT_EXT}")
 
     @classmethod
     def find_sources(cls, path):
         return [{"url": path, "format": "nyu_depth_v2"}]
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._FORMAT_EXT]

--- a/src/datumaro/plugins/data_formats/open_images.py
+++ b/src/datumaro/plugins/data_formats/open_images.py
@@ -15,7 +15,7 @@ import os
 import os.path as osp
 import re
 import types
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import cv2
 import numpy as np
@@ -617,6 +617,10 @@ class OpenImagesImporter(Importer):
             elif glob.glob(osp.join(glob.escape(path), pattern)):
                 return [{"url": path, "format": OpenImagesBase.NAME}]
         return []
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return list({osp.splitext(p)[1] for p in cls.POSSIBLE_ANNOTATION_PATTERNS})
 
 
 class _LazyCsvDictWriter:

--- a/src/datumaro/plugins/data_formats/roboflow/base_tfrecord.py
+++ b/src/datumaro/plugins/data_formats/roboflow/base_tfrecord.py
@@ -4,7 +4,7 @@
 
 import os
 import re
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.lazy_plugin import extra_deps
@@ -18,11 +18,13 @@ tf = _import_tf()
 
 @extra_deps("tensorflow")
 class RoboflowTfrecordImporter(Importer):
+    _ANNO_EXT = ".tfrecord"
+
     @classmethod
     def find_sources(cls, path):
         sources = cls._find_sources_recursive(
             path=path,
-            ext=".tfrecord",
+            ext=cls._ANNO_EXT,
             extractor_name="roboflow_tfrecord",
         )
         if len(sources) == 0:
@@ -51,6 +53,10 @@ class RoboflowTfrecordImporter(Importer):
         ]
 
         return sources
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
 
 
 class RoboflowTfrecordBase(TfDetectionApiBase):

--- a/src/datumaro/plugins/data_formats/roboflow/importer.py
+++ b/src/datumaro/plugins/data_formats/roboflow/importer.py
@@ -42,6 +42,10 @@ class RoboflowCocoImporter(Importer):
 
         return sources
 
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [osp.splitext(cls.ANN_FILE_NAME)[1]]
+
     @property
     def can_stream(self) -> bool:
         return True
@@ -131,6 +135,10 @@ class RoboflowVocImporter(Importer):
         ]
 
         return sources
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls.FORMAT_EXT]
 
 
 class RoboflowYoloImporter(RoboflowVocImporter):

--- a/src/datumaro/plugins/data_formats/segment_anything/importer.py
+++ b/src/datumaro/plugins/data_formats/segment_anything/importer.py
@@ -15,6 +15,7 @@ from datumaro.util import parse_json
 class SegmentAnythingImporter(Importer):
     _N_JSON_TO_TEST = 10
     _MAX_ANNOTATION_SECTION_BYTES = 100 * 1024 * 1024  # 100 MiB
+    _ANNO_EXT = ".json"
 
     @classmethod
     def detect(
@@ -23,7 +24,7 @@ class SegmentAnythingImporter(Importer):
     ) -> Optional[FormatDetectionConfidence]:
         # test maximum 10 annotation files only
         ctr = 0
-        for file in context.require_files_iter("*.json"):
+        for file in context.require_files_iter(f"*{cls._ANNO_EXT}"):
             ctr += 1
             with context.probe_text_file(
                 file, "Annotation format is not Segmentat-Anything format", is_binary_file=True
@@ -67,3 +68,7 @@ class SegmentAnythingImporter(Importer):
         if not os.path.isdir(path):
             return []
         return [{"url": path, "format": cls.NAME}]
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]

--- a/src/datumaro/plugins/data_formats/sly_pointcloud/base.py
+++ b/src/datumaro/plugins/data_formats/sly_pointcloud/base.py
@@ -5,7 +5,7 @@
 import errno
 import os.path as osp
 from glob import iglob
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.annotation import AnnotationType, Cuboid3d, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
@@ -187,7 +187,12 @@ class SuperviselyPointCloudBase(SubsetBase):
 
 class SuperviselyPointCloudImporter(Importer):
     NAME = "sly_pointcloud"
+    _ANNO_EXT = ".json"
 
     @classmethod
     def find_sources(cls, path):
-        return cls._find_sources_recursive(path, ".json", "sly_pointcloud", filename="meta")
+        return cls._find_sources_recursive(path, cls._ANNO_EXT, "sly_pointcloud", filename="meta")
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]

--- a/src/datumaro/plugins/data_formats/synthia/importer.py
+++ b/src/datumaro/plugins/data_formats/synthia/importer.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
+from typing import List
 
 from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
 from datumaro.components.importer import Importer
@@ -25,6 +26,10 @@ class _SynthiaImporter(Importer):
     @classmethod
     def find_sources(cls, path):
         return [{"url": path, "format": cls.FORMAT}]
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [".png"]
 
 
 class SynthiaRandImporter(_SynthiaImporter):

--- a/src/datumaro/plugins/data_formats/tabular.py
+++ b/src/datumaro/plugins/data_formats/tabular.py
@@ -177,6 +177,10 @@ class TabularDataImporter(Importer):
                 return [{"url": path, "format": TabularDataBase.NAME}]
         return []
 
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return list({f".{ext}" for ext in TABULAR_EXTENSIONS})
+
 
 class TabularDataExporter(Exporter):
     """

--- a/src/datumaro/plugins/data_formats/tf_detection_api/base.py
+++ b/src/datumaro/plugins/data_formats/tf_detection_api/base.py
@@ -6,7 +6,7 @@ import os
 import os.path as osp
 import re
 from collections import OrderedDict
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -200,11 +200,13 @@ class TfDetectionApiBase(SubsetBase):
 
 @extra_deps("tensorflow")
 class TfDetectionApiImporter(Importer):
+    _FORMAT_EXT = ".tfrecord"
+
     @classmethod
     def find_sources(cls, path):
         sources = cls._find_sources_recursive(
             path=path,
-            ext=".tfrecord",
+            ext=cls._FORMAT_EXT,
             extractor_name="tf_detection_api",
         )
         if len(sources) == 0:
@@ -229,3 +231,7 @@ class TfDetectionApiImporter(Importer):
         ]
 
         return sources
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._FORMAT_EXT]

--- a/src/datumaro/plugins/data_formats/vgg_face2.py
+++ b/src/datumaro/plugins/data_formats/vgg_face2.py
@@ -6,7 +6,7 @@ import csv
 import errno
 import os
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.annotation import AnnotationType, Bbox, Label, LabelCategories, Points
 from datumaro.components.dataset_base import DatasetBase, DatasetItem
@@ -198,12 +198,14 @@ class VggFace2Base(DatasetBase):
 
 
 class VggFace2Importer(Importer):
+    _ANNO_EXT = ".csv"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
         with context.require_any():
             for prefix in (VggFace2Path.BBOXES_FILE, VggFace2Path.LANDMARKS_FILE):
                 with context.alternative():
-                    context.require_file(f"{VggFace2Path.ANNOTATION_DIR}/{prefix}*.csv")
+                    context.require_file(f"{VggFace2Path.ANNOTATION_DIR}/{prefix}*{cls._ANNO_EXT}")
 
     @classmethod
     def find_sources(cls, path):
@@ -228,6 +230,10 @@ class VggFace2Importer(Importer):
                     }
                 ]
         return []
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
 
 
 class VggFace2Exporter(Exporter):

--- a/src/datumaro/plugins/data_formats/video.py
+++ b/src/datumaro/plugins/data_formats/video.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -96,6 +96,10 @@ class VideoFramesImporter(Importer):
         if not osp.isfile(path):
             return []
         return [{"url": path, "format": VideoFramesBase.NAME}]
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return list({f".{ext}" for ext in VIDEO_EXTENSIONS})
 
 
 class VideoFramesBase(DatasetBase):

--- a/src/datumaro/plugins/data_formats/voc/importer.py
+++ b/src/datumaro/plugins/data_formats/voc/importer.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import os.path as osp
-from typing import Optional, Type
+from typing import List, Optional, Type
 
 from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.importer import Importer
@@ -22,6 +22,7 @@ class _VocImporter(Importer):
         VocTask.voc_layout: ("voc_layout", "Layout"),
         VocTask.voc_action: ("voc_action", "Action"),
     }
+    ANNO_EXT = ".txt"
 
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
@@ -34,7 +35,9 @@ class _VocImporter(Importer):
             task_dirs = {task_dir for _, task_dir in cls._TASKS.values()}
             for task_dir in sorted(task_dirs):
                 with context.alternative():
-                    context.require_file(osp.join(VocPath.SUBSETS_DIR, task_dir, "*.txt"))
+                    context.require_file(
+                        osp.join(VocPath.SUBSETS_DIR, task_dir, f"*{cls.ANNO_EXT}")
+                    )
 
     @classmethod
     def find_sources(cls, path):
@@ -71,6 +74,10 @@ class _VocImporter(Importer):
 
     def get_extractor_merger(self) -> Optional[Type[ExtractorMerger]]:
         return ExtractorMerger
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls.ANNO_EXT]
 
 
 class VocImporter(_VocImporter):

--- a/src/datumaro/plugins/data_formats/vott_csv.py
+++ b/src/datumaro/plugins/data_formats/vott_csv.py
@@ -5,7 +5,7 @@
 import csv
 import errno
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
@@ -91,3 +91,7 @@ class VottCsvImporter(Importer):
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
         context.require_file("*" + VottCsvPath.ANNO_FILE_SUFFIX)
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [osp.splitext(VottCsvPath.ANNO_FILE_SUFFIX)[1]]

--- a/src/datumaro/plugins/data_formats/vott_json.py
+++ b/src/datumaro/plugins/data_formats/vott_json.py
@@ -4,7 +4,7 @@
 
 import errno
 import os.path as osp
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
@@ -113,3 +113,7 @@ class VottJsonImporter(Importer):
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
         context.require_file("*" + VottJsonPath.ANNO_FILE_SUFFIX)
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [osp.splitext(VottJsonPath.ANNO_FILE_SUFFIX)[1]]

--- a/src/datumaro/plugins/data_formats/widerface.py
+++ b/src/datumaro/plugins/data_formats/widerface.py
@@ -6,7 +6,7 @@ import errno
 import os
 import os.path as osp
 import re
-from typing import Optional
+from typing import List, Optional
 
 from datumaro.components.annotation import AnnotationType, Bbox, Label, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
@@ -171,15 +171,21 @@ class WiderFaceBase(SubsetBase):
 
 
 class WiderFaceImporter(Importer):
+    _ANNO_EXT = ".txt"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        context.require_file(f"{WiderFacePath.ANNOTATIONS_DIR}/*.txt")
+        context.require_file(f"{WiderFacePath.ANNOTATIONS_DIR}/*{cls._ANNO_EXT}")
 
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(
-            path, ".txt", "wider_face", dirname=WiderFacePath.ANNOTATIONS_DIR
+            path, cls._ANNO_EXT, "wider_face", dirname=WiderFacePath.ANNOTATIONS_DIR
         )
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
 
 
 class WiderFaceExporter(Exporter):

--- a/src/datumaro/plugins/data_formats/yolo/importer.py
+++ b/src/datumaro/plugins/data_formats/yolo/importer.py
@@ -17,9 +17,11 @@ from .format import YoloFormatType, YoloLoosePath, YoloPath, YoloUltralyticsPath
 
 
 class _YoloStrictImporter(Importer):
+    _FORMAT_EXT = ".data"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        context.require_file("obj.data")
+        context.require_file(f"obj{cls._FORMAT_EXT}")
 
     @classmethod
     def find_sources(cls, path: str) -> List[Dict[str, Any]]:
@@ -39,6 +41,10 @@ class _YoloStrictImporter(Importer):
             ]
 
         return sum([_extract_subset_wise_sources(source) for source in sources], [])
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._FORMAT_EXT]
 
 
 class _YoloLooseImporter(Importer):
@@ -155,6 +161,10 @@ class _YoloLooseImporter(Importer):
     def can_stream(self) -> bool:
         return True
 
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [".txt"]
+
 
 class _YoloUltralyticsImporter(_YoloLooseImporter):
     META_FILE = YoloUltralyticsPath.META_FILE
@@ -187,3 +197,13 @@ class YoloImporter(Importer):
 
     def get_extractor_merger(self) -> Optional[Type[ExtractorMerger]]:
         return ExtractorMerger
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return list(
+            {
+                ext
+                for importer in cls.SUB_IMPORTERS.values()
+                for ext in importer.get_file_extensions()
+            }
+        )

--- a/src/datumaro/plugins/specs.json
+++ b/src/datumaro/plugins/specs.json
@@ -11,974 +11,1055 @@
   {
     "import_path": "datumaro.plugins.configurable_validator.ConfigurableValidator",
     "plugin_name": "configurable",
-    "plugin_type": "Validator",
-    "extra_deps": []
+    "plugin_type": "Validator"
   },
   {
     "import_path": "datumaro.plugins.data_formats.ade20k2017.Ade20k2017Base",
     "plugin_name": "ade20k2017",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.ade20k2017.Ade20k2017Importer",
     "plugin_name": "ade20k2017",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.ade20k2020.Ade20k2020Base",
     "plugin_name": "ade20k2020",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.ade20k2020.Ade20k2020Importer",
     "plugin_name": "ade20k2020",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.arrow.base.ArrowBase",
     "plugin_name": "arrow",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.arrow.exporter.ArrowExporter",
     "plugin_name": "arrow",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.arrow.importer.ArrowImporter",
     "plugin_name": "arrow",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".arrow"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.ava.ava.AvaBase",
     "plugin_name": "ava",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.ava.ava.AvaExporter",
     "plugin_name": "ava",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.ava.ava.AvaImporter",
     "plugin_name": "ava",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".csv"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.brats.BratsBase",
     "plugin_name": "brats",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.brats.BratsImporter",
     "plugin_name": "brats",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".gz"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.brats_numpy.BratsNumpyBase",
     "plugin_name": "brats_numpy",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.brats_numpy.BratsNumpyImporter",
     "plugin_name": "brats_numpy",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".p"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.camvid.CamvidBase",
     "plugin_name": "camvid",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.camvid.CamvidExporter",
     "plugin_name": "camvid",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.camvid.CamvidImporter",
     "plugin_name": "camvid",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.celeba.align_celeba.AlignCelebaBase",
     "plugin_name": "align_celeba",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.celeba.align_celeba.AlignCelebaImporter",
     "plugin_name": "align_celeba",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.celeba.celeba.CelebaBase",
     "plugin_name": "celeba",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.celeba.celeba.CelebaImporter",
     "plugin_name": "celeba",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.cifar.CifarBase",
     "plugin_name": "cifar",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.cifar.CifarExporter",
     "plugin_name": "cifar",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.cifar.CifarImporter",
     "plugin_name": "cifar",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".meta", ""]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.cityscapes.CityscapesBase",
     "plugin_name": "cityscapes",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.cityscapes.CityscapesExporter",
     "plugin_name": "cityscapes",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.cityscapes.CityscapesImporter",
     "plugin_name": "cityscapes",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".png"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.base.CocoCaptionsBase",
     "plugin_name": "coco_captions",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.base.CocoImageInfoBase",
     "plugin_name": "coco_image_info",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.base.CocoInstancesBase",
     "plugin_name": "coco_instances",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.base.CocoLabelsBase",
     "plugin_name": "coco_labels",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.base.CocoPanopticBase",
     "plugin_name": "coco_panoptic",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.base.CocoPersonKeypointsBase",
     "plugin_name": "coco_person_keypoints",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.base.CocoStuffBase",
     "plugin_name": "coco_stuff",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.exporter.CocoCaptionsExporter",
     "plugin_name": "coco_captions",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.exporter.CocoExporter",
     "plugin_name": "coco",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.exporter.CocoImageInfoExporter",
     "plugin_name": "coco_image_info",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.exporter.CocoInstancesExporter",
     "plugin_name": "coco_instances",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.exporter.CocoLabelsExporter",
     "plugin_name": "coco_labels",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.exporter.CocoPanopticExporter",
     "plugin_name": "coco_panoptic",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.exporter.CocoPersonKeypointsExporter",
     "plugin_name": "coco_person_keypoints",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.exporter.CocoStuffExporter",
     "plugin_name": "coco_stuff",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.importer.CocoCaptionsImporter",
     "plugin_name": "coco_captions",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.importer.CocoImageInfoImporter",
     "plugin_name": "coco_image_info",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.importer.CocoImporter",
     "plugin_name": "coco",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.importer.CocoInstancesImporter",
     "plugin_name": "coco_instances",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.importer.CocoLabelsImporter",
     "plugin_name": "coco_labels",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.importer.CocoPanopticImporter",
     "plugin_name": "coco_panoptic",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.importer.CocoPersonKeypointsImporter",
     "plugin_name": "coco_person_keypoints",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.coco.importer.CocoStuffImporter",
     "plugin_name": "coco_stuff",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.common_semantic_segmentation.CommonSemanticSegmentationBase",
     "plugin_name": "common_semantic_segmentation",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.common_semantic_segmentation.CommonSemanticSegmentationImporter",
     "plugin_name": "common_semantic_segmentation",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.common_semantic_segmentation.CommonSemanticSegmentationWithSubsetDirsImporter",
     "plugin_name": "common_semantic_segmentation_with_subset_dirs",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.common_super_resolution.CommonSuperResolutionBase",
     "plugin_name": "common_super_resolution",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.common_super_resolution.CommonSuperResolutionImporter",
     "plugin_name": "common_super_resolution",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".jpg"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.cvat.base.CvatBase",
     "plugin_name": "cvat",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.cvat.base.CvatImporter",
     "plugin_name": "cvat",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".xml"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.cvat.exporter.CvatExporter",
     "plugin_name": "cvat",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.datumaro.base.DatumaroBase",
     "plugin_name": "datumaro",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.datumaro.exporter.DatumaroExporter",
     "plugin_name": "datumaro",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.datumaro.importer.DatumaroImporter",
     "plugin_name": "datumaro",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.datumaro_binary.base.DatumaroBinaryBase",
     "plugin_name": "datumaro_binary",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.datumaro_binary.exporter.DatumaroBinaryExporter",
     "plugin_name": "datumaro_binary",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.datumaro_binary.importer.DatumaroBinaryImporter",
     "plugin_name": "datumaro_binary",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".datum"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.icdar.base.IcdarTextLocalizationBase",
     "plugin_name": "icdar_text_localization",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.icdar.base.IcdarTextLocalizationImporter",
     "plugin_name": "icdar_text_localization",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.icdar.base.IcdarTextSegmentationBase",
     "plugin_name": "icdar_text_segmentation",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.icdar.base.IcdarTextSegmentationImporter",
     "plugin_name": "icdar_text_segmentation",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.icdar.base.IcdarWordRecognitionBase",
     "plugin_name": "icdar_word_recognition",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.icdar.base.IcdarWordRecognitionImporter",
     "plugin_name": "icdar_word_recognition",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.icdar.exporter.IcdarTextLocalizationExporter",
     "plugin_name": "icdar_text_localization",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.icdar.exporter.IcdarTextSegmentationExporter",
     "plugin_name": "icdar_text_segmentation",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.icdar.exporter.IcdarWordRecognitionExporter",
     "plugin_name": "icdar_word_recognition",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.image_dir.ImageDirBase",
     "plugin_name": "image_dir",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.image_dir.ImageDirExporter",
     "plugin_name": "image_dir",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.image_dir.ImageDirImporter",
     "plugin_name": "image_dir",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [
+        ".jpg",
+        ".jpeg",
+        ".jpe",
+        ".jp2",
+        ".png",
+        ".bmp",
+        ".dib",
+        ".tif",
+        ".tiff",
+        ".tga",
+        ".webp",
+        ".pfm",
+        ".sr",
+        ".ras",
+        ".exr",
+        ".hdr",
+        ".pic",
+        ".pbm",
+        ".pgm",
+        ".ppm",
+        ".pxm",
+        ".pnm"
+      ]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.image_zip.ImageZipBase",
     "plugin_name": "image_zip",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.image_zip.ImageZipExporter",
     "plugin_name": "image_zip",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.image_zip.ImageZipImporter",
     "plugin_name": "image_zip",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".zip"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.imagenet.ImagenetBase",
     "plugin_name": "imagenet",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.imagenet.ImagenetExporter",
     "plugin_name": "imagenet",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.imagenet.ImagenetImporter",
     "plugin_name": "imagenet",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [
+        ".jpg",
+        ".jpeg",
+        ".jpe",
+        ".jp2",
+        ".png",
+        ".bmp",
+        ".dib",
+        ".tif",
+        ".tiff",
+        ".tga",
+        ".webp",
+        ".pfm",
+        ".sr",
+        ".ras",
+        ".exr",
+        ".hdr",
+        ".pic",
+        ".pbm",
+        ".pgm",
+        ".ppm",
+        ".pxm",
+        ".pnm"
+      ]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.imagenet.ImagenetWithSubsetDirsExporter",
     "plugin_name": "imagenet_with_subset_dirs",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.imagenet.ImagenetWithSubsetDirsImporter",
     "plugin_name": "imagenet_with_subset_dirs",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [
+        ".jpg",
+        ".jpeg",
+        ".jpe",
+        ".jp2",
+        ".png",
+        ".bmp",
+        ".dib",
+        ".tif",
+        ".tiff",
+        ".tga",
+        ".webp",
+        ".pfm",
+        ".sr",
+        ".ras",
+        ".exr",
+        ".hdr",
+        ".pic",
+        ".pbm",
+        ".pgm",
+        ".ppm",
+        ".pxm",
+        ".pnm"
+      ]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.imagenet_txt.ImagenetTxtBase",
     "plugin_name": "imagenet_txt",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.imagenet_txt.ImagenetTxtExporter",
     "plugin_name": "imagenet_txt",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.imagenet_txt.ImagenetTxtImporter",
     "plugin_name": "imagenet_txt",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.kaggle.base.KaggleImageCsvBase",
     "plugin_name": "kaggle_image_csv",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kaggle.base.KaggleImageMaskBase",
     "plugin_name": "kaggle_image_mask",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kaggle.base.KaggleImageTxtBase",
     "plugin_name": "kaggle_image_txt",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kaggle.base.KaggleVocBase",
     "plugin_name": "kaggle_voc",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kaggle.base.KaggleYoloBase",
     "plugin_name": "kaggle_yolo",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kinetics.KineticsBase",
     "plugin_name": "kinetics",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kinetics.KineticsImporter",
     "plugin_name": "kinetics",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json", ".csv"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.kitti.base.KittiDetectionBase",
     "plugin_name": "kitti_detection",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kitti.base.KittiSegmentationBase",
     "plugin_name": "kitti_segmentation",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kitti.exporter.KittiDetectionExporter",
     "plugin_name": "kitti_detection",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kitti.exporter.KittiExporter",
     "plugin_name": "kitti",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kitti.exporter.KittiSegmentationExporter",
     "plugin_name": "kitti_segmentation",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kitti.importer.KittiDetectionImporter",
     "plugin_name": "kitti_detection",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.kitti.importer.KittiImporter",
     "plugin_name": "kitti",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt", ".png"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.kitti.importer.KittiSegmentationImporter",
     "plugin_name": "kitti_segmentation",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".png"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.kitti_raw.base.KittiRawBase",
     "plugin_name": "kitti_raw",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.kitti_raw.base.KittiRawImporter",
     "plugin_name": "kitti_raw",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".xml"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.kitti_raw.exporter.KittiRawExporter",
     "plugin_name": "kitti_raw",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.labelme.LabelMeBase",
     "plugin_name": "label_me",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.labelme.LabelMeExporter",
     "plugin_name": "label_me",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.labelme.LabelMeImporter",
     "plugin_name": "label_me",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".xml"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.lfw.LfwBase",
     "plugin_name": "lfw",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.lfw.LfwExporter",
     "plugin_name": "lfw",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.lfw.LfwImporter",
     "plugin_name": "lfw",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mapillary_vistas.base.MapillaryVistasInstancesBase",
     "plugin_name": "mapillary_vistas_instances",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mapillary_vistas.base.MapillaryVistasPanopticBase",
     "plugin_name": "mapillary_vistas_panoptic",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mapillary_vistas.importer.MapillaryVistasImporter",
     "plugin_name": "mapillary_vistas",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".jpg", ".png", ".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mapillary_vistas.importer.MapillaryVistasInstancesImporter",
     "plugin_name": "mapillary_vistas_instances",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".jpg", ".png", ".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mapillary_vistas.importer.MapillaryVistasPanopticImporter",
     "plugin_name": "mapillary_vistas_panoptic",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".jpg", ".png", ".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.market1501.Market1501Base",
     "plugin_name": "market1501",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.market1501.Market1501Exporter",
     "plugin_name": "market1501",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.market1501.Market1501Importer",
     "plugin_name": "market1501",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".jpg"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mars.MarsBase",
     "plugin_name": "mars",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mars.MarsImporter",
     "plugin_name": "mars",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".jpg"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mmdet.MmdetCocoBase",
     "plugin_name": "mmdet_coco",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mmdet.MmdetCocoImporter",
     "plugin_name": "mmdet_coco",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mnist.MnistBase",
     "plugin_name": "mnist",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mnist.MnistExporter",
     "plugin_name": "mnist",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mnist.MnistImporter",
     "plugin_name": "mnist",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".gz"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mnist_csv.MnistCsvBase",
     "plugin_name": "mnist_csv",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mnist_csv.MnistCsvExporter",
     "plugin_name": "mnist_csv",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mnist_csv.MnistCsvImporter",
     "plugin_name": "mnist_csv",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".csv"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mot.MotSeqBase",
     "plugin_name": "mot_seq",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mot.MotSeqGtExporter",
     "plugin_name": "mot_seq_gt",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mot.MotSeqImporter",
     "plugin_name": "mot_seq",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mots.MotsImporter",
     "plugin_name": "mots",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".png", ".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mots.MotsPngExporter",
     "plugin_name": "mots_png",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mots.MotsPngExtractor",
     "plugin_name": "mots_png_extractor",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mpii.mpii_json.MpiiJsonBase",
     "plugin_name": "mpii_json",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mpii.mpii_json.MpiiJsonImporter",
     "plugin_name": "mpii_json",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mpii.mpii_mat.MpiiBase",
     "plugin_name": "mpii",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mpii.mpii_mat.MpiiImporter",
     "plugin_name": "mpii",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".mat"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mvtec.base.MvtecClassificationBase",
     "plugin_name": "mvtec_classification",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mvtec.base.MvtecDetectionBase",
     "plugin_name": "mvtec_detection",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mvtec.base.MvtecSegmentationBase",
     "plugin_name": "mvtec_segmentation",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mvtec.exporter.MvtecClassificationExporter",
     "plugin_name": "mvtec_classification",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mvtec.exporter.MvtecDetectionExporter",
     "plugin_name": "mvtec_detection",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mvtec.exporter.MvtecExporter",
     "plugin_name": "mvtec",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mvtec.exporter.MvtecSegmentationExporter",
     "plugin_name": "mvtec_segmentation",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.mvtec.importer.MvtecClassificationImporter",
     "plugin_name": "mvtec_classification",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".png"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mvtec.importer.MvtecDetectionImporter",
     "plugin_name": "mvtec_detection",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".png"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mvtec.importer.MvtecImporter",
     "plugin_name": "mvtec",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".png"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.mvtec.importer.MvtecSegmentationImporter",
     "plugin_name": "mvtec_segmentation",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".png"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.nyu_depth_v2.NyuDepthV2Base",
     "plugin_name": "nyu_depth_v2",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.nyu_depth_v2.NyuDepthV2Importer",
     "plugin_name": "nyu_depth_v2",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".h5"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.open_images.OpenImagesBase",
     "plugin_name": "open_images",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.open_images.OpenImagesExporter",
     "plugin_name": "open_images",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.open_images.OpenImagesImporter",
     "plugin_name": "open_images",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".csv"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.base.RoboflowCocoBase",
     "plugin_name": "roboflow_coco",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.base.RoboflowCreateMlBase",
     "plugin_name": "roboflow_create_ml",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.base.RoboflowMulticlassBase",
     "plugin_name": "roboflow_multiclass",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.base.RoboflowVocBase",
     "plugin_name": "roboflow_voc",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.base.RoboflowYoloBase",
     "plugin_name": "roboflow_yolo",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.base.RoboflowYoloObbBase",
     "plugin_name": "roboflow_yolo_obb",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.base_tfrecord.RoboflowTfrecordBase",
@@ -994,133 +1075,151 @@
     "plugin_type": "Importer",
     "extra_deps": [
       "tensorflow"
-    ]
+    ],
+    "metadata": {
+      "file_extensions": [".tfrecord"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.importer.RoboflowCocoImporter",
     "plugin_name": "roboflow_coco",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.importer.RoboflowCreateMlImporter",
     "plugin_name": "roboflow_create_ml",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.importer.RoboflowMulticlassImporter",
     "plugin_name": "roboflow_multiclass",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".csv"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.importer.RoboflowVocImporter",
     "plugin_name": "roboflow_voc",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".xml"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.importer.RoboflowYoloImporter",
     "plugin_name": "roboflow_yolo",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.roboflow.importer.RoboflowYoloObbImporter",
     "plugin_name": "roboflow_yolo_obb",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.segment_anything.base.SegmentAnythingBase",
     "plugin_name": "segment_anything",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.segment_anything.exporter.SegmentAnythingExporter",
     "plugin_name": "segment_anything",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.segment_anything.importer.SegmentAnythingImporter",
     "plugin_name": "segment_anything",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.sly_pointcloud.base.SuperviselyPointCloudBase",
     "plugin_name": "sly_pointcloud",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.sly_pointcloud.base.SuperviselyPointCloudImporter",
     "plugin_name": "sly_pointcloud",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.sly_pointcloud.exporter.SuperviselyPointCloudExporter",
     "plugin_name": "sly_pointcloud",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.synthia.base.SynthiaAlBase",
     "plugin_name": "synthia_al",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.synthia.base.SynthiaRandBase",
     "plugin_name": "synthia_rand",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.synthia.base.SynthiaSfBase",
     "plugin_name": "synthia_sf",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.synthia.importer.SynthiaAlImporter",
     "plugin_name": "synthia_al",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".png"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.synthia.importer.SynthiaRandImporter",
     "plugin_name": "synthia_rand",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".png"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.synthia.importer.SynthiaSfImporter",
     "plugin_name": "synthia_sf",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".png"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.tabular.TabularDataBase",
     "plugin_name": "tabular",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.tabular.TabularDataExporter",
     "plugin_name": "tabular",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.tabular.TabularDataImporter",
     "plugin_name": "tabular",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".csv"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.tf_detection_api.base.TfDetectionApiBase",
@@ -1136,7 +1235,10 @@
     "plugin_type": "Importer",
     "extra_deps": [
       "tensorflow"
-    ]
+    ],
+    "metadata": {
+      "file_extensions": [".tfrecord"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.tf_detection_api.exporter.TfDetectionApiExporter",
@@ -1149,505 +1251,519 @@
   {
     "import_path": "datumaro.plugins.data_formats.vgg_face2.VggFace2Base",
     "plugin_name": "vgg_face2",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.vgg_face2.VggFace2Exporter",
     "plugin_name": "vgg_face2",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.vgg_face2.VggFace2Importer",
     "plugin_name": "vgg_face2",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".csv"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.video.VideoFramesBase",
     "plugin_name": "video_frames",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.video.VideoFramesImporter",
     "plugin_name": "video_frames",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [
+        ".3gp",
+        ".3g2",
+        ".asf",
+        ".wmv",
+        ".avi",
+        ".divx",
+        ".evo",
+        ".f4v",
+        ".flv",
+        ".mkv",
+        ".mk3d",
+        ".mp4",
+        ".mpg",
+        ".mpeg",
+        ".m2p",
+        ".ps",
+        ".ts",
+        ".m2ts",
+        ".mxf",
+        ".ogg",
+        ".ogv",
+        ".ogx",
+        ".mov",
+        ".qt",
+        ".rmvb",
+        ".vob",
+        ".webm"
+      ]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.video.VideoKeyframesBase",
     "plugin_name": "video_keyframes",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.video.VideoKeyframesImporter",
     "plugin_name": "video_keyframes",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [
+        ".3gp",
+        ".3g2",
+        ".asf",
+        ".wmv",
+        ".avi",
+        ".divx",
+        ".evo",
+        ".f4v",
+        ".flv",
+        ".mkv",
+        ".mk3d",
+        ".mp4",
+        ".mpg",
+        ".mpeg",
+        ".m2p",
+        ".ps",
+        ".ts",
+        ".m2ts",
+        ".mxf",
+        ".ogg",
+        ".ogv",
+        ".ogx",
+        ".mov",
+        ".qt",
+        ".rmvb",
+        ".vob",
+        ".webm"
+      ]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.base.VocActionBase",
     "plugin_name": "voc_action",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.base.VocBase",
     "plugin_name": "voc",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.base.VocClassificationBase",
     "plugin_name": "voc_classification",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.base.VocDetectionBase",
     "plugin_name": "voc_detection",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.base.VocInstanceSegmentationBase",
     "plugin_name": "voc_instance_segmentation",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.base.VocLayoutBase",
     "plugin_name": "voc_layout",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.base.VocSegmentationBase",
     "plugin_name": "voc_segmentation",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.exporter.VocActionExporter",
     "plugin_name": "voc_action",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.exporter.VocClassificationExporter",
     "plugin_name": "voc_classification",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.exporter.VocDetectionExporter",
     "plugin_name": "voc_detection",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.exporter.VocExporter",
     "plugin_name": "voc",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.exporter.VocInstanceSegmentationExporter",
     "plugin_name": "voc_instance_segmentation",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.exporter.VocLayoutExporter",
     "plugin_name": "voc_layout",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.exporter.VocSegmentationExporter",
     "plugin_name": "voc_segmentation",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.importer.VocActionImporter",
     "plugin_name": "voc_action",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.importer.VocClassificationImporter",
     "plugin_name": "voc_classification",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.importer.VocDetectionImporter",
     "plugin_name": "voc_detection",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.importer.VocImporter",
     "plugin_name": "voc",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.importer.VocInstanceSegmentationImporter",
     "plugin_name": "voc_instance_segmentation",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.importer.VocLayoutImporter",
     "plugin_name": "voc_layout",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.voc.importer.VocSegmentationImporter",
     "plugin_name": "voc_segmentation",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.vott_csv.VottCsvBase",
     "plugin_name": "vott_csv",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.vott_csv.VottCsvImporter",
     "plugin_name": "vott_csv",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".csv"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.vott_json.VottJsonBase",
     "plugin_name": "vott_json",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.vott_json.VottJsonImporter",
     "plugin_name": "vott_json",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".json"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.widerface.WiderFaceBase",
     "plugin_name": "wider_face",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.widerface.WiderFaceExporter",
     "plugin_name": "wider_face",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.widerface.WiderFaceImporter",
     "plugin_name": "wider_face",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.data_formats.yolo.base.YoloLooseBase",
     "plugin_name": "yolo_loose",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.yolo.base.YoloStrictBase",
     "plugin_name": "yolo_strict",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.yolo.base.YoloUltralyticsBase",
     "plugin_name": "yolo_ultralytics",
-    "plugin_type": "DatasetBase",
-    "extra_deps": []
+    "plugin_type": "DatasetBase"
   },
   {
     "import_path": "datumaro.plugins.data_formats.yolo.exporter.YoloExporter",
     "plugin_name": "yolo",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.yolo.exporter.YoloUltralyticsExporter",
     "plugin_name": "yolo_ultralytics",
-    "plugin_type": "Exporter",
-    "extra_deps": []
+    "plugin_type": "Exporter"
   },
   {
     "import_path": "datumaro.plugins.data_formats.yolo.importer.YoloImporter",
     "plugin_name": "yolo",
     "plugin_type": "Importer",
-    "extra_deps": []
+    "metadata": {
+      "file_extensions": [".data", ".txt"]
+    }
   },
   {
     "import_path": "datumaro.plugins.explorer.ExplorerLauncher",
     "plugin_name": "explorer",
-    "plugin_type": "Launcher",
-    "extra_deps": []
+    "plugin_type": "Launcher"
   },
   {
     "import_path": "datumaro.plugins.inference_server_plugin.base.LauncherForDedicatedInferenceServer",
     "plugin_name": "launcher_for_dedicated_inference_server",
-    "plugin_type": "Launcher",
-    "extra_deps": []
+    "plugin_type": "Launcher"
   },
   {
     "import_path": "datumaro.plugins.inference_server_plugin.ovms.OVMSLauncher",
     "plugin_name": "ovmslauncher",
-    "plugin_type": "Launcher",
-    "extra_deps": []
+    "plugin_type": "Launcher"
   },
   {
     "import_path": "datumaro.plugins.inference_server_plugin.triton.TritonLauncher",
     "plugin_name": "triton",
-    "plugin_type": "Launcher",
-    "extra_deps": []
+    "plugin_type": "Launcher"
   },
   {
     "import_path": "datumaro.plugins.missing_annotation_detection.MissingAnnotationDetection",
     "plugin_name": "missing_annotation_detection",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.ndr.NDR",
     "plugin_name": "ndr",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.openvino_plugin.launcher.OpenvinoLauncher",
     "plugin_name": "openvino",
-    "plugin_type": "Launcher",
-    "extra_deps": []
+    "plugin_type": "Launcher"
   },
   {
     "import_path": "datumaro.plugins.openvino_plugin.shift_launcher.ShiftLauncher",
     "plugin_name": "shift",
-    "plugin_type": "Launcher",
-    "extra_deps": []
+    "plugin_type": "Launcher"
   },
   {
     "import_path": "datumaro.plugins.sam_transforms.automatic_mask_gen.SAMAutomaticMaskGeneration",
     "plugin_name": "samautomatic_mask_generation",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.sam_transforms.bbox_to_inst_mask.SAMBboxToInstanceMask",
     "plugin_name": "sambbox_to_instance_mask",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.sampler.random_sampler.LabelRandomSampler",
     "plugin_name": "label_random_sampler",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.sampler.random_sampler.RandomSampler",
     "plugin_name": "random_sampler",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.sampler.relevancy_sampler.RelevancySampler",
     "plugin_name": "relevancy_sampler",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.splitter.Split",
     "plugin_name": "split",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.tiling.merge_tile.MergeTile",
     "plugin_name": "merge_tile",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.tiling.tile.Tile",
     "plugin_name": "tile",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.AnnsToLabels",
     "plugin_name": "anns_to_labels",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.BboxValuesDecrement",
     "plugin_name": "bbox_values_decrement",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.BoxesToMasks",
     "plugin_name": "boxes_to_masks",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.BoxesToPolygons",
     "plugin_name": "boxes_to_polygons",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.Correct",
     "plugin_name": "correct",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.CropCoveredSegments",
     "plugin_name": "crop_covered_segments",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.IdFromImageName",
     "plugin_name": "id_from_image_name",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.MapSubsets",
     "plugin_name": "map_subsets",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.MasksToPolygons",
     "plugin_name": "masks_to_polygons",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.MergeInstanceSegments",
     "plugin_name": "merge_instance_segments",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.PolygonsToMasks",
     "plugin_name": "polygons_to_masks",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.ProjectInfos",
     "plugin_name": "project_infos",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.ProjectLabels",
     "plugin_name": "project_labels",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.RandomSplit",
     "plugin_name": "random_split",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.Reindex",
     "plugin_name": "reindex",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.ReindexAnnotations",
     "plugin_name": "reindex_annotations",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.RemapLabels",
     "plugin_name": "remap_labels",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.RemoveAnnotations",
     "plugin_name": "remove_annotations",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.RemoveAttributes",
     "plugin_name": "remove_attributes",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.RemoveItems",
     "plugin_name": "remove_items",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.Rename",
     "plugin_name": "rename",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.ResizeTransform",
     "plugin_name": "resize",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.ShapesToBoxes",
     "plugin_name": "shapes_to_boxes",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.transforms.Sort",
     "plugin_name": "sort",
-    "plugin_type": "Transform",
-    "extra_deps": []
+    "plugin_type": "Transform"
   },
   {
     "import_path": "datumaro.plugins.validators.ClassificationValidator",
     "plugin_name": "classification",
-    "plugin_type": "Validator",
-    "extra_deps": []
+    "plugin_type": "Validator"
   },
   {
     "import_path": "datumaro.plugins.validators.DetectionValidator",
     "plugin_name": "detection",
-    "plugin_type": "Validator",
-    "extra_deps": []
+    "plugin_type": "Validator"
   },
   {
     "import_path": "datumaro.plugins.validators.SegmentationValidator",
     "plugin_name": "segmentation",
-    "plugin_type": "Validator",
-    "extra_deps": []
+    "plugin_type": "Validator"
   }
 ]

--- a/src/datumaro/plugins/specs.py
+++ b/src/datumaro/plugins/specs.py
@@ -17,7 +17,11 @@ def get_lazy_plugins():
         plugin
         for plugin in [
             get_lazy_plugin(
-                spec["import_path"], spec["plugin_name"], spec["plugin_type"], spec["extra_deps"]
+                spec["import_path"],
+                spec["plugin_name"],
+                spec["plugin_type"],
+                spec.get("extra_deps", []),
+                spec.get("metadata", {}),
             )
             for spec in parse_json_file(str(_SPECS_JSON_PATH))
         ]

--- a/src/datumaro/util/os_util.py
+++ b/src/datumaro/util/os_util.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import glob
 import importlib
 import os
 import os.path as osp
@@ -12,7 +13,7 @@ import sys
 import unicodedata
 from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout
 from io import StringIO
-from typing import Iterable, Iterator, Optional, Union
+from typing import Iterable, Iterator, List, Optional, Set, Union
 
 try:
     # Declare functions to remove files and directories.
@@ -303,3 +304,11 @@ def extract_subset_name_from_parent(url: str, start: str) -> str:
         return DEFAULT_SUBSET_NAME
 
     return subdir_name
+
+
+def get_all_file_extensions(path: str, ignore_dirs: Set[str]) -> List[str]:
+    extensions = set()
+    for p in glob.iglob(osp.join(path, "**", "*.*"), recursive=True):
+        if ignore_dirs.isdisjoint(p.split(os.sep)):
+            extensions.add(osp.splitext(p)[1])
+    return list(extensions)

--- a/tests/integration/cli/test_detect_format.py
+++ b/tests/integration/cli/test_detect_format.py
@@ -116,7 +116,6 @@ class DetectFormatTest(TestCase):
         self.assertIn(Ade20k2017Importer.NAME, output)
 
         self.assertIn(CamvidImporter.NAME, output)
-        self.assertIn(CamvidImporter.ANNO_PATH, output)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_json_report(self):
@@ -148,4 +147,4 @@ class DetectFormatTest(TestCase):
         self.assertEqual(camvid_rejection["reason"], "unmet_requirements")
         self.assertIn("message", camvid_rejection)
         self.assertIsInstance(camvid_rejection["message"], str)
-        self.assertTrue(CamvidImporter.ANNO_PATH in camvid_rejection["message"])
+        self.assertTrue(CamvidImporter._ANNO_EXT in camvid_rejection["message"])

--- a/tests/integration/cli/test_detect_format.py
+++ b/tests/integration/cli/test_detect_format.py
@@ -9,6 +9,7 @@ from unittest.case import TestCase
 
 from datumaro.plugins.data_formats.ade20k2017 import Ade20k2017Importer
 from datumaro.plugins.data_formats.ade20k2020 import Ade20k2020Importer
+from datumaro.plugins.data_formats.camvid import CamvidImporter
 from datumaro.plugins.data_formats.image_dir import ImageDirImporter
 from datumaro.plugins.data_formats.lfw import LfwImporter
 from datumaro.util.os_util import suppress_output
@@ -114,10 +115,8 @@ class DetectFormatTest(TestCase):
 
         self.assertIn(Ade20k2017Importer.NAME, output)
 
-        self.assertIn(Ade20k2020Importer.NAME, output)
-        self.assertIn("*/**/*.json", output)
-
-        self.assertIn(ImageDirImporter.NAME, output)
+        self.assertIn(CamvidImporter.NAME, output)
+        self.assertIn(CamvidImporter.ANNO_PATH, output)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_json_report(self):
@@ -142,19 +141,11 @@ class DetectFormatTest(TestCase):
 
         self.assertIn("rejected_formats", report)
 
-        self.assertIn("ade20k2020", report["rejected_formats"])
-        ade20k2020_rejection = report["rejected_formats"]["ade20k2020"]
+        self.assertIn("camvid", report["rejected_formats"])
+        camvid_rejection = report["rejected_formats"]["camvid"]
 
-        self.assertIn("reason", ade20k2020_rejection)
-        self.assertEqual(ade20k2020_rejection["reason"], "unmet_requirements")
-        self.assertIn("message", ade20k2020_rejection)
-        self.assertIsInstance(ade20k2020_rejection["message"], str)
-        self.assertTrue("*/**/*.json" in ade20k2020_rejection["message"])
-
-        self.assertIn("image_dir", report["rejected_formats"])
-        image_dir_rejection = report["rejected_formats"]["image_dir"]
-
-        self.assertIn("reason", image_dir_rejection)
-        self.assertEqual(image_dir_rejection["reason"], "insufficient_confidence")
-        self.assertIn("message", image_dir_rejection)
-        self.assertIsInstance(image_dir_rejection["message"], str)
+        self.assertIn("reason", camvid_rejection)
+        self.assertEqual(camvid_rejection["reason"], "unmet_requirements")
+        self.assertIn("message", camvid_rejection)
+        self.assertIsInstance(camvid_rejection["message"], str)
+        self.assertTrue(CamvidImporter.ANNO_PATH in camvid_rejection["message"])

--- a/tests/integration/cli/test_revpath.py
+++ b/tests/integration/cli/test_revpath.py
@@ -131,7 +131,7 @@ class TestRevpath(TestCase):
         test_dir = scope_add(TestDir())
         assets = {
             "ade20k2017_dataset/dataset/training/street/1_atr.txt": "training/street/1_atr.txt",
-            "mot_dataset/mot_seq/gt/gt.txt": "gt/gt.txt"
+            "mot_dataset/mot_seq/gt/gt.txt": "gt/gt.txt",
         }
 
         dataset_url = osp.join(test_dir, "source")
@@ -145,10 +145,7 @@ class TestRevpath(TestCase):
             dst = osp.join(dataset_url, local_dir)
             if local_dir:
                 os.makedirs(dst)
-            shutil.copy(
-                osp.join(assets_dir, asset),
-                dst
-            )
+            shutil.copy(osp.join(assets_dir, asset), dst)
 
         with self.subTest("no context"):
             with self.assertRaises(WrongRevpathError) as cm:

--- a/tests/integration/cli/test_revpath.py
+++ b/tests/integration/cli/test_revpath.py
@@ -129,19 +129,26 @@ class TestRevpath(TestCase):
     @scoped
     def test_ambiguous_format(self):
         test_dir = scope_add(TestDir())
+        assets = {
+            "ade20k2017_dataset/dataset/training/street/1_atr.txt": "training/street/1_atr.txt",
+            "mot_dataset/mot_seq/gt/gt.txt": "gt/gt.txt"
+        }
 
         dataset_url = osp.join(test_dir, "source")
 
         # create an ambiguous dataset by merging annotations from
         # datasets in different formats
-        annotation_dir = osp.join(dataset_url, "training/street")
         assets_dir = get_test_asset_path()
-        os.makedirs(annotation_dir)
-        for asset in [
-            "ade20k2017_dataset/dataset/training/street/1_atr.txt",
-            "ade20k2020_dataset/dataset/training/street/1.json",
-        ]:
-            shutil.copy(osp.join(assets_dir, asset), annotation_dir)
+
+        for asset, local_asset in assets.items():
+            local_dir = osp.dirname(local_asset)
+            dst = osp.join(dataset_url, local_dir)
+            if local_dir:
+                os.makedirs(dst)
+            shutil.copy(
+                osp.join(assets_dir, asset),
+                dst
+            )
 
         with self.subTest("no context"):
             with self.assertRaises(WrongRevpathError) as cm:

--- a/tests/unit/data_formats/base.py
+++ b/tests/unit/data_formats/base.py
@@ -28,7 +28,7 @@ class TestDataFormatBase:
             pytest.skip(reason="importer is None.")
 
         detected_formats = DEFAULT_ENVIRONMENT.detect_dataset(fxt_dataset_dir)
-        assert [importer.NAME] == detected_formats
+        assert [importer.NAME] == detected_formats, f"{[importer.NAME]} != {detected_formats}"
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import(

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -72,7 +72,7 @@ class DatasetTest(TestCase):
         importers_override: Callable[[Environment], List] = None,
         extractors_override: Callable[[Environment], List] = None,
     ) -> Environment:
-        env = Environment()
+        env = Environment(use_lazy_import=False)
         default_importers = [env.importers[DEFAULT_FORMAT]]
         default_extractors = [env.extractors[DEFAULT_FORMAT]]
         importers = importers_override(env) if importers_override is not None else default_importers


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
CVS-126682
This PR introduces grouping of importers by the required file extensions in dataset directory tree to speed up the detection process.
| File Extension | # of importers |
| --- | --- |
| `.txt` | 24 |
| `.json` | 23 |
| `.png` | 17 |
| `.jpg` | 9 |
| `.csv` | 8 |
| `.xml` | 4 |
| `.sr`, `.hdr`, `.dib`, `.tiff`, `.pgm`, `.bmp`, `.tga`, `.tif`, `.jpe`, `.pnm`, `.webp`, `.pxm`, `.pbm`, `.jp2`, `.jpeg`, `.ppm`, `.ras`, `.exr`, `.pfm`, `.pic` | 3 |
| `.gz`, `.tfrecord`, `.mpeg`, `.f4v`, `.m2p`, `.ps`, `.mp4`, `.ogx`, `.wmv`, `.vob`, `.m2ts`, `.3g2`, `.qt`, `.webm`, `.mk3d`, `.divx`, `.mov`, `.mkv`, `.3gp`, `.ogg`, `.evo`, `.ogv`, `.mpg`, `.ts`, `.asf`, `.mxf`, `.avi`, `.rmvb`, `.flv` | 2 |
| `.p`, ` `, `.meta`, `.datum`, `.arrow`, `.zip`, `.mat`, `.h5`, `data` | 1 |

Total number of importers: 74. The groups listed above can intersect.


### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
