### PR TITLE
Add DatasetImportError for yolo variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1360>)
 - Fix resize transform for RleMask annotation
 - (<https://github.com/openvinotoolkit/datumaro/pull/1361>)
+- Fix import YOLO variants from extractor when `urls` is not specified
+  (<https://github.com/openvinotoolkit/datumaro/pull/1362>)
 
 ## Jan. 2024 Release 1.5.2
 ### Enhancements

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -316,6 +316,9 @@ class YoloLooseBase(SubsetBase):
         if not osp.isdir(config_path):
             raise DatasetImportError(f"{config_path} should be a directory.")
 
+        if not urls:
+            raise DatasetImportError(f"urls should be specified for {self.__class__.__name__}.")
+
         rootpath = self._get_rootpath(config_path)
 
         self._image_info = YoloStrictBase.parse_image_info(rootpath, image_info)

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -317,7 +317,12 @@ class YoloLooseBase(SubsetBase):
             raise DatasetImportError(f"{config_path} should be a directory.")
 
         if not urls:
-            raise DatasetImportError(f"urls should be specified for {self.__class__.__name__}.")
+            raise DatasetImportError(
+                f"`urls` should be specified for {self.__class__.__name__}, "
+                f"if you want to import a dataset with using this {self.__class__.__name__} directly. "
+                "In most case, it happens by giving an incorrect format name to the import interface. "
+                'Please consider to import your dataset with this format name, "yolo", such as `Dataset.import_from(..., format="yolo")`'
+            )
 
         rootpath = self._get_rootpath(config_path)
 

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -321,7 +321,8 @@ class YoloLooseBase(SubsetBase):
                 f"`urls` should be specified for {self.__class__.__name__}, "
                 f"if you want to import a dataset with using this {self.__class__.__name__} directly. "
                 "In most case, it happens by giving an incorrect format name to the import interface. "
-                'Please consider to import your dataset with this format name, "yolo", such as `Dataset.import_from(..., format="yolo")`'
+                "Please consider to import your dataset with this format name, 'yolo', "
+                "such as `Dataset.import_from(..., format='yolo')`."
             )
 
         rootpath = self._get_rootpath(config_path)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

Datumaro is able to import a dataset from extractor directly as described in https://github.com/openvinotoolkit/datumaro/blob/f9366173a0a5ba6fe479703800a2f3a0caf15530/src/datumaro/components/dataset.py#L822
However, in this case, we have to be careful for importing a dataset.
For instance, Yolo extractors, i.e., `YoloLooseBase`, `YoloUltralyticsBase`, `RoboflowYoloBase`, and `RoboflowYoloObbBase`, require to have `urls` for specifying subset and all annotation files accordingly.

In this PR, I have added `DatasetImportError` when importing a Yolo dataset without `urls`.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
