### PR TITLE
Doc update to replace `--save-images` is replaced with `--save-media`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1484>)
 - Add TabularValidator
   (<https://github.com/openvinotoolkit/datumaro/pull/1498>)
-- Add TblStats in Configurable Validator
-  (<https://github.com/openvinotoolkit/datumaro/pull/1504>)
 
 ### Enhancements
 - Fix ambiguous COCO format detector
@@ -33,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 - Split the video directory into subsets to avoid overwriting
   (<https://github.com/openvinotoolkit/datumaro/pull/1485>)
+- Doc update to replace --save-images is replaced with --save-media
+  (<https://github.com/openvinotoolkit/datumaro/pull/1514>)
 
 ## May 2024 Release 1.6.1
 ### Enhancements

--- a/docs/source/docs/command-reference/context/export.md
+++ b/docs/source/docs/command-reference/context/export.md
@@ -16,10 +16,10 @@ such options, use the `--` separator after the main command arguments.
 The usage information can be printed with `datum import -f <format> -- --help`.
 
 Common export options:
-- Most formats (where applicable) support the `--save-images` option, which
+- Most formats (where applicable) support the `--save-media` option, which
   allows to export dataset images along with annotations. The option is
   disabled be default.
-- If `--save-images` is used, the `image-ext` option can be passed to
+- If `--save-media` is used, the `image-ext` option can be passed to
   specify the output image file extension (`.jpg`, `.png` etc.). By default,
   tries to Datumaro keep the original image extension. This option
   allows to convert all the images from one format into another.
@@ -63,5 +63,5 @@ datum project export \
   -p test_project \
   -o test_project-export \
   -f voc \
-  -- --save-images --image-ext='.png'
+  -- --save-media --image-ext='.png'
 ```

--- a/docs/source/docs/command-reference/context/sources.md
+++ b/docs/source/docs/command-reference/context/sources.md
@@ -65,7 +65,7 @@ datum project import -f cvat <path/to/cvat/default.xml>
 datum project import -f voc_detection -r custom_subset_dir/default.txt <path/to/voc>
 datum project import -f datumaro <path/to/datumaro/default.json>
 datum project import -f image_dir <path/to/images/dir>
-datum project export -f tf_detection_api -- --save-images
+datum project export -f tf_detection_api -- --save-media
 ```
 
 ## Add Dataset
@@ -117,7 +117,7 @@ export in YOLO for model training
 datum project create
 datum project add -f coco -r annotations/instances_train.json dataset1/
 datum project add -f cvat dataset2/train.xml
-datum project export -f yolo -- --save-images
+datum project export -f yolo -- --save-media
 ```
 
 Example: add an existing dataset into a project, avoid data copying

--- a/docs/source/docs/command-reference/context/util.md
+++ b/docs/source/docs/command-reference/context/util.md
@@ -62,5 +62,5 @@ datum util split_video -i video.avi -o video-frames
 datum project create -o proj
 datum project import -p proj -f image_dir video-frames
 datum project import -p proj -f coco_instances annotations.json
-datum project export -p proj -f yolo -- --save-images
+datum project export -p proj -f yolo -- --save-media
 ```

--- a/docs/source/docs/command-reference/context_free/convert.md
+++ b/docs/source/docs/command-reference/context_free/convert.md
@@ -35,5 +35,5 @@ Examples:
   ```console
   datum convert --input-format voc --input-path <path/to/voc-like/dataset/> \
                 --output-format coco \
-                -- --save-images
+                -- --save-media
   ```

--- a/docs/source/docs/command-reference/context_free/download.md
+++ b/docs/source/docs/command-reference/context_free/download.md
@@ -101,5 +101,5 @@ Parameters:
 Examples:
 - Download the MNIST dataset, saving it in the ImageNet text format
   ```console
-  datum download get -i tfds:mnist -f imagenet_txt -- --save-images
+  datum download get -i tfds:mnist -f imagenet_txt -- --save-media
   ```

--- a/docs/source/docs/command-reference/context_free/merge.md
+++ b/docs/source/docs/command-reference/context_free/merge.md
@@ -68,7 +68,7 @@ The command supports passing extra exporting options for the output
 dataset. The format can be specified with the `-f/--format` option.
 Extra options should be passed after the main arguments
 and after the `--` separator. Particularly, this is useful to include
-images in the output dataset with `--save-images`.
+images in the output dataset with `--save-media`.
 
 Usage:
 ```console
@@ -146,5 +146,5 @@ Examples:
 
 - Merge datasets and save in different format
   ```console
-  datum merge -f voc <path/to/dataset1/>:yolo <path/to/dataset2/>:coco -- --save-images
+  datum merge -f voc <path/to/dataset1/>:yolo <path/to/dataset2/>:coco -- --save-media
   ```

--- a/docs/source/docs/command-reference/context_free/patch.md
+++ b/docs/source/docs/command-reference/context_free/patch.md
@@ -7,7 +7,7 @@ Updates items of the first dataset with items from the second one.
 By default, datasets are updated in-place. The `-o/--output-dir`
 option can be used to specify another output directory. When
 updating in-place, use the `--overwrite` parameter along with the
-`--save-images` export option (in-place updates fail by default
+`--save-media` export option (in-place updates fail by default
 to prevent data loss).
 
 ```{eval-rst}
@@ -23,7 +23,7 @@ patched dataset.
 The command supports passing extra exporting options for the output
 dataset. The extra options should be passed after the main arguments
 and after the `--` separator. Particularly, this is useful to include
-images in the output dataset with `--save-images`.
+images in the output dataset with `--save-media`.
 
 This command can be applied to the current project targets or
 arbitrary datasets outside a project. Note that if the target dataset
@@ -58,7 +58,7 @@ Parameters:
 Examples:
 - Update a VOC-like dataset with COCO-like annotations
   ```console
-  datum patch --overwrite <path/to/dataset1/>:voc <path/to/dataset2/>:coco -- --save-images
+  datum patch --overwrite <path/to/dataset1/>:voc <path/to/dataset2/>:coco -- --save-media
   ```
 
 - Generate a patched dataset, based on a project

--- a/docs/source/docs/data-formats/formats/vgg_face2.md
+++ b/docs/source/docs/data-formats/formats/vgg_face2.md
@@ -77,7 +77,7 @@ There is few examples how to do it:
 ```
 # Using `convert` command
 datum convert -if vgg_face2 -i <path_to_vgg_face2> \
-    -f voc -o <output_dir> -- --save-images
+    -f voc -o <output_dir> -- --save-media
 
 # Using Datumaro project
 datum project create

--- a/docs/source/docs/get-started/quick-start-guide/examples.rst
+++ b/docs/source/docs/get-started/quick-start-guide/examples.rst
@@ -20,7 +20,7 @@ Examples
 
     # export Datumaro dataset in CVAT UI, extract somewhere, go to the project dir
     datum filter -e '/item/annotation[occluded="False"]' --mode items+anno
-    datum project export --format tf_detection_api -- --save-images
+    datum project export --format tf_detection_api -- --save-media
 
 - Annotate MS COCO dataset, extract image subset, re-annotate it in
   `CVAT <https://github.com/opencv/cvat>`_, update old dataset:

--- a/docs/source/docs/get-started/quick-start-guide/usage.rst
+++ b/docs/source/docs/get-started/quick-start-guide/usage.rst
@@ -45,4 +45,4 @@ formats and providing high performance operations:
         print(item.id, item.annotations)
 
     # export the resulting dataset in COCO format
-    dataset.export('dst/dir', 'coco', save_images=True)
+    dataset.export('dst/dir', 'coco', save_media=True)

--- a/docs/source/docs/user-manual/how_to_use_datumaro.md
+++ b/docs/source/docs/user-manual/how_to_use_datumaro.md
@@ -35,5 +35,5 @@ datum project commit -m "Transformed"
 datum project checkout HEAD~1 -- source1 # restore a previous revision
 datum project status # prints "modified source1"
 datum project checkout source1 # restore the last revision
-datum project export -f voc -- --save-images
+datum project export -f voc -- --save-media
 ```


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Fixed based on #1509
- Update document to replace `save-images` with `save-media` which is deprecated

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [X] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [X] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
