### PR TITLE
Add position information to PointsCategories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## \[Unreleased\]
 
 ### New features
+- Add default position information to PointsCategories class
+  (<https://github.com/openvinotoolkit/datumaro/pull/1695>)
 - Convert Cuboid2D annotation to/from 3D data
   (<https://github.com/openvinotoolkit/datumaro/pull/1639>)
 - Add label groups for hierarchical classification in ImageNet

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1601,7 +1601,7 @@ class PointsCategories(Categories):
         joints: Set[Tuple[int, int]] = field(factory=set, validator=default_if_none(set))
 
         # Set of default x, y coordinates of the points
-        positions: List[float] = field(factory=list)
+        positions: List[float] = field(default=[])
 
         @positions.validator
         def positions_validator(
@@ -1613,17 +1613,15 @@ class PointsCategories(Categories):
             To be used as an attrs validator for the positions field of PointsCategories.Category.
 
             Args:
-                attribute (attr.Attribute[list]): The attribute being validated (unused).
+                attribute (attr.Attribute[list]): The attribute being validated.
                 positions (list[float]): A list of point positions.
 
             Raises:
                 ValueError: If the provided value cannot be converted to a list of floats,
-                    or if the number of positions is not even.
+                    or if the number of positions is invalid.
             """
-            del attribute
-            print(len(self.labels))
-            if positions is None or positions == []:
-                self.positions = []
+            if positions is None:
+                positions = []
             else:
                 # convert to a list of floats
                 try:
@@ -1631,15 +1629,18 @@ class PointsCategories(Categories):
                 except (TypeError, ValueError):
                     msg = "Cannot convert positions to list of floats. Check your input data."
                     raise ValueError(msg)
-                # validate the positions
+                # check if number of coordinates is even
                 if len(positions) % 2 != 0:
                     msg = "positions must have an even number of elements"
                     raise ValueError(msg)
-                if len(self.labels) > 0 and len(self.positions) != len(self.labels) * 2:
-                    msg = "The number of positions should be equal to the number of labels"
-                    raise ValueError(msg)
-                # normalize the positions
-                self.positions = normalize_points(positions)
+                if len(positions) > 0:
+                    # check if the number of positions is equal to the number of labels
+                    if len(self.labels) > 0 and len(positions) != len(self.labels) * 2:
+                        msg = "The number of positions should be equal to the number of labels"
+                        raise ValueError(msg)
+                    # normalize the positions
+                    positions = normalize_points(positions)
+            setattr(self, attribute.name, positions)
 
     items: Dict[int, Category] = field(factory=dict, validator=default_if_none(dict))
 

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1602,6 +1602,14 @@ class PointsCategories(Categories):
         # Set of default x, y coordinates of the points
         positions: List[float] = field(factory=list, validator=validate_points_positions)
 
+        def __attrs_post_init__(self):
+            """
+            Validates that the number of positions is equal to the number of labels.
+            """
+            if len(self.positions) > 0 and len(self.positions) != len(self.labels) * 2:
+                msg = "The number of positions should be equal to the number of labels"
+                raise ValueError(msg)
+
     items: Dict[int, Category] = field(factory=dict, validator=default_if_none(dict))
 
     @classmethod
@@ -1610,7 +1618,7 @@ class PointsCategories(Categories):
         iterable: Union[
             Iterable[Sequence[int, List[str]]],
             Iterable[Sequence[int, List[str], Set[Tuple[int, int]]]],
-            Iterable[Sequence[int, List[str], Set[Tuple[int, int]], List[Tuple[float, float]]]],
+            Iterable[Sequence[int, List[str], Set[Tuple[int, int]], List[float]]],
         ],
     ) -> PointsCategories:
         """

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1604,14 +1604,16 @@ class PointsCategories(Categories):
         positions: List[float] = field(factory=list)
 
         @positions.validator
-        def positions_validator(self, attribute, positions: list[float] | None) -> None:
+        def positions_validator(
+            self, attribute: attr.Attribute[list], positions: list[float] | None
+        ) -> None:
             """
             Validate a list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
 
             To be used as an attrs validator for the positions field of PointsCategories.Category.
 
             Args:
-                attribute: The attribute being validated (unused).
+                attribute (attr.Attribute[list]): The attribute being validated (unused).
                 positions (list[float]): A list of point positions.
 
             Raises:

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -31,7 +31,7 @@ from attr import asdict, attrs, field
 from typing_extensions import Literal
 
 from datumaro.components.media import Image
-from datumaro.util.attrs_util import default_if_none, not_empty
+from datumaro.util.attrs_util import default_if_none, not_empty, validate_points_positions
 
 
 class AnnotationType(IntEnum):
@@ -1599,40 +1599,7 @@ class PointsCategories(Categories):
         joints: Set[Tuple[int, int]] = field(factory=set, validator=default_if_none(set))
 
         # Set of default x, y coordinates of the points
-        positions: List[Tuple[float, float]] = field(factory=list, validator=default_if_none(list))
-
-    @staticmethod
-    def normalize_positions(positions):
-        """
-        Normalize a set of keypoints to fit within a unit bounding box [0, 1] x [0, 1],
-        maintaining the aspect ratio.
-
-        Parameters:
-            keypoints (list of tuples): A list of (x, y) keypoints.
-
-        Returns:
-            list of tuples: Normalized keypoints within the unit bounding box, preserving aspect ratio.
-        """
-        # Convert keypoints to a NumPy array for easier manipulation
-        positions = np.array(positions, dtype=float)
-
-        # Find the minimum and maximum values for x and y
-        min = positions.min(axis=0)
-        max = positions.max(axis=0)
-
-        # Compute the width and height of the bounding box
-        size = max - min
-
-        # Handle edge case where all keypoints are the same (zero width or height)
-        size[np.where(size==0)] = 1e-6
-
-        # Determine the scaling factor to maintain aspect ratio
-        scale = size.max()
-
-        # Normalize the keypoints to fit within [0, 1] x [0, 1], preserving aspect ratio
-        normalized_positions = (positions - min) / scale
-
-        return list(map(tuple, normalized_positions))
+        positions: List[Tuple[float, float]] = field(factory=list, validator=validate_points_positions)
 
     items: Dict[int, Category] = field(factory=dict, validator=default_if_none(dict))
 
@@ -1672,10 +1639,6 @@ class PointsCategories(Categories):
         if joints is None:
             joints = []
         joints = set(map(tuple, joints))
-        if positions is None:
-            positions = []
-        if len(positions) > 0:
-            positions = self.normalize_positions(list(positions))
         self.items[label_id] = self.Category(labels, joints, positions)
 
     def __contains__(self, idx: int) -> bool:

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -16,6 +16,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -1607,8 +1608,9 @@ class PointsCategories(Categories):
     def from_iterable(
         cls,
         iterable: Union[
-            Tuple[int, List[str]],
-            Tuple[int, List[str], Set[Tuple[int, int]]],
+            Iterable[Sequence[int, List[str]]],
+            Iterable[Sequence[int, List[str], Set[Tuple[int, int]]]],
+            Iterable[Sequence[int, List[str], Set[Tuple[int, int]], List[Tuple[float, float]]]],
         ],
     ) -> PointsCategories:
         """

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1608,10 +1608,9 @@ class PointsCategories(Categories):
             """
             Validate a list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
 
-            To be used as an attrs validator for the positions field of PointsCategories Category.
+            To be used as an attrs validator for the positions field of PointsCategories.Category.
 
             Args:
-                inst: The instance being validated.
                 attribute: The attribute being validated (unused).
                 positions (list[float]): A list of point positions.
 

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1600,7 +1600,7 @@ class PointsCategories(Categories):
         joints: Set[Tuple[int, int]] = field(factory=set, validator=default_if_none(set))
 
         # Set of default x, y coordinates of the points
-        positions: List[Tuple[float, float]] = field(factory=list, validator=validate_points_positions)
+        positions: List[float] = field(factory=list, validator=validate_points_positions)
 
     items: Dict[int, Category] = field(factory=dict, validator=default_if_none(dict))
 
@@ -1636,7 +1636,7 @@ class PointsCategories(Categories):
         label_id: int,
         labels: Optional[Iterable[str]] = None,
         joints: Iterable[Tuple[int, int]] = None,
-        positions: Iterable[Tuple[float, float]] = None,
+        positions: Iterable[float] = None,
     ):
         if joints is None:
             joints = []

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1625,7 +1625,9 @@ class PointsCategories(Categories):
                 try:
                     positions = list(map(float, positions))
                 except (TypeError, ValueError):
-                    raise ValueError(f"Cannot convert {attribute.name} to list of floats. Check your input data.")
+                    raise ValueError(
+                        f"Cannot convert {attribute.name} to list of floats. Check your input data."
+                    )
                 # validate the positions
                 if len(positions) % 2 != 0:
                     raise ValueError(f"{attribute.name} must have an even number of elements")

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2024 Intel Corporation
+# Copyright (C) 2021-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1614,7 +1614,7 @@ class PointsCategories(Categories):
             list of tuples: Normalized keypoints within the unit bounding box, preserving aspect ratio.
         """
         # Convert keypoints to a NumPy array for easier manipulation
-        positions = np.array(positions)
+        positions = np.array(positions, dtype=float)
 
         # Find the minimum and maximum values for x and y
         min = positions.min(axis=0)

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1603,34 +1603,40 @@ class PointsCategories(Categories):
         # Set of default x, y coordinates of the points
         positions: List[float] = field(factory=list)
 
-        def __attrs_post_init__(self):
-            """
-            Validates that the number of positions is equal to the number of labels.
-            """
-            if len(self.positions) > 0 and len(self.positions) != len(self.labels) * 2:
-                msg = "The number of positions should be equal to the number of labels"
-                raise ValueError(msg)
-
         @positions.validator
-        def positions_validator(self, attribute, positions) -> list[float]:
+        def positions_validator(self, attribute, positions: list[float] | None) -> None:
             """
             Validate a list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
 
-            To be used as an attrs validator in PointsCategories class.
+            To be used as an attrs validator for the positions field of PointsCategories Category.
+
+            Args:
+                inst: The instance being validated.
+                attribute: The attribute being validated (unused).
+                positions (list[float]): A list of point positions.
+
+            Raises:
+                ValueError: If the provided value cannot be converted to a list of floats,
+                    or if the number of positions is not even.
             """
+            del attribute
+            print(len(self.labels))
             if positions is None or positions == []:
                 self.positions = []
             else:
-                # convert to a list of tuples
+                # convert to a list of floats
                 try:
                     positions = list(map(float, positions))
                 except (TypeError, ValueError):
-                    raise ValueError(
-                        f"Cannot convert {attribute.name} to list of floats. Check your input data."
-                    )
+                    msg = "Cannot convert positions to list of floats. Check your input data."
+                    raise ValueError(msg)
                 # validate the positions
                 if len(positions) % 2 != 0:
-                    raise ValueError(f"{attribute.name} must have an even number of elements")
+                    msg = "positions must have an even number of elements"
+                    raise ValueError(msg)
+                if len(self.labels) > 0 and len(self.positions) != len(self.labels) * 2:
+                    msg = "The number of positions should be equal to the number of labels"
+                    raise ValueError(msg)
                 # normalize the positions
                 self.positions = normalize_points(positions)
 

--- a/src/datumaro/plugins/data_formats/datumaro/base.py
+++ b/src/datumaro/plugins/data_formats/datumaro/base.py
@@ -115,7 +115,12 @@ class JsonReader:
         if parsed_points_cat:
             point_categories = PointsCategories()
             for item in parsed_points_cat["items"]:
-                point_categories.add(int(item["label_id"]), item["labels"], joints=item["joints"])
+                point_categories.add(
+                    int(item["label_id"]),
+                    item["labels"],
+                    joints=item["joints"],
+                    positions=item.get("positions"),
+                )
 
             categories[AnnotationType.points] = point_categories
 

--- a/src/datumaro/plugins/data_formats/datumaro/base.py
+++ b/src/datumaro/plugins/data_formats/datumaro/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -107,7 +107,7 @@ class JsonWriter:
                     "label_id": int(label_id),
                     "labels": [cast(label, str) for label in item.labels],
                     "joints": [list(map(int, j)) for j in item.joints],
-                    "positions": [list(map(float, p)) for p in item.positions],
+                    "positions": list(map(float, item.positions)),
                 }
             )
         return converted

--- a/src/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -107,6 +107,7 @@ class JsonWriter:
                     "label_id": int(label_id),
                     "labels": [cast(label, str) for label in item.labels],
                     "joints": [list(map(int, j)) for j in item.joints],
+                    "positions": [list(map(float, p)) for p in item.positions],
                 }
             )
         return converted

