### PR TITLE
Remove deprecation from tiling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Synthetic dataset generation
   - Data exploration
   - BBox to mask using SAM
-  - Tiling
   - Dataset versioning with DVCS
   - Telemetry
   - Anchor generation

--- a/src/datumaro/plugins/tiling/merge_tile.py
+++ b/src/datumaro/plugins/tiling/merge_tile.py
@@ -29,7 +29,6 @@ from datumaro.components.errors import DatumaroError
 from datumaro.components.media import BboxIntCoords, MosaicImage
 from datumaro.components.transformer import Transform
 from datumaro.plugins.tiling.util import x1y1x2y2_to_xywh, xywh_to_x1y1x2y2
-from datumaro.util.deprecation import deprecated
 
 AnnotationsForMerge = List[Tuple[Annotation, BboxIntCoords, sg.Polygon]]
 
@@ -194,7 +193,6 @@ def _merge_not_support(ann_type: AnnotationType, *args, **kwargs) -> None:
     raise DatumaroError(f"type(ann)={ann_type} is not support tiling.")
 
 
-@deprecated(deprecated_version="1.11", removed_version="1.12")
 class MergeTile(Transform, CliPlugin):
     """
     Transformation to merge the previously tiled dataset. It can generally

--- a/src/datumaro/plugins/tiling/tile.py
+++ b/src/datumaro/plugins/tiling/tile.py
@@ -30,7 +30,6 @@ from datumaro.plugins.tiling.util import (
     x1y1x2y2_to_xywh,
     xywh_to_x1y1x2y2,
 )
-from datumaro.util.deprecation import deprecated
 
 
 def _apply_offset(geom: sg.base.BaseGeometry, roi_box: sg.Polygon) -> sg.base.BaseGeometry:
@@ -133,7 +132,6 @@ def _tile_not_support(ann: Annotation, *args, **kwargs) -> None:
     raise DatumaroError(f"type(ann)={type(ann)} is not support tiling.")
 
 
-@deprecated(deprecated_version="1.11", removed_version="1.12")
 class Tile(Transform, CliPlugin):
     """
     Apply tile tranformation to items in the dataset.


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This PR removes the deprecation from tiling because it is still used by OTX and there is some interest in the wider community too.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
