### PR TITLE
Fix to show annotation label in TransformRemove

### DIFF
--- a/gui/datumaro_gui/components/multiple/tabs/transform.py
+++ b/gui/datumaro_gui/components/multiple/tabs/transform.py
@@ -459,9 +459,28 @@ class TransformRemove(MultipleTransformBase):
         )
         dataset = data_helper.dataset()
         selected_item = dataset.get(selected_id, selected_subset)
-        ann_ids = ["All"] + sorted({ann.id for ann in selected_item.annotations})
-        selected_ann_id = c3.selectbox(
-            "Select an annotation", ann_ids, key=f"sb_select_ann_id_mul_{col}"
+        labels = data_helper.dataset().get_label_cat_names()
+        item_annotations = [ann for ann in selected_item.annotations]
+
+        ann_dicts = {ann.id: ann.label for ann in item_annotations}
+        ann_labels = [labels[idx] for idx in ann_dicts.values()]
+        label_counts = {}
+        for label in ann_labels:
+            label_counts[label] = label_counts.get(label, 0) + 1
+
+        for i, label in enumerate(ann_labels):
+            if label_counts[label] > 1:
+                ann_labels[i] = f"{label}_{label_counts[label]}"
+                label_counts[label] -= 1
+
+        annotations = ["All"] + ann_labels
+        selected_ann_label = c3.selectbox(
+            "Select an annotation", annotations, key=f"sb_select_ann_id_mul_{col}"
+        )
+        selected_ann_id = (
+            "All"
+            if selected_ann_label == "All"
+            else list(ann_dicts.keys())[ann_labels.index(selected_ann_label)]
         )
 
         bc1, bc2 = st.columns(2)

--- a/gui/datumaro_gui/components/single/tabs/transform.py
+++ b/gui/datumaro_gui/components/single/tabs/transform.py
@@ -758,7 +758,7 @@ class TransformNDR(TransformBase):
             st.toast(f"Error: {repr(e)}", icon="🚨")
 
     def gui(self, data_helper: SingleDatasetHelper):
-        subsets = list(data_helper.dataset().subsets().keys())
+        subsets = sorted(list(data_helper.dataset().subsets().keys()))
 
         c1, c2 = st.columns([0.3, 0.7])
         with c1:

--- a/gui/datumaro_gui/components/single/tabs/transform.py
+++ b/gui/datumaro_gui/components/single/tabs/transform.py
@@ -539,10 +539,29 @@ class TransformRemove(TransformBase):
         )
         dataset = data_helper.dataset()
         selected_item = dataset.get(selected_id, selected_subset)
-        ann_ids = [
-            "All",
-        ] + sorted(list({ann.id for ann in selected_item.annotations}))
-        selected_ann_id = c3.selectbox("Select an annotation", ann_ids, key="sb_select_ann_id_sin")
+        labels = data_helper.dataset().get_label_cat_names()
+        item_annotations = [ann for ann in selected_item.annotations]
+
+        ann_dicts = {ann.id: ann.label for ann in item_annotations}
+        ann_labels = [labels[idx] for idx in ann_dicts.values()]
+        label_counts = {}
+        for label in ann_labels:
+            label_counts[label] = label_counts.get(label, 0) + 1
+
+        for i, label in enumerate(ann_labels):
+            if label_counts[label] > 1:
+                ann_labels[i] = f"{label}_{label_counts[label]}"
+                label_counts[label] -= 1
+
+        annotations = ["All"] + ann_labels
+        selected_ann_label = c3.selectbox(
+            "Select an annotation", annotations, key="sb_select_ann_id_sin"
+        )
+        selected_ann_id = (
+            "All"
+            if selected_ann_label == "All"
+            else list(ann_dicts.keys())[ann_labels.index(selected_ann_label)]
+        )
 
         bc1, bc2 = st.columns(2)
         btn_remove_item = bc1.button(

--- a/tests/unit/gui/multiple/test_transform.py
+++ b/tests/unit/gui/multiple/test_transform.py
@@ -348,9 +348,7 @@ class TransformTest(TestCase):
         selectbox_key = "sb_select_ann_id_mul_c1"
         assert at.selectbox(selectbox_key)
         assert at.selectbox(selectbox_key).label == "Select an annotation"
-        assert at.selectbox(selectbox_key).options == [
-            "All",
-        ] + sorted(list({str(ann.id) for ann in selected_item.annotations}))
+        assert at.selectbox(selectbox_key).options == ["All", "mary"]
 
         button_key = "btn_remove_item_remove_mul_c1"
         assert at.button(button_key)
@@ -1215,15 +1213,11 @@ class TransformRemoveTest(TestCase):
             at.selectbox(selectbox_key).options
             == at.session_state.data_helper_1.subset_to_ids()[selected_subset]
         )
