### PR TITLE
Improve PIL and COLOR_BGR context image decode performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1471>)
 - Add ExtractedMask and update importers who can use it to use it
   (<https://github.com/openvinotoolkit/datumaro/pull/1480>)
+- Improve PIL and COLOR_BGR context image decode performance
+  (<https://github.com/openvinotoolkit/datumaro/pull/1501>)
 
 ### Bug fixes
 - Split the video directory into subsets to avoid overwriting


### PR DESCRIPTION
### Summary

- Ticket no. 141409
- There was a significant performance degradation on `decode_by_pil()` if `ImageColorChannel.COLOR_BGR`.
- Improve it by returning a numpy array rather than `PIL.Image` and using `cv2.cvtColor()` rather than `np.flip()`.

### How to test

- `tests/unit/test_image.py` covers this change.
- Compare performance with this code (dataset: Imagenette2)

| before | after |
| :-: | :-: |
| ![image](https://github.com/openvinotoolkit/datumaro/assets/26541465/3fd115b0-26b3-4a71-b058-0153cea96b98) | ![image](https://github.com/openvinotoolkit/datumaro/assets/26541465/cb32adb6-cc70-4aef-9ab4-a47b862f1947) |
| 00:51<00:00, 361.65it/s | 00:19<00:00, 859.39it/s |


### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