--- a/src/datumaro/util/attrs_util.py
+++ b/src/datumaro/util/attrs_util.py
@@ -5,6 +5,7 @@
 import inspect
 
 import attrs
+from .points_util import normalize_points
 
 
 def not_empty(inst, attribute, x):
@@ -50,3 +51,29 @@ def ensure_cls(c):
             return c(**arg)
 
     return _converter
+
+
+def validate_points_positions(inst, attribute, positions) -> list[tuple[float, float]]:
+    """
+    Validate a list of point positions, ensuring that each position is a tuple of two floats.
+
+    To be used as an attrs validator in PointsCategories class.
+    """
+    if positions is None or positions == []:
+        value = []
+    else:
+        # convert to a list of tuples
+        try:
+            positions = list(map(tuple, positions))
+        except TypeError:
+            raise ValueError(f"Cannot convert {attribute.name} to list of tuples. Check your input data.")
+        # validate the positions
+        for position in positions:
+            if not len(position) == 2:
+                raise ValueError(f"Each tuple in {attribute.name} must have exactly 2 elements")
+            if not all(isinstance(coord, (int, float)) for coord in position):
+                raise ValueError(f"Each element in a tuple in {attribute.name} must be an int or float")
+        # normalize the positions
+        value = normalize_points(positions)
+
+    setattr(inst, attribute.name, value)

