### PR TITLE
Make bandit to ignore B311 for id_from_image_name transform

### DIFF
--- a/src/datumaro/plugins/transforms.py
+++ b/src/datumaro/plugins/transforms.py
@@ -662,8 +662,8 @@ class IdFromImageName(ItemTransform, CliPlugin):
         count = 0
         while name in self._names:
             suffix = "".join(
-                random.choices(self.SUFFIX_LETTERS, k=self._suffix_length)
-            )  # nosec B311
+                random.choices(self.SUFFIX_LETTERS, k=self._suffix_length)  # nosec B311
+            )
             new_name = f"{name}__{suffix}"
             if new_name not in self._names:
                 name = new_name


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Make bandit to ignore B311 for id_from_image_name transform
--> Re-located the comment, # nosec B311)
The result of bandit-scan is pasted:
```
Run started:2024-10-24 06:29:43.187490

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 51857
        Total lines skipped (#nosec): 6
        Total potential issues skipped due to specifically being disabled (e.g., #nosec BXXX): 12

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
Files skipped (0):
```
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
