### PR TITLE
Fix datumaro keypoint loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1603>)
 
 ### Bug fixes
+- Fix datumaro format to load visibility information from Points annotations
+  (<https://github.com/openvinotoolkit/datumaro/pull/1644>)
 
 ## Q4 2024 Release 1.9.1
 ### Enhancements

--- a/src/datumaro/plugins/data_formats/datumaro/base.py
+++ b/src/datumaro/plugins/data_formats/datumaro/base.py
@@ -339,6 +339,7 @@ class JsonReader:
                             points,
                             label=label_id,
                             id=ann_id,
+                            visibility=ann.get("visibility"),
                             attributes=attributes,
                             group=group,
                             object_id=object_id,

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -91,7 +91,7 @@ def fxt_test_datumaro_format_dataset():
                         },
                     ),
                     Points(
-                        [1, 2, 2, 0, 1, 1],
+                        [1, 2, 0, 0, 1, 1],
                         label=0,
                         id=5,
                         z_order=4,
@@ -99,6 +99,7 @@ def fxt_test_datumaro_format_dataset():
                             "x": 1,
                             "y": "2",
                         },
+                        visibility=[1, 0, 2],
                     ),
                     Mask(
                         label=3,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This fixes the bug in loading a keypoint dataset in datumaro format. 
The visibility information will be filled correctly by this fix.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
