### PR TITLE
Set TabularTransform to process clean transform in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/1603>)
 - Optimize path assignment to handle point cloud in JSON without images
   (<https://github.com/openvinotoolkit/datumaro/pull/1643>)
+- Set TabularTransform to process clean transform in parallel
+  (<https://github.com/openvinotoolkit/datumaro/pull/1648>)
 
 ### Bug fixes
 - Fix datumaro format to load visibility information from Points annotations

--- a/src/datumaro/plugins/transforms.py
+++ b/src/datumaro/plugins/transforms.py
@@ -64,7 +64,7 @@ from datumaro.components.errors import (
     UndefinedLabel,
 )
 from datumaro.components.media import Image, TableRow
-from datumaro.components.transformer import ItemTransform, Transform
+from datumaro.components.transformer import ItemTransform, TabularTransform, Transform
 from datumaro.util import NOTSET, filter_dict, parse_json_file, parse_str_enum_value, take_by
 from datumaro.util.annotation_util import find_group_leader, find_instances
 from datumaro.util.tabular_util import emoji_pattern
@@ -1864,7 +1864,7 @@ class AstypeAnnotations(ItemTransform):
         return self.wrap_item(item, annotations=annotations)
 
 
-class Clean(ItemTransform):
+class Clean(TabularTransform):
     """
     A class used to refine the media items in a dataset.|n
     |n
@@ -1883,8 +1883,10 @@ class Clean(ItemTransform):
     def __init__(
         self,
         extractor: IDataset,
+        batch_size: int = 1,
+        num_workers: int = 0,
     ):
-        super().__init__(extractor)
+        super().__init__(extractor, batch_size, num_workers)
 
         self._outlier_value = {}
         self._missing_value = {}

--- a/src/datumaro/plugins/transforms.py
+++ b/src/datumaro/plugins/transforms.py
@@ -63,7 +63,7 @@ from datumaro.components.errors import (
     UndefinedAttribute,
     UndefinedLabel,
 )
-from datumaro.components.media import Image, TableRow
+from datumaro.components.media import Image, TableRow, VideoFrame
 from datumaro.components.transformer import ItemTransform, TabularTransform, Transform
 from datumaro.util import NOTSET, filter_dict, parse_json_file, parse_str_enum_value, take_by
 from datumaro.util.annotation_util import find_group_leader, find_instances

--- a/src/datumaro/plugins/transforms.py
+++ b/src/datumaro/plugins/transforms.py
@@ -63,7 +63,7 @@ from datumaro.components.errors import (
     UndefinedAttribute,
     UndefinedLabel,
 )
-from datumaro.components.media import Image, TableRow, VideoFrame
+from datumaro.components.media import Image, TableRow
 from datumaro.components.transformer import ItemTransform, TabularTransform, Transform
 from datumaro.util import NOTSET, filter_dict, parse_json_file, parse_str_enum_value, take_by
 from datumaro.util.annotation_util import find_group_leader, find_instances

--- a/tests/unit/components/test_transformer.py
+++ b/tests/unit/components/test_transformer.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import pytest
 
@@ -11,7 +11,7 @@ from datumaro.components.annotation import Annotation
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.launcher import Launcher
-from datumaro.components.transformer import ModelTransform
+from datumaro.components.transformer import ModelTransform, TabularTransform
 
 
 class MockLauncher(Launcher):
@@ -64,3 +64,30 @@ class ModelTransformTest:
                 assert item.annotations == [Annotation(id=0), Annotation(id=1)]
             else:
                 assert item.annotations == [Annotation(id=1)]
+
+
+class TabularTransformTest:
+    @pytest.fixture
+    def fxt_dataset(self):
+        return Dataset.from_iterable(
+            [DatasetItem(id=f"item_{i}", annotations=[Annotation(id=0)]) for i in range(10)]
+        )
+
+    @pytest.mark.parametrize("batch_size", [1, 10])
+    @pytest.mark.parametrize("num_workers", [0, 2])
+    def test_tabular_transform(self, fxt_dataset, batch_size, num_workers):
+        class MockTabularTransform(TabularTransform):
+            def transform_item(self, item: DatasetItem) -> Optional[DatasetItem]:
+                # Mock transformation logic
+                item.annotations.append(Annotation(id=1))
+                return item
+
+        transform = MockTabularTransform(
+            extractor=fxt_dataset,
+            batch_size=batch_size,
+            num_workers=num_workers,
+        )
+
+        for idx, item in enumerate(transform):
+            assert item.id == f"item_{idx}"
+            assert item.annotations == [Annotation(id=0), Annotation(id=1)]


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- `Clean` transform took long time due to tabular dataset usually have large dataset
- To reduce the time for transform, I made `TabularTransform` to do this process in parallel
- When I set `batch_size` as 100 and `num_workers` as 2, then the total process time reduces in half (about 300s -> 166s)

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [X] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [X] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