--- a/src/datumaro/util/attrs_util.py
+++ b/src/datumaro/util/attrs_util.py
@@ -5,7 +5,6 @@
 import inspect
 
 import attrs
-from .points_util import normalize_points
 
 
 def not_empty(inst, attribute, x):
@@ -51,26 +50,3 @@ def ensure_cls(c):
             return c(**arg)
 
     return _converter
-
-
-def validate_points_positions(inst, attribute, positions) -> list[float]:
-    """
-    Validate a list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
-
-    To be used as an attrs validator in PointsCategories class.
-    """
-    if positions is None or positions == []:
-        value = []
-    else:
-        # convert to a list of tuples
-        try:
-            positions = list(map(float, positions))
-        except (TypeError, ValueError):
-            raise ValueError(f"Cannot convert {attribute.name} to list of floats. Check your input data.")
-        # validate the positions
-        if len(positions) % 2 != 0:
-            raise ValueError(f"{attribute.name} must have an even number of elements")
-        # normalize the positions
-        value = normalize_points(positions)
-
-    setattr(inst, attribute.name, value)

--- a/src/datumaro/util/attrs_util.py
+++ b/src/datumaro/util/attrs_util.py
@@ -53,9 +53,9 @@ def ensure_cls(c):
     return _converter
 
 
