### PR TITLE
Handle path separators in the subset when exporting a datumaro dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## \[Q3 2024 Release 1.9.0\]
+## \[Unreleased\]
+
+### New features
+
+### Enhancements
+
+### Bug fixes
+- Raise an appropriate error when exporting a datumaro dataset if its subset name contains path separators.
+  (<https://github.com/openvinotoolkit/datumaro/pull/1615>)
+
+## Q3 2024 Release 1.9.0
 ### New features
 - Add a new CLI command: datum format
   (<https://github.com/openvinotoolkit/datumaro/pull/1570>)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New features
 
 ### Enhancements
-
-### Bug fixes
 - Raise an appropriate error when exporting a datumaro dataset if its subset name contains path separators.
   (<https://github.com/openvinotoolkit/datumaro/pull/1615>)
+
+### Bug fixes
 
 ## Q3 2024 Release 1.9.0
 ### New features

--- a/docs/source/docs/data-formats/formats/datumaro.md
+++ b/docs/source/docs/data-formats/formats/datumaro.md
@@ -73,6 +73,8 @@ A Datumaro dataset directory should have the following structure:
         └── ...
 ```
 
+Note that the subset name shouldn't contain path separators.
+
 If your dataset is not following the above directory structure,
 it cannot detect and import your dataset as the Datumaro format properly.
 

--- a/docs/source/docs/data-formats/formats/datumaro_binary.md
+++ b/docs/source/docs/data-formats/formats/datumaro_binary.md
@@ -113,6 +113,8 @@ A DatumaroBinary dataset directory should have the following structure:
         └── ...
 ```
 
+Note that the subset name shouldn't contain path separators.
+
 If your dataset is not following the above directory structure,
 it cannot detect and import your dataset as the DatumaroBinary format properly.
 

--- a/src/datumaro/components/errors.py
+++ b/src/datumaro/components/errors.py
@@ -342,6 +342,16 @@ class RepeatedItemError(DatasetError):
         return f"Item {self.item_id} is repeated in the source sequence."
 
 
+@define(auto_exc=False)
+class PathSeparatorInSubsetNameError(DatasetError):
+    subset: str = field()
+
+    def __str__(self):
+        return (
+            f"Failed to export the subset '{self.subset}': subset name contains path separator(s)."
+        )
+
+
 class DatasetQualityError(DatasetError):
     pass
 

--- a/src/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -38,6 +38,7 @@ from datumaro.components.annotation import (
 from datumaro.components.crypter import NULL_CRYPTER
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.dataset_item_storage import ItemStatus
+from datumaro.components.errors import PathSeparatorInSubsetNameError
 from datumaro.components.exporter import ExportContextComponent, Exporter
 from datumaro.components.media import Image, MediaElement, PointCloud, Video, VideoFrame
 from datumaro.util import cast, dump_json_file
@@ -514,13 +515,16 @@ class DatumaroExporter(Exporter):
             default_image_ext=self._default_image_ext,
         )
 
+        if os.path.sep in subset:
+            raise PathSeparatorInSubsetNameError(subset)
+
         return (
             _SubsetWriter(
                 context=self,
                 subset=subset,
                 ann_file=osp.join(
                     self._annotations_dir,
-                    subset.replace(os.sep, "_") + self.PATH_CLS.ANNOTATION_EXT,
+                    subset + self.PATH_CLS.ANNOTATION_EXT,
                 ),
                 export_context=export_context,
             )
@@ -530,7 +534,7 @@ class DatumaroExporter(Exporter):
                 subset=subset,
                 ann_file=osp.join(
                     self._annotations_dir,
-                    subset.replace(os.sep, "_") + self.PATH_CLS.ANNOTATION_EXT,
+                    subset + self.PATH_CLS.ANNOTATION_EXT,
                 ),
                 export_context=export_context,
             )

--- a/src/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -185,7 +185,8 @@ class _SubsetWriter:
 
             if context.save_media:
                 fname = context.make_video_filename(item)
-                context.save_video(item, fname=fname, subdir=item.subset)
+                subdir = item.subset.replace(os.sep, "_") if item.subset else None
+                context.save_video(item, fname=fname, subdir=subdir)
                 item.media = Video(
                     path=fname,
                     step=video._step,
@@ -200,7 +201,8 @@ class _SubsetWriter:
 
             if context.save_media:
                 fname = context.make_video_filename(item)
-                context.save_video(item, fname=fname, subdir=item.subset)
+                subdir = item.subset.replace(os.sep, "_") if item.subset else None
+                context.save_video(item, fname=fname, subdir=subdir)
                 item.media = VideoFrame(Video(fname), video_frame.index)
 
             yield
@@ -210,8 +212,9 @@ class _SubsetWriter:
 
             if context.save_media:
                 # Temporarily update image path and save it.
-                fname = context.make_image_filename(item)
-                context.save_image(item, encryption=encryption, fname=fname, subdir=item.subset)
+                fname = context.make_image_filename(item, name=str(item.id).replace(os.sep, "_"))
+                subdir = item.subset.replace(os.sep, "_") if item.subset else None
+                context.save_image(item, encryption=encryption, fname=fname, subdir=subdir)
                 item.media = Image.from_file(path=fname, size=image._size)
 
             yield
@@ -220,14 +223,18 @@ class _SubsetWriter:
             pcd = item.media_as(PointCloud)
 
             if context.save_media:
-                pcd_fname = context.make_pcd_filename(item)
-                context.save_point_cloud(item, fname=pcd_fname, subdir=item.subset)
+                pcd_name = str(item.id).replace(os.sep, "_")
+                pcd_fname = context.make_pcd_filename(item, name=pcd_name)
+                subdir = item.subset.replace(os.sep, "_") if item.subset else None
+                context.save_point_cloud(item, fname=pcd_fname, subdir=subdir)
 
                 extra_images = []
                 for i, extra_image in enumerate(pcd.extra_images):
                     extra_images.append(
                         Image.from_file(
-                            path=context.make_pcd_extra_image_filename(item, i, extra_image)
+                            path=context.make_pcd_extra_image_filename(
+                                item, i, extra_image, name=f"{pcd_name}/extra_image_{i}"
+                            )
                         )
                     )
 
@@ -511,14 +518,20 @@ class DatumaroExporter(Exporter):
             _SubsetWriter(
                 context=self,
                 subset=subset,
-                ann_file=osp.join(self._annotations_dir, subset + self.PATH_CLS.ANNOTATION_EXT),
+                ann_file=osp.join(
+                    self._annotations_dir,
+                    subset.replace(os.sep, "_") + self.PATH_CLS.ANNOTATION_EXT,
+                ),
                 export_context=export_context,
             )
             if not self._stream
             else _StreamSubsetWriter(
                 context=self,
                 subset=subset,
-                ann_file=osp.join(self._annotations_dir, subset + self.PATH_CLS.ANNOTATION_EXT),
+                ann_file=osp.join(
+                    self._annotations_dir,
+                    subset.replace(os.sep, "_") + self.PATH_CLS.ANNOTATION_EXT,
+                ),
                 export_context=export_context,
             )
         )

--- a/src/datumaro/plugins/data_formats/datumaro_binary/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro_binary/exporter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Intel Corporation
+# Copyright (C) 2024 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/datumaro/plugins/data_formats/datumaro_binary/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro_binary/exporter.py
@@ -15,7 +15,7 @@ from typing import Any, List, Optional, Union
 
 from datumaro.components.crypter import NULL_CRYPTER, Crypter
 from datumaro.components.dataset_base import DatasetItem, IDataset
-from datumaro.components.errors import DatumaroError
+from datumaro.components.errors import DatumaroError, PathSeparatorInSubsetNameError
 from datumaro.components.exporter import ExportContext, ExportContextComponent, Exporter
 from datumaro.plugins.data_formats.datumaro.exporter import DatumaroExporter
 from datumaro.plugins.data_formats.datumaro.exporter import _SubsetWriter as __SubsetWriter
@@ -308,6 +308,9 @@ class DatumaroBinaryExporter(DatumaroExporter):
             image_ext=self._image_ext,
             default_image_ext=self._default_image_ext,
         )
+
+        if osp.sep in subset:
+            raise PathSeparatorInSubsetNameError(subset)
 
         return _SubsetWriter(
             context=self,

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -222,6 +222,190 @@ def fxt_test_datumaro_format_dataset():
 
 
 @pytest.fixture
+def fxt_test_datumaro_format_dataset_with_path_separator():
+    label_categories = LabelCategories(attributes={"a", "b", "score"})
+    for i in range(5):
+        label_categories.add("cat" + str(i), attributes={"x", "y"})
+
+    mask_categories = MaskCategories(generate_colormap(len(label_categories.items)))
+
+    points_categories = PointsCategories()
+    for index, _ in enumerate(label_categories.items):
+        points_categories.add(index, ["cat1", "cat2"], joints=[[0, 1]])
+
+    return Dataset.from_iterable(
+        [
+            DatasetItem(
+                id="100/0",
+                subset="my/train",
+                media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                annotations=[
+                    Caption("hello", id=1),
+                    Caption("world", id=2, group=5),
+                    Label(
+                        2,
+                        id=3,
+                        attributes={
+                            "x": 1,
+                            "y": "2",
+                        },
+                    ),
+                    Bbox(
+                        1,
+                        2,
+                        3,
+                        4,
+                        label=4,
+                        id=4,
+                        z_order=1,
+                        attributes={
+                            "score": 1.0,
+                        },
+                    ),
+                    Bbox(
+                        5,
+                        6,
+                        7,
+                        8,
+                        id=5,
+                        group=5,
+                        attributes={
+                            "a": 1.5,
+                            "b": "text",
+                        },
+                    ),
+                    Points(
+                        [1, 2, 2, 0, 1, 1],
+                        label=0,
+                        id=5,
+                        z_order=4,
+                        attributes={
+                            "x": 1,
+                            "y": "2",
+                        },
+                    ),
+                    Mask(
+                        label=3,
+                        id=5,
+                        z_order=2,
+                        image=np.ones((2, 3)),
+                        attributes={
+                            "x": 1,
+                            "y": "2",
+                        },
+                    ),
+                    Ellipse(
+                        5,
+                        6,
+                        7,
+                        8,
+                        label=3,
+                        id=5,
+                        z_order=2,
+                        attributes={
+                            "x": 1,
+                            "y": "2",
+                        },
+                    ),
+                    Cuboid2D(
+                        [
+                            (1, 1),
+                            (3, 1),
+                            (3, 3),
+                            (1, 3),
+                            (1.5, 1.5),
+                            (3.5, 1.5),
+                            (3.5, 3.5),
+                            (1.5, 3.5),
+                        ],
+                        label=3,
+                        id=5,
+                        z_order=2,
+                        attributes={
+                            "x": 1,
+                            "y": "2",
+                        },
+                    ),
+                ],
+            ),
+            DatasetItem(
+                id=21,
+                media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                subset="train",
+                annotations=[
+                    Caption("test"),
+                    Label(2),
+                    Bbox(1, 2, 3, 4, label=5, id=42, group=42),
+                ],
+            ),
+            DatasetItem(
+                id=2,
+                media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                subset="my/val",
+                annotations=[
+                    PolyLine([1, 2, 3, 4, 5, 6, 7, 8], id=11, z_order=1),
+                    Polygon([1, 2, 3, 4, 5, 6, 7, 8], id=12, z_order=4),
+                ],
+            ),
+            DatasetItem(
+                id="1/1",
+                media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                subset="test",
+                annotations=[
+                    Cuboid3d(
+                        [1.0, 2.0, 3.0],
+                        [2.0, 2.0, 4.0],
+                        [1.0, 3.0, 4.0],
+                        id=6,
+                        label=0,
+                        attributes={"occluded": True},
+                        group=6,
+                    )
+                ],
+            ),
+            DatasetItem(
+                id=42,
+                media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                subset="my/test",
+                attributes={"a1": 5, "a2": "42"},
+            ),
+            DatasetItem(
+                id=42,
+                media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                # id and group integer value can be higher than 32bits limits (COCO instances).
+                annotations=[
+                    Mask(
+                        id=900100087038, group=900100087038, image=np.ones((2, 3), dtype=np.uint8)
+                    ),
+                    RleMask(
+                        rle=mask_tools.encode(np.ones((2, 3), dtype=np.uint8, order="F")),
+                        id=900100087038,
+                        group=900100087038,
+                    ),
+                ],
+            ),
+            DatasetItem(
+                id="1/b/c",
+                media=Image.from_file(path="1/b/c.qq", size=(2, 4)),
+            ),
+        ],
+        categories={
+            AnnotationType.label: label_categories,
+            AnnotationType.mask: mask_categories,
+            AnnotationType.points: points_categories,
+        },
+        infos={
+            "string": "test",
+            "int": 0,
+            "float": 0.0,
+            "string_list": ["test0", "test1", "test2"],
+            "int_list": [0, 1, 2],
+            "float_list": [0.0, 0.1, 0.2],
+        },
+    )
+
+
+@pytest.fixture
 def fxt_test_datumaro_format_video_dataset(test_dir) -> Dataset:
     video_path = osp.join(test_dir, "video.avi")
     make_sample_video(video_path, frame_size=(4, 6), frames=4)

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -233,11 +233,12 @@ def fxt_test_datumaro_format_dataset_with_path_separator():
     for index, _ in enumerate(label_categories.items):
         points_categories.add(index, ["cat1", "cat2"], joints=[[0, 1]])
 
+    sep = os.path.sep
     return Dataset.from_iterable(
         [
             DatasetItem(
                 id="100/0",
-                subset="my/train",
+                subset=f"my{sep}train",
                 media=Image.from_numpy(data=np.ones((10, 6, 3))),
                 annotations=[
                     Caption("hello", id=1),
@@ -341,7 +342,7 @@ def fxt_test_datumaro_format_dataset_with_path_separator():
             DatasetItem(
                 id=2,
                 media=Image.from_numpy(data=np.ones((10, 6, 3))),
-                subset="my/val",
+                subset=f"my{sep}val",
                 annotations=[
                     PolyLine([1, 2, 3, 4, 5, 6, 7, 8], id=11, z_order=1),
                     Polygon([1, 2, 3, 4, 5, 6, 7, 8], id=12, z_order=4),
@@ -366,7 +367,7 @@ def fxt_test_datumaro_format_dataset_with_path_separator():
             DatasetItem(
                 id=42,
                 media=Image.from_numpy(data=np.ones((10, 6, 3))),
-                subset="my/test",
+                subset=f"my{sep}test",
                 attributes={"a1": 5, "a2": "42"},
             ),
             DatasetItem(

--- a/tests/unit/data_formats/datumaro/test_datumaro_format.py
+++ b/tests/unit/data_formats/datumaro/test_datumaro_format.py
@@ -14,6 +14,7 @@ import pytest
 
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.environment import Environment
+from datumaro.components.errors import PathSeparatorInSubsetNameError
 from datumaro.components.importer import DatasetImportError
 from datumaro.components.media import Image
 from datumaro.components.project import Dataset
@@ -154,6 +155,31 @@ class DatumaroFormatTest:
             importer_args=fxt_import_kwargs,
             stream=stream,
         )
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    @pytest.mark.parametrize("require_media", [True, False])
+    @pytest.mark.parametrize("stream", [True, False])
+    def test_cannot_export_dataset_with_subset_containing_path_separators(
+        self,
+        fxt_test_datumaro_format_dataset_with_path_separator,
+        test_dir,
+        fxt_import_kwargs,
+        fxt_export_kwargs,
+        stream,
+        require_media,
+        helper_tc,
+    ):
+        with pytest.raises(PathSeparatorInSubsetNameError):
+            self._test_save_and_load(
+                helper_tc,
+                fxt_test_datumaro_format_dataset_with_path_separator,
+                partial(self.exporter.convert, save_media=True, stream=stream, **fxt_export_kwargs),
+                test_dir,
+                compare=compare_datasets,
+                require_media=require_media,
+                importer_args=fxt_import_kwargs,
+                stream=stream,
+            )
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_export_video_only_once(


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Ticket: 152928
Raise an error when exporting a dataset in Datumaro format if the subset name contains path separators.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [x] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
