### PR TITLE
Improve get_area() for polygons through Shoelace formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1480>)
 - Improve PIL and COLOR_BGR context image decode performance
   (<https://github.com/openvinotoolkit/datumaro/pull/1501>)
+- Improve get_area() of Polygon through Shoelace formula
+  (<https://github.com/openvinotoolkit/datumaro/pull/1507>)
 
 ### Bug fixes
 - Split the video directory into subsets to avoid overwriting

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1385,7 +1385,7 @@ class Tabular(Annotation):
     values: Dict[str, TableDtype] = field(converter=dict)
 
 
-class Annotations(list[Annotation]):
+class Annotations(List[Annotation]):
     """List of `Annotation` equipped with additional utility functions."""
 
     def get_semantic_seg_mask(

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -845,14 +845,15 @@ class Polygon(_Shape):
 
     def _get_shoelace_area(self):
         points = self.get_points()
-        n = len(points) // 2
+        n = len(points)
         # Not a polygon
         if n < 3:
             return 0
+
         area = 0.0
         for i in range(n):
-            x1, y1 = points[2 * i], points[2 * i + 1]
-            x2, y2 = points[2 * ((i + 1) % n)], points[2 * ((i + 1) % n) + 1]
+            x1, y1 = points[i]
+            x2, y2 = points[(i + 1) % n]  # Next vertex, wrapping around using modulo
             area += x1 * y2 - y1 * x2
 
         return abs(area) / 2.0

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -812,11 +812,12 @@ class Polygon(_Shape):
         )
 
     def get_area(self):
-        import pycocotools.mask as mask_utils
+        # import pycocotools.mask as mask_utils
 
-        x, y, w, h = self.get_bbox()
-        rle = mask_utils.frPyObjects([self.points], y + h, x + w)
-        area = mask_utils.area(rle)[0]
+        # x, y, w, h = self.get_bbox()
+        # rle = mask_utils.frPyObjects([self.points], y + h, x + w)
+        # area = mask_utils.area(rle)[0]
+        area = self._get_shoelace_area()
         return area
 
     def as_polygon(self) -> List[float]:
@@ -841,6 +842,20 @@ class Polygon(_Shape):
             return self_points == other_points
         inter_area = self_polygon.intersection(other_polygon).area
         return abs(self_polygon.area - inter_area) < CHECK_POLYGON_EQ_EPSILONE
+
+    def _get_shoelace_area(self):
+        points = self.get_points()
+        n = len(points) // 2
+        # Not a polygon
+        if n < 3:
+            return 0
+        area = 0.0
+        for i in range(n):
+            x1, y1 = points[2 * i], points[2 * i + 1]
+            x2, y2 = points[2 * ((i + 1) % n)], points[2 * ((i + 1) % n) + 1]
+            area += x1 * y2 - y1 * x2
+
+        return abs(area) / 2.0
 
 
 @attrs(slots=True, init=False, order=False)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

![image](https://github.com/openvinotoolkit/datumaro/assets/89109581/dfaf5ac6-1876-4904-814e-21bf32c6f27e)

about 25 times faster computation compared to previous RLE mask based area computation

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
