### PR TITLE
Relax old pandas version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1436>)
 - Modify Numpy dependency constraint
   (<https://github.com/openvinotoolkit/datumaro/pull/1435>)
+- Relax old pandas version constraint
+  (<https://github.com/openvinotoolkit/datumaro/pull/1467>)
 
 ## Apr. 2024 Release 1.6.0
 ### New features

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -31,7 +31,7 @@ scipy
 requests
 
 # Sampler
-pandas~=1.4.0
+pandas>=1.4.0
 
 # OpenVINO
 openvino>=2023.2.0


### PR DESCRIPTION
### Summary

- To address https://github.com/openvinotoolkit/datumaro/issues/1466

### How to test
Our existing tests can validate the new pandas version

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
