### PR TITLE
Add new annotation type RotatedBbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New features
 - Add task_type property for dataset
   (<https://github.com/openvinotoolkit/datumaro/pull/1422>)
+- Add AnnotationType.rotated_bbox for oriented object detection
+  (<https://github.com/openvinotoolkit/datumaro/pull/1459>)
 
 ### Enhancements
 - Fix ambiguous COCO format detector

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -856,7 +856,7 @@ class RotatedBbox(_Shape):
         self.__attrs_init__([cx, cy, w, h, r], *args, **kwargs)
 
     @classmethod
-    def from_polygon(cls, points: List[Tuple[float, float]], *args, **kwargs):
+    def from_rectangle(cls, points: List[Tuple[float, float]], *args, **kwargs):
         assert len(points) == 4, "polygon for a rotated bbox should have only 4 coordinates."
 
         # Calculate rotation angle

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -856,7 +856,7 @@ class RotatedBbox(_Shape):
         self.__attrs_init__([cx, cy, w, h, r], *args, **kwargs)
 
     @classmethod
-    def from_polygon(cls, points: List[Tuple[float, float]]):
+    def from_polygon(cls, points: List[Tuple[float, float]], *args, **kwargs):
         assert len(points) == 4, "polygon for a rotated bbox should have only 4 coordinates."
 
         # Calculate rotation angle
@@ -870,7 +870,7 @@ class RotatedBbox(_Shape):
         width = math.sqrt((points[1][0] - points[0][0]) ** 2 + (points[1][1] - points[0][1]) ** 2)
         height = math.sqrt((points[2][0] - points[1][0]) ** 2 + (points[2][1] - points[1][1]) ** 2)
 
-        return cls(cx=cx, cy=cy, w=width, h=height, r=math.degrees(rot))
+        return cls(cx=cx, cy=cy, w=width, h=height, r=math.degrees(rot), *args, **kwargs)
 
     @property
     def cx(self):
@@ -896,9 +896,9 @@ class RotatedBbox(_Shape):
         return self.w * self.h
 
     def get_bbox(self):
-        points = self.as_polygon()
-        xs = [p for p in points[0::2]]
-        ys = [p for p in points[1::2]]
+        polygon = self.as_polygon()
+        xs = [pt[0] for pt in polygon]
+        ys = [pt[1] for pt in polygon]
 
         return [min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys)]
 

--- a/src/datumaro/components/annotations/matcher.py
+++ b/src/datumaro/components/annotations/matcher.py
@@ -9,7 +9,7 @@ from attr import attrib, attrs
 
 from datumaro.components.abstracts import IMergerContext
 from datumaro.components.abstracts.merger import IMatcherContext
-from datumaro.components.annotation import Annotation
+from datumaro.components.annotation import Annotation, Points
 from datumaro.util.annotation_util import (
     OKS,
     approximate_line,
@@ -371,5 +371,7 @@ class TabularMatcher(AnnotationMatcher):
 
 @attrs
 class RotatedBboxMatcher(ShapeMatcher):
+    sigma: Optional[list] = attrib(default=None)
+
     def distance(self, a, b):
-        return OKS(a, b, sigma=self.sigma)
+        return OKS(Points(a.as_polygon()), Points(b.as_polygon()), sigma=self.sigma)

--- a/src/datumaro/components/annotations/matcher.py
+++ b/src/datumaro/components/annotations/matcher.py
@@ -367,3 +367,9 @@ class FeatureVectorMatcher(AnnotationMatcher):
 class TabularMatcher(AnnotationMatcher):
     def match_annotations(self, sources):
         raise NotImplementedError()
+
+
+@attrs
+class RotatedBboxMatcher(ShapeMatcher):
+    def distance(self, a, b):
+        return OKS(a, b, sigma=self.sigma)

--- a/src/datumaro/components/annotations/matcher.py
+++ b/src/datumaro/components/annotations/matcher.py
@@ -374,4 +374,7 @@ class RotatedBboxMatcher(ShapeMatcher):
     sigma: Optional[list] = attrib(default=None)
 
     def distance(self, a, b):
-        return OKS(Points(a.as_polygon()), Points(b.as_polygon()), sigma=self.sigma)
+        a = Points([p for pt in a.as_polygon() for p in pt])
+        b = Points([p for pt in b.as_polygon() for p in pt])
+
+        return OKS(a, b, sigma=self.sigma)

--- a/src/datumaro/components/annotations/merger.py
+++ b/src/datumaro/components/annotations/merger.py
@@ -21,6 +21,7 @@ from .matcher import (
     MaskMatcher,
     PointsMatcher,
     PolygonMatcher,
+    RotatedBboxMatcher,
     ShapeMatcher,
     TabularMatcher,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "AnnotationMerger",
     "LabelMerger",
     "BboxMerger",
+    "RotatedBboxMerger",
     "PolygonMerger",
     "MaskMerger",
     "PointsMerger",
@@ -202,4 +204,9 @@ class FeatureVectorMerger(AnnotationMerger, FeatureVectorMatcher):
 
 @attrs
 class TabularMerger(AnnotationMerger, TabularMatcher):
+    pass
+
+
+@attrs
+class RotatedBboxMerger(_ShapeMerger, RotatedBboxMatcher):
     pass

--- a/src/datumaro/components/merge/intersect_merge.py
+++ b/src/datumaro/components/merge/intersect_merge.py
@@ -29,6 +29,7 @@ from datumaro.components.annotations.merger import (
     MaskMerger,
     PointsMerger,
     PolygonMerger,
+    RotatedBboxMerger,
     TabularMerger,
 )
 from datumaro.components.dataset_base import DatasetItem, IDataset
@@ -452,6 +453,8 @@ class IntersectMerge(Merger):
                 return _make(FeatureVectorMerger, **kwargs)
             elif t is AnnotationType.tabular:
                 return _make(TabularMerger, **kwargs)
+            elif t is AnnotationType.rotated_bbox:
+                return _make(RotatedBboxMerger, **kwargs)
             else:
                 raise NotImplementedError("Type %s is not supported" % t)
 

--- a/src/datumaro/components/task.py
+++ b/src/datumaro/components/task.py
@@ -42,8 +42,7 @@ class TaskAnnotationMapping(Mapping[TaskType, Set[AnnotationType]]):
                 AnnotationType.points,
             },
             TaskType.detection_rotated: {
-                AnnotationType.label,
-                AnnotationType.polygon,
+                AnnotationType.rotated_bbox,
             },
             TaskType.detection_3d: {AnnotationType.label, AnnotationType.cuboid_3d},
             TaskType.segmentation_semantic: {
@@ -53,6 +52,7 @@ class TaskAnnotationMapping(Mapping[TaskType, Set[AnnotationType]]):
             TaskType.segmentation_instance: {
                 AnnotationType.label,
                 AnnotationType.bbox,
+                AnnotationType.rotated_bbox,
                 AnnotationType.ellipse,
                 AnnotationType.polygon,
                 AnnotationType.points,
@@ -65,6 +65,7 @@ class TaskAnnotationMapping(Mapping[TaskType, Set[AnnotationType]]):
             TaskType.mixed: {
                 AnnotationType.label,
                 AnnotationType.bbox,
+                AnnotationType.rotated_bbox,
                 AnnotationType.cuboid_3d,
                 AnnotationType.ellipse,
                 AnnotationType.polygon,

--- a/src/datumaro/plugins/data_formats/roboflow/base.py
+++ b/src/datumaro/plugins/data_formats/roboflow/base.py
@@ -16,7 +16,7 @@ from datumaro.components.annotation import (
     Bbox,
     Label,
     LabelCategories,
-    Polygon,
+    RotatedBbox,
 )
 from datumaro.components.dataset import DatasetItem
 from datumaro.components.dataset_base import SubsetBase
@@ -171,8 +171,8 @@ class RoboflowYoloObbBase(RoboflowYoloBase):
             x4 = self._parse_field(x4, float, "x4")
             y4 = self._parse_field(y4, float, "y4")
             annotations.append(
-                Polygon(
-                    points=[x1, y1, x2, y2, x3, y3, x4, y4],
+                RotatedBbox.from_polygon(
+                    points=[(x1, y1), (x2, y2), (x3, y3), (x4, y4)],
                     label=label_id,
                     id=idx,
                     group=idx,

--- a/src/datumaro/plugins/data_formats/roboflow/base.py
+++ b/src/datumaro/plugins/data_formats/roboflow/base.py
@@ -171,7 +171,7 @@ class RoboflowYoloObbBase(RoboflowYoloBase):
             x4 = self._parse_field(x4, float, "x4")
             y4 = self._parse_field(y4, float, "y4")
             annotations.append(
-                RotatedBbox.from_polygon(
+                RotatedBbox.from_rectangle(
                     points=[(x1, y1), (x2, y2), (x3, y3), (x4, y4)],
                     label=label_id,
                     id=idx,

--- a/src/datumaro/util/annotation_util.py
+++ b/src/datumaro/util/annotation_util.py
@@ -2,21 +2,13 @@
 #
 # SPDX-License-Identifier: MIT
 
-import math
 from itertools import groupby
 from typing import Callable, Dict, Iterable, NewType, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from typing_extensions import Literal
 
-from datumaro.components.annotation import (
-    AnnotationType,
-    LabelCategories,
-    Mask,
-    Points,
-    RleMask,
-    _Shape,
-)
+from datumaro.components.annotation import AnnotationType, LabelCategories, Mask, RleMask, _Shape
 from datumaro.util.mask_tools import mask_to_rle
 
 
@@ -297,26 +289,3 @@ def make_label_id_mapping(
         return id_mapping.get(src_id, fallback)
 
     return map_id, id_mapping, source_labels, target_labels
-
-
-def points_to_rotated_bbox(points: Points):
-    """Convert 8 points representing a rotated bounding box to [top_left_x, top_left_y, width, height, rotation]."""
-    # Extract individual coordinates from the flat list
-    x1, y1, x2, y2, x3, y3, _, _ = points  # [x1, y1, x1 + w, y1, x1 + w, y1 + h, x1, y1 + h]
-
-    # Calculate rotation angle
-    angle = math.atan2(y2 - y1, x2 - x1)
-
-    # Calculate the center of the bounding box
-    center_x = (x1 + x3) / 2
-    center_y = (y1 + y3) / 2
-
-    # Calculate width and height
-    width = (x3 - x1) / math.cos(angle)
-    height = (y3 - y1) / math.sin(angle)
-
-    # Calculate top-left corner coordinates
-    top_left_x = center_x - width / 2
-    top_left_y = center_y - height / 2
-
-    return [top_left_x, top_left_y, width, height, angle]

--- a/src/datumaro/util/annotation_util.py
+++ b/src/datumaro/util/annotation_util.py
@@ -2,13 +2,21 @@
 #
 # SPDX-License-Identifier: MIT
 
+import math
 from itertools import groupby
 from typing import Callable, Dict, Iterable, NewType, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from typing_extensions import Literal
 
-from datumaro.components.annotation import AnnotationType, LabelCategories, Mask, RleMask, _Shape
+from datumaro.components.annotation import (
+    AnnotationType,
+    LabelCategories,
+    Mask,
+    Points,
+    RleMask,
+    _Shape,
+)
 from datumaro.util.mask_tools import mask_to_rle
 
 
@@ -289,3 +297,26 @@ def make_label_id_mapping(
         return id_mapping.get(src_id, fallback)
 
     return map_id, id_mapping, source_labels, target_labels
+
+
+def points_to_rotated_bbox(points: Points):
+    """Convert 8 points representing a rotated bounding box to [top_left_x, top_left_y, width, height, rotation]."""
+    # Extract individual coordinates from the flat list
+    x1, y1, x2, y2, x3, y3, _, _ = points  # [x1, y1, x1 + w, y1, x1 + w, y1 + h, x1, y1 + h]
+
+    # Calculate rotation angle
+    angle = math.atan2(y2 - y1, x2 - x1)
+
+    # Calculate the center of the bounding box
+    center_x = (x1 + x3) / 2
+    center_y = (y1 + y3) / 2
+
+    # Calculate width and height
+    width = (x3 - x1) / math.cos(angle)
+    height = (y3 - y1) / math.sin(angle)
+
+    # Calculate top-left corner coordinates
+    top_left_x = center_x - width / 2
+    top_left_y = center_y - height / 2
+
+    return [top_left_x, top_left_y, width, height, angle]

--- a/tests/unit/data_formats/test_roboflow.py
+++ b/tests/unit/data_formats/test_roboflow.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import numpy as np
 import pytest
 
-from datumaro.components.annotation import Bbox, Label, Polygon
+from datumaro.components.annotation import Bbox, Label, Polygon, RotatedBbox
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.environment import DEFAULT_ENVIRONMENT
@@ -174,8 +174,12 @@ def fxt_yolo_obb_dataset():
                 subset="train",
                 media=Image.from_numpy(data=np.ones((5, 10, 3))),
                 annotations=[
-                    Polygon(
-                        points=[0, 0, 0, 2, 2, 2, 2, 0],
+                    RotatedBbox(
+                        1,
+                        1,
+                        2,
+                        2,
+                        90,
                         label=0,
                         group=0,
                         id=0,
@@ -187,8 +191,12 @@ def fxt_yolo_obb_dataset():
                 subset="train",
                 media=Image.from_numpy(data=np.ones((5, 10, 3))),
                 annotations=[
-                    Polygon(
-                        points=[1, 1, 1, 5, 5, 5, 5, 1],
+                    RotatedBbox(
+                        3,
+                        3,
+                        4,
+                        4,
+                        90,
                         label=1,
                         group=0,
                         id=0,
@@ -200,14 +208,22 @@ def fxt_yolo_obb_dataset():
                 subset="val",
                 media=Image.from_numpy(data=np.ones((5, 10, 3))),
                 annotations=[
-                    Polygon(
-                        points=[0, 0, 0, 1, 1, 1, 1, 0],
+                    RotatedBbox(
+                        0.5,
+                        0.5,
+                        1,
+                        1,
+                        90,
                         label=0,
                         group=0,
                         id=0,
                     ),
-                    Polygon(
-                        points=[1, 2, 1, 5, 10, 5, 10, 2],
+                    RotatedBbox(
+                        5.5,
+                        3.5,
+                        3,
+                        9,
+                        90,
                         label=1,
                         group=1,
                         id=1,

--- a/tests/unit/data_formats/test_roboflow.py
+++ b/tests/unit/data_formats/test_roboflow.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import numpy as np
 import pytest
 
-from datumaro.components.annotation import Bbox, Label, Polygon, RotatedBbox
+from datumaro.components.annotation import Bbox, Label, RotatedBbox
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.environment import DEFAULT_ENVIRONMENT

--- a/tests/unit/operations/test_statistics.py
+++ b/tests/unit/operations/test_statistics.py
@@ -10,7 +10,7 @@ import cv2
 import numpy as np
 import pytest
 
-from datumaro.components.annotation import Bbox, Caption, Ellipse, Label, Mask, Points
+from datumaro.components.annotation import Bbox, Caption, Ellipse, Label, Mask, Points, RotatedBbox
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.errors import DatumaroError
@@ -222,6 +222,16 @@ class AnnStatisticsTest:
                                 "occluded": False,
                             },
                         ),
+                        RotatedBbox(
+                            4,
+                            4,
+                            2,
+                            2,
+                            20,
+                            attributes={
+                                "tiny": True,
+                            },
+                        ),
                     ],
                 ),
                 DatasetItem(id=3),
@@ -232,7 +242,7 @@ class AnnStatisticsTest:
 
         expected = {
             "images count": 4,
-            "annotations count": 11,
+            "annotations count": 12,
             "unannotated images count": 2,
             "unannotated images": ["3", "2.2"],
             "annotations by type": {
@@ -256,6 +266,9 @@ class AnnStatisticsTest:
                 },
                 "caption": {
                     "count": 2,
+                },
+                "rotated_bbox": {
+                    "count": 1,
                 },
                 "cuboid_3d": {"count": 0},
                 "super_resolution_annotation": {"count": 0},
@@ -375,27 +388,13 @@ class AnnStatisticsTest:
             "unannotated images count": 0,
             "unannotated images": [],
             "annotations by type": {
-                "label": {
-                    "count": 0,
-                },
-                "polygon": {
-                    "count": 0,
-                },
-                "polyline": {
-                    "count": 0,
-                },
-                "bbox": {
-                    "count": 0,
-                },
-                "mask": {
-                    "count": 0,
-                },
-                "points": {
-                    "count": 0,
-                },
-                "caption": {
-                    "count": 0,
-                },
+                "label": {"count": 0},
+                "polygon": {"count": 0},
+                "polyline": {"count": 0},
+                "bbox": {"count": 0},
+                "mask": {"count": 0},
+                "points": {"count": 0},
+                "caption": {"count": 0},
                 "cuboid_3d": {"count": 0},
                 "super_resolution_annotation": {"count": 0},
                 "depth_annotation": {"count": 0},
@@ -403,6 +402,7 @@ class AnnStatisticsTest:
                 "hash_key": {"count": 0},
                 "feature_vector": {"count": 0},
                 "tabular": {"count": 0},
+                "rotated_bbox": {"count": 0},
                 "unknown": {"count": 0},
             },
             "annotations": {

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 import shapely.geometry as sg
 
-from datumaro.components.annotation import Ellipse, HashKey
+from datumaro.components.annotation import Ellipse, HashKey, RotatedBbox
 
 
 class EllipseTest:
@@ -52,3 +52,18 @@ class HashKeyTest:
     def test_compare_hashkey(self, fxt_hashkeys, expected, request):
         hashkey1, hashkey2 = request.getfixturevalue(fxt_hashkeys)
         assert (expected, hashkey1 == hashkey2)
+
+
+class RotatedBboxTest:
+    @pytest.fixture
+    def fxt_rot_bbox(self):
+        coords = np.random.randint(0, 180, size=(5,), dtype=np.uint8)
+        return RotatedBbox(coords[0], coords[1], coords[2], coords[3], coords[4])
+
+    @pytest.mark.parametrize("fxt_ann", ["fxt_rot_bbox"])
+    def test_create_polygon(self, fxt_ann, request):
+        fxt_rot_bbox = request.getfixturevalue(fxt_ann)
+        polygon = fxt_rot_bbox.as_polygon()
+
+        expected = RotatedBbox.from_polygon(polygon)
+        assert fxt_rot_bbox == expected

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -60,10 +60,8 @@ class RotatedBboxTest:
         coords = np.random.randint(0, 180, size=(5,), dtype=np.uint8)
         return RotatedBbox(coords[0], coords[1], coords[2], coords[3], coords[4])
 
-    @pytest.mark.parametrize("fxt_ann", ["fxt_rot_bbox"])
-    def test_create_polygon(self, fxt_ann, request):
-        fxt_rot_bbox = request.getfixturevalue(fxt_ann)
+    def test_create_polygon(self, fxt_rot_bbox):
         polygon = fxt_rot_bbox.as_polygon()
 
-        expected = RotatedBbox.from_polygon(polygon)
+        expected = RotatedBbox.from_rectangle(polygon)
         assert fxt_rot_bbox == expected

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -17,6 +17,7 @@ from datumaro.components.annotation import (
     PointsCategories,
     Polygon,
     PolyLine,
+    RotatedBbox,
 )
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DEFAULT_SUBSET_NAME, DatasetItem
@@ -222,6 +223,7 @@ class TestMultimerge(TestCase):
                         Points([5, 6], label=0, group=1),
                         Points([6, 8], label=1, group=1),
                         PolyLine([1, 1, 2, 1, 3, 1]),
+                        RotatedBbox(4, 5, 2, 4, 20, label=2),
                     ],
                 ),
             ],
@@ -251,6 +253,7 @@ class TestMultimerge(TestCase):
                         Points([5.5, 6.5], label=0, group=2),
                         Points([6, 8], label=1, group=2),
                         PolyLine([1, 1.5, 2, 1.5]),
+                        RotatedBbox(2, 4, 2, 4, 10, label=1),
                     ],
                 ),
             ],
@@ -280,6 +283,7 @@ class TestMultimerge(TestCase):
                         Bbox(3, 6, 2, 3, label=2, z_order=4, group=3),
                         Points([4.5, 5.5], label=0, group=3),
                         PolyLine([1, 1.25, 3, 1, 4, 2]),
+                        RotatedBbox(2, 4, 2, 4, 10, label=1),
                     ],
                 ),
             ],
@@ -313,6 +317,8 @@ class TestMultimerge(TestCase):
                         Points([5, 6], label=0, group=1),
                         Points([6, 8], label=1, group=1),
                         PolyLine([1, 1.25, 3, 1, 4, 2]),
+                        RotatedBbox(4, 5, 2, 4, 20, label=2),
+                        RotatedBbox(2, 4, 2, 4, 10, label=1),
                     ],
                 ),
             ],
@@ -332,8 +338,18 @@ class TestMultimerge(TestCase):
                 ),
                 NoMatchingAnnError(
                     item_id=("1", DEFAULT_SUBSET_NAME),
+                    sources={0},
+                    ann=source1.get("1").annotations[6],
+                ),
+                NoMatchingAnnError(
+                    item_id=("1", DEFAULT_SUBSET_NAME),
                     sources={1, 2},
                     ann=source0.get("1").annotations[0],
+                ),
+                NoMatchingAnnError(
+                    item_id=("1", DEFAULT_SUBSET_NAME),
+                    sources={1, 2},
+                    ann=source0.get("1").annotations[7],
                 ),
             ],
             sorted(


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

Add a new RotatedBbox annotation type for detection_rotated task.
This provides from_polygon and as_polygon methods for converting set of coordinates to (cx, cy, w, h, r).

This updates the RoboflowYoloObb behavior as a detection_rotated task.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