-def validate_points_positions(inst, attribute, positions) -> list[tuple[float, float]]:
+def validate_points_positions(inst, attribute, positions) -> list[float]:
     """
-    Validate a list of point positions, ensuring that each position is a tuple of two floats.
+    Validate a list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
 
     To be used as an attrs validator in PointsCategories class.
     """
@@ -64,15 +64,12 @@ def validate_points_positions(inst, attribute, positions) -> list[tuple[float, f
     else:
         # convert to a list of tuples
         try:
-            positions = list(map(tuple, positions))
-        except TypeError:
-            raise ValueError(f"Cannot convert {attribute.name} to list of tuples. Check your input data.")
+            positions = list(map(float, positions))
+        except (TypeError, ValueError):
+            raise ValueError(f"Cannot convert {attribute.name} to list of floats. Check your input data.")
         # validate the positions
-        for position in positions:
-            if not len(position) == 2:
-                raise ValueError(f"Each tuple in {attribute.name} must have exactly 2 elements")
-            if not all(isinstance(coord, (int, float)) for coord in position):
-                raise ValueError(f"Each element in a tuple in {attribute.name} must be an int or float")
+        if len(positions) % 2 != 0:
+            raise ValueError(f"{attribute.name} must have an even number of elements")
         # normalize the positions
         value = normalize_points(positions)
 

--- a/src/datumaro/util/points_util.py
+++ b/src/datumaro/util/points_util.py
@@ -5,19 +5,19 @@
 import numpy as np
 
 
-def normalize_points(positions):
+def normalize_points(positions: list[float]) -> list[float]:
     """
     Normalize a set of keypoints to fit within a unit bounding box [0, 1] x [0, 1],
     maintaining the aspect ratio.
 
     Parameters:
-        keypoints (list of tuples): A list of (x, y) keypoints.
+        keypoints (list[float]): A list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
 
     Returns:
-        list of tuples: Normalized keypoints within the unit bounding box, preserving aspect ratio.
+        list[float]: Normalized keypoints within the unit bounding box, preserving aspect ratio.
     """
     # Convert keypoints to a NumPy array for easier manipulation
-    positions = np.array(positions, dtype=float)
+    positions = np.array(positions, dtype=float).reshape(-1, 2)
 
     # Find the minimum and maximum values for x and y
     min = positions.min(axis=0)
@@ -35,4 +35,4 @@ def normalize_points(positions):
     # Normalize the keypoints to fit within [0, 1] x [0, 1], preserving aspect ratio
     normalized_positions = (positions - min) / scale
 
-    return list(map(tuple, normalized_positions))
+    return list(map(float, normalized_positions.flatten()))

--- a/src/datumaro/util/points_util.py
+++ b/src/datumaro/util/points_util.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import numpy as np
+
+
+def normalize_points(positions):
+    """
+    Normalize a set of keypoints to fit within a unit bounding box [0, 1] x [0, 1],
+    maintaining the aspect ratio.
+
+    Parameters:
+        keypoints (list of tuples): A list of (x, y) keypoints.
+
+    Returns:
+        list of tuples: Normalized keypoints within the unit bounding box, preserving aspect ratio.
+    """
+    # Convert keypoints to a NumPy array for easier manipulation
+    positions = np.array(positions, dtype=float)
+
+    # Find the minimum and maximum values for x and y
+    min = positions.min(axis=0)
+    max = positions.max(axis=0)
+
+    # Compute the width and height of the bounding box
+    size = max - min
+
+    # Handle edge case where all keypoints are the same (zero width or height)
+    size[np.where(size==0)] = 1e-6
+
+    # Determine the scaling factor to maintain aspect ratio
+    scale = size.max()
+
+    # Normalize the keypoints to fit within [0, 1] x [0, 1], preserving aspect ratio
+    normalized_positions = (positions - min) / scale
+
+    return list(map(tuple, normalized_positions))

--- a/src/datumaro/util/points_util.py
+++ b/src/datumaro/util/points_util.py
@@ -27,7 +27,7 @@ def normalize_points(positions: list[float]) -> list[float]:
     size = max - min
 
     # Handle edge case where all keypoints are the same (zero width or height)
-    size[np.where(size==0)] = 1e-6
+    size[np.where(size == 0)] = 1e-6
 
     # Determine the scaling factor to maintain aspect ratio
     scale = size.max()

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -680,3 +680,59 @@ def fxt_legacy_dataset_pair(test_dir):
     )
 
     yield source_dataset, target_dataset
+
+
+@pytest.fixture
+def fxt_test_pointscategories_without_positions():
+
+    points_categories = PointsCategories()
+    for index in range(5):
+        points_categories.add(
+            index,
+            labels=["label1", "label2", "label3"],
+            joints=[[0, 1], [1, 2]]
+        )
+
+    return Dataset.from_iterable(
+        [
+            DatasetItem(
+                id=100,
+                subset="train",
+                media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                annotations=[
+                    Points([1, 2, 0, 0, 1, 1]),
+                ],
+            ),
+        ],
+        categories={
+            AnnotationType.points: points_categories,
+        },
+    )
+
+@pytest.fixture
+def fxt_test_pointscategories_with_positions():
+
+    points_categories = PointsCategories()
+    for index in range(5):
+        points_categories.add(
+            index,
+            labels=["label1", "label2", "label3"],
+            joints=[[0, 1], [1, 2]],
+            positions=[[0, 1], [1, 2], [2, 3]]
+        )
+
+    return Dataset.from_iterable(
+        [
+            DatasetItem(
+                id=100,
+                subset="train",
+                media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                annotations=[
+                    Points([1, 2, 0, 0, 1, 1]),
+                ],
+            ),
+        ],
+        categories={
+            AnnotationType.points: points_categories,
+        },
+    )

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -684,14 +684,9 @@ def fxt_legacy_dataset_pair(test_dir):
 
 @pytest.fixture
 def fxt_test_pointscategories_without_positions():
-
     points_categories = PointsCategories()
     for index in range(5):
-        points_categories.add(
-            index,
-            labels=["label1", "label2", "label3"],
-            joints=[[0, 1], [1, 2]]
-        )
+        points_categories.add(index, labels=["label1", "label2", "label3"], joints=[[0, 1], [1, 2]])
 
     return Dataset.from_iterable(
         [
@@ -709,16 +704,16 @@ def fxt_test_pointscategories_without_positions():
         },
     )
 
+
 @pytest.fixture
 def fxt_test_pointscategories_with_positions():
-
     points_categories = PointsCategories()
     for index in range(5):
         points_categories.add(
             index,
             labels=["label1", "label2", "label3"],
             joints=[[0, 1], [1, 2]],
-            positions=[0, 1, 1, 2, 2, 3]
+            positions=[0, 1, 1, 2, 2, 3],
         )
 
     return Dataset.from_iterable(

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -718,7 +718,7 @@ def fxt_test_pointscategories_with_positions():
             index,
             labels=["label1", "label2", "label3"],
             joints=[[0, 1], [1, 2]],
-            positions=[[0, 1], [1, 2], [2, 3]]
+            positions=[0, 1, 1, 2, 2, 3]
         )
 
     return Dataset.from_iterable(

--- a/tests/unit/data_formats/datumaro/test_datumaro_format.py
+++ b/tests/unit/data_formats/datumaro/test_datumaro_format.py
@@ -122,6 +122,18 @@ class DatumaroFormatTest:
                 True,
                 id="test_can_save_and_load_infos",
             ),
+            pytest.param(
+                "fxt_test_pointscategories_without_positions",
+                compare_datasets,
+                False,
+                id="test_pointscategories_without_positions",
+            ),
+            pytest.param(
+                "fxt_test_pointscategories_with_positions",
+                compare_datasets,
+                False,
+                id="test_pointscategories_with_positions",
+            ),
         ],
     )
     @pytest.mark.parametrize("stream", [True, False])

