### PR TITLE
1.10: Add position information to PointsCategories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Q4 2024 Release 1.10.0
 
 ### New features
+- Add default position information to PointsCategories class
+  (<https://github.com/openvinotoolkit/datumaro/pull/1695>)
 - Support KITTI 3D format
   (<https://github.com/openvinotoolkit/datumaro/pull/1619>)
   (<https://github.com/openvinotoolkit/datumaro/pull/1621>)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 - Add default position information to PointsCategories class
-  (<https://github.com/openvinotoolkit/datumaro/pull/1695>)
+  (<https://github.com/openvinotoolkit/datumaro/pull/1702>)
 - Support KITTI 3D format
   (<https://github.com/openvinotoolkit/datumaro/pull/1619>)
   (<https://github.com/openvinotoolkit/datumaro/pull/1621>)

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2024 Intel Corporation
+# Copyright (C) 2021-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1420,14 +1420,16 @@ class PointsCategories(Categories):
         positions: List[float] = field(factory=list)
 
         @positions.validator
-        def positions_validator(self, attribute, positions: list[float] | None) -> None:
+        def positions_validator(
+            self, attribute: attr.Attribute[list], positions: list[float] | None
+        ) -> None:
             """
             Validate a list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
 
             To be used as an attrs validator for the positions field of PointsCategories.Category.
 
             Args:
-                attribute: The attribute being validated (unused).
+                attribute (attr.Attribute[list]): The attribute being validated (unused).
                 positions (list[float]): A list of point positions.
 
             Raises:

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1417,7 +1417,7 @@ class PointsCategories(Categories):
         joints: Set[Tuple[int, int]] = field(factory=set, validator=default_if_none(set))
 
         # Set of default x, y coordinates of the points
-        positions: List[float] = field(factory=list)
+        positions: List[float] = field(default=[])
 
         @positions.validator
         def positions_validator(
@@ -1429,17 +1429,15 @@ class PointsCategories(Categories):
             To be used as an attrs validator for the positions field of PointsCategories.Category.
 
             Args:
-                attribute (attr.Attribute[list]): The attribute being validated (unused).
+                attribute (attr.Attribute[list]): The attribute being validated.
                 positions (list[float]): A list of point positions.
 
             Raises:
                 ValueError: If the provided value cannot be converted to a list of floats,
-                    or if the number of positions is not even.
+                    or if the number of positions is invalid.
             """
-            del attribute
-            print(len(self.labels))
-            if positions is None or positions == []:
-                self.positions = []
+            if positions is None:
+                positions = []
             else:
                 # convert to a list of floats
                 try:
@@ -1447,15 +1445,18 @@ class PointsCategories(Categories):
                 except (TypeError, ValueError):
                     msg = "Cannot convert positions to list of floats. Check your input data."
                     raise ValueError(msg)
-                # validate the positions
+                # check if number of coordinates is even
                 if len(positions) % 2 != 0:
                     msg = "positions must have an even number of elements"
                     raise ValueError(msg)
-                if len(self.labels) > 0 and len(self.positions) != len(self.labels) * 2:
-                    msg = "The number of positions should be equal to the number of labels"
-                    raise ValueError(msg)
-                # normalize the positions
-                self.positions = normalize_points(positions)
+                if len(positions) > 0:
+                    # check if the number of positions is equal to the number of labels
+                    if len(self.labels) > 0 and len(positions) != len(self.labels) * 2:
+                        msg = "The number of positions should be equal to the number of labels"
+                        raise ValueError(msg)
+                    # normalize the positions
+                    positions = normalize_points(positions)
+            setattr(self, attribute.name, positions)
 
     items: Dict[int, Category] = field(factory=dict, validator=default_if_none(dict))
 

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -16,6 +16,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -1425,8 +1426,9 @@ class PointsCategories(Categories):
     def from_iterable(
         cls,
         iterable: Union[
-            Tuple[int, List[str]],
-            Tuple[int, List[str], Set[Tuple[int, int]]],
+            Iterable[Sequence[int, List[str]]],
+            Iterable[Sequence[int, List[str], Set[Tuple[int, int]]]],
+            Iterable[Sequence[int, List[str], Set[Tuple[int, int]], List[Tuple[float, float]]]],
         ],
     ) -> PointsCategories:
         """

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1414,6 +1414,42 @@ class PointsCategories(Categories):
         # Pairs of connected point indices
         joints: Set[Tuple[int, int]] = field(factory=set, validator=default_if_none(set))
 
+        # Set of default x, y coordinates of the points
+        positions: List[Tuple[float, float]] = field(factory=list, validator=default_if_none(list))
+
+    @staticmethod
+    def normalize_positions(positions):
+        """
+        Normalize a set of keypoints to fit within a unit bounding box [0, 1] x [0, 1],
+        maintaining the aspect ratio.
+
+        Parameters:
+            keypoints (list of tuples): A list of (x, y) keypoints.
+
+        Returns:
+            list of tuples: Normalized keypoints within the unit bounding box, preserving aspect ratio.
+        """
+        # Convert keypoints to a NumPy array for easier manipulation
+        positions = np.array(positions)
+
+        # Find the minimum and maximum values for x and y
+        min = positions.min(axis=0)
+        max = positions.max(axis=0)
+
+        # Compute the width and height of the bounding box
+        size = max - min
+
+        # Handle edge case where all keypoints are the same (zero width or height)
+        size[np.where(size==0)] = 1e-6
+
+        # Determine the scaling factor to maintain aspect ratio
+        scale = size.max()
+
+        # Normalize the keypoints to fit within [0, 1] x [0, 1], preserving aspect ratio
+        normalized_positions = (positions - min) / scale
+
+        return list(map(tuple, normalized_positions))
+
     items: Dict[int, Category] = field(factory=dict, validator=default_if_none(dict))
 
     @classmethod
@@ -1447,11 +1483,16 @@ class PointsCategories(Categories):
         label_id: int,
         labels: Optional[Iterable[str]] = None,
         joints: Iterable[Tuple[int, int]] = None,
+        positions: Iterable[Tuple[float, float]] = None,
     ):
         if joints is None:
             joints = []
         joints = set(map(tuple, joints))
-        self.items[label_id] = self.Category(labels, joints)
+        if positions is None:
+            positions = []
+        if len(positions) > 0:
+            positions = self.normalize_positions(list(positions))
+        self.items[label_id] = self.Category(labels, joints, positions)
 
     def __contains__(self, idx: int) -> bool:
         return idx in self.items

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1419,34 +1419,40 @@ class PointsCategories(Categories):
         # Set of default x, y coordinates of the points
         positions: List[float] = field(factory=list)
 
-        def __attrs_post_init__(self):
-            """
-            Validates that the number of positions is equal to the number of labels.
-            """
-            if len(self.positions) > 0 and len(self.positions) != len(self.labels) * 2:
-                msg = "The number of positions should be equal to the number of labels"
-                raise ValueError(msg)
-
         @positions.validator
-        def positions_validator(self, attribute, positions) -> list[float]:
+        def positions_validator(self, attribute, positions: list[float] | None) -> None:
             """
             Validate a list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
 
-            To be used as an attrs validator in PointsCategories class.
+            To be used as an attrs validator for the positions field of PointsCategories Category.
+
+            Args:
+                inst: The instance being validated.
+                attribute: The attribute being validated (unused).
+                positions (list[float]): A list of point positions.
+
+            Raises:
+                ValueError: If the provided value cannot be converted to a list of floats,
+                    or if the number of positions is not even.
             """
+            del attribute
+            print(len(self.labels))
             if positions is None or positions == []:
                 self.positions = []
             else:
-                # convert to a list of tuples
+                # convert to a list of floats
                 try:
                     positions = list(map(float, positions))
                 except (TypeError, ValueError):
-                    raise ValueError(
-                        f"Cannot convert {attribute.name} to list of floats. Check your input data."
-                    )
+                    msg = "Cannot convert positions to list of floats. Check your input data."
+                    raise ValueError(msg)
                 # validate the positions
                 if len(positions) % 2 != 0:
-                    raise ValueError(f"{attribute.name} must have an even number of elements")
+                    msg = "positions must have an even number of elements"
+                    raise ValueError(msg)
+                if len(self.labels) > 0 and len(self.positions) != len(self.labels) * 2:
+                    msg = "The number of positions should be equal to the number of labels"
+                    raise ValueError(msg)
                 # normalize the positions
                 self.positions = normalize_points(positions)
 

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1430,7 +1430,7 @@ class PointsCategories(Categories):
             list of tuples: Normalized keypoints within the unit bounding box, preserving aspect ratio.
         """
         # Convert keypoints to a NumPy array for easier manipulation
-        positions = np.array(positions)
+        positions = np.array(positions, dtype=float)
 
         # Find the minimum and maximum values for x and y
         min = positions.min(axis=0)

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -30,7 +30,7 @@ from attr import asdict, attrs, field
 from typing_extensions import Literal
 
 from datumaro.components.media import Image
-from datumaro.util.attrs_util import default_if_none, not_empty
+from datumaro.util.attrs_util import default_if_none, not_empty, validate_points_positions
 
 
 class AnnotationType(IntEnum):
@@ -1415,40 +1415,9 @@ class PointsCategories(Categories):
         joints: Set[Tuple[int, int]] = field(factory=set, validator=default_if_none(set))
 
         # Set of default x, y coordinates of the points
-        positions: List[Tuple[float, float]] = field(factory=list, validator=default_if_none(list))
-
-    @staticmethod
-    def normalize_positions(positions):
-        """
-        Normalize a set of keypoints to fit within a unit bounding box [0, 1] x [0, 1],
-        maintaining the aspect ratio.
-
-        Parameters:
-            keypoints (list of tuples): A list of (x, y) keypoints.
-
-        Returns:
-            list of tuples: Normalized keypoints within the unit bounding box, preserving aspect ratio.
-        """
-        # Convert keypoints to a NumPy array for easier manipulation
-        positions = np.array(positions, dtype=float)
-
-        # Find the minimum and maximum values for x and y
-        min = positions.min(axis=0)
-        max = positions.max(axis=0)
-
-        # Compute the width and height of the bounding box
-        size = max - min
-
-        # Handle edge case where all keypoints are the same (zero width or height)
-        size[np.where(size==0)] = 1e-6
-
-        # Determine the scaling factor to maintain aspect ratio
-        scale = size.max()
-
-        # Normalize the keypoints to fit within [0, 1] x [0, 1], preserving aspect ratio
-        normalized_positions = (positions - min) / scale
-
-        return list(map(tuple, normalized_positions))
+        positions: List[Tuple[float, float]] = field(
+            factory=list, validator=validate_points_positions
+        )
 
     items: Dict[int, Category] = field(factory=dict, validator=default_if_none(dict))
 
@@ -1488,10 +1457,6 @@ class PointsCategories(Categories):
         if joints is None:
             joints = []
         joints = set(map(tuple, joints))
-        if positions is None:
-            positions = []
-        if len(positions) > 0:
-            positions = self.normalize_positions(list(positions))
         self.items[label_id] = self.Category(labels, joints, positions)
 
     def __contains__(self, idx: int) -> bool:

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1418,6 +1418,14 @@ class PointsCategories(Categories):
         # Set of default x, y coordinates of the points
         positions: List[float] = field(factory=list, validator=validate_points_positions)
 
+        def __attrs_post_init__(self):
+            """
+            Validates that the number of positions is equal to the number of labels.
+            """
+            if len(self.positions) > 0 and len(self.positions) != len(self.labels) * 2:
+                msg = "The number of positions should be equal to the number of labels"
+                raise ValueError(msg)
+
     items: Dict[int, Category] = field(factory=dict, validator=default_if_none(dict))
 
     @classmethod
@@ -1426,7 +1434,7 @@ class PointsCategories(Categories):
         iterable: Union[
             Iterable[Sequence[int, List[str]]],
             Iterable[Sequence[int, List[str], Set[Tuple[int, int]]]],
-            Iterable[Sequence[int, List[str], Set[Tuple[int, int]], List[Tuple[float, float]]]],
+            Iterable[Sequence[int, List[str], Set[Tuple[int, int]], List[float]]],
         ],
     ) -> PointsCategories:
         """

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1424,10 +1424,9 @@ class PointsCategories(Categories):
             """
             Validate a list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
 
-            To be used as an attrs validator for the positions field of PointsCategories Category.
+            To be used as an attrs validator for the positions field of PointsCategories.Category.
 
             Args:
-                inst: The instance being validated.
                 attribute: The attribute being validated (unused).
                 positions (list[float]): A list of point positions.
 

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1416,9 +1416,7 @@ class PointsCategories(Categories):
         joints: Set[Tuple[int, int]] = field(factory=set, validator=default_if_none(set))
 
         # Set of default x, y coordinates of the points
-        positions: List[Tuple[float, float]] = field(
-            factory=list, validator=validate_points_positions
-        )
+        positions: List[float] = field(factory=list, validator=validate_points_positions)
 
     items: Dict[int, Category] = field(factory=dict, validator=default_if_none(dict))
 
@@ -1454,7 +1452,7 @@ class PointsCategories(Categories):
         label_id: int,
         labels: Optional[Iterable[str]] = None,
         joints: Iterable[Tuple[int, int]] = None,
-        positions: Iterable[Tuple[float, float]] = None,
+        positions: Iterable[float] = None,
     ):
         if joints is None:
             joints = []

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -31,7 +31,8 @@ from attr import asdict, attrs, field
 from typing_extensions import Literal
 
 from datumaro.components.media import Image
-from datumaro.util.attrs_util import default_if_none, not_empty, validate_points_positions
+from datumaro.util.attrs_util import default_if_none, not_empty
+from datumaro.util.points_util import normalize_points
 
 
 class AnnotationType(IntEnum):
@@ -1416,7 +1417,7 @@ class PointsCategories(Categories):
         joints: Set[Tuple[int, int]] = field(factory=set, validator=default_if_none(set))
 
         # Set of default x, y coordinates of the points
-        positions: List[float] = field(factory=list, validator=validate_points_positions)
+        positions: List[float] = field(factory=list)
 
         def __attrs_post_init__(self):
             """
@@ -1425,6 +1426,29 @@ class PointsCategories(Categories):
             if len(self.positions) > 0 and len(self.positions) != len(self.labels) * 2:
                 msg = "The number of positions should be equal to the number of labels"
                 raise ValueError(msg)
+
+        @positions.validator
+        def positions_validator(self, attribute, positions) -> list[float]:
+            """
+            Validate a list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
+
+            To be used as an attrs validator in PointsCategories class.
+            """
+            if positions is None or positions == []:
+                self.positions = []
+            else:
+                # convert to a list of tuples
+                try:
+                    positions = list(map(float, positions))
+                except (TypeError, ValueError):
+                    raise ValueError(
+                        f"Cannot convert {attribute.name} to list of floats. Check your input data."
+                    )
+                # validate the positions
+                if len(positions) % 2 != 0:
+                    raise ValueError(f"{attribute.name} must have an even number of elements")
+                # normalize the positions
+                self.positions = normalize_points(positions)
 
     items: Dict[int, Category] = field(factory=dict, validator=default_if_none(dict))
 

--- a/src/datumaro/plugins/data_formats/datumaro/base.py
+++ b/src/datumaro/plugins/data_formats/datumaro/base.py
@@ -115,7 +115,12 @@ class JsonReader:
         if parsed_points_cat:
             point_categories = PointsCategories()
             for item in parsed_points_cat["items"]:
-                point_categories.add(int(item["label_id"]), item["labels"], joints=item["joints"])
+                point_categories.add(
+                    int(item["label_id"]),
+                    item["labels"],
+                    joints=item["joints"],
+                    positions=item.get("positions"),
+                )
 
             categories[AnnotationType.points] = point_categories
 

--- a/src/datumaro/plugins/data_formats/datumaro/base.py
+++ b/src/datumaro/plugins/data_formats/datumaro/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -107,7 +107,7 @@ class JsonWriter:
                     "label_id": int(label_id),
                     "labels": [cast(label, str) for label in item.labels],
                     "joints": [list(map(int, j)) for j in item.joints],
-                    "positions": [list(map(float, p)) for p in item.positions],
+                    "positions": list(map(float, item.positions)),
                 }
             )
         return converted

--- a/src/datumaro/plugins/data_formats/datumaro/exporter.py
+++ b/src/datumaro/plugins/data_formats/datumaro/exporter.py
@@ -107,6 +107,7 @@ class JsonWriter:
                     "label_id": int(label_id),
                     "labels": [cast(label, str) for label in item.labels],
                     "joints": [list(map(int, j)) for j in item.joints],
+                    "positions": [list(map(float, p)) for p in item.positions],
                 }
             )
         return converted

--- a/src/datumaro/util/attrs_util.py
+++ b/src/datumaro/util/attrs_util.py
@@ -6,6 +6,8 @@ import inspect
 
 import attrs
 
+from .points_util import normalize_points
+
 
 def not_empty(inst, attribute, x):
     assert len(x) != 0, x
@@ -50,3 +52,33 @@ def ensure_cls(c):
             return c(**arg)
 
     return _converter
+
+
+def validate_points_positions(inst, attribute, positions) -> list[tuple[float, float]]:
+    """
+    Validate a list of point positions, ensuring that each position is a tuple of two floats.
+
+    To be used as an attrs validator in PointsCategories class.
+    """
+    if positions is None or positions == []:
+        value = []
+    else:
+        # convert to a list of tuples
+        try:
+            positions = list(map(tuple, positions))
+        except TypeError:
+            raise ValueError(
+                f"Cannot convert {attribute.name} to list of tuples. Check your input data."
+            )
+        # validate the positions
+        for position in positions:
+            if not len(position) == 2:
+                raise ValueError(f"Each tuple in {attribute.name} must have exactly 2 elements")
+            if not all(isinstance(coord, (int, float)) for coord in position):
+                raise ValueError(
+                    f"Each element in a tuple in {attribute.name} must be an int or float"
+                )
+        # normalize the positions
+        value = normalize_points(positions)
+
+    setattr(inst, attribute.name, value)

--- a/src/datumaro/util/attrs_util.py
+++ b/src/datumaro/util/attrs_util.py
@@ -6,8 +6,6 @@ import inspect
 
 import attrs
 
-from .points_util import normalize_points
-
 
 def not_empty(inst, attribute, x):
     assert len(x) != 0, x
@@ -52,28 +50,3 @@ def ensure_cls(c):
             return c(**arg)
 
     return _converter
-
-
-def validate_points_positions(inst, attribute, positions) -> list[float]:
-    """
-    Validate a list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
-
-    To be used as an attrs validator in PointsCategories class.
-    """
-    if positions is None or positions == []:
-        value = []
-    else:
-        # convert to a list of tuples
-        try:
-            positions = list(map(float, positions))
-        except (TypeError, ValueError):
-            raise ValueError(
-                f"Cannot convert {attribute.name} to list of floats. Check your input data."
-            )
-        # validate the positions
-        if len(positions) % 2 != 0:
-            raise ValueError(f"{attribute.name} must have an even number of elements")
-        # normalize the positions
-        value = normalize_points(positions)
-
-    setattr(inst, attribute.name, value)

--- a/src/datumaro/util/attrs_util.py
+++ b/src/datumaro/util/attrs_util.py
@@ -54,9 +54,9 @@ def ensure_cls(c):
     return _converter
 
 
-def validate_points_positions(inst, attribute, positions) -> list[tuple[float, float]]:
+def validate_points_positions(inst, attribute, positions) -> list[float]:
     """
-    Validate a list of point positions, ensuring that each position is a tuple of two floats.
+    Validate a list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
 
     To be used as an attrs validator in PointsCategories class.
     """
@@ -65,19 +65,14 @@ def validate_points_positions(inst, attribute, positions) -> list[tuple[float, f
     else:
         # convert to a list of tuples
         try:
-            positions = list(map(tuple, positions))
-        except TypeError:
+            positions = list(map(float, positions))
+        except (TypeError, ValueError):
             raise ValueError(
-                f"Cannot convert {attribute.name} to list of tuples. Check your input data."
+                f"Cannot convert {attribute.name} to list of floats. Check your input data."
             )
         # validate the positions
-        for position in positions:
-            if not len(position) == 2:
-                raise ValueError(f"Each tuple in {attribute.name} must have exactly 2 elements")
-            if not all(isinstance(coord, (int, float)) for coord in position):
-                raise ValueError(
-                    f"Each element in a tuple in {attribute.name} must be an int or float"
-                )
+        if len(positions) % 2 != 0:
+            raise ValueError(f"{attribute.name} must have an even number of elements")
         # normalize the positions
         value = normalize_points(positions)
 

--- a/src/datumaro/util/points_util.py
+++ b/src/datumaro/util/points_util.py
@@ -5,19 +5,19 @@
 import numpy as np
 
 
-def normalize_points(positions):
+def normalize_points(positions: list[float]) -> list[float]:
     """
     Normalize a set of keypoints to fit within a unit bounding box [0, 1] x [0, 1],
     maintaining the aspect ratio.
 
     Parameters:
-        keypoints (list of tuples): A list of (x, y) keypoints.
+        keypoints (list[float]): A list of point positions in the format [x1, y1, x2, y2, ..., xn, yn].
 
     Returns:
-        list of tuples: Normalized keypoints within the unit bounding box, preserving aspect ratio.
+        list[float]: Normalized keypoints within the unit bounding box, preserving aspect ratio.
     """
     # Convert keypoints to a NumPy array for easier manipulation
-    positions = np.array(positions, dtype=float)
+    positions = np.array(positions, dtype=float).reshape(-1, 2)
 
     # Find the minimum and maximum values for x and y
     min = positions.min(axis=0)
@@ -35,4 +35,4 @@ def normalize_points(positions):
     # Normalize the keypoints to fit within [0, 1] x [0, 1], preserving aspect ratio
     normalized_positions = (positions - min) / scale
 
-    return list(map(tuple, normalized_positions))
+    return list(map(float, normalized_positions.flatten()))

--- a/src/datumaro/util/points_util.py
+++ b/src/datumaro/util/points_util.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import numpy as np
+
+
+def normalize_points(positions):
+    """
+    Normalize a set of keypoints to fit within a unit bounding box [0, 1] x [0, 1],
+    maintaining the aspect ratio.
+
+    Parameters:
+        keypoints (list of tuples): A list of (x, y) keypoints.
+
+    Returns:
+        list of tuples: Normalized keypoints within the unit bounding box, preserving aspect ratio.
+    """
+    # Convert keypoints to a NumPy array for easier manipulation
+    positions = np.array(positions, dtype=float)
+
+    # Find the minimum and maximum values for x and y
+    min = positions.min(axis=0)
+    max = positions.max(axis=0)
+
+    # Compute the width and height of the bounding box
+    size = max - min
+
+    # Handle edge case where all keypoints are the same (zero width or height)
+    size[np.where(size == 0)] = 1e-6
+
+    # Determine the scaling factor to maintain aspect ratio
+    scale = size.max()
+
+    # Normalize the keypoints to fit within [0, 1] x [0, 1], preserving aspect ratio
+    normalized_positions = (positions - min) / scale
+
+    return list(map(tuple, normalized_positions))

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -680,3 +680,59 @@ def fxt_legacy_dataset_pair(test_dir):
     )
 
     yield source_dataset, target_dataset
+
+
+@pytest.fixture
+def fxt_test_pointscategories_without_positions():
+
+    points_categories = PointsCategories()
+    for index in range(5):
+        points_categories.add(
+            index,
+            labels=["label1", "label2", "label3"],
+            joints=[[0, 1], [1, 2]]
+        )
+
+    return Dataset.from_iterable(
+        [
+            DatasetItem(
+                id=100,
+                subset="train",
+                media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                annotations=[
+                    Points([1, 2, 0, 0, 1, 1]),
+                ],
+            ),
+        ],
+        categories={
+            AnnotationType.points: points_categories,
+        },
+    )
+
+@pytest.fixture
+def fxt_test_pointscategories_with_positions():
+
+    points_categories = PointsCategories()
+    for index in range(5):
+        points_categories.add(
+            index,
+            labels=["label1", "label2", "label3"],
+            joints=[[0, 1], [1, 2]],
+            positions=[[0, 1], [1, 2], [2, 3]]
+        )
+
+    return Dataset.from_iterable(
+        [
+            DatasetItem(
+                id=100,
+                subset="train",
+                media=Image.from_numpy(data=np.ones((10, 6, 3))),
+                annotations=[
+                    Points([1, 2, 0, 0, 1, 1]),
+                ],
+            ),
+        ],
+        categories={
+            AnnotationType.points: points_categories,
+        },
+    )

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/unit/data_formats/datumaro/conftest.py
+++ b/tests/unit/data_formats/datumaro/conftest.py
@@ -684,14 +684,9 @@ def fxt_legacy_dataset_pair(test_dir):
 
 @pytest.fixture
 def fxt_test_pointscategories_without_positions():
-
     points_categories = PointsCategories()
     for index in range(5):
-        points_categories.add(
-            index,
-            labels=["label1", "label2", "label3"],
-            joints=[[0, 1], [1, 2]]
-        )
+        points_categories.add(index, labels=["label1", "label2", "label3"], joints=[[0, 1], [1, 2]])
 
     return Dataset.from_iterable(
         [
@@ -709,16 +704,16 @@ def fxt_test_pointscategories_without_positions():
         },
     )
 
+
 @pytest.fixture
 def fxt_test_pointscategories_with_positions():
-
     points_categories = PointsCategories()
     for index in range(5):
         points_categories.add(
             index,
             labels=["label1", "label2", "label3"],
             joints=[[0, 1], [1, 2]],
-            positions=[[0, 1], [1, 2], [2, 3]]
+            positions=[0, 1, 1, 2, 2, 3],
         )
 
     return Dataset.from_iterable(

--- a/tests/unit/data_formats/datumaro/test_datumaro_format.py
+++ b/tests/unit/data_formats/datumaro/test_datumaro_format.py
@@ -122,6 +122,18 @@ class DatumaroFormatTest:
                 True,
                 id="test_can_save_and_load_infos",
             ),
+            pytest.param(
+                "fxt_test_pointscategories_without_positions",
+                compare_datasets,
+                False,
+                id="test_pointscategories_without_positions",
+            ),
+            pytest.param(
+                "fxt_test_pointscategories_with_positions",
+                compare_datasets,
+                False,
+                id="test_pointscategories_with_positions",
+            ),
         ],
     )
     @pytest.mark.parametrize("stream", [True, False])

--- a/tests/unit/data_formats/datumaro/test_datumaro_format.py
+++ b/tests/unit/data_formats/datumaro/test_datumaro_format.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2024 Intel Corporation
+# Copyright (C) 2020-2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -152,34 +152,25 @@ class PointsCategoriesTest:
         "positions, expected",
         [
             (
-                [(2, 3), (4, 6), (3, 5)],
-                [(0.0, 0.0), (0.666667, 1.0), (0.333333, 0.666667)],
+                [2, 3, 4, 6, 3, 5],
+                [0.0, 0.0, 0.666667, 1.0, 0.333333, 0.666667],
             ),  # basic functionality
+            ([1, 1, 1, 1, 1, 1], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),  # all points are the same
+            ([1, 1, 3, 1, 5, 1], [0.0, 0.0, 0.5, 0.0, 1.0, 0.0]),  # points form horizontal line
+            ([1, 1, 1, 3, 1, 5], [0.0, 0.0, 0.0, 0.5, 0.0, 1.0]),  # points form vertical line
             (
-                [(1, 1), (1, 1), (1, 1)],
-                [(0.0, 0.0), (0.0, 0.0), (0.0, 0.0)],
-            ),  # all points are the same
-            (
-                [(1, 1), (3, 1), (5, 1)],
-                [(0.0, 0.0), (0.5, 0.0), (1.0, 0.0)],
-            ),  # points form horizontal line
-            (
-                [(1, 1), (1, 3), (1, 5)],
-                [(0.0, 0.0), (0.0, 0.5), (0.0, 1.0)],
-            ),  # points form vertical line
-            (
-                [(-2, -3), (-4, -6), (-3, -5)],
-                [(0.666667, 1.0), (0.0, 0.0), (0.333333, 0.333333)],
+                [-2, -3, -4, -6, -3, -5],
+                [0.666667, 1.0, 0.0, 0.0, 0.333333, 0.333333],
             ),  # negative coords
             (
-                [(1000, 2000), (4000, 6000), (3000, 5000)],
-                [(0.0, 0.0), (0.75, 1.0), (0.50, 0.75)],
+                [1000, 2000, 4000, 6000, 3000, 5000],
+                [0.0, 0.0, 0.75, 1.0, 0.50, 0.75],
             ),  # large range
             (
-                [(0.001, 0.002), (0.004, 0.006), (0.003, 0.005)],
-                [(0.0, 0.0), (0.75, 1.0), (0.50, 0.75)],
+                [0.001, 0.002, 0.004, 0.006, 0.003, 0.005],
+                [0.0, 0.0, 0.75, 1.0, 0.50, 0.75],
             ),  # small range
-            ([(2, 3)], [(0.0, 0.0)]),  # single point
+            ([2, 3], [0.0, 0.0]),  # single point
         ],
     )
     def test_normalize_positions(self, positions, expected):
@@ -242,5 +233,7 @@ class PointsCategoriesTest:
             """Test that the number of positions must match the number of labels."""
             labels = ["p1", "p2", "p3"]  # 3 labels
             positions = [1.0, 2.0, 3.0, 4.0]  # 2 positions
-            with pytest.raises(ValueError, match="number of positions should be equal to the number of labels"):
+            with pytest.raises(
+                ValueError, match="number of positions should be equal to the number of labels"
+            ):
                 PointsCategories.Category(labels=labels, positions=positions)

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -204,8 +204,9 @@ class PointsCategoriesTest:
         @staticmethod
         def test_valid_positions():
             """Test that valid positions are allowed."""
+            labels = ["p1", "p2"]
             positions = [1.0, 2.0, 3.0, 4.0]
-            obj = PointsCategories.Category(positions=positions)
+            obj = PointsCategories.Category(labels=labels, positions=positions)
             assert obj
 
         @staticmethod
@@ -217,17 +218,29 @@ class PointsCategoriesTest:
         @staticmethod
         def test_coordinates_as_string():
             """Test that the coordinates may be represented as a string."""
-            obj = PointsCategories.Category(positions=["1", "2", "3", "4"])
+            labels = ["p1", "p2"]
+            positions = ["1", "2", "3", "4"]
+            obj = PointsCategories.Category(labels=labels, positions=positions)
             assert obj
 
         @staticmethod
         def test_non_numeric_elements():
             """Test that passing non-numeric elements raises an error."""
+            labels = ["p1", "p2"]
+            positions = [1.0, 2.0, 3.0, "not_a_number"]
             with pytest.raises(ValueError, match="Cannot convert positions to list of floats"):
-                PointsCategories.Category(positions=["1", "2", "3", "not_a_number"])
+                PointsCategories.Category(labels=labels, positions=positions)
 
         @staticmethod
         def test_uneven_number_of_elements():
             """Test that an uneven number of elements raises an error."""
             with pytest.raises(ValueError, match="positions must have an even number of elements"):
                 PointsCategories.Category(positions=[1.0, 2.0, 3.0])
+
+        @staticmethod
+        def test_num_positions_not_same_as_num_labels():
+            """Test that the number of positions must match the number of labels."""
+            labels = ["p1", "p2", "p3"]  # 3 labels
+            positions = [1.0, 2.0, 3.0, 4.0]  # 2 positions
+            with pytest.raises(ValueError, match="number of positions should be equal to the number of labels"):
+                PointsCategories.Category(labels=labels, positions=positions)

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -17,6 +17,7 @@ from datumaro.components.annotation import (
     ExtractedMask,
     HashKey,
     Mask,
+    PointsCategories,
     RotatedBbox,
 )
 from datumaro.util.image import lazy_image
@@ -142,3 +143,43 @@ class AnnotationsTest:
         semantic_seg_mask = annotations.get_semantic_seg_mask(ignore_index=255, dtype=dtype)
 
         assert np.allclose(semantic_seg_mask, fxt_index_mask)
+
+
+class PointsCategoriesTest:
+    @pytest.mark.parametrize(
+        "positions, expected",
+        [
+            (
+                [(2, 3), (4, 6), (3, 5)],
+                [(0.0, 0.0), (0.666667, 1.0), (0.333333, 0.666667)],
+            ),  # basic functionality
+            (
+                [(1, 1), (1, 1), (1, 1)],
+                [(0.0, 0.0), (0.0, 0.0), (0.0, 0.0)],
+            ),  # all points are the same
+            (
+                [(1, 1), (3, 1), (5, 1)],
+                [(0.0, 0.0), (0.5, 0.0), (1.0, 0.0)],
+            ),  # points form horizontal line
+            (
+                [(1, 1), (1, 3), (1, 5)],
+                [(0.0, 0.0), (0.0, 0.5), (0.0, 1.0)],
+            ),  # points form vertical line
+            (
+                [(-2, -3), (-4, -6), (-3, -5)],
+                [(0.666667, 1.0), (0.0, 0.0), (0.333333, 0.333333)],
+            ),  # negative coords
+            (
+                [(1000, 2000), (4000, 6000), (3000, 5000)],
+                [(0.0, 0.0), (0.75, 1.0), (0.50, 0.75)],
+            ),  # large range
+            (
+                [(0.001, 0.002), (0.004, 0.006), (0.003, 0.005)],
+                [(0.0, 0.0), (0.75, 1.0), (0.50, 0.75)],
+            ),  # small range
+            ([(2, 3)], [(0.0, 0.0)]),  # single point
+        ],
+    )
+    def test_normalize_positions(self, positions, expected):
+        result = PointsCategories.normalize_positions(positions)
+        assert np.allclose(result, expected), f"Expected {expected}, got {result}"

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -204,34 +204,30 @@ class PointsCategoriesTest:
         @staticmethod
         def test_valid_positions():
             """Test that valid positions are allowed."""
-            positions = [(1.0, 2.0), (3.0, 4.0)]
+            positions = [1.0, 2.0, 3.0, 4.0]
             obj = PointsCategories.Category(positions=positions)
             assert obj
 
         @staticmethod
         def test_type_not_list():
             """Test that a non-list type for positions raises an error."""
-            with pytest.raises(ValueError, match="Cannot convert positions to list of tuples"):
+            with pytest.raises(ValueError, match="Cannot convert positions to list of floats"):
                 PointsCategories.Category(positions=56)
 
         @staticmethod
-        def test_type_not_tuple():
-            """Test that a non-tuple type for a position raises an error."""
-            with pytest.raises(ValueError, match="Cannot convert positions to list of tuples"):
-                PointsCategories.Category(positions=[[1.0, 2.0], 543])
-
-        @staticmethod
-        def test_tuple_wrong_length():
-            """Test that a tuple with the wrong number of elements raises an error."""
-            with pytest.raises(
-                ValueError, match="Each tuple in positions must have exactly 2 elements"
-            ):
-                PointsCategories.Category(positions=[(1.0, 2.0), (3.0,)])
+        def test_coordinates_as_string():
+            """Test that the coordinates may be represented as a string."""
+            obj = PointsCategories.Category(positions=["1", "2", "3", "4"])
+            assert obj
 
         @staticmethod
         def test_non_numeric_elements():
-            """Test that a tuple with non-numeric elements raises an error."""
-            with pytest.raises(
-                ValueError, match="Each element in a tuple in positions must be an int or float"
-            ):
-                PointsCategories.Category(positions=[(1.0, 2.0), (3.0, "4.0")])
+            """Test that passing non-numeric elements raises an error."""
+            with pytest.raises(ValueError, match="Cannot convert positions to list of floats"):
+                PointsCategories.Category(positions=["1", "2", "3", "not_a_number"])
+
+        @staticmethod
+        def test_uneven_number_of_elements():
+            """Test that an uneven number of elements raises an error."""
+            with pytest.raises(ValueError, match="positions must have an even number of elements"):
+                PointsCategories.Category(positions=[1.0, 2.0, 3.0])

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -20,7 +20,9 @@ from datumaro.components.annotation import (
     PointsCategories,
     RotatedBbox,
 )
+from datumaro.util.attrs_util import validate_points_positions
 from datumaro.util.image import lazy_image
+from datumaro.util.points_util import normalize_points
 
 
 class EllipseTest:
@@ -181,5 +183,55 @@ class PointsCategoriesTest:
         ],
     )
     def test_normalize_positions(self, positions, expected):
-        result = PointsCategories.normalize_positions(positions)
+        result = normalize_points(positions)
         assert np.allclose(result, expected), f"Expected {expected}, got {result}"
+
+    class PointsPositionsValidatorTest:
+        """Tests for the validator of the `positions` field in PointsCategories.Category."""
+
+        @staticmethod
+        def test_empty_positions():
+            """Test that an empty list of positions is allowed."""
+            obj = PointsCategories.Category(positions=[])
+            assert obj.positions == []  # Should allow empty list
+
+        @staticmethod
+        def test_none_positions():
+            """Test that None is allowed and converted to an empty list."""
+            obj = PointsCategories.Category(positions=None)
+            assert obj.positions == []  # Should allow None and convert to empty list
+
+        @staticmethod
+        def test_valid_positions():
+            """Test that valid positions are allowed."""
+            positions = [(1.0, 2.0), (3.0, 4.0)]
+            obj = PointsCategories.Category(positions=positions)
+            assert obj
+
+        @staticmethod
+        def test_type_not_list():
+            """Test that a non-list type for positions raises an error."""
+            with pytest.raises(ValueError, match="Cannot convert positions to list of tuples"):
+                PointsCategories.Category(positions=56)
+
+        @staticmethod
+        def test_type_not_tuple():
+            """Test that a non-tuple type for a position raises an error."""
+            with pytest.raises(ValueError, match="Cannot convert positions to list of tuples"):
+                PointsCategories.Category(positions=[[1.0, 2.0], 543])
+
+        @staticmethod
+        def test_tuple_wrong_length():
+            """Test that a tuple with the wrong number of elements raises an error."""
+            with pytest.raises(
+                ValueError, match="Each tuple in positions must have exactly 2 elements"
+            ):
+                PointsCategories.Category(positions=[(1.0, 2.0), (3.0,)])
+
+        @staticmethod
+        def test_non_numeric_elements():
+            """Test that a tuple with non-numeric elements raises an error."""
+            with pytest.raises(
+                ValueError, match="Each element in a tuple in positions must be an int or float"
+            ):
+                PointsCategories.Category(positions=[(1.0, 2.0), (3.0, "4.0")])

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -20,7 +20,6 @@ from datumaro.components.annotation import (
     PointsCategories,
     RotatedBbox,
 )
-from datumaro.util.attrs_util import validate_points_positions
 from datumaro.util.image import lazy_image
 from datumaro.util.points_util import normalize_points
 

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -181,9 +181,15 @@ class PointsCategoriesTest:
         """Tests for the validator of the `positions` field in PointsCategories.Category."""
 
         @staticmethod
-        def test_empty_positions():
+        def test_empty_positions_list():
             """Test that an empty list of positions is allowed."""
             obj = PointsCategories.Category(positions=[])
+            assert obj.positions == []  # Should allow empty list
+
+        @staticmethod
+        def test_empty_positions_tuple():
+            """Test that an empty list of positions is allowed."""
+            obj = PointsCategories.Category(positions=())
             assert obj.positions == []  # Should allow empty list
 
         @staticmethod
@@ -237,3 +243,19 @@ class PointsCategoriesTest:
                 ValueError, match="number of positions should be equal to the number of labels"
             ):
                 PointsCategories.Category(labels=labels, positions=positions)
+
+        @staticmethod
+        def test_positions_allowed_with_empty_labels():
+            """Test that the the number of coordinates check is skipped when labels is empty."""
+            labels = []  # no labels
+            positions = [1.0, 2.0, 3.0, 4.0]  # 2 positions
+            obj = PointsCategories.Category(labels=labels, positions=positions)
+            assert obj
+
+        @staticmethod
+        def test_labels_allowed_with_empty_positions():
+            """Test that the the number of coordinates check is skipped when positions is empty."""
+            labels = ["p1", "p2", "p3"]  # 3 labels
+            positions = []  # no positions
+            obj = PointsCategories.Category(labels=labels, positions=positions)
+            assert obj


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

# Duplicate of https://github.com/openvinotoolkit/datumaro/pull/1695, targeted to release branch instead of develop

### Summary

This PR adds optional position information as meta-info for (key)point annotations. The position information can be used to define one or multiple default relative positions of a set of keypoints, for example a set of default human poses (standing, running etc) for human keypoint detection datasets. This type of meta-information about points data is useful in annotation tools.

### Changes

- Adds `positions` attribute to `PointsCategories.Category` class. Similar to the `Points` annotation type, the positions are represented as a list of floats in the format `[x1, y1, x2, y2, ..., xn, yn]`. The positions are optional and default to an empty list.
- Adds a validator that validates the position coordinates that are passed to the `Category` constructor. Also validates if the number of position coordinates is the same as the number of labels.
- Adds a normalization function that normalizes the positions to the [0, 1] range (preserving aspect ratio). The normalization function is called by the validator to ensure that position information in the `PointsCategories` instance is always normalized.
- Adds logic to Datumaro format importer and exporter, to ensure that position information gets stored in the annotations json, and is also loaded correctly during import. The importer can handle datasets where position information is missing, so backward compatibility is preserved.
- Adds unit tests for normalization, validation and import/export functionality described above.


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
Add some position information to the `PointsCategories` instance of a keypoint detection dataset, then try export and importing the dataset.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
