### PR TITLE
Verify w and h input multiplication overflow to rleEncode()

### DIFF
--- a/src/datumaro/capi/pybind.cpp
+++ b/src/datumaro/capi/pybind.cpp
@@ -50,7 +50,12 @@ struct RLE
 
 RLE rleEncode(const byte *M, siz h, siz w)
 {
+
     siz j, k, a = w * h;
+
+    if (a / w != h)
+        throw std::runtime_error("result overflow. input size is too big.");
+
     uint c;
     byte p;
     auto cnts = std::make_unique<std::vector<uint>>(a + 1);
@@ -82,6 +87,7 @@ py::dict pyRleEncode(py::array_t<std::uint8_t, py::array::f_style | py::array::f
 
     const siz h = buf.shape[0];
     const siz w = buf.shape[1];
+
     const auto rle = rleEncode(static_cast<const byte *>(buf.ptr), h, w);
 
     py::array_t<uint> cnts(rle.m);


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
