### PR TITLE
Pass Keyword Argument to TabularDataBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1480>)
 - Set label name with parents to avoid duplicates for AstypeAnnotations
   (<https://github.com/openvinotoolkit/datumaro/pull/1492>)
+- Pass Keyword Argument to TabularDataBase
+  (<https://github.com/openvinotoolkit/datumaro/pull/1522>)
 
 ### Bug fixes
 - Split the video directory into subsets to avoid overwriting

--- a/src/datumaro/plugins/data_formats/tabular.py
+++ b/src/datumaro/plugins/data_formats/tabular.py
@@ -33,6 +33,7 @@ class TabularDataBase(DatasetBase):
         target: Optional[Union[str, List[str]]] = None,
         dtype: Optional[Dict[str, Type[TableDtype]]] = None,
         ctx: Optional[ImportContext] = None,
+        **kwargs,
     ) -> None:
         """
         Read and compose a tabular dataset.
@@ -59,13 +60,14 @@ class TabularDataBase(DatasetBase):
         super().__init__(media_type=TableRow, ctx=ctx)
 
         self._infos = {"path": path}
-        self._items, self._categories = self._parse(paths, target, dtype)
+        self._items, self._categories = self._parse(paths, target, dtype, **kwargs)
 
     def _parse(
         self,
         paths: List[str],
         target: Optional[Dict[str, List[str]]] = None,
         dtype: Optional[Dict[str, Type[TableDtype]]] = None,
+        **kwargs,
     ) -> Tuple[List[DatasetItem], Dict[AnnotationType, Categories]]:
         """
         parse tabular files. Each file is regarded as a subset.
@@ -91,7 +93,7 @@ class TabularDataBase(DatasetBase):
                 raise TypeError('Target should have both "input" and "output"')
 
         for path in paths:
-            table = Table.from_csv(path, dtype=dtype)
+            table = Table.from_csv(path, dtype=dtype, **kwargs)
 
             targets: List[str] = []
             targets_ann: List[str] = []


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Pass kwargs to TabularDataBase during importing dataset
- It could contain any arguments like `encoding`

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [X] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
