### PR TITLE
Disable weekly checks for python 3.12

### DIFF
--- a/.github/workflows/weekly_check.yml
+++ b/.github/workflows/weekly_check.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11']
         extra: ['default', 'tf', 'tfds', 'torch']
         include:
           - python-version: "3.9"
@@ -28,8 +28,6 @@ jobs:
             tox-env-py: "310"
           - python-version: "3.11"
             tox-env-py: "311"
-          - python-version: "3.12"
-            tox-env-py: "312"
     name: stability test (Python ${{ matrix.python-version }}, Extra ${{ matrix.extra }})
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->
### Summary

This PR disables the weekly stability checks for Python 3.12. For the CLI fuzzing tests, the weekly checks depend on the Atheris package, which is not compatible with Python 3.12 at this moment. 

As a temporary fix, I am disabling the weekly checks for Python 3.12. This is safe, because the fuzzing tests still run for Python <= 3.11. For a long term solution, we need to wait until Python 3.12 support is added to Atheris, or switch to a different package for fuzzing tests.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
