### PR TITLE
Add deprecation notice to features that will soon be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mark pyemd as optional since it does not support Python 3.12
   (<https://github.com/open-edge-platform/datumaro/pull/1770>)
 
+### Deprecations
+- Added deprecation notices to features that will soon be removed
+  (<https://github.com/open-edge-platform/datumaro/pull/1776>)
+
 ## Q1 2025 Release 1.10.0
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/open-edge-platform/datumaro/pull/1770>)
 
 ### Deprecations
-- Added deprecation notices to features that will soon be removed
+- Added deprecation notices to the following features that will soon be removed:
+  - Crypter
+  - Advanced dataset comparison based on similarity search with OpenVINO
+  - Synthetic dataset generation
+  - Data exploration
+  - BBox to mask using SAM
+  - Tiling
+  - Dataset versioning with DVCS
+  - Telemetry
+  - Anchor generation
+  - Missing annotation detection
+  - Model inference explanation
+  - Near-duplicate removal
+  - Pruning
+  - Pseudo-labels
   (<https://github.com/open-edge-platform/datumaro/pull/1776>)
 
 ## Q1 2025 Release 1.10.0

--- a/src/datumaro/__init__.py
+++ b/src/datumaro/__init__.py
@@ -4,13 +4,6 @@
 
 import warnings
 
-warnings.warn(
-    "We are planning to clean up the entities in datumaro/__init__.py until datumaro==1.5.0. "
-    'This will affect the following import pattern: "import datumaro as dm; dm.<entity>". '
-    "If you are using this pattern in your code, please revisit it after upgrading datumaro>=1.5.0.",
-    DeprecationWarning,
-)
-
 from . import errors as errors
 from . import ops as ops
 from . import project as project

--- a/src/datumaro/components/algorithms/hash_key_inference/explorer.py
+++ b/src/datumaro/components/algorithms/hash_key_inference/explorer.py
@@ -18,7 +18,7 @@ from datumaro.components.errors import DatumaroError, MediaTypeError
 from datumaro.util.deprecation import deprecated
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class Explorer(HashInference):
     def __init__(
         self,

--- a/src/datumaro/components/algorithms/hash_key_inference/explorer.py
+++ b/src/datumaro/components/algorithms/hash_key_inference/explorer.py
@@ -15,8 +15,10 @@ from datumaro.components.annotation import HashKey
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.errors import DatumaroError, MediaTypeError
+from datumaro.util.deprecation import deprecated
 
 
+@deprecated()
 class Explorer(HashInference):
     def __init__(
         self,

--- a/src/datumaro/components/algorithms/hash_key_inference/prune.py
+++ b/src/datumaro/components/algorithms/hash_key_inference/prune.py
@@ -20,6 +20,7 @@ from datumaro.components.algorithms.hash_key_inference.hashkey_util import (
 from datumaro.components.annotation import HashKey, Label, LabelCategories
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
+from datumaro.util.deprecation import deprecated
 
 if TYPE_CHECKING:
     import datumaro.plugins.ndr as ndr
@@ -53,6 +54,7 @@ def match_num_item_for_cluster(ratio, dataset_len, cluster_num_item_list):
     return norm_cluster_num_item_list.tolist()
 
 
+@deprecated()
 class PruneBase(ABC):
     @abstractmethod
     def base(
@@ -237,6 +239,7 @@ class Entropy(PruneBase):
         return selected_items, None
 
 
+@deprecated()
 class NDRSelect(PruneBase):
     """
     Select items based on NDR among each subset.
@@ -255,6 +258,7 @@ class NDRSelect(PruneBase):
         return selected_items, None
 
 
+@deprecated()
 class Prune(HashInference):
     def __init__(
         self,

--- a/src/datumaro/components/algorithms/hash_key_inference/prune.py
+++ b/src/datumaro/components/algorithms/hash_key_inference/prune.py
@@ -54,7 +54,7 @@ def match_num_item_for_cluster(ratio, dataset_len, cluster_num_item_list):
     return norm_cluster_num_item_list.tolist()
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class PruneBase(ABC):
     @abstractmethod
     def base(
@@ -239,7 +239,7 @@ class Entropy(PruneBase):
         return selected_items, None
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class NDRSelect(PruneBase):
     """
     Select items based on NDR among each subset.
@@ -258,7 +258,7 @@ class NDRSelect(PruneBase):
         return selected_items, None
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class Prune(HashInference):
     def __init__(
         self,

--- a/src/datumaro/components/algorithms/noisy_label_detection/loss_dynamics_analyzer.py
+++ b/src/datumaro/components/algorithms/noisy_label_detection/loss_dynamics_analyzer.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 from datumaro.components.annotation import AnnotationType, LabelCategories
 from datumaro.components.dataset_base import IDataset
 from datumaro.errors import DatasetError
+from datumaro.util.deprecation import deprecated
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
@@ -31,6 +32,7 @@ class NoisyLabelCandidate:
         return self.id == __o.id and self.subset == __o.subset and self.ann_id == __o.ann_id
 
 
+@deprecated()
 class LossDynamicsAnalyzer:
     """A class for analyzing the dynamics of training loss to identify noisy labels.
 

--- a/src/datumaro/components/algorithms/noisy_label_detection/loss_dynamics_analyzer.py
+++ b/src/datumaro/components/algorithms/noisy_label_detection/loss_dynamics_analyzer.py
@@ -32,7 +32,7 @@ class NoisyLabelCandidate:
         return self.id == __o.id and self.subset == __o.subset and self.ann_id == __o.ann_id
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class LossDynamicsAnalyzer:
     """A class for analyzing the dynamics of training loss to identify noisy labels.
 

--- a/src/datumaro/components/algorithms/rise.py
+++ b/src/datumaro/components/algorithms/rise.py
@@ -11,10 +11,12 @@ from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.media import Image
 from datumaro.util import take_by
+from datumaro.util.deprecation import deprecated
 
 __all__ = ["RISE"]
 
 
+@deprecated()
 class RISE:
     """
     Implements RISE: Randomized Input Sampling for

--- a/src/datumaro/components/algorithms/rise.py
+++ b/src/datumaro/components/algorithms/rise.py
@@ -16,7 +16,7 @@ from datumaro.util.deprecation import deprecated
 __all__ = ["RISE"]
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class RISE:
     """
     Implements RISE: Randomized Input Sampling for

--- a/src/datumaro/components/crypter.py
+++ b/src/datumaro/components/crypter.py
@@ -8,8 +8,10 @@ from typing import Optional, Union
 from cryptography.fernet import Fernet, InvalidToken
 
 from datumaro.components.errors import DatumaroError
+from datumaro.util.deprecation import deprecated
 
 
+@deprecated()
 class Crypter:
     # Prefix (datum-) = 6 and Fernet = 44, 6 + 44 = 50
     FERNET_KEY_LEN = 50

--- a/src/datumaro/components/crypter.py
+++ b/src/datumaro/components/crypter.py
@@ -11,7 +11,7 @@ from datumaro.components.errors import DatumaroError
 from datumaro.util.deprecation import deprecated
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class Crypter:
     # Prefix (datum-) = 6 and Fernet = 44, 6 + 44 = 50
     FERNET_KEY_LEN = 50

--- a/src/datumaro/components/hl_ops/__init__.py
+++ b/src/datumaro/components/hl_ops/__init__.py
@@ -26,6 +26,7 @@ from datumaro.components.merge import DEFAULT_MERGE_POLICY, get_merger
 from datumaro.components.transformer import ModelTransform, Transform
 from datumaro.components.validator import TaskType, Validator
 from datumaro.util import parse_str_enum_value
+from datumaro.util.deprecation import deprecated
 from datumaro.util.scope import on_error_do, scoped
 
 if TYPE_CHECKING:
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
 __all__ = ["HLOps"]
 
 
+@deprecated()
 class HLOps:
     """High-level dataset operations for Python API."""
 

--- a/src/datumaro/components/hl_ops/__init__.py
+++ b/src/datumaro/components/hl_ops/__init__.py
@@ -26,7 +26,6 @@ from datumaro.components.merge import DEFAULT_MERGE_POLICY, get_merger
 from datumaro.components.transformer import ModelTransform, Transform
 from datumaro.components.validator import TaskType, Validator
 from datumaro.util import parse_str_enum_value
-from datumaro.util.deprecation import deprecated
 from datumaro.util.scope import on_error_do, scoped
 
 if TYPE_CHECKING:
@@ -36,7 +35,6 @@ if TYPE_CHECKING:
 __all__ = ["HLOps"]
 
 
-@deprecated()
 class HLOps:
     """High-level dataset operations for Python API."""
 

--- a/src/datumaro/plugins/anchor_generator.py
+++ b/src/datumaro/plugins/anchor_generator.py
@@ -88,7 +88,7 @@ try:
 
             return self._bbox_overlaps(bboxes1, bboxes2)
 
-    @deprecated()
+    @deprecated(deprecated_version="1.11", removed_version="1.12")
     class DataAwareAnchorGenerator:
         def __init__(
             self,
@@ -380,7 +380,7 @@ try:
 
 except ImportError:
 
-    @deprecated()
+    @deprecated(deprecated_version="1.11", removed_version="1.12")
     class DataAwareAnchorGenerator:
         def __init__(self):
             raise ImportError("Torch package not found. Cannot optimize anchor generator.")

--- a/src/datumaro/plugins/anchor_generator.py
+++ b/src/datumaro/plugins/anchor_generator.py
@@ -6,6 +6,7 @@ import logging as log
 from typing import List, Optional, Tuple
 
 from datumaro.components.dataset import Dataset
+from datumaro.util.deprecation import deprecated
 
 log.basicConfig(level=log.INFO)
 
@@ -87,6 +88,7 @@ try:
 
             return self._bbox_overlaps(bboxes1, bboxes2)
 
+    @deprecated()
     class DataAwareAnchorGenerator:
         def __init__(
             self,
@@ -378,6 +380,7 @@ try:
 
 except ImportError:
 
+    @deprecated()
     class DataAwareAnchorGenerator:
         def __init__(self):
             raise ImportError("Torch package not found. Cannot optimize anchor generator.")

--- a/src/datumaro/plugins/explorer.py
+++ b/src/datumaro/plugins/explorer.py
@@ -12,8 +12,10 @@ from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.media import Image
 from datumaro.plugins.openvino_plugin.launcher import OpenvinoLauncher
+from datumaro.util.deprecation import deprecated
 
 
+@deprecated()
 class ExplorerLauncher(OpenvinoLauncher):
     def __init__(
         self,

--- a/src/datumaro/plugins/explorer.py
+++ b/src/datumaro/plugins/explorer.py
@@ -15,7 +15,7 @@ from datumaro.plugins.openvino_plugin.launcher import OpenvinoLauncher
 from datumaro.util.deprecation import deprecated
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class ExplorerLauncher(OpenvinoLauncher):
     def __init__(
         self,

--- a/src/datumaro/plugins/missing_annotation_detection.py
+++ b/src/datumaro/plugins/missing_annotation_detection.py
@@ -10,8 +10,10 @@ from datumaro.components.annotations.matcher import BboxMatcher, match_segments_
 from datumaro.components.dataset_base import DatasetItem, IDataset
 from datumaro.components.launcher import Launcher
 from datumaro.components.transformer import ModelTransform
+from datumaro.util.deprecation import deprecated
 
 
+@deprecated()
 class MissingAnnotationDetection(ModelTransform):
     """This class is used to find annotations that are missing from the ground truth annotations.
 

--- a/src/datumaro/plugins/missing_annotation_detection.py
+++ b/src/datumaro/plugins/missing_annotation_detection.py
@@ -13,7 +13,7 @@ from datumaro.components.transformer import ModelTransform
 from datumaro.util.deprecation import deprecated
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class MissingAnnotationDetection(ModelTransform):
     """This class is used to find annotations that are missing from the ground truth annotations.
 

--- a/src/datumaro/plugins/sam_transforms/bbox_to_inst_mask.py
+++ b/src/datumaro/plugins/sam_transforms/bbox_to_inst_mask.py
@@ -18,11 +18,13 @@ from datumaro.plugins.inference_server_plugin.base import (
     ProtocolType,
     TLSConfig,
 )
+from datumaro.util.deprecation import deprecated
 from datumaro.util.mask_tools import extract_contours
 
 __all__ = ["SAMBboxToInstanceMask"]
 
 
+@deprecated()
 class SAMBboxToInstanceMask(ModelTransform, CliPlugin):
     """Convert bounding boxes to instance mask using Segment Anything Model.
 

--- a/src/datumaro/plugins/sam_transforms/bbox_to_inst_mask.py
+++ b/src/datumaro/plugins/sam_transforms/bbox_to_inst_mask.py
@@ -24,7 +24,7 @@ from datumaro.util.mask_tools import extract_contours
 __all__ = ["SAMBboxToInstanceMask"]
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class SAMBboxToInstanceMask(ModelTransform, CliPlugin):
     """Convert bounding boxes to instance mask using Segment Anything Model.
 

--- a/src/datumaro/plugins/synthetic_data/image_generator.py
+++ b/src/datumaro/plugins/synthetic_data/image_generator.py
@@ -17,12 +17,14 @@ import requests
 
 from datumaro.components.generator import DatasetGenerator
 from datumaro.util.definitions import get_datumaro_cache_dir
+from datumaro.util.deprecation import deprecated
 from datumaro.util.image import save_image
 from datumaro.util.scope import on_error_do, on_exit_do, scope_add, scoped
 
 from .utils import IFSFunction, augment, colorize, suppress_computation_warnings
 
 
+@deprecated()
 class FractalImageGenerator(DatasetGenerator):
     """
     ImageGenerator generates 3-channel synthetic images with provided shape.

--- a/src/datumaro/plugins/synthetic_data/image_generator.py
+++ b/src/datumaro/plugins/synthetic_data/image_generator.py
@@ -24,7 +24,7 @@ from datumaro.util.scope import on_error_do, on_exit_do, scope_add, scoped
 from .utils import IFSFunction, augment, colorize, suppress_computation_warnings
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class FractalImageGenerator(DatasetGenerator):
     """
     ImageGenerator generates 3-channel synthetic images with provided shape.

--- a/src/datumaro/plugins/tiling/merge_tile.py
+++ b/src/datumaro/plugins/tiling/merge_tile.py
@@ -29,6 +29,7 @@ from datumaro.components.errors import DatumaroError
 from datumaro.components.media import BboxIntCoords, MosaicImage
 from datumaro.components.transformer import Transform
 from datumaro.plugins.tiling.util import x1y1x2y2_to_xywh, xywh_to_x1y1x2y2
+from datumaro.util.deprecation import deprecated
 
 AnnotationsForMerge = List[Tuple[Annotation, BboxIntCoords, sg.Polygon]]
 
@@ -193,6 +194,7 @@ def _merge_not_support(ann_type: AnnotationType, *args, **kwargs) -> None:
     raise DatumaroError(f"type(ann)={ann_type} is not support tiling.")
 
 
+@deprecated()
 class MergeTile(Transform, CliPlugin):
     """
     Transformation to merge the previously tiled dataset. It can generally

--- a/src/datumaro/plugins/tiling/merge_tile.py
+++ b/src/datumaro/plugins/tiling/merge_tile.py
@@ -194,7 +194,7 @@ def _merge_not_support(ann_type: AnnotationType, *args, **kwargs) -> None:
     raise DatumaroError(f"type(ann)={ann_type} is not support tiling.")
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class MergeTile(Transform, CliPlugin):
     """
     Transformation to merge the previously tiled dataset. It can generally

--- a/src/datumaro/plugins/tiling/tile.py
+++ b/src/datumaro/plugins/tiling/tile.py
@@ -133,7 +133,7 @@ def _tile_not_support(ann: Annotation, *args, **kwargs) -> None:
     raise DatumaroError(f"type(ann)={type(ann)} is not support tiling.")
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class Tile(Transform, CliPlugin):
     """
     Apply tile tranformation to items in the dataset.

--- a/src/datumaro/plugins/tiling/tile.py
+++ b/src/datumaro/plugins/tiling/tile.py
@@ -30,6 +30,7 @@ from datumaro.plugins.tiling.util import (
     x1y1x2y2_to_xywh,
     xywh_to_x1y1x2y2,
 )
+from datumaro.util.deprecation import deprecated
 
 
 def _apply_offset(geom: sg.base.BaseGeometry, roi_box: sg.Polygon) -> sg.base.BaseGeometry:
@@ -132,6 +133,7 @@ def _tile_not_support(ann: Annotation, *args, **kwargs) -> None:
     raise DatumaroError(f"type(ann)={type(ann)} is not support tiling.")
 
 
+@deprecated()
 class Tile(Transform, CliPlugin):
     """
     Apply tile tranformation to items in the dataset.

--- a/src/datumaro/plugins/transforms.py
+++ b/src/datumaro/plugins/transforms.py
@@ -68,6 +68,7 @@ from datumaro.components.media import Image, TableRow, VideoFrame
 from datumaro.components.transformer import ItemTransform, TabularTransform, Transform
 from datumaro.util import NOTSET, filter_dict, parse_json_file, parse_str_enum_value, take_by
 from datumaro.util.annotation_util import find_group_leader, find_instances
+from datumaro.util.deprecation import deprecated
 from datumaro.util.tabular_util import emoji_pattern
 
 
@@ -2108,6 +2109,7 @@ class Clean(TabularTransform):
         return self.wrap_item(item, media=refined_media, annotations=refined_annotations)
 
 
+@deprecated()
 class PseudoLabeling(ItemTransform):
     """
     A class used to assign pseudo-labels to items in a dataset based on

--- a/src/datumaro/plugins/transforms.py
+++ b/src/datumaro/plugins/transforms.py
@@ -2109,7 +2109,7 @@ class Clean(TabularTransform):
         return self.wrap_item(item, media=refined_media, annotations=refined_annotations)
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class PseudoLabeling(ItemTransform):
     """
     A class used to assign pseudo-labels to items in a dataset based on

--- a/src/datumaro/util/deprecation.py
+++ b/src/datumaro/util/deprecation.py
@@ -6,7 +6,7 @@ import warnings
 from functools import wraps
 
 
-def deprecated():
+def deprecated(deprecated_version: str, removed_version: str):
     """Class decorator that marks a class as deprecated."""
 
     def decorator(cls):
@@ -15,8 +15,8 @@ def deprecated():
         @wraps(original_init)
         def new_init(self, *args, **kwargs):
             warnings.warn(
-                f"The {cls.__name__} class will be deprecated in version 1.11 "
-                f"and will be removed in version 1.12.",
+                f"The {cls.__name__} class will be deprecated in version {deprecated_version} "
+                f"and will be removed in version {removed_version}.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/datumaro/util/deprecation.py
+++ b/src/datumaro/util/deprecation.py
@@ -1,0 +1,24 @@
+import warnings
+from functools import wraps
+
+
+def deprecated():
+    """Class decorator that marks a class as deprecated."""
+
+    def decorator(cls):
+        original_init = cls.__init__
+
+        @wraps(original_init)
+        def new_init(self, *args, **kwargs):
+            warnings.warn(
+                f"The {cls.__name__} class will be deprecated in version 1.11 "
+                f"and will be removed in version 1.12.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            original_init(self, *args, **kwargs)
+
+        cls.__init__ = new_init
+        return cls
+
+    return decorator

--- a/src/datumaro/util/deprecation.py
+++ b/src/datumaro/util/deprecation.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2019-2025 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import warnings
 from functools import wraps
 

--- a/src/datumaro/util/telemetry_stub.py
+++ b/src/datumaro/util/telemetry_stub.py
@@ -1,8 +1,10 @@
 # Copyright (C) 2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
+from datumaro.util.deprecation import deprecated
 
 
+@deprecated()
 class Telemetry(object):
     """
     A stub for the Telemetry class, which is used when the Telemetry class

--- a/src/datumaro/util/telemetry_stub.py
+++ b/src/datumaro/util/telemetry_stub.py
@@ -4,7 +4,7 @@
 from datumaro.util.deprecation import deprecated
 
 
-@deprecated()
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class Telemetry(object):
     """
     A stub for the Telemetry class, which is used when the Telemetry class

--- a/tests/unit/test_deprecation.py
+++ b/tests/unit/test_deprecation.py
@@ -11,7 +11,7 @@ from datumaro.util.deprecation import deprecated
 class TestDeprecationDecorator(unittest.TestCase):
     def test_deprecated_class_warning(self):
         # Create a test class with the deprecated decorator
-        @deprecated()
+        @deprecated(deprecated_version="1.11", removed_version="1.12")
         class TestClass:
             def __init__(self, value):
                 self.value = value

--- a/tests/unit/test_deprecation.py
+++ b/tests/unit/test_deprecation.py
@@ -1,5 +1,6 @@
-# Copyright (C) 2022-2025 Intel Corporation
-# LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+# Copyright (C) 2019-2025 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
 
 import unittest
 import warnings

--- a/tests/unit/test_deprecation.py
+++ b/tests/unit/test_deprecation.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2022-2025 Intel Corporation
+# LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+import unittest
+import warnings
+
+from datumaro.util.deprecation import deprecated
+
+
+class TestDeprecationDecorator(unittest.TestCase):
+    def test_deprecated_class_warning(self):
+        # Create a test class with the deprecated decorator
+        @deprecated()
+        class TestClass:
+            def __init__(self, value):
+                self.value = value
+
+            def get_value(self):
+                return self.value
+
+        # Test that a warning is raised when instantiating the class
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            instance = TestClass(42)
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            expected_message = "The TestClass class will be deprecated in version 1.11 and will be removed in version 1.12."
+            self.assertEqual(str(w[0].message), expected_message)


### PR DESCRIPTION
### Summary
This pull request introduces a new `@deprecated` decorator to mark classes as deprecated and applies it across multiple files to notify users of upcoming removals. Additionally, it includes a unit test to verify the functionality of the decorator. 

Resolves #1775

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
