### PR TITLE
Download Kaggle datasets

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include requirements-core.txt
 include requirements-default.txt
 include 3rd-party.txt
 include src/datumaro/plugins/specs.json
+include src/datumaro/cli/commands/downloaders/kaggle_formats.json
 
 include rust/Cargo.toml
 recursive-include rust/src *

--- a/src/datumaro/cli/commands/download.py
+++ b/src/datumaro/cli/commands/download.py
@@ -3,78 +3,45 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
-import contextlib
-import logging as log
-import os
-import os.path as osp
-import sys
 from typing import Dict
 
-from datumaro.components.environment import DEFAULT_ENVIRONMENT
-from datumaro.components.extractor_tfds import (
-    AVAILABLE_TFDS_DATASETS,
-    TFDS_EXTRACTOR_AVAILABLE,
-    TfdsDatasetRemoteMetadata,
-)
-from datumaro.util import dump_json
-from datumaro.util.os_util import make_file_name
-
 from ..util import MultilineFormatter
-from ..util.errors import CliException
-from ..util.project import generate_next_file_name
+from .downloaders import IDatasetDownloader, KaggleDatasetDownloader, TfdsDatasetDownloader
 
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
         help="Download a publicly available dataset",
-        description="""
+        description=f"""
         Downloads a publicly available dataset and saves it in a given format.|n
         |n
-        Currently, the only source of datasets is the TensorFlow Datasets
-        library. Therefore, to use this command you must install TensorFlow &
-        TFDS, which you can do as follows:|n
-        |n
-        |s|spip install datumaro[tf,tfds]|n
-        |n
-        To download the dataset, run "datum download run". On the other hand,
-        for information about the datasets, run "datum download describe".
+        To download the dataset, run "datum download <dataset_type> get". On the other hand,
+        for information about the datasets, run "datum download <dataset_type> describe".
+        Supported dataset types are: {list(DOWNLOADERS.keys())}
         """,
         formatter_class=MultilineFormatter,
     )
-    subparsers = parser.add_subparsers(title="Commands")
+    subparsers = parser.add_subparsers(title="Dataset types")
+    for name, downloader in DOWNLOADERS.items():
+        dataset_type_parser = subparsers.add_parser(
+            name=name,
+            help=f"Download {name} dataset",
+            formatter_class=MultilineFormatter,
+        )
+        _subparsers = dataset_type_parser.add_subparsers(title="Commands")
+        build_get_subparser(_subparsers, name, downloader)
+        build_describe_subparser(_subparsers, name, downloader)
 
-    build_get_subparser(subparsers)
-    build_describe_subparser(subparsers)
 
-
-def build_get_subparser(subparsers: argparse._SubParsersAction):
-    builtin_writers = sorted(DEFAULT_ENVIRONMENT.exporters)
-    if TFDS_EXTRACTOR_AVAILABLE:
-        available_datasets = ", ".join(f"tfds:{name}" for name in AVAILABLE_TFDS_DATASETS)
-    else:
-        available_datasets = "N/A (TensorFlow and/or TensorFlow Datasets " "are not installed)"
-
+def build_get_subparser(
+    subparsers: argparse._SubParsersAction, name: str, downloader: IDatasetDownloader
+):
     parser = subparsers.add_parser(
         name="get",
         help="Download a publicly available dataset",
-        description="""
-        Supported datasets: {}|n
-        |n
-        Supported output formats: {}|n
-        |n
-        Examples:|n
-        - Download the MNIST dataset:|n
-        |s|s%(prog)s -i tfds:mnist -- --save-media|n
-        |n
-        - Download the VOC 2012 dataset, saving only the annotations in the COCO
-          format into a specific directory:|n
-        |s|s%(prog)s -i tfds:voc/2012 -f coco -o path/I/like/
-        """.format(
-            available_datasets, ", ".join(builtin_writers)
-        ),
+        description=downloader.get_command_description(),
         formatter_class=MultilineFormatter,
     )
-
     parser.add_argument("-i", "--dataset-id", required=True, help="Which dataset to download")
     parser.add_argument(
         "-f", "--output-format", help="Output format (default: original format of the dataset)"
@@ -96,22 +63,22 @@ def build_get_subparser(subparsers: argparse._SubParsersAction):
         "Must be specified after the main command arguments",
     )
 
-    parser.set_defaults(command=download_command)
+    parser.set_defaults(command=download_command, downloader=downloader)
 
     return parser
 
 
-def build_describe_subparser(subparsers: argparse._SubParsersAction):
+def build_describe_subparser(
+    subparsers: argparse._SubParsersAction, name: str, downloader: IDatasetDownloader
+):
     parser = subparsers.add_parser(
         name="describe",
         help="Print information about downloadable datasets",
-        description="""
+        description=f"""
         Reports information about datasets that can be downloaded with the
-        "datum download" command. The information is reported either as
-        human-readable text (the default) or as a JSON object. More detailed
-        information can be found in the TFDS Catalog:
-        <https://www.tensorflow.org/datasets/catalog/overview>.
-        """,
+        "datum download {name}" command. The information is reported either as
+        human-readable text (the default) or as a JSON object."""
+        + downloader.describe_command_description(),
         formatter_class=MultilineFormatter,
     )
 
@@ -124,7 +91,7 @@ def build_describe_subparser(subparsers: argparse._SubParsersAction):
     parser.add_argument(
         "--report-file", help="File to which to write the report (default: standard output)"
     )
-    parser.set_defaults(command=describe_downloads_command)
+    parser.set_defaults(command=describe_downloads_command, downloader=downloader)
 
     return parser
 
@@ -136,144 +103,22 @@ def get_sensitive_args():
     }
 
 
+DOWNLOADERS: Dict[str, IDatasetDownloader] = {
+    "tfds": TfdsDatasetDownloader,
+    "kaggle": KaggleDatasetDownloader,
+}
+
+
 def download_command(args):
-    env = DEFAULT_ENVIRONMENT
-
-    if args.dataset_id.startswith("tfds:"):
-        if TFDS_EXTRACTOR_AVAILABLE:
-            tfds_ds_name = args.dataset_id[5:]
-            tfds_ds = AVAILABLE_TFDS_DATASETS.get(tfds_ds_name)
-            if tfds_ds:
-                default_output_format = tfds_ds.metadata.default_output_format
-                extractor_factory = tfds_ds.make_extractor
-            else:
-                raise CliException(f"Unsupported TFDS dataset '{tfds_ds_name}'")
-        else:
-            raise CliException(
-                "TFDS datasets are not available, because TFDS and/or "
-                "TensorFlow are not installed.\n"
-                "You can install them with: pip install datumaro[tf,tfds]"
-            )
-    else:
-        raise CliException(f"Unknown dataset ID '{args.dataset_id}'")
-
-    output_format = args.output_format or default_output_format
-
-    try:
-        exporter = env.exporters[output_format]
-    except KeyError:
-        raise CliException("Exporter for format '%s' is not found" % output_format)
-    extra_args = exporter.parse_cmdline(args.extra_args)
-
-    dst_dir = args.dst_dir
-    if dst_dir:
-        if not args.overwrite and osp.isdir(dst_dir) and os.listdir(dst_dir):
-            raise CliException(
-                "Directory '%s' already exists " "(pass --overwrite to overwrite)" % dst_dir
-            )
-    else:
-        dst_dir = generate_next_file_name(
-            "%s-%s"
-            % (
-                make_file_name(args.dataset_id),
-                make_file_name(output_format),
-            )
-        )
-    dst_dir = osp.abspath(dst_dir)
-
-    log.info("Downloading the dataset")
-    extractor = extractor_factory()
-
-    if args.subset:
-        try:
-            extractor = extractor.subsets()[args.subset]
-        except KeyError:
-            raise CliException("Subset '%s' is not present in the dataset" % args.subset)
-
-    log.info("Exporting the dataset")
-    exporter.convert(extractor, dst_dir, default_image_ext=".png", **extra_args)
-
-    log.info("Dataset exported to '%s' as '%s'" % (dst_dir, output_format))
+    args.downloader.download(
+        args.dataset_id,
+        args.dst_dir,
+        args.overwrite,
+        args.output_format,
+        args.subset,
+        args.extra_args,
+    )
 
 
 def describe_downloads_command(args):
-    dataset_metas: Dict[str, TfdsDatasetRemoteMetadata] = {}
-
-    if TFDS_EXTRACTOR_AVAILABLE:
-        for dataset_name, dataset in AVAILABLE_TFDS_DATASETS.items():
-            dataset_metas[f"tfds:{dataset_name}"] = dataset.query_remote_metadata()
-
-    if args.report_format == "text":
-        with open(
-            args.report_file, "w"
-        ) if args.report_file else contextlib.nullcontext() as report_file:
-            if dataset_metas:
-                print("Available datasets:", file=report_file)
-
-                for name, meta in sorted(dataset_metas.items()):
-                    print(file=report_file)
-                    print(f"{name} ({meta.human_name}):", file=report_file)
-                    print(
-                        f"  default output format: {meta.default_output_format}",
-                        file=report_file,
-                    )
-
-                    print("  description:", file=report_file)
-                    for line in meta.description.rstrip("\n").split("\n"):
-                        print(f"    {line}", file=report_file)
-
-                    print(f"  download size: {meta.download_size} bytes", file=report_file)
-                    print(f"  home URL: {meta.home_url or 'N/A'}", file=report_file)
-                    print(f"  number of classes: {meta.num_classes}", file=report_file)
-                    print("  subsets:", file=report_file)
-                    for subset_name, subset_meta in sorted(meta.subsets.items()):
-                        print(f"    {subset_name}: {subset_meta.num_items} items", file=report_file)
-                    print(f"  version: {meta.version}", file=report_file)
-            else:
-                print("No datasets available.", file=report_file)
-                print(file=report_file)
-                print(
-                    "You can enable TFDS datasets by installing "
-                    "TensorFlow and TensorFlow Datasets:",
-                    file=report_file,
-                )
-                print("    pip install datumaro[tf,tfds]", file=report_file)
-
-    elif args.report_format == "json":
-
-        def meta_to_raw(meta: TfdsDatasetRemoteMetadata):
-            raw = {}
-
-            # We omit the media type from the output, because there is currently no mechanism
-            # for mapping media types to strings. The media type could be useful information
-            # for users, though, so we might want to implement such a mechanism eventually.
-
-            for attribute in (
-                "default_output_format",
-                "description",
-                "download_size",
-                "home_url",
-                "human_name",
-                "num_classes",
-                "version",
-            ):
-                raw[attribute] = getattr(meta, attribute)
-
-            raw["subsets"] = {
-                name: {"num_items": subset.num_items} for name, subset in meta.subsets.items()
-            }
-
-            return raw
-
-        with (
-            open(args.report_file, "w") if args.report_file else contextlib.nullcontext(sys.stdout)
-        ) as report_file:
-            report_file.write(
-                dump_json(
-                    {name: meta_to_raw(meta) for name, meta in dataset_metas.items()},
-                    indent=True,
-                    append_newline=True,
-                ).decode()
-            )
-    else:
-        assert False, "unreachable code"
+    return args.downloader.describe(args.report_format, args.report_file)

--- a/src/datumaro/cli/commands/downloaders/__init__.py
+++ b/src/datumaro/cli/commands/downloaders/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+from .downloader import IDatasetDownloader
+from .kaggle import KaggleDatasetDownloader
+from .tfds import TfdsDatasetDownloader
+
+__all__ = [IDatasetDownloader, KaggleDatasetDownloader, TfdsDatasetDownloader]

--- a/src/datumaro/cli/commands/downloaders/downloader.py
+++ b/src/datumaro/cli/commands/downloaders/downloader.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+from typing import Any
+
+
+class IDatasetDownloader:
+    @classmethod
+    def download(
+        cls,
+        dataset_id: str,
+        dst_dir: str,
+        overwrite: bool,
+        output_format: str,
+        subset: str,
+        extra_args: Any,
+    ):
+        raise NotImplementedError()
+
+    @classmethod
+    def describe(cls, report_format, report_file=None) -> str:
+        raise NotImplementedError()
+
+    @classmethod
+    def get_command_description(cls, *args, **kwargs) -> str:
+        raise NotImplementedError()
+
+    @classmethod
+    def describe_command_description(cls):
+        raise NotImplementedError()

--- a/src/datumaro/cli/commands/downloaders/kaggle.py
+++ b/src/datumaro/cli/commands/downloaders/kaggle.py
@@ -29,7 +29,7 @@ def make_all_paths_absolute(d: Dict, root: str = "."):
                 d[k] = str(relpath.resolve())
 
 
-KAGGLE_API_KEY_EXISTS = bool(os.environ["KAGGLE_KEY"]) or os.path.exists(
+KAGGLE_API_KEY_EXISTS = bool(os.environ.get("KAGGLE_KEY")) or os.path.exists(
     os.path.join(os.path.expanduser("~"), ".kaggle")
 )
 

--- a/src/datumaro/cli/commands/downloaders/kaggle.py
+++ b/src/datumaro/cli/commands/downloaders/kaggle.py
@@ -29,6 +29,11 @@ def make_all_paths_absolute(d: Dict, root: str = "."):
                 d[k] = str(relpath.resolve())
 
 
+KAGGLE_API_KEY_EXISTS = bool(os.environ["KAGGLE_KEY"]) or os.path.exists(
+    os.path.join(os.path.expanduser("~"), ".kaggle")
+)
+
+
 class KaggleDatasetDownloader(IDatasetDownloader):
     @classmethod
     def download(

--- a/src/datumaro/cli/commands/downloaders/kaggle.py
+++ b/src/datumaro/cli/commands/downloaders/kaggle.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import json
+import logging as log
+import os
+from argparse import Namespace
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Dict
+
+from datumaro.cli.commands.require_project.modification import create, import_
+
+from ...util.errors import CliException
+from . import IDatasetDownloader
+
+with open(Path(__file__).parent / "kaggle_formats.json") as f:
+    _SUPPORTED_DATASETS = json.load(f)
+
+
+def make_all_paths_absolute(d: Dict, root: str = "."):
+    for k, v in d.items():
+        if isinstance(v, dict):
+            make_all_paths_absolute(v, root)
+        if isinstance(v, str):
+            relpath = Path(root) / v
+            if relpath.exists():
+                d[k] = str(relpath.resolve())
+
+
+class KaggleDatasetDownloader(IDatasetDownloader):
+    @classmethod
+    def download(
+        cls,
+        dataset_id,
+        dst_dir=None,
+        overwrite=False,
+        output_format=None,
+        subset=None,
+        extra_args=None,
+    ):
+        try:
+            import kaggle
+        except ImportError:
+            raise CliException(
+                "Kaggle API is not installed. To install it, run `pip install kaggle`."
+            )
+
+        import_kwargs = _SUPPORTED_DATASETS.get(dataset_id, {})
+        if not import_kwargs:
+            if not extra_args:
+                raise CliException(
+                    f"Dataset {dataset_id} has no datumaro-compatible implementation.\n"
+                    "Please specify the format and constructor arguments explicitly:\n"
+                    "'-- --format=<format> --arg1=<arg1> --arg2=<arg2> ...'"
+                )
+        else:
+            log.info(f"{dataset_id} is supported. Settings:\n{import_kwargs}")
+        if output_format:
+            log.info(f"Overriding the format with {output_format}...")
+            import_kwargs["format"] = output_format
+        if "subsets" in import_kwargs:
+            if not subset or subset not in import_kwargs["subsets"]:
+                raise CliException(
+                    f"Please specify the subset. Options : {[k for k in import_kwargs['subsets']]}"
+                )
+            log.info(f"Getting subset {subset}...")
+            import_kwargs = import_kwargs["subsets"][subset]
+        if extra_args:
+            parsed = import_.build_parser().parse(extra_args)
+            format = parsed.format
+        else:
+            format = import_kwargs.pop("format")
+
+        with TemporaryDirectory() as tmp_dir:
+            kaggle.api.dataset_download_cli(dataset_id, path=tmp_dir, force=overwrite, unzip=True)
+            create.create_command(Namespace(dst_dir=dst_dir))
+            make_all_paths_absolute(import_kwargs, tmp_dir)
+            if not extra_args:
+                extra_args = {}
+                for k, v in import_kwargs.items():
+                    if isinstance(v, (dict, list, tuple)):
+                        extra_args[k] = json.dumps(v)
+                    else:
+                        extra_args[k] = str(v)
+                extra_args = [f"--{k}={v}" for k, v in extra_args.items()]
+            source_name = kaggle.api.split_dataset_string(dataset_id)[1]
+            import_.import_command(
+                Namespace(
+                    _positionals=[],
+                    url=tmp_dir,
+                    project_dir=dst_dir,
+                    format=format,
+                    extra_args=extra_args,
+                    name=source_name,
+                    rpath=None,
+                    no_check=False,
+                )
+            )
+            log.info("Dataset downloaded successfully.")
+
+    @classmethod
+    def describe(cls, report_format="txt", report_file=None) -> None:
+        file = report_file if report_file else None
+        if report_format == "txt":
+            print(cls.get_command_description(), file=file)
+
+    @classmethod
+    def get_command_description(cls) -> str:
+        return f"""
+Supported datasets: {os.linesep.join(_SUPPORTED_DATASETS)}|n
+|n
+Examples:|n
+- Download the face mask detection dataset:|n
+|s|s%(prog)s -i andrewmvd/face-mask-detection"""
+
+    @classmethod
+    def describe_command_description(cls):
+        return """More detailed
+        information can be found in the Kaggle datasets catalog:
+        <https://www.kaggle.com/datasets>."""

