### PR TITLE
Enhance 'id_from_image_name' transform to ensure each identifier is unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1594>)
 
 ### Enhancements
+- Enhance 'id_from_image_name' transform to ensure each identifier is unique
+  (<https://github.com/openvinotoolkit/datumaro/pull/1635>)
 - Raise an appropriate error when exporting a datumaro dataset if its subset name contains path separators.
   (<https://github.com/openvinotoolkit/datumaro/pull/1615>)
 - Update docs for transform plugins

--- a/docs/source/docs/command-reference/context_free/transform.md
+++ b/docs/source/docs/command-reference/context_free/transform.md
@@ -176,15 +176,36 @@ Examples:
 
 #### `id_from_image_name`
 
-Renames items in the dataset using image file name (without extension).
+Renames items in the dataset based on the image file name, excluding the extension.
+When 'ensure_unique' is enabled, a random suffix is appened to ensure each identifier is unique
+in cases where the image name is not distinct. By default, the random suffix is three characters long,
+but this can be adjusted with the 'suffix_length' parameter.
 
 Usage:
 ```console
-id_from_image_name [-h]
+id_from_image_name [-h] [-u] [-l SUFFIX_LENGTH]
 ```
 
 Optional arguments:
-- `-h`, `--help` (flag) - Show this help message and exit
+- `-h`, `--help` (flag) - show this help message and exit
+- `-u`, `--ensure_unique` (flag) - Appends a random suffix to ensure each identifier is unique if the image name is duplicated
+- `-l`, `--suffix_length` (int) - Alters the length of the random suffix if the `ensure_unique` is enabled(default: 3)
+
+Examples:
+- Renames items without duplication check
+  ```console
+  datum transform -t id_from_image_name
+  ```
+
+- Renames items with duplication check
+  ```console
+  datum transform -t id_from_image_name -- --ensure_unique
+  ```
+
+- Renames items with duplication check and alters the suffix length(default: 3)
+  ```console
+  datum transform -t id_from_image_name -- --ensure_unique --suffix_length 2
+  ```
 
 #### `reindex`
 

--- a/tests/unit/test_transforms.py
+++ b/tests/unit/test_transforms.py
@@ -5,7 +5,9 @@ import logging as log
 import os
 import os.path as osp
 import random
+import re
 from unittest import TestCase
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -33,10 +35,10 @@ from datumaro.components.annotation import (
     Tabular,
     TabularCategories,
 )
-from datumaro.components.dataset import Dataset
+from datumaro.components.dataset import Dataset, eager_mode
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.errors import AnnotationTypeError
-from datumaro.components.media import Image, Table, TableRow
+from datumaro.components.media import Image, Table, TableRow, Video, VideoFrame
 
 from ..requirements import Requirements, mark_bug, mark_requirement
 
@@ -418,26 +420,6 @@ class TransformsTest(TestCase):
         )
 
         actual = transforms.ShapesToBoxes(source_dataset)
-        compare_datasets(self, target_dataset, actual)
-
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_id_from_image(self):
-        source_dataset = Dataset.from_iterable(
-            [
-                DatasetItem(id=1, media=Image.from_file(path="path.jpg")),
-                DatasetItem(id=2),
-                DatasetItem(id=3, media=Image.from_numpy(data=np.ones([5, 5, 3]))),
-            ]
-        )
-        target_dataset = Dataset.from_iterable(
-            [
-                DatasetItem(id="path", media=Image.from_file(path="path.jpg")),
-                DatasetItem(id=2),
-                DatasetItem(id=3, media=Image.from_numpy(data=np.ones([5, 5, 3]))),
-            ]
-        )
-
-        actual = transforms.IdFromImageName(source_dataset)
         compare_datasets(self, target_dataset, actual)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
@@ -1225,6 +1207,66 @@ class ReindexAnnotationsTest:
         assert n_anns == len(
             {(item.id, ann.id) for item in fxt_dataset for ann in item.annotations}
         )
+
+
+class IdFromImageNameTest:
+    @pytest.fixture
+    def fxt_dataset(self, n_labels=3, n_anns=5, n_items=7) -> Dataset:
+        video = Video("video.mp4")
+        return Dataset.from_iterable(
+            [
+                DatasetItem(id=1, media=Image.from_file(path="path1.jpg")),
+                DatasetItem(id=2, media=Image.from_file(path="path1.jpg")),
+                DatasetItem(id=3, media=Image.from_file(path="path1.jpg")),
+                DatasetItem(id=4, media=VideoFrame(video, index=30)),
+                DatasetItem(id=5, media=VideoFrame(video, index=30)),
+                DatasetItem(id=6, media=VideoFrame(video, index=60)),
+                DatasetItem(id=7),
+                DatasetItem(id=8, media=Image.from_numpy(data=np.ones([5, 5, 3]))),
+            ]
+        )
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    @pytest.mark.parametrize("ensure_unique", [True, False])
+    def test_id_from_image(self, fxt_dataset, ensure_unique):
+        source_dataset = fxt_dataset
+        actual_dataset = transforms.IdFromImageName(source_dataset, ensure_unique=ensure_unique)
+
+        unique_names: set[str] = set()
+        for src, actual in zip(source_dataset, actual_dataset):
+            if not isinstance(src.media, Image) or not hasattr(src.media, "path"):
+                src == actual
+            else:
+                if isinstance(src.media, VideoFrame):
+                    expected_id = f"video_frame-{src.media.index}"
+                else:
+                    expected_id = os.path.splitext(src.media.path)[0]
+                if ensure_unique:
+                    assert actual.id.startswith(expected_id)
+                    assert actual.wrap(id=src.id) == src
+                    assert actual.id not in unique_names
+                    unique_names.add(actual.id)
+                else:
+                    assert actual == src.wrap(id=expected_id)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_id_from_image_wrong_suffix_length(self, fxt_dataset):
+        with pytest.raises(ValueError) as e:
+            transforms.IdFromImageName(fxt_dataset, ensure_unique=True, suffix_length=0)
+        assert str(e.value).startswith("The 'suffix_length' must be greater than 0.")
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_id_from_image_too_many_duplication(self, fxt_dataset):
+        with patch("datumaro.plugins.transforms.IdFromImageName.DEFAULT_RETRY", 1), patch(
+            "datumaro.plugins.transforms.IdFromImageName.SUFFIX_LETTERS", "a"
+        ), pytest.raises(Exception) as e:
+            with eager_mode():
+                fxt_dataset.transform(
+                    "id_from_image_name",
+                    ensure_unique=True,
+                    suffix_length=1,
+                )
+        assert str(e.value).startswith("Too many duplicate names.")
 
 
 class AstypeAnnotationsTest(TestCase):

--- a/tests/unit/test_transforms.py
+++ b/tests/unit/test_transforms.py
@@ -1269,6 +1269,22 @@ class IdFromImageNameTest:
                 )
         assert str(e.value).startswith("Too many duplicate names.")
 
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    @pytest.mark.parametrize(
+        "args,ensure_unique,suffix_length",
+        [
+            ([], False, 3),
+            (["--ensure_unique", "--suffix_length", "2"], True, 2),
+        ],
+        ids=["default", "ensure_unique"],
+    )
+    def test_parser(self, args, ensure_unique, suffix_length):
+        parser = transforms.IdFromImageName.build_cmdline_parser()
+        args = parser.parse_args(args)
+
+        assert hasattr(args, "ensure_unique") and args.ensure_unique == ensure_unique
+        assert hasattr(args, "suffix_length") and args.suffix_length == suffix_length
+
 
 class AstypeAnnotationsTest(TestCase):
     def setUp(self):