--- a/tests/unit/data_formats/datumaro/test_datumaro_format.py
+++ b/tests/unit/data_formats/datumaro/test_datumaro_format.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -248,8 +248,9 @@ class PointsCategoriesTest:
         @staticmethod
         def test_valid_positions():
             """Test that valid positions are allowed."""
+            labels = ["p1", "p2"]
             positions = [1.0, 2.0, 3.0, 4.0]
-            obj = PointsCategories.Category(positions=positions)
+            obj = PointsCategories.Category(labels=labels, positions=positions)
             assert obj
 
         @staticmethod
@@ -261,17 +262,29 @@ class PointsCategoriesTest:
         @staticmethod
         def test_coordinates_as_string():
             """Test that the coordinates may be represented as a string."""
-            obj = PointsCategories.Category(positions=["1", "2", "3", "4"])
+            labels = ["p1", "p2"]
+            positions = ["1", "2", "3", "4"]
+            obj = PointsCategories.Category(labels=labels, positions=positions)
             assert obj
 
         @staticmethod
         def test_non_numeric_elements():
             """Test that passing non-numeric elements raises an error."""
+            labels = ["p1", "p2"]
+            positions = [1.0, 2.0, 3.0, "not_a_number"]
             with pytest.raises(ValueError, match="Cannot convert positions to list of floats"):