--- a/src/datumaro/cli/commands/downloaders/kaggle_formats.json
+++ b/src/datumaro/cli/commands/downloaders/kaggle_formats.json
@@ -1,0 +1,1332 @@
+{
+  "moltean/fruits": {
+    "path": "./fruits-360_dataset/fruits-360/Training",
+    "format": "imagenet"
+  },
+  "paultimothymooney/chest-xray-pneumonia": {
+    "path": "./chest_xray",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "zalando-research/fashionmnist": {
+    "path": "./",
+    "format": "mnist_csv"
+  },
+  "alxmamaev/flowers-recognition": {
+    "path": "./flowers",
+    "format": "imagenet"
+  },
+  "muratkokludataset/rice-image-dataset": {
+    "path": "./Rice_Image_Dataset",
+    "format": "imagenet"
+  },
+  "andrewmvd/face-mask-detection": {
+    "path": "./images",
+    "format": "kaggle_voc",
+    "ann_path": "./annotations"
+  },
+  "kmader/skin-cancer-mnist-ham10000": {
+    "path": "./HAM10000_images_part_1",
+    "format": "kaggle_image_csv",
+    "ann_file": "./HAM10000_metadata.csv",
+    "columns": {
+      "media": "image_id",
+      "label": "dx"
+    }
+  },
+  "muratkokludataset/pistachio-image-dataset": {
+    "path": "./Pistachio_Image_Dataset/Pistachio_Image_Dataset",
+    "format": "imagenet"
+  },
+  "muratkokludataset/durum-wheat-dataset": {
+    "path": "./Durum_Wheat_Dataset/Dataset2-Durum Wheat Video Images",
+    "format": "imagenet"
+  },
+  "puneet6060/intel-image-classification": {
+    "path": "./seg_train/seg_train/",
+    "format": "imagenet"
+  },
+  "gpiosenka/100-bird-species": {
+    "path": ".",
+    "format": "kaggle_image_csv",
+    "ann_file": "./birds.csv",
+    "columns": {
+      "media": "filepaths",
+      "label": "labels"
+    }
+  },
+  "meowmeowmeowmeowmeow/gtsrb-german-traffic-sign": {
+    "path": ".",
+    "format": "kaggle_image_csv",
+    "ann_file": "./Train.csv",
+    "columns": {
+      "media": "Path",
+      "bbox": {
+        "x1": "Roi.X1",
+        "y1": "Roi.Y1",
+        "x2": "Roi.X2",
+        "y2": "Roi.Y2"
+      },
+      "label": "ClassId"
+    }
+  },
+  "ikarus777/best-artworks-of-all-time": {
+    "path": "./images/images",
+    "format": "imagenet"
+  },
+  "crowww/a-large-scale-fish-dataset": {
+    "path": "./Fish_Dataset/Fish_Dataset/Shrimp/Shrimp",
+    "format": "kaggle_image_mask",
+    "mask_path": "./Fish_Dataset/Fish_Dataset/Shrimp/Shrimp GT"
+  },
+  "paultimothymooney/breast-histopathology-images": {
+    "path": "./10253/",
+    "format": "imagenet"
+  },
+  "tawsifurrahman/covid19-radiography-database": {
+    "path": "./COVID-19_Radiography_Dataset/COVID/images",
+    "format": "kaggle_image_mask",
+    "mask_path": "./COVID-19_Radiography_Dataset/COVID/masks"
+  },
+  "grassknoted/asl-alphabet": {
+    "path": "./asl_alphabet_train/asl_alphabet_train",
+    "format": "imagenet"
+  },
+  "vipoooool/new-plant-diseases-dataset": {
+    "path": "./new plant diseases dataset(augmented)/New Plant Diseases Dataset(Augmented)",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "paultimothymooney/blood-cells": {
+    "path": "./dataset-master/dataset-master/JPEGImages/",
+    "format": "kaggle_voc",
+    "ann_path": "./dataset-master/dataset-master/Annotations"
+  },
+  "alessiocorrado99/animals10": {
+    "path": "./raw-img",
+    "format": "imagenet"
+  },
+  "oddrationale/mnist-in-csv": {
+    "path": "./",
+    "format": "mnist_csv"
+  },
+  "sachinpatel21/az-handwritten-alphabets-in-csv-format": {
+    "path": "./A_Z Handwritten Data",
+    "format": "tabular"
+  },
+  "gti-upm/leapgestrecog": {
+    "path": "./leapGestRecog/00",
+    "format": "imagenet"
+  },
+  "paramaggarwal/fashion-product-images-dataset": {
+    "path": "./fashion-dataset/images",
+    "format": "kaggle_image_csv",
+    "ann_file": "./fashion-dataset/styles.csv",
+    "columns": {
+      "media": "id",
+      "label": "masterCategory"
+    }
+  },
+  "alexattia/the-simpsons-characters-dataset": {
+    "path": ".",
+    "format": "kaggle_image_txt",
+    "ann_file": "./annotation.txt",
+    "columns": {
+      "media": 0,
+      "bbox": {
+        "x1": 1,
+        "y1": 2,
+        "width": 3,
+        "height": 4
+      },
+      "label": 5
+    }
+  },
+  "paultimothymooney/kermany2018": {
+    "path": "./oct2017/OCT2017 ",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "slothkong/10-monkey-species": {
+    "path": "./training/training",
+    "format": "imagenet"
+  },
+  "tanlikesmath/diabetic-retinopathy-resized": {
+    "path": "./resized_train/resized_train",
+    "format": "kaggle_image_csv",
+    "ann_file": "./tanlikesmath/diabetic-retinopathy-resized/trainLabels.csv",
+    "columns": {
+      "media": "image",
+      "label": "level"
+    }
+  },
+  "jboysen/mri-and-alzheimers": {
+    "path": ".",
+    "format": "tabular"
+  },
+  "asdasdasasdas/garbage-classification": {
+    "path": "./garbage classification/Garbage classification",
+    "format": "imagenet"
+  },
+  "prasunroy/natural-images": {
+    "path": "./natural_images",
+    "format": "imagenet"
+  },
+  "shaunthesheep/microsoft-catsvsdogs-dataset": {
+    "path": "./PetImages",
+    "format": "imagenet"
+  },
+  "kmader/rsna-bone-age": {
+    "path": "./boneage-training-dataset/boneage-training-dataset",
+    "format": "kaggle_image_csv",
+    "ann_file": "./boneage-training-dataset.csv",
+    "columns": {
+      "media": "id",
+      "label": "boneage"
+    }
+  },
+  "techsash/waste-classification-data": {
+    "path": "./dataset/DATASET",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "landlord/handwriting-recognition": {
+    "path": "./train_v2",
+    "format": "kaggle_image_csv",
+    "ann_file": "./written_name_train_v2.csv",
+    "columns": {
+      "media": "FILENAME",
+      "label": "IDENTITY"
+    }
+  },
+  "andrewmvd/ocular-disease-recognition-odir5k": {
+    "path": "./ODIR-5K/Training Images/",
+    "format": "kaggle_image_csv",
+    "ann_file": "./full_df.csv",
+    "columns": {
+      "media": "filename",
+      "label": "labels"
+    }
+  },
+  "xhlulu/140k-real-and-fake-faces": {
+    "path": "./real_vs_fake/real-vs-fake",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "mbkinaci/fruit-images-for-object-detection": {
+    "path": "./train_zip/train",
+    "format": "kaggle_voc",
+    "ann_path": "./train_zip/train"
+  },
+  "masoudnickparvar/brain-tumor-mri-dataset": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "fournierp/captcha-version-2-images": {
+    "path": "./samples/samples",
+    "format": "image_dir"
+  },
+  "chrisfilo/fruit-recognition": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "andrewmvd/hard-hat-detection": {
+    "path": "./images",
+    "format": "kaggle_voc",
+    "ann_path": "./annotations"
+  },
+  "nipunarora8/age-gender-and-ethnicity-face-data-csv": {
+    "path": ".",
+    "format": "tabular"
+  },
+  "paramaggarwal/fashion-product-images-small": {
+    "path": "./images",
+    "format": "kaggle_image_csv",
+    "ann_file": "./styles.csv",
+    "columns": {
+      "media": "id",
+      "label": "masterCategory"
+    }
+  },
+  "kvpratama/pokemon-images-dataset": {
+    "path": "./pokemon/pokemon",
+    "format": "image_dir"
+  },
+  "ravirajsinh45/real-life-industrial-dataset-of-casting-product": {
+    "path": "./casting_512x512/casting_512x512",
+    "format": "imagenet"
+  },
+  "mohamedhanyyy/chest-ctscan-images": {
+    "subsets": {
+      "Data": {
+        "path": ".",
+        "format": "imagenet_with_subset_dirs"
+      },
+      "Data/train": {
+        "path": ".",
+        "format": "imagenet"
+      }
+    }
+  },
+  "thedownhill/art-images-drawings-painting-sculpture-engraving": {
+    "path": "./dataset/dataset_updated",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "ihelon/lego-minifigures-classification": {
+    "path": ".",
+    "format": "kaggle_image_csv",
+    "ann_file": "./index.csv",
+    "columns": {
+      "media": "path",
+      "label": "class_id"
+    }
+  },
+  "kmader/finding-lungs-in-ct-data": {
+    "path": "./2d_images/",
+    "format": "kaggle_image_mask",
+    "mask_path": "./2d_masks/"
+  },
+  "aryashah2k/breast-ultrasound-images-dataset": {
+    "path": "./Dataset_BUSI_with_GT/benign",
+    "format": "kaggle_image_mask",
+    "mask_path": "./Dataset_BUSI_with_GT/benign"
+  },
+  "ruizgara/socofing": {
+    "path": "./socofing/SOCOFing/Real",
+    "format": "image_dir"
+  },
+  "kritikseth/fruit-and-vegetable-image-recognition": {
+    "path": "./",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "jenny18/honey-bee-annotated-images": {
+    "path": "./bee_imgs",
+    "format": "kaggle_image_csv",
+    "ann_file": "./bee_data.csv",
+    "columns": {
+      "media": "file",
+      "label": "health"
+    }
+  },
+  "iamsouravbanerjee/animal-image-dataset-90-different-animals": {
+    "path": "./animals/animals",
+    "format": "imagenet"
+  },
+  "nih-chest-xrays/sample": {
+    "path": "./sample/images",
+    "format": "kaggle_image_csv",
+    "ann_file": "./sample/sample_labels.csv",
+    "columns": {
+      "media": "Image Index",
+      "label": "Finding Labels"
+    }
+  },
+  "andrewmvd/animal-faces": {
+    "path": "./afhq",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "awsaf49/coco-2017-dataset": {
+    "path": "./coco2017",
+    "format": "mmdet_coco"
+  },
+  "bulentsiyah/semantic-drone-dataset": {
+    "path": "./dataset/semantic_drone_dataset/original_images",
+    "format": "kaggle_image_mask",
+    "mask_path": "./dataset/semantic_drone_dataset/label_images_semantic",
+    "labelmap_file": "./class_dict_seg.csv"
+  },
+  "plameneduardo/sarscov2-ctscan-dataset": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "dansbecker/cityscapes-image-pairs": {
+    "path": "./cityscapes_data",
+    "format": "image_dir"
+  },
+  "dasmehdixtr/drone-dataset-uav": {
+    "subsets": {
+      "dataset_xml_format": {
+        "path": "./dataset_xml_format",
+        "format": "kaggle_voc",
+        "ann_path": "./dataset_xml_format/dataset_xml_format"
+      },
+      "drone_dataset_yolo": {
+        "path": "./drone_dataset_yolo/dataset_txt",
+        "format": "kaggle_yolo",
+        "ann_path": "./drone_dataset_yolo/dataset_txt"
+      }
+    }
+  },
+  "minhhuy2810/rice-diseases-image-dataset": {
+    "path": "./LabelledRice/Labelled",
+    "format": "imagenet"
+  },
+  "anokas/kuzushiji": {
+    "path": ".",
+    "format": "mnist"
+  },
+  "olgabelitskaya/classification-of-handwritten-letters": {
+    "path": "./letters",
+    "format": "kaggle_image_csv",
+    "ann_file": "./letters.csv",
+    "columns": {
+      "media": "file",
+      "label": "letter"
+    }
+  },
+  "diyer22/retail-product-checkout-dataset": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "jangedoo/utkface-new": {
+    "path": "./UTKFace",
+    "format": "image_dir"
+  },
+  "arnaud58/landscape-pictures": {
+    "path": ".",
+    "format": "image_dir"
+  },
+  "joosthazelzet/lego-brick-images": {
+    "path": "./LEGO brick images v1",
+    "format": "imagenet"
+  },
+  "olgabelitskaya/flower-color-images": {
+    "path": "./flower_images/flower_images",
+    "format": "kaggle_image_csv",
+    "ann_file": "./flower_images/flower_images/flower_labels.csv",
+    "columns": {
+      "media": "file",
+      "label": "label"
+    }
+  },
+  "ananthu017/emotion-detection-fer": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "jessicali9530/caltech256": {
+    "path": "./256_ObjectCategories",
+    "format": "imagenet"
+  },
+  "gpiosenka/sports-classification": {
+    "path": ".",
+    "format": "kaggle_image_csv",
+    "ann_file": "./sports.csv",
+    "columns": {
+      "media": "filepaths",
+      "label": "labels"
+    }
+  },
+  "soumikrakshit/anime-faces": {
+    "path": ".",
+    "format": "image_dir"
+  },
+  "andrewmvd/leukemia-classification": {
+    "path": "./C-NMC_Leukemia/training_data/fold_0",
+    "format": "imagenet"
+  },
+  "andrewmvd/lung-and-colon-cancer-histopathological-images": {
+    "path": "./lung_colon_image_set/lung_image_sets",
+    "format": "imagenet"
+  },
+  "drgfreeman/rockpaperscissors": {
+    "path": "./rps-cv-images",
+    "format": "imagenet"
+  },
+  "pankrzysiu/cifar10-python": {
+    "path": "./cifar-10-batches-py",
+    "format": "cifar"
+  },
+  "koryakinp/chess-positions": {
+    "path": "./",
+    "format": "image_dir"
+  },
+  "nancyalaswad90/breast-cancer-dataset": {
+    "path": ".",
+    "format": "tabular"
+  },
+  "clorichel/boat-types-recognition": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "smeschke/four-shapes": {
+    "path": "./shapes",
+    "format": "imagenet"
+  },
+  "andyczhao/covidx-cxr2": {
+    "path": "./train",
+    "format": "kaggle_image_txt",
+    "ann_file": "./train.txt",
+    "columns": {
+      "media": 1,
+      "label": 2
+    }
+  },
+  "nodoubttome/skin-cancer9-classesisic": {
+    "path": "./Skin cancer ISIC The International Skin Imaging Collaboration/",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "vencerlanz09/sea-animals-image-dataste": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "kmkarakaya/logos-bk-kfc-mcdonald-starbucks-subway-none": {
+    "path": "./logos3",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "shubhamgoel27/dermnet": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "nikhilpandey360/chest-xray-masks-and-labels": {
+    "path": "./data/Lung Segmentation/CXR_png",
+    "format": "kaggle_image_mask",
+    "mask_path": "./data/Lung Segmentation"
+  },
+  "vbookshelf/rice-leaf-diseases": {
+    "path": "./rice_leaf_diseases",
+    "format": "imagenet"
+  },
+  "khoongweihao/covid19-xray-dataset-train-test-sets": {
+    "path": "./xray_dataset_covid19/",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "hojjatk/mnist-dataset": {
+    "path": ".",
+    "format": "mnist"
+  },
+  "fatiimaezzahra/famous-iconic-women": {
+    "path": "./output",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "bryanb/abstract-art-gallery": {
+    "path": "./Abstract_gallery/Abstract_gallery",
+    "format": "image_dir"
+  },
+  "hasibalmuzdadid/shoe-vs-sandal-vs-boot-dataset-15k-images": {
+    "path": "./Shoe vs Sandal vs Boot Dataset",
+    "format": "imagenet"
+  },
+  "ifigotin/imagenetmini-1000": {
+    "path": "./imagenet-mini",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "sshikamaru/glaucoma-detection": {
+    "path": "./Fundus_Train_Val_Data/Fundus_Scanes_Sorted/",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "andrewmvd/retinal-disease-classification": {
+    "path": "./Training_Set/Training_Set/Training/",
+    "format": "kaggle_image_csv",
+    "ann_file": "./Training_Set/Training_Set/RFMiD_Training_Labels.csv",
+    "columns": {
+      "media": "ID",
+      "label": "Disease_Risk"
+    }
+  },
+  "tanlikesmath/the-oxfordiiit-pet-dataset": {
+    "path": "./images",
+    "format": "image_dir"
+  },
+  "BengaliAI/numta": {
+    "path": "./training-a",
+    "format": "kaggle_image_csv",
+    "ann_file": "./training-a.csv",
+    "columns": {
+      "media": "filename",
+      "label": "digit"
+    }
+  },
+  "sayangoswami/reddit-memes-dataset": {
+    "path": "./memes/memes",
+    "format": "image_dir"
+  },
+  "jehanbhathena/weather-dataset": {
+    "path": "./dataset",
+    "format": "imagenet"
+  },
+  "kumaresanmanickavelu/lyft-udacity-challenge": {
+    "path": "./dataa/dataA/CameraRGB",
+    "format": "kaggle_image_mask",
+    "mask_path": "./dataa/dataA/CameraSeg"
+  },
+  "fedesoriano/cifar100": {
+    "path": ".",
+    "format": "cifar"
+  },
+  "andrewmvd/doom-crossing": {
+    "path": "./animal_crossing/",
+    "format": "kaggle_image_csv",
+    "ann_file": "./animal_crossing_dataset.csv",
+    "columns": {
+      "media": "filename",
+      "label": "total_awards_received"
+    }
+  },
+  "cactus3/basicshapes": {
+    "path": "./shapes/",
+    "format": "imagenet"
+  },
+  "agrigorev/clothing-dataset-full": {
+    "path": "./images_compressed",
+    "format": "kaggle_image_csv",
+    "ann_file": "./agrigorev/clothing-dataset-full/images.csv",
+    "columns": {
+      "media": "image",
+      "label": "label"
+    }
+  },
+  "odins0n/ucf-crime-dataset": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "hgunraj/covidxct": {
+    "path": "./3A_images",
+    "format": "kaggle_image_txt",
+    "ann_file": "./hgunraj/covidxct/val_COVIDx_CT-3A.txt",
+    "columns": {
+      "media": 0,
+      "bbox": {
+        "x1": 2,
+        "y1": 3,
+        "x2": 4,
+        "y2": 5
+      },
+      "label": 1
+    }
+  },
+  "dhruvildave/english-handwritten-characters-dataset": {
+    "path": ".",
+    "format": "kaggle_image_csv",
+    "ann_file": "./english.csv",
+    "columns": {
+      "media": "image",
+      "label": "label"
+    }
+  },
+  "tunguz/deep-solar-dataset": {
+    "path": ".",
+    "format": "tabular"
+  },
+  "maysee/mushrooms-classification-common-genuss-images": {
+    "path": "./Mushrooms",
+    "format": "imagenet"
+  },
+  "sanikamal/horses-or-humans-dataset": {
+    "path": "./horse-or-human/horse-or-human",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "misrakahmed/vegetable-image-dataset": {
+    "path": "./Vegetable Images",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "ambarish/breakhis": {
+    "path": "./",
+    "format": "kaggle_image_csv",
+    "ann_file": "./Folds.csv",
+    "columns": {
+      "media": "filename",
+      "label": "fold"
+    }
+  },
+  "aelchimminut/fruits262": {
+    "path": "./Fruit-262",
+    "format": "imagenet"
+  },
+  "brsdincer/vehicle-detection-image-set": {
+    "path": "./data",
+    "format": "imagenet"
+  },
+  "valentynsichkar/traffic-signs-dataset-in-yolo-format": {
+    "path": "./ts/ts",
+    "format": "kaggle_yolo",
+    "ann_path": "./ts/ts"
+  },
+  "aalborguniversity/aau-rainsnow": {
+    "path": "./",
+    "format": "kaggle_coco",
+    "ann_file": "./aauRainSnow-rgb.json"
+  },
+  "kostastokis/simpsons-faces": {
+    "path": "./cropped",
+    "format": "image_dir"
+  },
+  "sachinkumar413/alzheimer-mri-dataset": {
+    "path": "./Dataset",
+    "format": "imagenet"
+  },
+  "mistag/arthropod-taxonomy-orders-object-detection-dataset": {
+    "path": "./ArTaxOr",
+    "format": "imagenet"
+  },
+  "jessicali9530/stl10": {
+    "path": "./train_images",
+    "format": "image_dir"
+  },
+  "vencerlanz09/pharmaceutical-drugs-and-vitamins-synthetic-images": {
+    "path": "./ImageClassesCombinedWithCOCOAnnotations/images_raw",
+    "format": "kaggle_coco",
+    "ann_file": "./ImageClassesCombinedWithCOCOAnnotations/coco_instances.json"
+  },
+  "anshtanwar/pets-facial-expression-dataset": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "tunguz/1-million-fake-faces": {
+    "path": "./1m_faces_00_01_02_03/1m_faces_00_01_02_03/1m_faces_00",
+    "format": "image_dir"
+  },
+  "gpiosenka/butterfly-images40-species": {
+    "path": ".",
+    "format": "kaggle_image_csv",
+    "ann_file": "./gpiosenka/butterfly-images40-species/butterflies and moths.csv",
+    "columns": {
+      "media": "filepaths",
+      "label": "labels"
+    }
+  },
+  "meetnagadia/human-action-recognition-har-dataset": {
+    "path": "./Human Action Recognition/train",
+    "format": "kaggle_image_csv",
+    "ann_file": "./Human Action Recognition/Training_set.csv",
+    "columns": {
+      "media": "filename",
+      "label": "label"
+    }
+  },
+  "antoreepjana/animals-detection-images-dataset": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "mahmoudreda55/satellite-image-classification": {
+    "path": "./data",
+    "format": "imagenet"
+  },
+  "andrewmvd/medical-mnist": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "frabbisw/facial-age": {
+    "path": "./face_age",
+    "format": "imagenet"
+  },
+  "odins0n/guie-custom-data": {
+    "path": "./images_224",
+    "format": "imagenet"
+  },
+  "zippyz/cats-and-dogs-breeds-classification-oxford-dataset": {
+    "path": "./images/images",
+    "format": "kaggle_voc",
+    "ann_path": "./annotations/annotations/xmls"
+  },
+  "muhammedtausif/best-selling-mobile-phones": {
+    "path": ".",
+    "format": "tabular"
+  },
+  "kneroma/tacotrashdataset": {
+    "path": "./data",
+    "format": "kaggle_image_csv",
+    "ann_file": "./meta_df.csv",
+    "columns": {
+      "media": "img_file",
+      "bbox": {
+        "x1": "x",
+        "y1": "y",
+        "width": "width",
+        "height": "height"
+      },
+      "label": "cat_name"
+    }
+  },
+  "vencerlanz09/bottle-synthetic-images-dataset": {
+    "path": "./ImageClassesCombinedWithCOCOAnnotations/images_raw",
+    "format": "kaggle_coco",
+    "ann_file": "./ImageClassesCombinedWithCOCOAnnotations/coco_instances.json"
+  },
+  "preetviradiya/brian-tumor-dataset": {
+    "path": "./Brain Tumor Data Set/Brain Tumor Data Set/Brain Tumor",
+    "format": "kaggle_image_csv",
+    "ann_file": "./metadata.csv",
+    "columns": {
+      "media": "image",
+      "label": "class"
+    }
+  },
+  "benjaminwarner/resized-2015-2019-blindness-detection-images": {
+    "path": "./resized train 19",
+    "format": "kaggle_image_csv",
+    "ann_file": "./benjaminwarner/resized-2015-2019-blindness-detection-images/labels/trainLabels19.csv",
+    "columns": {
+      "media": "id_code",
+      "label": "diagnosis"
+    }
+  },
+  "luisblanche/covidct": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "anujms/car-damage-detection": {
+    "path": "./data1a/",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "iamsouravbanerjee/indian-actor-images-dataset": {
+    "path": "./Bollywood Actor Images/Bollywood Actor Images",
+    "format": "imagenet"
+  },
+  "vikramtiwari/pix2pix-dataset": {
+    "path": "./cityscapes/cityscapes/train",
+    "format": "image_dir"
+  },
+  "vencerlanz09/taco-dataset-yolo-format": {
+    "path": ".",
+    "format": "roboflow_yolo"
+  },
+  "balraj98/deepglobe-road-extraction-dataset": {
+    "path": "./train",
+    "format": "kaggle_image_mask",
+    "mask_path": "./train"
+  },
+  "kwentar/blur-dataset": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "vencerlanz09/plastic-paper-garbage-bag-synthetic-images": {
+    "path": "./ImageClassesCombinedWithCOCOAnnotations/images_raw",
+    "format": "kaggle_coco",
+    "ann_file": "./ImageClassesCombinedWithCOCOAnnotations/coco_instances.json"
+  },
+  "utkarshsaxenadn/fast-food-classification-dataset": {
+    "path": "./Fast Food Classification V2",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "robikscube/textocr-text-extraction-from-images-dataset": {
+    "path": "./train_val_images/train_images",
+    "format": "kaggle_image_csv",
+    "ann_file": "./annot.csv",
+    "columns": {
+      "media": "image_id",
+      "bbox": "bbox"
+    }
+  },
+  "andrewmvd/helmet-detection": {
+    "path": "./images",
+    "format": "kaggle_voc",
+    "ann_path": "./annotations/"
+  },
+  "ashfakyeafi/road-vehicle-images-dataset": {
+    "path": "./trafic_data/train/images",
+    "format": "kaggle_yolo",
+    "ann_path": "./ashfakyeafi/road-vehicle-images-dataset/trafic_data/train/labels"
+  },
+  "mostafaabla/garbage-classification": {
+    "path": "./garbage_classification",
+    "format": "imagenet"
+  },
+  "franciscoescobar/satellite-images-of-water-bodies": {
+    "path": "./Water Bodies Dataset/Images",
+    "format": "kaggle_image_mask",
+    "mask_path": "./Water Bodies Dataset/Masks"
+  },
+  "gavinarmstrong/open-sprayer-images": {
+    "path": "./Docknet",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "aaronyin/oneshotpokemon": {
+    "path": "./kaggle-one-shot-pokemon/pokemon-a",
+    "format": "image_dir"
+  },
+  "arashnic/faces-age-detection-dataset": {
+    "path": ".//Train",
+    "format": "kaggle_image_csv",
+    "ann_file": "./train.csv",
+    "columns": {
+      "media": "ID",
+      "label": "Class"
+    }
+  },
+  "ayuraj/asl-dataset": {
+    "path": "./asl_dataset",
+    "format": "imagenet"
+  },
+  "balabaskar/tom-and-jerry-image-classification": {
+    "path": "./tom_and_jerry/tom_and_jerry",
+    "format": "imagenet"
+  },
+  "nafin59/monkeypox-skin-lesion-dataset": {
+    "path": "./Original Images/Original Images",
+    "format": "imagenet"
+  },
+  "trolukovich/food11-image-dataset": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "mrgeislinger/asl-rgb-depth-fingerspelling-spelling-it-out": {
+    "path": ".//dataset5/A",
+    "format": "imagenet"
+  },
+  "balraj98/massachusetts-roads-dataset": {
+    "path": "./tiff/test",
+    "format": "kaggle_image_mask",
+    "mask_path": "./balraj98/massachusetts-roads-dataset/tiff/test_labels"
+  },
+  "kutaykutlu/forest-fire": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "sachinpatel21/pothole-image-dataset": {
+    "path": "./pothole_image_data/Pothole_Image_Data",
+    "format": "image_dir"
+  },
+  "raddar/chest-xrays-indiana-university": {
+    "path": "./images/images_normalized",
+    "format": "kaggle_image_csv",
+    "ann_file": "./raddar/chest-xrays-indiana-university/indiana_projections.csv",
+    "columns": {
+      "media": "filename",
+      "label": "projection"
+    }
+  },
+  "ashfakyeafi/cat-dog-images-for-classification": {
+    "path": "./cat_dog",
+    "format": "kaggle_image_csv",
+    "ann_file": "./cat_dog.csv",
+    "columns": {
+      "media": "image",
+      "label": "labels"
+    }
+  },
+  "meetnaren/goodreads-best-books": {
+    "path": "./images/images",
+    "format": "image_dir"
+  },
+  "kondwani/eye-disease-dataset": {
+    "path": "./Eye_diseases",
+    "format": "imagenet"
+  },
+  "niten19/face-shape-dataset": {
+    "path": "./FaceShape Dataset",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "rishianand/devanagari-character-set": {
+    "path": "./Images/Images",
+    "format": "imagenet"
+  },
+  "pkdarabi/cardetection": {
+    "path": "./",
+    "format": "roboflow_yolo"
+  },
+  "gpiosenka/cards-image-datasetclassification": {
+    "path": "./",
+    "format": "kaggle_image_csv",
+    "ann_file": "./gpiosenka/cards-image-datasetclassification/cards.csv",
+    "columns": {
+      "media": "filepaths",
+      "label": "labels"
+    }
+  },
+  "piterfm/2022-ukraine-russia-war-equipment-losses-oryx": {
+    "path": "./img_russia/img_russia",
+    "format": "imagenet"
+  },
+  "swaroopkml/cifar10-pngs-in-folders": {
+    "path": "./cifar10/cifar10",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "tustunkok/synthetic-turkish-license-plates": {
+    "path": "./license-plates",
+    "format": "image_dir"
+  },
+  "die9origephit/nike-adidas-and-converse-imaged": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "aniruddhsharma/structural-defects-network-concrete-crack-images": {
+    "path": "./Pavements",
+    "format": "imagenet"
+  },
+  "andrewmvd/dog-and-cat-detection": {
+    "path": "./images",
+    "format": "kaggle_voc",
+    "ann_path": "./annotations"
+  },
+  "arpitjain007/game-of-deep-learning-ship-datasets": {
+    "path": "./train/images",
+    "format": "kaggle_image_csv",
+    "ann_file": "./train/train.csv",
+    "columns": {
+      "media": "image",
+      "label": "category"
+    }
+  },
+  "andrewmvd/tomato-detection": {
+    "path": "./images",
+    "format": "kaggle_voc",
+    "ann_path": "./annotations"
+  },
+  "sanikamal/rock-paper-scissors-dataset": {
+    "path": "./Rock-Paper-Scissors",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "mdwaquarazam/agricultural-crops-image-classification": {
+    "path": "./Agricultural-crops",
+    "format": "imagenet"
+  },
+  "akash2907/bird-species-classification": {
+    "path": "./train_data/train_data",
+    "format": "imagenet"
+  },
+  "niteshfre/chessman-image-dataset": {
+    "path": "./Chessman-image-dataset/Chess",
+    "format": "imagenet"
+  },
+  "anshulmehtakaggl/chess-pieces-detection-images-dataset": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "usharengaraju/grassclover-dataset": {
+    "path": "./biomass_data/train/images",
+    "format": "kaggle_image_csv",
+    "ann_file": "./usharengaraju/grassclover-dataset/biomass_data/train/biomass_train_data.csv",
+    "columns": {
+      "media": "image_file_name",
+      "label": "label_type"
+    }
+  },
+  "farjanakabirsamanta/skin-cancer-dataset": {
+    "path": "./Skin Cancer/Skin Cancer",
+    "format": "kaggle_image_csv",
+    "ann_file": "./HAM10000_metadata.csv",
+    "columns": {
+      "media": "image_id",
+      "label": "dx"
+    }
+  },
+  "vaishnaviasonawane/indian-sign-language-dataset": {
+    "path": "./data",
+    "format": "imagenet"
+  },
+  "l3llff/flowers": {
+    "path": "./flowers",
+    "format": "imagenet"
+  },
+  "sharansmenon/animals141": {
+    "path": "./dataset/dataset",
+    "format": "imagenet"
+  },
+  "balabaskar/wonders-of-the-world-image-classification": {
+    "path": "./Wonders of World/Wonders of World",
+    "format": "imagenet"
+  },
+  "nancyalaswad90/us-airports": {
+    "path": ".",
+    "format": "tabular"
+  },
+  "wanderdust/skin-lesion-analysis-toward-melanoma-detection": {
+    "path": "./skin-lesions",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "shashwatwork/knee-osteoarthritis-dataset-with-severity": {
+    "path": "./",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "sadhliroomyprime/spatial-vehicle-detection": {
+    "subsets": {
+      "images": {
+        "path": "./images",
+        "format": "kaggle_coco",
+        "ann_file": "./COCO_Tokyo Japan.json"
+      },
+      ".": {
+        "path": ".",
+        "format": "imagenet_with_subset_dirs"
+      }
+    }
+  },
+  "linchundan/fundusimage1000": {
+    "path": "./1000images",
+    "format": "imagenet"
+  },
+  "rashikrahmanpritom/plant-disease-recognition-dataset": {
+    "path": "./Train/Train",
+    "format": "imagenet"
+  },
+  "ahemateja19bec1025/traffic-sign-dataset-classification": {
+    "path": "./traffic_Data/DATA",
+    "format": "imagenet"
+  },
+  "maedemaftouni/large-covid19-ct-slice-dataset": {
+    "path": "./curated_data/curated_data",
+    "format": "imagenet"
+  },
+  "lplenka/coco-car-damage-detection-dataset": {
+    "path": "./train",
+    "format": "kaggle_coco",
+    "ann_file": "./train/COCO_train_annos.json"
+  },
+  "rhtsingh/130k-images-512x512-universal-image-embeddings": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "anasmohammedtahir/covidqu": {
+    "path": "./Lung Segmentation Data/Lung Segmentation Data/Train/COVID-19/images",
+    "format": "kaggle_image_mask",
+    "mask_path": "./Lung Segmentation Data/Lung Segmentation Data/Train/COVID-19/lung masks"
+  },
+  "d4rklucif3r/cat-and-dogs": {
+    "path": "./dataset/training_set/",
+    "format": "imagenet"
+  },
+  "vencerlanz09/shells-or-pebbles-an-image-classification-dataset": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "andrewmvd/drive-digital-retinal-images-for-vessel-extraction": {
+    "path": "./DRIVE/training/images",
+    "format": "kaggle_image_mask",
+    "mask_path": "./DRIVE/training/mask"
+  },
+  "williamscott701/memotion-dataset-7k": {
+    "path": "./memotion_dataset_7k/images",
+    "format": "kaggle_image_csv",
+    "ann_file": "./williamscott701/memotion-dataset-7k/memotion_dataset_7k/labels.csv",
+    "columns": {
+      "media": "image_name",
+      "label": "overall_sentiment"
+    }
+  },
+  "gunavenkatdoddi/eye-diseases-classification": {
+    "path": "./dataset",
+    "format": "imagenet"
+  },
+  "soumendraprasad/fifa-2022-all-players-image-dataset": {
+    "path": "./Images/Images/Group B/England Players",
+    "format": "imagenet"
+  },
+  "karimabdulnabi/fruit-classification10-class": {
+    "path": "./MY_data/train",
+    "format": "imagenet"
+  },
+  "akhiljethwa/blood-cancer-image-dataset": {
+    "path": "./Blood_Cancer",
+    "format": "image_dir"
+  },
+  "pkdarabi/the-drug-name-detection-dataset": {
+    "path": "./train/images",
+    "format": "kaggle_yolo",
+    "ann_path": "./train/labels"
+  },
+  "dionisiusdh/indonesian-batik-motifs": {
+    "path": ".",
+    "format": "imagenet"
+  },
+  "subinium/emojiimage-dataset": {
+    "path": "./image",
+    "format": "imagenet"
+  },
+  "sadhliroomyprime/motorcycle-night-ride-semantic-segmentation": {
+    "path": "./www.acmeai.tech ODataset 1 - Motorcycle Night Ride Dataset/images",
+    "format": "kaggle_coco",
+    "ann_file": "./www.acmeai.tech ODataset 1 - Motorcycle Night Ride Dataset/COCO_motorcycle (pixel).json"
+  },
+  "nitishabharathi/scene-classification": {
+    "path": "./train-scene classification/train",
+    "format": "kaggle_image_csv",
+    "ann_file": "./nitishabharathi/scene-classification/train-scene classification/train.csv",
+    "columns": {
+      "media": "image_name",
+      "label": "label"
+    }
+  },
+  "harshalhonde/starbucks-reviews-dataset": {
+    "path": ".",
+    "format": "tabular"
+  },
+  "eliasdabbas/emoji-data-descriptions-codepoints": {
+    "path": ".",
+    "format": "tabular"
+  },
+  "lgmoneda/br-coins": {
+    "path": "./COCO_labelme_classification/classification/coco/JPEGImages",
+    "format": "kaggle_coco",
+    "ann_file": "./COCO_labelme_classification/classification/coco/annotations.json"
+  },
+  "preetviradiya/covid19-radiography-dataset": {
+    "path": "./COVID-19_Radiography_Dataset/COVID-19_Radiography_Dataset",
+    "format": "imagenet"
+  },
+  "tapakah68/yandextoloka-water-meters-dataset": {
+    "path": "./WaterMeters/images",
+    "format": "kaggle_image_mask",
+    "mask_path": "./WaterMeters/masks"
+  },
+  "yusufberksardoan/traffic-detection-project": {
+    "path": ".",
+    "format": "roboflow_yolo"
+  },
+  "jtiptj/chest-xray-pneumoniacovid19tuberculosis": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "vijaykumar1799/face-mask-detection": {
+    "path": "./Dataset",
+    "format": "imagenet"
+  },
+  "nancyalaswad90/trip-data-ford-go-bike": {
+    "path": ".",
+    "format": "tabular"
+  },
+  "alifrahman/covid19-chest-xray-image-dataset": {
+    "path": "./dataset",
+    "format": "imagenet"
+  },
+  "vitaminc/cigarette-smoker-detection": {
+    "path": "./data/data",
+    "format": "imagenet"
+  },
+  "tapakah68/segmentation-full-body-mads-dataset": {
+    "path": "./segmentation_full_body_mads_dataset_1192_img/segmentation_full_body_mads_dataset_1192_img/images",
+    "format": "kaggle_image_mask",
+    "mask_path": "./segmentation_full_body_mads_dataset_1192_img/segmentation_full_body_mads_dataset_1192_img/masks"
+  },
+  "mpwolke/cusersmarildownloadsdeadjpg": {
+    "path": ".",
+    "format": "image_dir"
+  },
+  "lsind18/gemstones-images": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "balabaskar/golden-foot-football-players-image-dataset": {
+    "path": "./football_golden_foot/football_golden_foot",
+    "format": "imagenet"
+  },
+  "fantacher/neu-metal-surface-defects-data": {
+    "path": "./NEU Metal Surface Defects Data",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "olgabelitskaya/style-color-images": {
+    "path": "./style",
+    "format": "kaggle_image_csv",
+    "ann_file": "./style/style.csv",
+    "columns": {
+      "media": "file",
+      "label": "brand_name"
+    }
+  },
+  "salmaneunus/rock-classification": {
+    "path": "./Dataset/Metamorphic",
+    "format": "imagenet"
+  },
+  "adhoppin/blood-cell-detection-datatset": {
+    "path": "./",
+    "format": "roboflow_yolo"
+  },
+  "carlosrunner/pizza-not-pizza": {
+    "path": "./pizza_not_pizza",
+    "format": "imagenet"
+  },
+  "maciejgronczynski/biggest-genderface-recognition-dataset": {
+    "path": "./faces",
+    "format": "imagenet"
+  },
+  "balabaskar/cricket-legends-in-world-image-dataset": {
+    "path": "./Cricket Legends/Cricket Legends",
+    "format": "imagenet"
+  },
+  "mksaad/wider-face-a-face-detection-benchmark": {
+    "path": "./WIDER_train/WIDER_train/images",
+    "format": "imagenet"
+  },
+  "vencerlanz09/insect-village-synthetic-dataset": {
+    "path": "./ImageClassesCombinedWithCOCOAnnotations/images_raw",
+    "format": "kaggle_coco",
+    "ann_file": "./ImageClassesCombinedWithCOCOAnnotations/coco_instances.json"
+  },
+  "balraj98/massachusetts-buildings-dataset": {
+    "path": "./png/train",
+    "format": "kaggle_image_mask",
+    "mask_path": "./png/train_labels"
+  },
+  "wwymak/architecture-dataset": {
+    "path": "./arcDataset",
+    "format": "imagenet"
+  },
+  "kmader/parkinsons-drawings": {
+    "path": "./drawings/spiral",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "ivanfel/honey-bee-pollen": {
+    "path": "./PollenDataset/images",
+    "format": "kaggle_image_csv",
+    "ann_file": "./ivanfel/honey-bee-pollen/PollenDataset/pollen_data.csv",
+    "columns": {
+      "media": "filename",
+      "label": "pollen_carrying"
+    }
+  },
+  "birdy654/cifake-real-and-ai-generated-synthetic-images": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "theoviel/rsna-2023-abdominal-trauma-detection-pngs-18": {
+    "path": ".",
+    "format": "image_dir"
+  },
+  "coloradokb/dandelionimages": {
+    "path": "./Images",
+    "format": "imagenet"
+  },
+  "ayanzadeh93/color-classification": {
+    "path": "./ColorClassification",
+    "format": "imagenet"
+  },
+  "vijaygiitk/multiclass-weather-dataset": {
+    "path": "./dataset",
+    "format": "imagenet"
+  },
+  "ashfakyeafi/glasses-classification-dataset": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "samuelcortinhas/muffin-vs-chihuahua-image-classification": {
+    "path": ".",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "subinium/highresolution-anime-face-dataset-512x512": {
+    "path": "./portraits",
+    "format": "image_dir"
+  },
+  "edoardoba/fitness-exercises-with-animations": {
+    "path": ".",
+    "format": "tabular"
+  },
+  "vishesh1412/celebrity-face-image-dataset": {
+    "path": "./Celebrity Faces Dataset",
+    "format": "imagenet"
+  },
+  "mcagriaksoy/amateur-unmanned-air-vehicle-detection-dataset": {
+    "path": "./Database1/Database1",
+    "format": "kaggle_yolo",
+    "ann_path": "./Database1/Database1"
+  },
+  "dataclusterlabs/fire-and-smoke-dataset": {
+    "path": "./Datacluster Fire and Smoke Sample/Datacluster Fire and Smoke Sample",
+    "format": "kaggle_voc",
+    "ann_path": "./dataclusterlabs/fire-and-smoke-dataset/Annotations/Annotations"
+  },
+  "vencerlanz09/pharmaceutical-drugs-and-vitamins-dataset-v2": {
+    "path": ".//Capsure Dataset",
+    "format": "imagenet_with_subset_dirs"
+  },
+  "fernando2rad/brain-tumor-mri-images-44c": {
+    "path": "./",
+    "format": "imagenet"
+  },
+  "roydatascience/training-car": {
+    "path": "./data",
+    "format": "kaggle_image_csv",
+    "ann_file": "./data/driving_log.csv",
+    "columns": {
+      "media": "center",
+      "label": "brake"
+    }
+  },
+  "stoicstatic/face-recognition-dataset": {
+    "path": "./Face Data/Face Dataset",
+    "format": "imagenet"
+  }
+}

--- a/src/datumaro/cli/commands/downloaders/tfds.py
+++ b/src/datumaro/cli/commands/downloaders/tfds.py
@@ -1,0 +1,196 @@
+# Copyright (C) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import contextlib
+import logging as log
+import os
+import os.path as osp
+import sys
+from typing import Dict, Tuple
+
+from datumaro.components.dataset_base import IDataset
+from datumaro.components.environment import DEFAULT_ENVIRONMENT
+from datumaro.components.extractor_tfds import (
+    AVAILABLE_TFDS_DATASETS,
+    TFDS_EXTRACTOR_AVAILABLE,
+    TfdsDatasetRemoteMetadata,
+)
+from datumaro.util import dump_json
+from datumaro.util.os_util import make_file_name
+
+from ...util.errors import CliException
+from ...util.project import generate_next_file_name
+from .downloader import IDatasetDownloader
+
+
+class TfdsDatasetDownloader(IDatasetDownloader):
+    @classmethod
+    def get_extractor(cls, dataset_id: str) -> Tuple[str, IDataset]:
+        if dataset_id.startswith("tfds:"):
+            if TFDS_EXTRACTOR_AVAILABLE:
+                tfds_ds_name = dataset_id[5:]
+                tfds_ds = AVAILABLE_TFDS_DATASETS.get(tfds_ds_name)
+                if tfds_ds:
+                    default_output_format = tfds_ds.metadata.default_output_format
+                    extractor_factory = tfds_ds.make_extractor
+                    return default_output_format, extractor_factory
+                else:
+                    raise CliException(f"Unsupported TFDS dataset '{tfds_ds_name}'")
+            else:
+                raise CliException(
+                    "TFDS datasets are not available, because TFDS and/or"
+                    "TensorFlow are not installed.\n"
+                    "You can install them with: pip install datumaro[tf,tfds]"
+                )
+        else:
+            raise CliException(f"Unknown dataset ID TFDS dataset '{tfds_ds_name}'")
+
+    @staticmethod
+    def _describe_txt(dataset_metas: Dict[str, TfdsDatasetRemoteMetadata], report_file=None):
+        with open(report_file, "w") if report_file else contextlib.nullcontext() as report_file:
+            if dataset_metas:
+                print("Available datasets:", file=report_file)
+                for name, meta in sorted(dataset_metas.items()):
+                    print(
+                        f"""
+{name} ({meta.human_name}):
+  default output format: {meta.default_output_format}
+  description:""",
+                        file=report_file,
+                    )
+                    for line in meta.description.rstrip("\n").split("\n"):
+                        print(f"    {line}", file=report_file)
+                    print(
+                        f"""  download size: {meta.download_size} bytes
+  home URL: {meta.home_url or 'N/A'}
+  number of classes: {meta.num_classes}
+  subsets:""",
+                        file=report_file,
+                    )
+                    for subset_name, subset_meta in sorted(meta.subsets.items()):
+                        print(f"    {subset_name}: {subset_meta.num_items} items", file=report_file)
+                    print(f"  version: {meta.version}" "", file=report_file)
+            else:
+                print(
+                    """No datasets available.
+
+"You can enable TFDS datasets by installing TensorFlow and TensorFlow Datasets:
+    pip install datumaro[tf,tfds]""",
+                    file=report_file,
+                )
+
+    @staticmethod
+    def _describe_json(dataset_metas, report_file):
+        def meta_to_raw(meta: TfdsDatasetRemoteMetadata):
+            raw = {}
+
+            # We omit the media type from the output, because there is currently no mechanism
+            # for mapping media types to strings. The media type could be useful information
+            # for users, though, so we might want to implement such a mechanism eventually.
+
+            for attribute in (
+                "default_output_format",
+                "description",
+                "download_size",
+                "home_url",
+                "human_name",
+                "num_classes",
+                "version",
+            ):
+                raw[attribute] = getattr(meta, attribute)
+
+            raw["subsets"] = {
+                name: {"num_items": subset.num_items} for name, subset in meta.subsets.items()
+            }
+
+            return raw
+
+        with (
+            open(report_file, "w") if report_file else contextlib.nullcontext(sys.stdout)
+        ) as report_file:
+            report_file.write(
+                dump_json(
+                    {name: meta_to_raw(meta) for name, meta in dataset_metas.items()},
+                    indent=True,
+                    append_newline=True,
+                ).decode()
+            )
+
+    @classmethod
+    def describe(cls, report_format, report_file=None):
+        dataset_metas: Dict[str, TfdsDatasetRemoteMetadata] = {}
+
+        if TFDS_EXTRACTOR_AVAILABLE:
+            for dataset_name, dataset in AVAILABLE_TFDS_DATASETS.items():
+                dataset_metas[f"tfds:{dataset_name}"] = dataset.query_remote_metadata()
+
+        if report_format == "text":
+            cls._describe_txt(dataset_metas, report_file)
+
+        elif report_format == "json":
+            cls._describe_json(dataset_metas, report_file)
+
+    @classmethod
+    def describe_command_description(_):
+        return """More detailed
+        information can be found in the TFDS Catalog:
+        <https://www.tensorflow.org/datasets/catalog/overview>."""
+
+    @classmethod
+    def get_command_description(cls):
+        builtin_writers = sorted(DEFAULT_ENVIRONMENT.exporters)
+        if TFDS_EXTRACTOR_AVAILABLE:
+            available_datasets = ", ".join(f"tfds:{name}" for name in AVAILABLE_TFDS_DATASETS)
+        else:
+            available_datasets = "N/A (TensorFlow and/or TensorFlow Datasets are not installed)"
+            return f"""
+Supported datasets: {available_datasets}|n
+|n
+Supported output formats: {", ".join(builtin_writers)}|n
+|n
+Examples:|n
+- Download the MNIST dataset:|n
+|s|s%(prog)s -i tfds:mnist -- --save-media|n
+|n
+- Download the VOC 2012 dataset, saving only the annotations in the COCO
+format into a specific directory:|n
+|s|s%(prog)s -i tfds:voc/2012 -f coco -o path/I/like/
+"""
+
+    @classmethod
+    def download(cls, dataset_id, dst_dir, overwrite, output_format, subset, extra_args):
+        env = DEFAULT_ENVIRONMENT
+        default_output_format, extractor_factory = cls.get_extractor(dataset_id)
+        output_format = output_format or default_output_format
+
+        try:
+            exporter = env.exporters[output_format]
+        except KeyError:
+            raise CliException(f"Exporter for format '{output_format}' is not found")
+        extra_args = exporter.parse_cmdline(extra_args)
+
+        if dst_dir:
+            if not overwrite and osp.isdir(dst_dir) and os.listdir(dst_dir):
+                raise CliException(
+                    f"Directory '{dst_dir}' already exists (pass --overwrite to overwrite)"
+                )
+        else:
+            dst_dir = generate_next_file_name(
+                f"{make_file_name(dataset_id)}-{make_file_name(output_format)}"
+            )
+        dst_dir = osp.abspath(dst_dir)
+
+        log.info("Downloading the dataset")
+        extractor = extractor_factory()
+
+        if subset:
+            try:
+                extractor = extractor.subsets()[subset]
+            except KeyError:
+                raise CliException(f"Subset '{subset}' is not present in the dataset")
+
+        log.info("Exporting the dataset")
+        exporter.convert(extractor, dst_dir, default_image_ext=".png", **extra_args)
+
+        log.info(f"Dataset exported to '{dst_dir}' as '{output_format}'")

--- a/src/datumaro/components/project.py
+++ b/src/datumaro/components/project.py
@@ -100,6 +100,8 @@ class ProjectSourceDataset(IDataset):
         rpath = path
         if config.path:
             rpath = osp.join(path, config.path)
+        if "path" in config.options:
+            rpath = osp.join(path, config.options.pop("path"))
 
         dataset = Dataset.import_from(rpath, env=tree.env, format=config.format, **config.options)
 

--- a/src/datumaro/plugins/data_formats/imagenet.py
+++ b/src/datumaro/plugins/data_formats/imagenet.py
@@ -133,6 +133,14 @@ class ImagenetImporter(Importer):
     def get_file_extensions(cls) -> List[str]:
         return list(IMAGE_EXTENSIONS)
 
+    @classmethod
+    def build_cmdline_parser(cls, **kwargs):
+        parser = super().build_cmdline_parser(**kwargs)
+        parser.add_argument("--path", required=True)
+        parser.add_argument("--subset")
+
+        return parser
+
 
 @with_subset_dirs
 class ImagenetWithSubsetDirsImporter(ImagenetImporter):

--- a/src/datumaro/plugins/data_formats/kaggle/base.py
+++ b/src/datumaro/plugins/data_formats/kaggle/base.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import json
 import os
 import os.path as osp
 import re
@@ -156,7 +157,7 @@ class KaggleImageCsvBase(DatasetBase):
             item_id = osp.splitext(media_name)[0]
 
             media_path = self._get_media_path(media_name)
-            if not osp.exists(media_path):
+            if not media_path or not osp.exists(media_path):
                 warnings.warn(
                     f"'{media_path}' is not existed in the directory, "
                     f"so we skip to create an dataset item according to {row}."
@@ -181,6 +182,15 @@ class KaggleImageCsvBase(DatasetBase):
 
     def __iter__(self):
         yield from self._items
+
+    @classmethod
+    def build_cmdline_parser(cls, **kwargs):
+        parser = super().build_cmdline_parser(**kwargs)
+        parser.add_argument("--path", required=True)
+        parser.add_argument("--ann_file", required=True)
+        parser.add_argument("--columns", required=True, type=json.loads)
+
+        return parser
 
 
 class KaggleImageTxtBase(KaggleImageCsvBase):
@@ -220,7 +230,7 @@ class KaggleImageTxtBase(KaggleImageCsvBase):
                 item_id = osp.splitext(media_name)[0]
 
                 media_path = self._get_media_path(media_name)
-                if not osp.exists(media_path):
+                if not media_path or not osp.exists(media_path):
                     warnings.warn(
                         f"'{media_path}' is not existed in the directory, "
                         f"so we skip to create an dataset item according to {line}."
@@ -330,6 +340,15 @@ class KaggleImageMaskBase(DatasetBase):
     def __iter__(self):
         yield from self._items
 
+    @classmethod
+    def build_cmdline_parser(cls, **kwargs):
+        parser = super().build_cmdline_parser(**kwargs)
+        parser.add_argument("--path", required=True)
+        parser.add_argument("--mask_path", required=True)
+        parser.add_argument("--labelmap_file")
+
+        return parser
+
 
 class KaggleVocBase(SubsetBase):
     ann_extensions = ".xml"
@@ -424,6 +443,15 @@ class KaggleVocBase(SubsetBase):
             return cls(elem.text)
         except Exception as e:
             raise InvalidFieldError(xpath) from e
+
+    @classmethod
+    def build_cmdline_parser(cls, **kwargs):
+        parser = super().build_cmdline_parser(**kwargs)
+        parser.add_argument("--path", required=True)
+        parser.add_argument("--ann_path", required=True)
+        parser.add_argument("--subset")
+
+        return parser
 
 
 class KaggleYoloBase(KaggleVocBase, SubsetBase):
@@ -524,3 +552,12 @@ class KaggleCocoBase(CocoInstancesBase, SubsetBase):
             )
 
             self._length = None
+
+    @classmethod
+    def build_cmdline_parser(cls, **kwargs):
+        parser = super().build_cmdline_parser(**kwargs)
+        parser.add_argument("--path", required=True)
+        parser.add_argument("--ann_file", required=True)
+        parser.add_argument("--subset")
+
+        return parser

--- a/tests/integration/cli/test_download.py
+++ b/tests/integration/cli/test_download.py
@@ -136,7 +136,7 @@ class DownloadGetTest:
             expected_code=1,
         )
 
-    @pytest.mark.skipif(not KAGGLE_API_KEY_EXISTS)
+    @pytest.mark.skipif(not KAGGLE_API_KEY_EXISTS, reason="Kaggle API key missing")
     @pytest.mark.parametrize(
         ("dataset_id", "extra_args"),
         (
@@ -271,7 +271,7 @@ class DownloadDescribeTest:
 
         assert redirected_output == stdout_output
 
-    @pytest.mark.skipif(not KAGGLE_API_KEY_EXISTS)
+    @pytest.mark.skipif(not KAGGLE_API_KEY_EXISTS, reason="Kaggle API key missing")
     def test_kaggle(self):
         run(
             self._helper_tc,

--- a/tests/integration/cli/test_download.py
+++ b/tests/integration/cli/test_download.py
@@ -31,6 +31,7 @@ class DownloadGetTest:
         run(
             self._helper_tc,
             "download",
+            "tfds",
             "get",
             "--dataset-id=tfds:mnist",
             f"--output-dir={test_dir}",
@@ -49,6 +50,7 @@ class DownloadGetTest:
         run(
             self._helper_tc,
             "download",
+            "tfds",
             "get",
             "--dataset-id=tfds:mnist",
             "--output-format=datumaro",
@@ -68,6 +70,7 @@ class DownloadGetTest:
         run(
             self._helper_tc,
             "download",
+            "tfds",
             "get",
             "--dataset-id=tfds:mnist",
             "--output-format=datumaro",
@@ -84,6 +87,7 @@ class DownloadGetTest:
         run(
             self._helper_tc,
             "download",
+            "tfds",
             "get",
             "--dataset-id=tfds:mnist",
             "--output-format=datumaro",
@@ -103,6 +107,7 @@ class DownloadGetTest:
         run(
             self._helper_tc,
             "download",
+            "tfds",
             "get",
             "--dataset-id=tfds:mnist",
             "--output-format=datumaro",
@@ -121,12 +126,42 @@ class DownloadGetTest:
         run(
             self._helper_tc,
             "download",
+            "tfds",
             "get",
             "--dataset-id=tfds:mnist",
             "--output-format=datumaro",
             f"--output-dir={test_dir}",
             "--subset=test",
             expected_code=1,
+        )
+
+    @pytest.mark.parametrize(
+        ("dataset_id", "extra_args"),
+        (
+            ("andrewmvd/face-mask-detection", {}),  # kaggle_voc
+            ("kmader/skin-cancer-mnist-ham10000", {}),  # kaggle_image_csv
+            ("alexattia/the-simpsons-characters-dataset", {}),  # kaggle_image_txt
+            ("dasmehdixtr/drone-dataset-uav", {"subset": "drone_dataset_yolo"}),  # kaggle_yolo,
+            ("aalborguniversity/aau-rainsnow", {}),  # kaggle_coco,
+            ("kmader/finding-lungs-in-ct-data", {}),  # kaggle_image_mask
+            ("moltean/fruits", {}),  # imagenet
+        ),
+    )
+    def test_kaggle(self, dataset_id, extra_args, test_dir: str):
+        args = [
+            "download",
+            "kaggle",
+            "get",
+            f"--dataset-id={dataset_id}",
+            f"--output-dir={test_dir}",
+        ]
+        if "subset" in extra_args:
+            args += ["--subset", extra_args.pop("subset")]
+        if extra_args:
+            args += ["--", *[f"--{key}={value}" for key, value in extra_args.items()]]
+        run(
+            self._helper_tc,
+            *args,
         )
 
 
@@ -140,7 +175,7 @@ class DownloadDescribeTest:
         output_file = io.StringIO()
 
         with contextlib.redirect_stdout(output_file):
-            run(self._helper_tc, "download", "describe")
+            run(self._helper_tc, "download", "tfds", "describe")
 
         output = output_file.getvalue()
 
@@ -180,7 +215,7 @@ class DownloadDescribeTest:
         output_file = io.StringIO()
 
         with contextlib.redirect_stdout(output_file):
-            run(self._helper_tc, "download", "describe", "--report-format=json")
+            run(self._helper_tc, "download", "tfds", "describe", "--report-format=json")
 
         output = parse_json(output_file.getvalue())
 
@@ -215,7 +250,7 @@ class DownloadDescribeTest:
         stdout_file = io.StringIO()
 
         with contextlib.redirect_stdout(stdout_file):
-            run(self._helper_tc, "download", "describe", f"--report-format={format}")
+            run(self._helper_tc, "download", "tfds", "describe", f"--report-format={format}")
 
         stdout_output = stdout_file.getvalue()
 
@@ -223,6 +258,7 @@ class DownloadDescribeTest:
         run(
             self._helper_tc,
             "download",
+            "tfds",
             "describe",
             f"--report-format={format}",
             f"--report-file={redirect_path}",
@@ -232,3 +268,11 @@ class DownloadDescribeTest:
             redirected_output = redirect_file.read()
 
         assert redirected_output == stdout_output
+
+    def test_kaggle(self):
+        run(
+            self._helper_tc,
+            "download",
+            "kaggle",
+            "describe",
+        )

--- a/tests/integration/cli/test_download.py
+++ b/tests/integration/cli/test_download.py
@@ -9,6 +9,7 @@ from unittest.case import skipIf
 
 import pytest
 
+from datumaro.cli.commands.downloaders.kaggle import KAGGLE_API_KEY_EXISTS
 from datumaro.components.dataset import Dataset
 from datumaro.components.extractor_tfds import AVAILABLE_TFDS_DATASETS, TFDS_EXTRACTOR_AVAILABLE
 from datumaro.util import parse_json
@@ -135,6 +136,7 @@ class DownloadGetTest:
             expected_code=1,
         )
 
+    @pytest.mark.skipif(not KAGGLE_API_KEY_EXISTS)
     @pytest.mark.parametrize(
         ("dataset_id", "extra_args"),
         (
@@ -269,6 +271,7 @@ class DownloadDescribeTest:
 
         assert redirected_output == stdout_output
 
+    @pytest.mark.skipif(not KAGGLE_API_KEY_EXISTS)
     def test_kaggle(self):
         run(
             self._helper_tc,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary


CVS-137601
Adds the downloading logic for Kaggle datasets.
258 pre-defined configurations are implemented.

Kaggle API has a request limit, so fetching the metadata for each dataset is still unresolved.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
