### PR TITLE
Handling tfds import part to prevent cli error when installing datumaro with default option only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1450>)
 
 ### Bug fixes
+- Fix CLI error occurring when installed with default option only
+  (<https://github.com/openvinotoolkit/datumaro/issues/1444>, <https://github.com/openvinotoolkit/datumaro/pull/1454>)
 - Relax Pillow dependency constraint
   (<https://github.com/openvinotoolkit/datumaro/pull/1436>)
 - Modify Numpy dependency constraint

--- a/src/datumaro/components/extractor_tfds.py
+++ b/src/datumaro/components/extractor_tfds.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2023 Intel Corporation
+# Copyright (C) 2024 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -30,23 +30,23 @@ from attrs import field, frozen
 from datumaro.components.annotation import AnnotationType, Bbox, Label, LabelCategories
 from datumaro.components.dataset_base import CategoriesInfo, DatasetInfo, DatasetItem, IDataset
 from datumaro.components.media import Image, MediaElement
+from datumaro.util.import_util import lazy_import
 from datumaro.util.tf_util import import_tf
 
 TFDS_EXTRACTOR_AVAILABLE = True if find_spec("tensorflow_datasets") is not None else False
 
-if TYPE_CHECKING:
+if TFDS_EXTRACTOR_AVAILABLE:
     try:
-        tf = import_tf()
-        import tensorflow_datasets as tfds
+        if TYPE_CHECKING:
+            tf = import_tf()
+            import tensorflow_datasets as tfds
+        else:
+            tfds = lazy_import("tensorflow_datasets")
     except ImportError:
         log.debug(
             "Unable to import TensorFlow or TensorFlow Datasets. "
             "Dataset downloading via TFDS is disabled."
         )
-else:
-    from datumaro.util.import_util import lazy_import
-
-    tfds = lazy_import("tensorflow_datasets")
 
 
 @frozen(kw_only=True)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
This is a bug fix for the issue #1444 

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
1. uninstall tfds if it exists.
2. install datumaro with default option (`pip install datumaro[default]` or `pip install -e .[default]`)
3. run `datum --version` or `datum --help`

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