-                PointsCategories.Category(positions=["1", "2", "3", "not_a_number"])
+                PointsCategories.Category(labels=labels, positions=positions)
 
         @staticmethod
         def test_uneven_number_of_elements():
             """Test that an uneven number of elements raises an error."""
             with pytest.raises(ValueError, match="positions must have an even number of elements"):
                 PointsCategories.Category(positions=[1.0, 2.0, 3.0])
+
+        @staticmethod
+        def test_num_positions_not_same_as_num_labels():
+            """Test that the number of positions must match the number of labels."""
+            labels = ["p1", "p2", "p3"]  # 3 labels
+            positions = [1.0, 2.0, 3.0, 4.0]  # 2 positions
+            with pytest.raises(ValueError, match="number of positions should be equal to the number of labels"):
+                PointsCategories.Category(labels=labels, positions=positions)

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -23,7 +23,6 @@ from datumaro.components.annotation import (
 )
 from datumaro.util.image import lazy_image
 from datumaro.util.points_util import normalize_points
-from datumaro.util.attrs_util import validate_points_positions
 
 
 class EllipseTest:

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -244,9 +244,15 @@ class PointsCategoriesTest:
         """Tests for the validator of the `positions` field in PointsCategories.Category."""
 
         @staticmethod
-        def test_empty_positions():
+        def test_empty_positions_list():
             """Test that an empty list of positions is allowed."""
             obj = PointsCategories.Category(positions=[])
+            assert obj.positions == []  # Should allow empty list
+
+        @staticmethod
+        def test_empty_positions_tuple():
+            """Test that an empty list of positions is allowed."""
+            obj = PointsCategories.Category(positions=())
             assert obj.positions == []  # Should allow empty list
 
         @staticmethod
@@ -300,3 +306,19 @@ class PointsCategoriesTest:
                 ValueError, match="number of positions should be equal to the number of labels"
             ):
                 PointsCategories.Category(labels=labels, positions=positions)
+
+        @staticmethod
+        def test_positions_allowed_with_empty_labels():
+            """Test that the the number of coordinates check is skipped when labels is empty."""
+            labels = []  # no labels
+            positions = [1.0, 2.0, 3.0, 4.0]  # 2 positions
+            obj = PointsCategories.Category(labels=labels, positions=positions)
+            assert obj
+
+        @staticmethod
+        def test_labels_allowed_with_empty_positions():
+            """Test that the the number of coordinates check is skipped when positions is empty."""
+            labels = ["p1", "p2", "p3"]  # 3 labels
+            positions = []  # no positions
+            obj = PointsCategories.Category(labels=labels, positions=positions)
+            assert obj

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -18,8 +18,8 @@ from datumaro.components.annotation import (
     ExtractedMask,
     HashKey,
     Mask,
-    RotatedBbox,
     PointsCategories,
+    RotatedBbox,
 )
 from datumaro.util.image import lazy_image
 from datumaro.util.points_util import normalize_points
@@ -211,17 +211,28 @@ class Cuboid2DTest:
 
 
 class PointsCategoriesTest:
-
     @pytest.mark.parametrize(
         "positions, expected",
         [
-            ([2, 3, 4, 6, 3, 5], [0.0, 0.0, 0.666667, 1.0, 0.333333, 0.666667]),  # basic functionality
+            (
+                [2, 3, 4, 6, 3, 5],
+                [0.0, 0.0, 0.666667, 1.0, 0.333333, 0.666667],
+            ),  # basic functionality
             ([1, 1, 1, 1, 1, 1], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),  # all points are the same
             ([1, 1, 3, 1, 5, 1], [0.0, 0.0, 0.5, 0.0, 1.0, 0.0]),  # points form horizontal line
             ([1, 1, 1, 3, 1, 5], [0.0, 0.0, 0.0, 0.5, 0.0, 1.0]),  # points form vertical line
-            ([-2, -3, -4, -6, -3, -5], [0.666667, 1.0, 0.0, 0.0, 0.333333, 0.333333]),  # negative coords
-            ([1000, 2000, 4000, 6000, 3000, 5000], [0.0, 0.0, 0.75, 1.0, 0.50, 0.75]),  # large range
-            ([0.001, 0.002, 0.004, 0.006, 0.003, 0.005], [0.0, 0.0, 0.75, 1.0, 0.50, 0.75]),  # small range
+            (
+                [-2, -3, -4, -6, -3, -5],
+                [0.666667, 1.0, 0.0, 0.0, 0.333333, 0.333333],
+            ),  # negative coords
+            (
+                [1000, 2000, 4000, 6000, 3000, 5000],
+                [0.0, 0.0, 0.75, 1.0, 0.50, 0.75],
+            ),  # large range
+            (
+                [0.001, 0.002, 0.004, 0.006, 0.003, 0.005],
+                [0.0, 0.0, 0.75, 1.0, 0.50, 0.75],
+            ),  # small range
             ([2, 3], [0.0, 0.0]),  # single point
         ],
     )
