### PR TITLE
Deprecate the SAM Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Pruning
   - Pseudo-labels
   (<https://github.com/open-edge-platform/datumaro/pull/1776>, <https://github.com/open-edge-platform/datumaro/pull/1780>)
+- Deprecation of the SAM Docker image
+  (<https://github.com/open-edge-platform/datumaro/pull/1783>)
 
 ## Q1 2025 Release 1.10.0
 

--- a/docker/segment-anything/README.md
+++ b/docker/segment-anything/README.md
@@ -1,5 +1,8 @@
 # Segment Anything Model for Datumaro
 
+> [!WARNING]
+> The Segment Anything Model for Datumaro is deprecated and will be removed in Datumaro 2.12.
+
 ## Introduction
 
 [Segment Anything Model](https://github.com/facebookresearch/segment-anything) provides high quality object masks for the given point, bounding box, and text prompts.


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This PR deprecates the SAM Docker image since we are deprecating inference in Datumaro in favour of model_api.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
