### PR TITLE
Fix bug where custom environment plugins were lost on dataset merge

### DIFF
--- a/src/datumaro/components/environment.py
+++ b/src/datumaro/components/environment.py
@@ -275,7 +275,7 @@ class Environment:
         merged = Environment()
 
         def _register(registry: PluginRegistry):
-            merged.register_plugins(plugin for plugin in registry)
+            merged.register_plugins(list(registry._items.values()))
 
         for env in envs:
             _register(env.extractors)

--- a/src/datumaro/components/hl_ops/__init__.py
+++ b/src/datumaro/components/hl_ops/__init__.py
@@ -282,13 +282,14 @@ class HLOps:
         merger = get_merger(merge_policy, **kwargs)
         merged = merger(*datasets)
         env = Environment.merge(
-            dataset.env
-            for dataset in datasets
-            if hasattr(
-                dataset, "env"
-            )  # TODO: Sometimes, there is dataset which is not exactly "Dataset",
-            # e.g., VocClassificationBase. this should be fixed and every object from
-            # Dataset.import_from should have "Dataset" type.
+            [
+                dataset.env
+                for dataset in datasets
+                if hasattr(dataset, "env")
+                # TODO: Sometimes, there is dataset which is not exactly "Dataset",
+                # e.g., VocClassificationBase. this should be fixed and every object from
+                # Dataset.import_from should have "Dataset" type.
+            ]
         )
         if report_path:
             merger.save_merge_report(report_path)

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -5,7 +5,8 @@
 import pytest
 
 import datumaro.components.lazy_plugin
-from datumaro.components.environment import Environment, PluginRegistry
+from datumaro.components.environment import DEFAULT_ENVIRONMENT, Environment, PluginRegistry
+from datumaro.components.exporter import Exporter
 
 real_find_spec = datumaro.components.lazy_plugin.find_spec
 
@@ -77,3 +78,17 @@ class EnvironmentTest:
         )
 
         assert "tf_detection_api" not in loaded_plugin_names
+
+    def test_merge_default_env(self):
+        merged_env = Environment.merge([DEFAULT_ENVIRONMENT, DEFAULT_ENVIRONMENT])
+        assert merged_env is DEFAULT_ENVIRONMENT
+
+    def test_merge_custom_env(self):
+        class TestPlugin(Exporter):
+            pass
+
+        envs = [Environment(), Environment()]
+        envs[0].exporters.register("test_plugin", TestPlugin)
+
+        merged = Environment.merge(envs)
+        assert "test_plugin" in merged.exporters


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

I ran into an issue where plugins loaded into the `Environment` are not retained after merging. Turns out a generator is being passed to [Environment.merge](https://github.com/openvinotoolkit/datumaro/blob/30b1add52d6fe458dba5e32e1f63ffeea999ad7b/src/datumaro/components/environment.py#L271) instead of the expected Sequence. This meant that custom plugins were never registered into the merged environment.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

Reproducible example:

```python
from datumaro.components.dataset import Dataset
from datumaro.components.environment import Environment
from datumaro.components.exporter import Exporter
from datumaro.components.hl_ops import HLOps
from datumaro.components.media import Image


class MyPlugin(Exporter):
    pass


environment = Environment()
environment.exporters.register('my_plugin', MyPlugin)

dataset1 = Dataset(media_type=Image, env=environment)
datasets = [dataset1, dataset1.clone()]
merged = HLOps.merge(*datasets)

assert 'my_plugin' in dataset1.env.exporters  # Passes
assert 'my_plugin' in merged.env.exporters  # Fails

```

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
