### PR TITLE
fix absl-py version in tfds extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setuptools.setup(
     install_requires=CORE_REQUIREMENTS,
     extras_require={
         "tf": ["tensorflow"],
-        "tfds": ["tensorflow-datasets<4.9.3"],
+        "tfds": ["tensorflow-datasets<4.9.3", "absl-py>=0.12.0"],
         "torch": ["torch", "torchvision"],
         "default": DEFAULT_REQUIREMENTS,
     },


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
Quick PR to fix the failing weekly checks for tfds in python 3.10 (see example [here](https://github.com/openvinotoolkit/datumaro/actions/runs/13618405842/job/38064455696)). 

The root cause was [this issue](https://github.com/abseil/abseil-py/issues/161) which causes installation of the `absl-py` package to fail in python 3.10. The issue was fixed in `absl-py==0.12`, so we need to ensure that we use at least that version. `absl-py` is a dependency of `tfds`, which we only use in the `tfds` extras, so the fix is to enforce the absl-py version for `tfds`.



<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
