### PR TITLE
Use DataFrame.map instead of DataFrame.applymap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements
 - Support multiple labels for kaggle format
   (<https://github.com/openvinotoolkit/datumaro/pull/1607>)
+- Use DataFrame.map instead of DataFrame.applymap
+  (<https://github.com/openvinotoolkit/datumaro/pull/1613>)
 
 ### Bug fixes
 - Fix StreamDataset merging when importing in eager mode

--- a/src/datumaro/plugins/transforms.py
+++ b/src/datumaro/plugins/transforms.py
@@ -1957,7 +1957,7 @@ class Clean(ItemTransform):
             or item.media.table.dtype(col) is int
         ]
 
-        df[str_cols] = df[str_cols].applymap(lambda x: self.remove_unnecessary_char(x))
+        df[str_cols] = df[str_cols].map(lambda x: self.remove_unnecessary_char(x))
 
         if not (self._outlier_value):
             self.check_outlier(media.table.data[float_cols + int_cols], float_cols + int_cols)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Use `DataFrame.map` instead of `DataFrame.applymap`
- `DataFrame.applymap` has been deprecated.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [X] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