@@ -285,5 +296,7 @@ class PointsCategoriesTest:
             """Test that the number of positions must match the number of labels."""
             labels = ["p1", "p2", "p3"]  # 3 labels
             positions = [1.0, 2.0, 3.0, 4.0]  # 2 positions
-            with pytest.raises(ValueError, match="number of positions should be equal to the number of labels"):
+            with pytest.raises(
+                ValueError, match="number of positions should be equal to the number of labels"
+            ):
                 PointsCategories.Category(labels=labels, positions=positions)

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2024 Intel Corporation
+# Copyright (C) 2020-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -216,14 +216,14 @@ class PointsCategoriesTest:
     @pytest.mark.parametrize(
         "positions, expected",
         [
-            ([(2, 3), (4, 6), (3, 5)], [(0.0, 0.0), (0.666667, 1.0), (0.333333, 0.666667)]),  # basic functionality
-            ([(1, 1), (1, 1), (1, 1)], [(0.0, 0.0), (0.0, 0.0), (0.0, 0.0)]),  # all points are the same
-            ([(1, 1), (3, 1), (5, 1)], [(0.0, 0.0), (0.5, 0.0), (1.0, 0.0)]),  # points form horizontal line
-            ([(1, 1), (1, 3), (1, 5)], [(0.0, 0.0), (0.0, 0.5), (0.0, 1.0)]),  # points form vertical line
-            ([(-2, -3), (-4, -6), (-3, -5)], [(0.666667, 1.0), (0.0, 0.0), (0.333333, 0.333333)]),  # negative coords
-            ([(1000, 2000), (4000, 6000), (3000, 5000)], [(0.0, 0.0), (0.75, 1.0), (0.50, 0.75)]),  # large range
-            ([(0.001, 0.002), (0.004, 0.006), (0.003, 0.005)], [(0.0, 0.0), (0.75, 1.0), (0.50, 0.75)]),  # small range
-            ([(2, 3)], [(0.0, 0.0)]),  # single point
+            ([2, 3, 4, 6, 3, 5], [0.0, 0.0, 0.666667, 1.0, 0.333333, 0.666667]),  # basic functionality
+            ([1, 1, 1, 1, 1, 1], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),  # all points are the same
+            ([1, 1, 3, 1, 5, 1], [0.0, 0.0, 0.5, 0.0, 1.0, 0.0]),  # points form horizontal line
+            ([1, 1, 1, 3, 1, 5], [0.0, 0.0, 0.0, 0.5, 0.0, 1.0]),  # points form vertical line
+            ([-2, -3, -4, -6, -3, -5], [0.666667, 1.0, 0.0, 0.0, 0.333333, 0.333333]),  # negative coords
+            ([1000, 2000, 4000, 6000, 3000, 5000], [0.0, 0.0, 0.75, 1.0, 0.50, 0.75]),  # large range
+            ([0.001, 0.002, 0.004, 0.006, 0.003, 0.005], [0.0, 0.0, 0.75, 1.0, 0.50, 0.75]),  # small range
+            ([2, 3], [0.0, 0.0]),  # single point
         ],
     )
     def test_normalize_positions(self, positions, expected):
@@ -248,30 +248,30 @@ class PointsCategoriesTest:
         @staticmethod
         def test_valid_positions():
             """Test that valid positions are allowed."""
-            positions = [(1.0, 2.0), (3.0, 4.0)]
+            positions = [1.0, 2.0, 3.0, 4.0]
             obj = PointsCategories.Category(positions=positions)
             assert obj
 
         @staticmethod
         def test_type_not_list():
             """Test that a non-list type for positions raises an error."""
-            with pytest.raises(ValueError, match="Cannot convert positions to list of tuples"):
+            with pytest.raises(ValueError, match="Cannot convert positions to list of floats"):
                 PointsCategories.Category(positions=56)
 
         @staticmethod
