### PR TITLE
Add dtype argument when calling media.data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1492>)
 - Pass Keyword Argument to TabularDataBase
   (<https://github.com/openvinotoolkit/datumaro/pull/1522>)
+- Enable dtype argument when calling media.data
+  (<https://github.com/openvinotoolkit/datumaro/pull/1546>)
 
 ### Bug fixes
 - Preserve end_frame information of a video when it is zero.

--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -51,12 +51,6 @@ else:
 
     pd = lazy_import("pandas")
 
-if TYPE_CHECKING:
-    try:
-        # Introduced in 1.20
-        from numpy.typing import DTypeLike
-    except ImportError:
-        DTypeLike = Any
 
 AnyData = TypeVar("AnyData", bytes, np.ndarray)
 

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -387,6 +387,7 @@ class lazy_image:
         assert isinstance(cache, (ImageCache, bool))
         self._cache = cache
         self._crypter = crypter
+        self._dtype = dtype
 
     def __call__(self) -> np.ndarray:
         image = None

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -372,6 +372,7 @@ class lazy_image:
 
         self._path = path
         self._loader = loader
+        self._dtype = dtype
 
         assert isinstance(cache, (ImageCache, bool))
         self._cache = cache

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -286,7 +286,7 @@ def encode_image(image: np.ndarray, ext: str, dtype: DTypeLike = np.uint8, **kwa
 def decode_image(image_bytes: bytes, dtype: np.dtype = np.uint8) -> np.ndarray:
     ctx_color_scale = IMAGE_COLOR_CHANNEL.get()
 
-    if dtype != np.uint8:
+    if np.issubdtype(dtype, np.floating):
         # PIL doesn't support floating point image loading
         # CV doesn't support floating point image with color channel setting (IMREAD_COLOR)
         with decode_image_context(

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -261,7 +261,7 @@ def encode_image(image: np.ndarray, ext: str, dtype: DTypeLike = np.uint8, **kwa
         if not success:
             raise Exception("Failed to encode image to '%s' format" % (ext))
         return result.tobytes()
-    elif IMAGE_BACKEND.get() == ImageBackend.PIL or dtype != np.uint8:
+    elif IMAGE_BACKEND.get() == ImageBackend.PIL:
         from PIL import Image
 
         if ext.startswith("."):
@@ -383,7 +383,6 @@ class lazy_image:
 
         self._path = path
         self._loader = loader
-        self._dtype = dtype
 
         assert isinstance(cache, (ImageCache, bool))
         self._cache = cache

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,3 +7,5 @@ pytest-stress
 pytest-html
 coverage
 pytest-csv
+
+tifffile

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -193,6 +193,26 @@ class ImageTest(TestCase):
         image = Image.from_bytes(data=image_bytes)
         self.assertEqual(image.ext, None)
 
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_floating_image_from_numpy(self):
+        image_float = np.random.rand(32, 32, 3).astype(np.float16) * 255.0
+        media = Image.from_numpy(image_float)
+        data = media.get_data_as_dtype(dtype=np.float16)
+        self.assertTrue(np.all(image_float == data))
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_floating_image_from_file(self):
+        import tifffile
+
+        with TestDir() as test_dir:
+            image_float = np.random.rand(32, 32, 3).astype(np.float32) * 255.0
+            image_path = osp.join(test_dir, "floating_image.tiff")
+            tifffile.imwrite(image_path, image_float)
+
+            media = Image.from_file(image_path)
+            data = media.get_data_as_dtype(dtype=np.float32)
+            self.assertTrue(np.all(image_float == data))
+
 
 class RoIImageTest(TestCase):
     def _test_ctors(self, img_ctor, args_list, test_dir, is_bytes=False):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
