### PR TITLE
Make ImageNet data format streamable

### DIFF
--- a/src/datumaro/components/dataset.py
+++ b/src/datumaro/components/dataset.py
@@ -1018,9 +1018,11 @@ class StreamDataset(Dataset):
             source = sources[0]
             dataset = cls(source=source, env=env)
         else:
-            class _StreamDatasetUnion(cls):
-                def __init__(self, *sources: IDataset, env: Optional[Environment]=None):
+
+            class _MergedStreamDataset(cls):
+                def __init__(self, *sources: IDataset):
                     from datumaro.components.hl_ops import HLOps
+
                     self.merged = HLOps.merge(*sources, merge_policy=merge_policy)
 
                 def __iter__(self):
@@ -1033,7 +1035,7 @@ class StreamDataset(Dataset):
                 def subsets(self) -> Dict[str, DatasetSubset]:
                     return self.merged.subsets()
 
-            return _StreamDatasetUnion(*sources)
+            return _MergedStreamDataset(*sources)
 
         return dataset
 

--- a/src/datumaro/components/dataset.py
+++ b/src/datumaro/components/dataset.py
@@ -989,6 +989,54 @@ class StreamDataset(Dataset):
     def is_eager(self) -> bool:
         return False
 
+    @classmethod
+    def from_extractors(
+        cls,
+        *sources: IDataset,
+        env: Optional[Environment] = None,
+        merge_policy: str = DEFAULT_MERGE_POLICY,
+    ) -> Dataset:
+        """
+        Creates a new dataset from one or several `Extractor`s.
+
+        In case of a single input, creates a lazy wrapper around the input.
+        In case of several inputs, unifies them and caches the resulting
+        dataset. We cannot apply regular dataset merge, since items list cannot be accessed.
+
+        Parameters:
+            sources: one or many input extractors
+            env: A context for plugins, which will be used for this dataset.
+                If not specified, the builtin plugins will be used.
+            merge_policy: Policy on how to merge multiple datasets.
+                Possible options are "exact", "intersect", and "union".
+
+        Returns:
+            dataset: A new dataset with contents produced by input extractors
+        """
+
+        if len(sources) == 1:
+            source = sources[0]
+            dataset = cls(source=source, env=env)
+        else:
+            class _StreamDatasetUnion(cls):
+                def __init__(self, *sources: IDataset, env: Optional[Environment]=None):
+                    from datumaro.components.hl_ops import HLOps
+                    self.merged = HLOps.merge(*sources, merge_policy=merge_policy)
+
+                def __iter__(self):
+                    yield from self.merged
+
+                @property
+                def is_stream(self):
+                    return True
+
+                def subsets(self) -> Dict[str, DatasetSubset]:
+                    return self.merged.subsets()
+
+            return _StreamDatasetUnion(*sources)
+
+        return dataset
+
 
 @contextmanager
 def eager_mode(new_mode: bool = True, dataset: Optional[Dataset] = None) -> None:

--- a/src/datumaro/plugins/data_formats/imagenet.py
+++ b/src/datumaro/plugins/data_formats/imagenet.py
@@ -41,7 +41,7 @@ class ImagenetBase(SubsetBase):
         self._max_depth = min_depth
         self._min_depth = max_depth
         self._categories = self._load_categories(path)
-        self.path = path
+        self._items = list(self._load_items(path).values())
 
     def _load_categories(self, path):
         label_cat = LabelCategories()
@@ -52,35 +52,39 @@ class ImagenetBase(SubsetBase):
                 label_cat.add(str(dirname))
         return {AnnotationType.label: label_cat}
 
-    def __iter__(self):
-        cache = {}
+    def _load_items(self, path):
+        items = {}
+
         for image_path in find_images(
-            self.path, recursive=True, max_depth=self._max_depth, min_depth=self._min_depth
+            path, recursive=True, max_depth=self._max_depth, min_depth=self._min_depth
         ):
-            label = str(Path(image_path).parent.relative_to(self.path))
+            label = str(Path(image_path).parent.relative_to(path))
             if label == ".":  # image is located in the root directory
                 label = ImagenetPath.IMAGE_DIR_NO_LABEL
             image_name = Path(image_path).stem
             item_id = str(label) + ImagenetPath.SEP_TOKEN + image_name
-            item = cache.get(item_id)
-            if item is None:
-                try:
+            item = items.get(item_id)
+            try:
+                if item is None:
                     item = DatasetItem(
                         id=item_id, subset=self._subset, media=Image.from_file(path=image_path)
                     )
-                    cache[item_id] = item
-                except Exception as e:
-                    self._ctx.error_policy.report_item_error(e, item_id=(item_id, self._subset))
+                    items[item_id] = item
+            except Exception as e:
+                self._ctx.error_policy.report_item_error(e, item_id=(item_id, self._subset))
+            annotations = item.annotations
+
             if label != ImagenetPath.IMAGE_DIR_NO_LABEL:
                 try:
                     label = self._categories[AnnotationType.label].find(label)[0]
-                    item.annotations.append(Label(label=label))
+                    annotations.append(Label(label=label))
                     self._ann_types.add(AnnotationType.label)
                 except Exception as e:
                     self._ctx.error_policy.report_annotation_error(
                         e, item_id=(item_id, self._subset)
                     )
-            yield item
+
+        return items
 
     @property
     def is_stream(self) -> bool:


### PR DESCRIPTION
Geti requires all data formats to be streamable, i. e. generate dataset items on demand.
This PR allows streaming for ImageNet format.