--- a/tests/unit/test_transforms.py
+++ b/tests/unit/test_transforms.py
@@ -5,9 +5,8 @@ import logging as log
 import os
 import os.path as osp
 import random
-import re
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -1213,6 +1212,8 @@ class IdFromImageNameTest:
     @pytest.fixture
     def fxt_dataset(self, n_labels=3, n_anns=5, n_items=7) -> Dataset:
         video = Video("video.mp4")
+        video._frame_size = MagicMock(return_value=(32, 32))
+        video.get_frame_data = MagicMock(return_value=np.ndarray((32, 32, 3), dtype=np.uint8))
         return Dataset.from_iterable(
             [
                 DatasetItem(id=1, media=Image.from_file(path="path1.jpg")),
@@ -1229,7 +1230,7 @@ class IdFromImageNameTest:
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @pytest.mark.parametrize("ensure_unique", [True, False])
     def test_id_from_image(self, fxt_dataset, ensure_unique):
-        source_dataset = fxt_dataset
+        source_dataset: Dataset = fxt_dataset
         actual_dataset = transforms.IdFromImageName(source_dataset, ensure_unique=ensure_unique)
 
         unique_names: set[str] = set()
@@ -1247,7 +1248,7 @@ class IdFromImageNameTest:
                     assert actual.id not in unique_names
                     unique_names.add(actual.id)
                 else:
-                    assert actual == src.wrap(id=expected_id)
+                    assert src.wrap(id=expected_id) == actual
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_id_from_image_wrong_suffix_length(self, fxt_dataset):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Ticket: 153389
1. Enhance 'id_from_image_name' transform to ensure each identifier is unique.
    - add random suffix if the image name is not distinct: [image_name]__[suffix]
    - introduce related parameters: ensure_unique(default: false), suffix_length (default: 3)
2. Handle VideoFrame considering its index
   - format: [video_name]_frame-[index]

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [x] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
