### PR TITLE
Set OV version upper limit to <2024.0.0

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -34,7 +34,7 @@ requests
 pandas~=1.4.0
 
 # OpenVINO
-openvino>=2023.2.0
+openvino>=2023.2.0,<2024.0.0 # Accuracy checker is deprecated >=2024.0.0
 tokenizers
 
 # Encryption


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

- OpenVINO accuracy checker is deprecated >= 2024.0.0 and it makes this error from `AcLauncher`: https://github.com/openvinotoolkit/datumaro/actions/runs/8215356435/job/22468743875#step:6:28

### How to test
Our existing tests can cover it.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
