### PR TITLE
Split video directory by subset in datumaro format. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ExtractedMask and update importers who can use it to use it
   (<https://github.com/openvinotoolkit/datumaro/pull/1480>)
 
+### Bug fixes
+- Split the video directory into subsets to avoid overwriting
+  (<https://github.com/openvinotoolkit/datumaro/pull/1485>)
+
 ## May 2024 Release 1.6.1
 ### Enhancements
 - Prevent AcLauncher for OpenVINO 2024.0

--- a/docs/source/docs/data-formats/formats/datumaro.md
+++ b/docs/source/docs/data-formats/formats/datumaro.md
@@ -58,6 +58,14 @@ A Datumaro dataset directory should have the following structure:
     │       ├── <image_name2.ext>
     │       └── ...
     ├── videos/  # directory to store video files
+    │   ├── <subset_name_1>/
+    │   │   ├── <video_name1.ext>
+    │   │   ├── <video_name2.ext>
+    │   │   └── ...
+    │   └── <subset_name_2> /
+    │       ├── <video_name1.ext>
+    │       ├── <video_name2.ext>
+    │       └── ...
     └── annotations/
         ├── <subset_name_1>.json
         ├── <subset_name_2>.json

--- a/src/datumaro/components/exporter.py
+++ b/src/datumaro/components/exporter.py
@@ -400,12 +400,14 @@ class ExportContextComponent:
         item: DatasetItem,
         *,
         basedir: Optional[str] = None,
+        subdir: Optional[str] = None,
         fname: Optional[str] = None,
     ):
         if not item.media or not isinstance(item.media, VideoFrame):
             log.warning("Item '%s' has no video", item.id)
             return
         basedir = self._video_dir if basedir is None else basedir
+        basedir = osp.join(basedir, subdir) if subdir is not None else basedir
         fname = self.make_video_filename(item) if fname is None else fname
 
         path = osp.join(basedir, fname)

--- a/src/datumaro/plugins/data_formats/datumaro/base.py
+++ b/src/datumaro/plugins/data_formats/datumaro/base.py
@@ -190,7 +190,9 @@ class JsonReader:
             if media and video_frame_info:
                 raise MediaTypeError("Dataset cannot contain multiple media types")
             if video_frame_info:
-                video_path = osp.join(self._video_dir, video_frame_info.get("video_path"))
+                video_path = osp.join(
+                    self._video_dir, self._subset, video_frame_info.get("video_path")
+                )
                 if video_path not in self._videos:
                     self._videos[video_path] = Video(video_path)
                 video = self._videos[video_path]

--- a/src/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -185,7 +185,7 @@ class _SubsetWriter:
             if context.save_media:
                 fname = context.make_video_filename(item)
                 if not osp.exists(fname):
-                    context.save_video(item, fname=fname)
+                    context.save_video(item, fname=fname, subdir=item.subset)
                 item.media = VideoFrame(Video(fname), video_frame.index)
 
             yield

--- a/src/datumaro/plugins/data_formats/kitti/base.py
+++ b/src/datumaro/plugins/data_formats/kitti/base.py
@@ -12,7 +12,7 @@ from datumaro.components.annotation import AnnotationType, Bbox, ExtractedMask, 
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.importer import ImportContext
 from datumaro.components.media import Image
-from datumaro.util.image import find_images, load_image
+from datumaro.util.image import find_images, lazy_image
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
 
 from .format import KittiLabelMap, KittiPath, KittiTask, make_kitti_categories, parse_label_map

--- a/src/datumaro/plugins/data_formats/mots.py
+++ b/src/datumaro/plugins/data_formats/mots.py
@@ -19,7 +19,7 @@ from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
-from datumaro.util.image import find_images, load_image, save_image
+from datumaro.util.image import find_images, lazy_image, save_image
 from datumaro.util.mask_tools import merge_masks
 from datumaro.util.meta_file_util import has_meta_file, parse_meta_file
 


### PR DESCRIPTION
### Summary

* ticket No.: 137978

According to the [datumaro documentation](https://openvinotoolkit.github.io/datumaro/latest/docs/data-formats/formats/datumaro.html), video directory is not separated by subset. 
![image](https://github.com/openvinotoolkit/datumaro/assets/75776702/2f6431dc-baac-4278-8e2e-2475b1c2ed59)

So a video will be overwritten if it has a duplicated filename in other subset. 

Following example has two subsets, `train` and `val`, and both subsets have Video_0.avi, ..., Video_9.avi. 
So the videos in the train subset is overwritten by the videos in the val subset.
![image](https://github.com/openvinotoolkit/datumaro/assets/75776702/4e3d22bc-bf78-491c-8ac6-311a7d1f3ba0)

So I'd like to split the video directory by subset to avoid this situation. 

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [x] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```

