### PR TITLE
Fix wrong documentation for filtering example

### DIFF
--- a/docs/source/docs/level-up/intermediate_skills/09_data_filtering.rst
+++ b/docs/source/docs/level-up/intermediate_skills/09_data_filtering.rst
@@ -109,4 +109,4 @@ The more advanced Python example is given :doc:`this notebook <../../jupyter_not
             dataset_path = '/path/to/data'
             dataset = Dataset.import_from(dataset_path, format='datumaro')
 
-            filtered_result = Dataset.filter(dataset, filter_func)
+            filtered_result = Dataset.filter(dataset, filter_func, filter_annotations=True)

--- a/src/datumaro/components/dataset.py
+++ b/src/datumaro/components/dataset.py
@@ -441,7 +441,7 @@ class Dataset(IDataset):
         Returns: self
 
         Example:
-            - (`filter_annotations=True`) This is an example of filtering
+            - (`filter_annotations=False`) This is an example of filtering
                 dataset items with images larger than 1024 pixels::
 
                 from datumaro.components.media import Image
@@ -450,8 +450,7 @@ class Dataset(IDataset):
                     h, w = item.media_as(Image).size
                     return h > 1024 or w > 1024
 
-                filtered = UserFunctionDatasetFilter(
-                    extractor=dataset, filter_func=filter_func)
+                filtered = dataset.filter(filter_func=filter_func, filter_annotations=False)
                 # No items with an image height or width greater than 1024
                 filtered_items = [item for item in filtered]
 
@@ -473,8 +472,7 @@ class Dataset(IDataset):
                     # Accept Bboxes smaller than 50% of the image size
                     return bbox_size < 0.5 * image_size
 
-                filtered = UserFunctionAnnotationsFilter(
-                    extractor=dataset, filter_func=filter_func)
+                filtered = dataset.filter(filter_func=filter_func, filter_annotations=True)
                 # No bounding boxes with a size greater than 50% of their image
                 filtered_items = [item for item in filtered]
         """

--- a/src/datumaro/components/hl_ops/__init__.py
+++ b/src/datumaro/components/hl_ops/__init__.py
@@ -190,7 +190,7 @@ class HLOps:
             during iteration
 
         Example:
-            - (`filter_annotations=True`) This is an example of filtering
+            - (`filter_annotations=False`) This is an example of filtering
                 dataset items with images larger than 1024 pixels::
 
                 from datumaro.components.media import Image
@@ -199,8 +199,11 @@ class HLOps:
                     h, w = item.media_as(Image).size
                     return h > 1024 or w > 1024
 
-                filtered = UserFunctionDatasetFilter(
-                    extractor=dataset, filter_func=filter_func)
+                filtered = HLOps.filter(
+                    dataset=dataset,
+                    filter_func=filter_func,
+                    filter_annotations=False,
+                )
                 # No items with an image height or width greater than 1024
                 filtered_items = [item for item in filtered]
 
@@ -222,8 +225,11 @@ class HLOps:
                     # Accept Bboxes smaller than 50% of the image size
                     return bbox_size < 0.5 * image_size
 
-                filtered = UserFunctionAnnotationsFilter(
-                    extractor=dataset, filter_func=filter_func)
+                filtered = HLOps.filter(
+                    dataset=dataset,
+                    filter_func=filter_func,
+                    filter_annotations=True,
+                )
                 # No bounding boxes with a size greater than 50% of their image
                 filtered_items = [item for item in filtered]
         """


### PR DESCRIPTION
### Summary
- There were wrong documentations for filtering via an user-provided Python function

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [x] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