-        def test_type_not_tuple():
-            """Test that a non-tuple type for a position raises an error."""
-            with pytest.raises(ValueError, match="Cannot convert positions to list of tuples"):
-                PointsCategories.Category(positions=[[1.0, 2.0], 543])
-
-        @staticmethod
-        def test_tuple_wrong_length():
-            """Test that a tuple with the wrong number of elements raises an error."""
-            with pytest.raises(ValueError, match="Each tuple in positions must have exactly 2 elements"):
-                PointsCategories.Category(positions=[(1.0, 2.0), (3.0,)])
+        def test_coordinates_as_string():
+            """Test that the coordinates may be represented as a string."""
+            obj = PointsCategories.Category(positions=["1", "2", "3", "4"])
+            assert obj
 
         @staticmethod
         def test_non_numeric_elements():
-            """Test that a tuple with non-numeric elements raises an error."""
-            with pytest.raises(ValueError, match="Each element in a tuple in positions must be an int or float"):
-                PointsCategories.Category(positions=[(1.0, 2.0), (3.0, "4.0")])
+            """Test that passing non-numeric elements raises an error."""
+            with pytest.raises(ValueError, match="Cannot convert positions to list of floats"):
+                PointsCategories.Category(positions=["1", "2", "3", "not_a_number"])
+
+        @staticmethod
+        def test_uneven_number_of_elements():
+            """Test that an uneven number of elements raises an error."""
+            with pytest.raises(ValueError, match="positions must have an even number of elements"):
+                PointsCategories.Category(positions=[1.0, 2.0, 3.0])

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -19,6 +19,7 @@ from datumaro.components.annotation import (
     HashKey,
     Mask,
     RotatedBbox,
+    PointsCategories,
 )
 from datumaro.util.image import lazy_image
 
@@ -206,3 +207,24 @@ class Cuboid2DTest:
         actual = fxt_cuboid_2d.to_3d(P_inv)
         for act, exp in zip(actual, fxt_kitti_data):
             assert np.allclose(act, exp, atol=2)
+
+
+class PointsCategoriesTest:
+
+
+    @pytest.mark.parametrize(
+        "positions, expected",
+        [
+            ([(2, 3), (4, 6), (3, 5)], [(0.0, 0.0), (0.666667, 1.0), (0.333333, 0.666667)]),  # basic functionality
+            ([(1, 1), (1, 1), (1, 1)], [(0.0, 0.0), (0.0, 0.0), (0.0, 0.0)]),  # all points are the same
+            ([(1, 1), (3, 1), (5, 1)], [(0.0, 0.0), (0.5, 0.0), (1.0, 0.0)]),  # points form horizontal line
+            ([(1, 1), (1, 3), (1, 5)], [(0.0, 0.0), (0.0, 0.5), (0.0, 1.0)]),  # points form vertical line
+            ([(-2, -3), (-4, -6), (-3, -5)], [(0.666667, 1.0), (0.0, 0.0), (0.333333, 0.333333)]),  # negative coords
+            ([(1000, 2000), (4000, 6000), (3000, 5000)], [(0.0, 0.0), (0.75, 1.0), (0.50, 0.75)]),  # large range
+            ([(0.001, 0.002), (0.004, 0.006), (0.003, 0.005)], [(0.0, 0.0), (0.75, 1.0), (0.50, 0.75)]),  # small range
+            ([(2, 3)], [(0.0, 0.0)]),  # single point
+        ],
+    )
+    def test_normalize_positions(self, positions, expected):
+        result = PointsCategories.normalize_positions(positions)
+        assert np.allclose(result, expected), f"Expected {expected}, got {result}"


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This PR adds optional position information as meta-info for (key)point annotations. The position information can be used to define one or multiple default relative positions of a set of keypoints, for example a set of default human poses (standing, running etc) for human keypoint detection datasets. This type of meta-information about points data is useful in annotation tools.

### Changes

- Adds `positions` attribute to `PointsCategories.Category` class. Similar to the `Points` annotation type, the positions are represented as a list of floats in the format `[x1, y1, x2, y2, ..., xn, yn]`. The positions are optional and default to an empty list.
- Adds a validator that validates the position coordinates that are passed to the `Category` constructor. Also validates if the number of position coordinates is the same as the number of labels.
- Adds a normalization function that normalizes the positions to the [0, 1] range (preserving aspect ratio). The normalization function is called by the validator to ensure that position information in the `PointsCategories` instance is always normalized.
- Adds logic to Datumaro format importer and exporter, to ensure that position information gets stored in the annotations json, and is also loaded correctly during import. The importer can handle datasets where position information is missing, so backward compatibility is preserved.
- Adds unit tests for normalization, validation and import/export functionality described above.


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
Add some position information to the `PointsCategories` instance of a keypoint detection dataset, then try export and importing the dataset.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
