### PR TITLE
Video bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 - Preserve end_frame information of a video when it is zero.
   (<https://github.com/openvinotoolkit/datumaro/pull/1541>)
+- Changed the Datumaro format to ensure exported videos have relative paths and to prevent the same video from being overwritten.
+  (<https://github.com/openvinotoolkit/datumaro/pull/1547>)
 
 ## Q2 2024 Release 1.7.0
 ### New features

--- a/src/datumaro/components/exporter.py
+++ b/src/datumaro/components/exporter.py
@@ -418,12 +418,15 @@ class ExportContextComponent:
         path = osp.join(basedir, fname)
         path = osp.abspath(path)
 
-        os.makedirs(osp.dirname(path), exist_ok=True)
+        # To prevent the video from being overwritten
+        # (A video can have same path but different start/end frames)
+        if not osp.exists(path):
+            os.makedirs(osp.dirname(path), exist_ok=True)
 
-        if isinstance(item.media, VideoFrame):
-            item.media.video.save(path, crypter=NULL_CRYPTER)
-        else:  # Video
-            item.media.save(path, crypter=NULL_CRYPTER)
+            if isinstance(item.media, VideoFrame):
+                item.media.video.save(path, crypter=NULL_CRYPTER)
+            else:  # Video
+                item.media.save(path, crypter=NULL_CRYPTER)
 
     @property
     def images_dir(self) -> str:

--- a/src/datumaro/components/exporter.py
+++ b/src/datumaro/components/exporter.py
@@ -422,7 +422,6 @@ class ExportContextComponent:
         # (A video can have same path but different start/end frames)
         if not osp.exists(path):
             os.makedirs(osp.dirname(path), exist_ok=True)
-
             if isinstance(item.media, VideoFrame):
                 item.media.video.save(path, crypter=NULL_CRYPTER)
             else:  # Video

--- a/src/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -184,12 +184,9 @@ class _SubsetWriter:
 
             if context.save_media:
                 fname = context.make_video_filename(item)
-                # To prevent the video from being overwritten
-                # (A video can have same path but different start/end frames)
-                if not osp.exists(fname):
-                    context.save_video(item, fname=fname, subdir=item.subset)
+                context.save_video(item, fname=fname, subdir=item.subset)
                 item.media = Video(
-                    path=video.path,
+                    path=fname,
                     step=video._step,
                     start_frame=video._start_frame,
                     end_frame=video._end_frame,
@@ -202,8 +199,7 @@ class _SubsetWriter:
 
             if context.save_media:
                 fname = context.make_video_filename(item)
-                if not osp.exists(fname):
-                    context.save_video(item, fname=fname, subdir=item.subset)
+                context.save_video(item, fname=fname, subdir=item.subset)
                 item.media = VideoFrame(Video(fname), video_frame.index)
 
             yield

--- a/tests/unit/data_formats/datumaro/test_datumaro_format.py
+++ b/tests/unit/data_formats/datumaro/test_datumaro_format.py
@@ -5,6 +5,7 @@
 import os
 import os.path as osp
 import shutil
+import sys
 from functools import partial
 from unittest.mock import patch
 
@@ -189,6 +190,10 @@ class DatumaroFormatTest:
     def test_source_target_pair(
         self, fxt_dataset_pair, compare, require_media, dimension, test_dir, helper_tc, request
     ):
+        if fxt_dataset_pair == "fxt_point_cloud_dataset_pair" and sys.platform == "win32":
+            # TODO: Remove this skip in the future
+            pytest.skip("'test_can_save_and_load_point_cloud' test fails on windows.")
+
         source_dataset, target_dataset = request.getfixturevalue(fxt_dataset_pair)
         self._test_save_and_load(
             helper_tc,

--- a/tests/unit/data_formats/datumaro/test_datumaro_format.py
+++ b/tests/unit/data_formats/datumaro/test_datumaro_format.py
@@ -190,10 +190,6 @@ class DatumaroFormatTest:
     def test_source_target_pair(
         self, fxt_dataset_pair, compare, require_media, dimension, test_dir, helper_tc, request
     ):
-        if fxt_dataset_pair == "fxt_point_cloud_dataset_pair" and sys.platform == "win32":
-            # TODO: Remove this skip in the future
-            pytest.skip("'test_can_save_and_load_point_cloud' test fails on windows.")
-
         source_dataset, target_dataset = request.getfixturevalue(fxt_dataset_pair)
         self._test_save_and_load(
             helper_tc,

--- a/tests/unit/data_formats/datumaro/test_datumaro_format.py
+++ b/tests/unit/data_formats/datumaro/test_datumaro_format.py
@@ -14,7 +14,7 @@ import pytest
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.environment import Environment
 from datumaro.components.importer import DatasetImportError
-from datumaro.components.media import Image, Video
+from datumaro.components.media import Image
 from datumaro.components.project import Dataset
 from datumaro.plugins.data_formats.datumaro.exporter import DatumaroExporter
 from datumaro.plugins.data_formats.datumaro.format import DatumaroPath

--- a/tests/unit/data_formats/datumaro/test_datumaro_format.py
+++ b/tests/unit/data_formats/datumaro/test_datumaro_format.py
@@ -152,6 +152,51 @@ class DatumaroFormatTest:
             stream=stream,
         )
 
+    # @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    # @pytest.mark.parametrize(
+    #     "fxt_dataset, compare, require_media",
+    #     [
+    #         pytest.param(
+    #             "fxt_test_datumaro_format_video_dataset",
+    #             compare_datasets,
+    #             True,
+    #             id="test_can_save_and_load_video_dataset",
+    #         ),
+    #     ],
+    # )
+    # @pytest.mark.parametrize("stream", [True, False])
+    # def test_video_and_videoframe_should_have_relative_path(
+    #     self,
+    #     fxt_test_datumaro_format_video_dataset,
+    #     test_dir,
+    #     fxt_import_kwargs,
+    #     fxt_export_kwargs,
+    #     stream,
+    #     helper_tc,
+    #     request,
+    # ):
+    #     if stream and type(self) != DatumaroFormatTest:
+    #         # TODO: Remove this skip in the future
+    #         pytest.skip(
+    #             "stream=True is only available for DatumaroFormatTest for now "
+    #             "(It is impossible for test_datumaro_binary_format.py)."
+    #         )
+
+    #     fxt_dataset: Dataset = fxt_test_datumaro_format_video_dataset
+    #     # export
+    #     partial(self.exporter.convert, save_media=True, stream=stream, **fxt_export_kwargs)
+
+    #     self._test_save_and_load(
+    #         helper_tc,
+    #         fxt_dataset,
+    #         partial(self.exporter.convert, save_media=True, stream=stream, **fxt_export_kwargs),
+    #         test_dir,
+    #         compare=compare,
+    #         require_media=require_media,
+    #         importer_args=fxt_import_kwargs,
+    #         stream=stream,
+    #     )
+
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @pytest.mark.parametrize(
         "fxt_dataset_pair, compare, require_media, dimension",

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -327,8 +327,13 @@ def check_save_and_load(
         for item in dataset:
             if item.media:
                 if hasattr(item.media, "path") and item.media.path:
-                    path = item.media.path.replace(source_path, target_path)
-                    item.media = item.media.from_self(path=path)
+                    if isinstance(item.media, VideoFrame):
+                        path = (
+                            item.media.video._path
+                        )  # _path includes the OS-specific directory separator
+                    else:
+                        path = item.media._path
+                    item.media = item.media.from_self(path=path.replace(source_path, target_path))
                 if isinstance(item.media, PointCloud):
                     new_images = []
                     for image in item.media.extra_images:

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -347,7 +347,6 @@ def check_save_and_load(
             save_dir = tmp_dir
             for file in os.listdir(test_dir):
                 shutil.move(osp.join(test_dir, file), save_dir)
-                # os.symlink(osp.join(test_dir, file), osp.join(save_dir, file))
         else:
             save_dir = test_dir
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -346,7 +346,8 @@ def check_save_and_load(
         if move_save_dir:
             save_dir = tmp_dir
             for file in os.listdir(test_dir):
-                os.symlink(osp.join(test_dir, file), osp.join(save_dir, file))
+                shutil.move(osp.join(test_dir, file), save_dir)
+                # os.symlink(osp.join(test_dir, file), osp.join(save_dir, file))
         else:
             save_dir = test_dir
 


### PR DESCRIPTION
### Summary
Resolves 145146 and 145169 for datumaro format.
* 145146
  - When exporting a video several times, it should be saved only once to prevent the video from being overwritten. 
* 145169
  - Exported video paths should be relative from `videos/<subset>` directory.

### How to test
Tests are automatically done by tests in tests/unit/data_formats/datumaro/test_datumaro_format.py.
* Test for 145146: test_export_video_only_once
* Test for 145169: test_can_save_and_load

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
