### PR TITLE
Mark pyemd as optional since it does not support Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 - Fix assertion to compare hashkeys against expected value
   (<https://github.com/open-edge-platform/datumaro/pull/1641>)
+- Mark pyemd as optional since it does not support Python 3.12
+  (<https://github.com/open-edge-platform/datumaro/pull/1770>)
 
 ## Q1 2025 Release 1.10.0
 

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -40,9 +40,6 @@ tokenizers
 # Encryption
 cryptography>= 38.03
 
-# Shift analyzer
-pyemd
-
 # apache arrow
 pyarrow
 

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setuptools.setup(
         "tf": ["tensorflow"],
         "tfds": ["tensorflow-datasets<4.9.3", "absl-py>=0.12.0"],
         "torch": ["torch", "torchvision"],
+        "pyemd": ["pyemd"],
         "default": DEFAULT_REQUIREMENTS,
     },
     ext_modules=ext_modules,

--- a/src/datumaro/components/shift_analyzer.py
+++ b/src/datumaro/components/shift_analyzer.py
@@ -15,14 +15,12 @@ from datumaro.components.launcher import LauncherWithModelInterpreter
 from datumaro.util import take_by
 
 if TYPE_CHECKING:
-    import pyemd
     from scipy import linalg, stats
 
     from datumaro.plugins.openvino_plugin import shift_launcher
 else:
     from datumaro.util.import_util import lazy_import
 
-    pyemd = lazy_import("pyemd")
     linalg = lazy_import("scipy.linalg")
     stats = lazy_import("scipy.stats")
     shift_launcher = lazy_import("datumaro.plugins.openvino_plugin.shift_launcher")
@@ -264,6 +262,8 @@ class ShiftAnalyzer:
 
         f_concat = np.concatenate([f_s, f_t], axis=0)
         distances = np.linalg.norm(f_concat[:, None] - f_concat[None, :], axis=2).astype(np.float64)
+
+        import pyemd
 
         emd = pyemd.emd(w_1, w_2, distances)
         return np.exp(-gamma * emd).item()

--- a/tests/unit/test_shift_analyzer.py
+++ b/tests/unit/test_shift_analyzer.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from typing import List
+from unittest import skipIf
 
 import numpy as np
 import pytest
@@ -11,6 +12,13 @@ from datumaro.components.media import Image
 from datumaro.components.shift_analyzer import ShiftAnalyzer
 
 from ..requirements import Requirements, mark_requirement
+
+try:
+    import pyemd
+
+    import_failed = False
+except ImportError:
+    import_failed = True
 
 
 @pytest.fixture
@@ -57,6 +65,7 @@ def fxt_dataset_different():
     return [src_dataset, tgt_dataset]
 
 
+@skipIf(import_failed, "Failed to import pyemd")
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
 @pytest.mark.parametrize(
     "fxt_datasets,method,expected",


### PR DESCRIPTION
pyemd is only used for data shift analysis and does not seem to be maintained anymore.
Most of the code does not use pyemd so it is better to mark it as optional.

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
