### PR TITLE
Fix assertion to compare hashkeys against expected value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1599>)
 
 ### Bug fixes
+- Fix assertion to compare hashkeys against expected value
+  (<https://github.com/openvinotoolkit/datumaro/pull/1641>)
 
 ## Q4 2024 Release 1.9.1
 ### Enhancements

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -62,7 +62,7 @@ class HashKeyTest:
     )
     def test_compare_hashkey(self, fxt_hashkeys, expected, request):
         hashkey1, hashkey2 = request.getfixturevalue(fxt_hashkeys)
-        assert (expected, hashkey1 == hashkey2)
+        assert (hashkey1 == hashkey2) == expected
 
 
 class RotatedBboxTest:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Fix `SyntaxWarning: assertion is always true, perhaps remove parentheses` in `test_annotation`
- Updated assert statement to ensure the comparison of hashkey1 and hashkey2 matches the expected boolean value.
- Removed unnecessary parentheses to address SyntaxWarning.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