-        selected_id = at.selectbox(selectbox_key).value
-        selected_item = at.session_state.data_helper_1.dataset().get(selected_id, selected_subset)
 
         selectbox_key = "sb_select_ann_id_mul_c1"
         assert at.selectbox(selectbox_key)
         assert at.selectbox(selectbox_key).label == "Select an annotation"
-        assert at.selectbox(selectbox_key).options == [
-            "All",
-        ] + sorted(list({str(ann.id) for ann in selected_item.annotations}))
+        assert at.selectbox(selectbox_key).options == ["All", "mary"]
 
         # button
         button_key = "btn_remove_item_remove_mul_c1"
@@ -1270,7 +1264,13 @@ class TransformRemoveTest(TestCase):
         at.selectbox(selectbox_id_key).select("b").run()
 
         assert at.selectbox(selectbox_id_key).value == "b"
-        assert at.selectbox(selectbox_ann_id_key).options == ["All", "0", "1", "2", "3"]
+        assert at.selectbox(selectbox_ann_id_key).options == [
+            "All",
+            "car",
+            "bicycle",
+            "tom",
+            "mary",
+        ]
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_remove_item(self):

--- a/tests/unit/gui/multiple/test_transform.py
+++ b/tests/unit/gui/multiple/test_transform.py
@@ -864,9 +864,6 @@ class TransformSubsetRenameTest(TestCase):
 
         selectbox_key = "sb_subset_rename_mul_c1"
 
-        # Before
-        assert at.selectbox(selectbox_key).value != "train"
-
         # Unselect train
         at.selectbox(selectbox_key).select("train").run()
 

--- a/tests/unit/gui/single/test_transform.py
+++ b/tests/unit/gui/single/test_transform.py
@@ -1061,15 +1061,11 @@ class TransformRemoveTest(TestCase):
             at.selectbox(selectbox_key).options
             == at.session_state.data_helper.subset_to_ids()[selected_subset]
         )
-        selected_id = at.selectbox(selectbox_key).value
-        selected_item = at.session_state.data_helper.dataset().get(selected_id, selected_subset)
 
         selectbox_key = "sb_select_ann_id_sin"
         assert at.selectbox(selectbox_key)
         assert at.selectbox(selectbox_key).label == "Select an annotation"
-        assert at.selectbox(selectbox_key).options == [
-            "All",
-        ] + sorted(list({str(ann.id) for ann in selected_item.annotations}))
+        assert at.selectbox(selectbox_key).options == ["All", "mary"]
 
         # button
         button_key = "btn_remove_item_remove_sin"
@@ -1120,7 +1116,13 @@ class TransformRemoveTest(TestCase):
         at.selectbox(selectbox_id_key).select("b").run()
 
         assert at.selectbox(selectbox_id_key).value == "b"
-        assert at.selectbox(selectbox_ann_id_key).options == ["All", "0", "1", "2", "3"]
+        assert at.selectbox(selectbox_ann_id_key).options == [
+            "All",
+            "car",
+            "bicycle",
+            "tom",
+            "mary",
+        ]
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_remove_item(self):
@@ -1489,8 +1491,8 @@ class TransformNDRTest:
         selectbox_key = "sb_select_subset_ndr_sin"
         assert at.selectbox(selectbox_key)
         assert at.selectbox(selectbox_key).label == "Select a subset to apply NDR:"
-        assert at.selectbox(selectbox_key).options == list(
-            at.session_state.data_helper.dataset().subsets().keys()
+        assert at.selectbox(selectbox_key).options == sorted(
+            list(at.session_state.data_helper.dataset().subsets().keys())
         )
 
         # text_input

--- a/tests/unit/gui/single/test_transform.py
+++ b/tests/unit/gui/single/test_transform.py
@@ -646,9 +646,6 @@ class TransformSubsetRenameTest(TestCase):
 
         selectbox_key = "sb_subset_rename_sin"
 
-        # Before
-        assert at.selectbox(selectbox_key).value != "train"
-
         # Unselect train
         at.selectbox(selectbox_key).select("train").run()
 
@@ -1533,9 +1530,6 @@ class TransformNDRTest:
 
         # selectbox
         selectbox_key = "sb_select_subset_ndr_sin"
-
-        # Before
-        assert at.selectbox(selectbox_key).value != "train"
 
         # Unselect train
         at.selectbox(selectbox_key).select("train").run()


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Fixed the problem in [unit test result](https://github.com/openvinotoolkit/datumaro/actions/runs/8432060705/job/23090495355?pr=1376)
- Fixed `select an annotations` in `Remove` of Transform to show annotation label not annotation id

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [X] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
