### PR TITLE
Fix coco stream parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/open-edge-platform/datumaro/pull/1645>)
 
 ### Enhancements
+- Add non-strict mode to JsonPageMapper in rust API and enable it for COCO
+  (<https://github.com/open-edge-platform/datumaro/pull/1753>)
 - Enhance 'id_from_image_name' transform to ensure each identifier is unique
   (<https://github.com/open-edge-platform/datumaro/pull/1635>)
 - Optimize path assignment to handle point cloud in JSON without images

--- a/rust/src/coco_page_mapper.rs
+++ b/rust/src/coco_page_mapper.rs
@@ -113,7 +113,7 @@ impl CocoPageMapperImpl {
         self.annotations.get_anns(&mut reader, img_id)
     }
     pub fn new(mut reader: impl Read + Seek) -> Result<Self, io::Error> {
-        let sections = Self::parse_json(&mut reader)?;
+        let sections = Self::parse_json(&mut reader, false)?;
 
         let mut licenses = None;
         let mut info = None;

--- a/rust/src/datum_page_mapper.rs
+++ b/rust/src/datum_page_mapper.rs
@@ -118,7 +118,7 @@ impl DatumPageMapperImpl {
     }
 
     pub fn new(mut reader: impl Read + Seek) -> Result<Self, io::Error> {
-        let sections = Self::parse_json(&mut reader)?;
+        let sections = Self::parse_json(&mut reader, true)?;
 
         let mut dm_format_version = None;
         let mut media_type = None;

--- a/rust/src/datum_page_mapper.rs
+++ b/rust/src/datum_page_mapper.rs
@@ -1,4 +1,4 @@
-//  Copyright (C) 2023 Intel Corporation
+//  Copyright (C) 2025 Intel Corporation
 //
 //  SPDX-License-Identifier: MIT
 

--- a/rust/src/json_section_page_mapper.rs
+++ b/rust/src/json_section_page_mapper.rs
@@ -157,7 +157,7 @@ impl JsonPageMapper<JsonSection> for JsonSectionPageMapperImpl {}
 
 impl JsonSectionPageMapperImpl {
     pub fn new(mut reader: impl Read + Seek) -> Result<Self, io::Error> {
-        let sections = Self::parse_json(&mut reader)?;
+        let sections = Self::parse_json(&mut reader, true)?;
 
         Ok(JsonSectionPageMapperImpl { sections: sections })
     }

--- a/rust/src/json_section_page_mapper.rs
+++ b/rust/src/json_section_page_mapper.rs
@@ -1,4 +1,4 @@
-//  Copyright (C) 2023 Intel Corporation
+//  Copyright (C) 2025 Intel Corporation
 //
 //  SPDX-License-Identifier: MIT
 

--- a/rust/src/page_mapper.rs
+++ b/rust/src/page_mapper.rs
@@ -1,4 +1,4 @@
-use crate::utils::{invalid_data, read_skipping_ws};
+use crate::utils::{invalid_data, read_skipping_ws, skip_serde_json_value};
 use std::io::{Error, Read, Seek};
 
 pub trait ParsedJsonSection: Sized {
@@ -9,7 +9,7 @@ pub trait JsonPageMapper<T>: Sized
 where
     T: ParsedJsonSection,
 {
-    fn parse_json(mut reader: impl Read + Seek) -> Result<Vec<Box<T>>, Error> {
+    fn parse_json(mut reader: impl Read + Seek, strict: bool) -> Result<Vec<Box<T>>, Error> {
         let mut brace_level = 0;
         let mut json_sections = Vec::new();
 
@@ -26,8 +26,21 @@ where
                     }
                     match String::from_utf8(buf_key.clone()) {
                         Ok(key) => {
-                            let section = T::parse(key, &mut reader)?;
-                            json_sections.push(section);
+                            match T::parse(key.clone(), &mut reader) {
+                                Ok(section) => {
+                                    json_sections.push(section);
+                                }
+                                Err(e) => {
+                                    if strict {
+                                        return Err(e);
+                                    } else {
+                                        // Skip unknown section
+                                        eprintln!("Skipping unknown section key: \"{}\"", key);
+                                        read_skipping_ws(&mut reader)?;
+                                        let _ = skip_serde_json_value(&mut reader);
+                                    }
+                                }
+                            }
                         }
                         Err(e) => {
                             let cur_pos = reader.stream_position()?;

--- a/rust/src/page_mapper.rs
+++ b/rust/src/page_mapper.rs
@@ -1,3 +1,7 @@
+//  Copyright (C) 2025 Intel Corporation
+//
+//  SPDX-License-Identifier: MIT
+
 use crate::utils::{invalid_data, read_skipping_ws, skip_serde_json_value};
 use std::io::{Error, Read, Seek};
 

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -8,6 +8,9 @@ use pyo3::{
     prelude::*,
     types::{PyBool, PyDict, PyFloat, PyList, PyUnicode},
 };
+use serde::de::{IgnoredAny, Deserialize};
+use serde_json::{self, Deserializer};
+
 
 pub fn read_skipping_ws(mut reader: impl io::Read) -> io::Result<u8> {
     loop {
@@ -64,6 +67,15 @@ pub fn parse_serde_json_value(
             let msg = format!("Parse error: {} at pos: {}", e, cur_pos);
             Err(invalid_data(msg.as_str()))
         }
+    }
+}
+
+pub fn skip_serde_json_value<R: io::Read>(reader: &mut R) -> Result<(), std::io::Error> {
+    // Skip the next JSON value in the stream
+    let mut de = Deserializer::from_reader(reader);
+    match IgnoredAny::deserialize(&mut de) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(io::Error::new(io::ErrorKind::InvalidData, "Failed to skip JSON value")),
     }
 }
 

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,4 +1,4 @@
-//  Copyright (C) 2023 Intel Corporation
+//  Copyright (C) 2025 Intel Corporation
 //
 //  SPDX-License-Identifier: MIT
 

--- a/rust/tests/coco_page_mapper.rs
+++ b/rust/tests/coco_page_mapper.rs
@@ -1,4 +1,4 @@
-//  Copyright (C) 2023 Intel Corporation
+//  Copyright (C) 2025 Intel Corporation
 //
 //  SPDX-License-Identifier: MIT
 

--- a/rust/tests/coco_page_mapper.rs
+++ b/rust/tests/coco_page_mapper.rs
@@ -53,6 +53,25 @@ fn test_instance() {
 }
 
 #[test]
+fn test_unknown_keys() {
+    // Tests if the dataset can be parsed when the JSON contains additional unknown keys
+    const EXAMPLE: &str = r#"
+    {
+        "licenses":[{"name":"","id":0,"url":""}],
+        "info":{"contributor":"","date_created":"","description":"","url":"","version":"","year":""},
+        "categories":[]
+        "images":[],
+        "annotations":[]
+        "unknown_key": "unknown_value",
+    }"#;
+
+    let (tempfile, mut reader) = prepare_reader(EXAMPLE);
+    let coco_page_mapper = CocoPageMapperImpl::new(&mut reader).unwrap();
+
+    println!("{:?}", coco_page_mapper);
+}
+
+#[test]
 fn test_image_info_default() {
     const EXAMPLE: &str = r#"
     {"licenses": [{"name": "", "id": 0, "url": ""}], "info": {"contributor": "", "date_created": "", "description": "", "url": "", "version": "", "year": ""}, "categories": [], "images": [{"id": 1, "width": 2, "height": 4, "file_name": "1.jpg", "license": 0, "flickr_url": "", "coco_url": "", "date_captured": 0}], "annotations": []}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This PR fixes an issue causing coco dataset parsing to fail in stream mode when the annotations json contains additional, unused keys. To achieve this, the PR adds a non-strict mode to the `JsonPageMapper` in the rust API, and uses it in the `CocoPageMapper` to allow and ignore unknown keys. With these changes, the behaviour of COCO parsing is now similar between stream mode and non-stream mode.

Changes:
- Adds strict argument to `JsonPageMapper`
- Enable strict mode for `CocoPageMapper`, while disabling it for other page mapper classes.
- Adds `skip_serde_json_value` function to `rust/src/utils.rs`
- Add unit test to confirm that unknown keys are ignored.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
