### PR TITLE
docs: change infos to info in datumaro format json file

### DIFF
--- a/docs/source/docs/data-formats/datumaro_format.md
+++ b/docs/source/docs/data-formats/datumaro_format.md
@@ -21,7 +21,7 @@ Here is the example of `json` annotation file:
 ```json
 {
     "dm_format_version": "1.0",
-    "infos": {
+    "info": {
         "task": "anomaly_detection",
         "creation time": "2023.4.1"
     },


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
On the Datumaro format documentation site there is a typo in the json. The plural `infos` should be the singular `info` as described in the explanatory text above the json. 
I know that this is a tiny documentation change but it caused a little bit of confusion on our end and so I would like to avoid the same confusion for others :) Don't know if such a tiny change requires a Changelog addition but if it does I can add it!
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
