### PR TITLE
Add deprecation notices for deprecated CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/open-edge-platform/datumaro/pull/1770>)
 
 ### Deprecations
+- Added deprecation to the following CLI commmands:
+  - explain, explore, generate, prune
+  - model: add, remove, run, info
+  - project: add, create, export, import, remove, checkout, commit, log, info, status
+  - source: import, add, remove
+  (<https://github.com/open-edge-platform/datumaro/pull/1792>)
 - Added deprecation notices to the following features that will soon be removed:
-  - Inference
+  - Model inference
   - Model-based transformations
   - Crypter
   - Synthetic dataset generation
@@ -44,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Near-duplicate removal
   - Pruning
   - Pseudo-labels
-  (<https://github.com/open-edge-platform/datumaro/pull/1776>, <https://github.com/open-edge-platform/datumaro/pull/1780>)
+  (<https://github.com/open-edge-platform/datumaro/pull/1776>, <https://github.com/open-edge-platform/datumaro/pull/1780>, <https://github.com/open-edge-platform/datumaro/pull/1792>, <https://github.com/open-edge-platform/datumaro/pull/1795>)
 - Deprecation of the SAM Docker image
   (<https://github.com/open-edge-platform/datumaro/pull/1783>)
 

--- a/src/datumaro/cli/__main__.py
+++ b/src/datumaro/cli/__main__.py
@@ -70,12 +70,15 @@ class _LogManager:
         return parser
 
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
+
 # TODO: revisit during CLI refactoring
 def _get_known_contexts():
     return [
-        ("model", contexts.model, "Actions with models"),
-        ("project", contexts.project, "Actions with projects"),
-        ("source", contexts.source, "Actions with data sources"),
+        ("model", contexts.model, f"{deprecated} Actions with models"),
+        ("project", contexts.project, f"{deprecated} Actions with projects"),
+        ("source", contexts.source, f"{deprecated} Actions with data sources"),
         ("util", contexts.util, "Auxillary tools and utilities"),
     ]
 

--- a/src/datumaro/cli/commands/explain.py
+++ b/src/datumaro/cli/commands/explain.py
@@ -14,12 +14,14 @@ from ..util import MultilineFormatter
 from ..util.errors import CliException
 from ..util.project import load_project, parse_full_revpath
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Run Explainable AI algorithm",
-        description="""
-        Runs an explainable AI algorithm for a model.|n
+        help=f"{deprecated} Run Explainable AI algorithm",
+        description=f"""
+        {deprecated} Runs an explainable AI algorithm for a model.|n
         |n
         This tool is supposed to help an AI developer to debug
         a model and a dataset. Basically, it executes inference and
@@ -183,6 +185,7 @@ def get_sensitive_args():
 
 @scoped
 def explain_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     import cv2
     from matplotlib import cm
 

--- a/src/datumaro/cli/commands/explore.py
+++ b/src/datumaro/cli/commands/explore.py
@@ -22,12 +22,14 @@ from datumaro.util.scope import scope_add, scoped
 from ..util import MultilineFormatter
 from ..util.project import load_project, parse_full_revpath
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Explore similar data of query in dataset",
-        description="""
-        Applies data exploration to a dataset for image/text query.
+        help=f"{deprecated} Explore similar data of query in dataset",
+        description=f"""
+        {deprecated} Applies data exploration to a dataset for image/text query.
         The command can be useful if you have to find similar data in dataset.
         |n
         The current project (-p/--project) is used as a context for plugins
@@ -125,6 +127,7 @@ def get_sensitive_args():
 
 @scoped
 def explore_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     project = None
     try:
         project = scope_add(load_project(args.project_dir))

--- a/src/datumaro/cli/commands/generate.py
+++ b/src/datumaro/cli/commands/generate.py
@@ -13,12 +13,14 @@ from datumaro.util.definitions import get_datumaro_cache_dir
 
 from ..util import MultilineFormatter
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Generate synthetic dataset",
-        description="""
-        Creates a synthetic dataset with elements of the specified type and shape,
+        help=f"{deprecated} Generate synthetic dataset",
+        description=f"""
+        {deprecated} Creates a synthetic dataset with elements of the specified type and shape,
         and saves it in the provided directory.|n
         |n
         Currently, can only generate fractal images, useful for network compression.|n
@@ -75,6 +77,7 @@ def get_sensitive_args():
 
 
 def generate_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     from datumaro.plugins.synthetic_data import FractalImageGenerator
 
     log.info("Generating dataset...")

--- a/src/datumaro/cli/commands/prune.py
+++ b/src/datumaro/cli/commands/prune.py
@@ -13,12 +13,14 @@ from datumaro.util.scope import scope_add, scoped
 from ..util import MultilineFormatter
 from ..util.project import load_project, parse_full_revpath
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Prune dataset and make a representative subset",
-        description="""
-        Apply data pruning to a dataset.|n
+        help=f"{deprecated} Prune dataset and make a representative subset",
+        description=f"""
+        {deprecated} Apply data pruning to a dataset.|n
         The command can be useful if you have to extract representative subset.
         |n
         The current project (-p/--project) is used as a context for plugins
@@ -36,12 +38,12 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         targets will be affected.|n
         |n
         Examples:|n
-        - Prune dataset with selecting random and ratio 80%:|n
+        - Prune dataset with selecting random and ratio 80%%:|n
         |s|s%(prog)s -m random -r 0.8|n
-        - Prune dataset with clustering in image hash and ratio 50%:|n
-        |s|s%(prog)s -m query_clust -h img -r 0.5|
-        - Prune dataset based on entropy with clustering in image hash and ratio 50%:|n
-        |s|s%(prog)s -m entropy -h img -r 0.5|
+        - Prune dataset with clustering in image hash and ratio 50%%:|n
+        |s|s%(prog)s -m query_clust -h img -r 0.5|n
+        - Prune dataset based on entropy with clustering in image hash and ratio 50%%:|n
+        |s|s%(prog)s -m entropy -h img -r 0.5
         """,
         formatter_class=MultilineFormatter,
     )
@@ -105,6 +107,7 @@ def get_sensitive_args():
 
 @scoped
 def prune_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     project = None
     try:
         project = scope_add(load_project(args.project_dir))

--- a/src/datumaro/cli/commands/require_project/modification/add.py
+++ b/src/datumaro/cli/commands/require_project/modification/add.py
@@ -20,14 +20,17 @@ __all__ = [
 ]
 
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
+
 def build_parser(parser_ctor=argparse.ArgumentParser):
     env = DEFAULT_ENVIRONMENT
     builtins = sorted(set(env.extractors) | set(env.importers))
 
     parser = parser_ctor(
-        help="Add data source to project",
-        description="""
-        Adds a data source to a project. A data source is a dataset
+        help=f"{deprecated} Add data source to project",
+        description=f"""
+        {deprecated} Adds a data source to a project. A data source is a dataset
         in a supported format (check 'formats' section below).|n
         |n
         The command adds a project-local directory as a data source in
@@ -48,7 +51,7 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         Each dataset format has its own import options, which are passed
         after the '--' separator (see examples), pass '-- -h' for more info.|n
         |n
-        Builtin formats: {}|n
+        Builtin formats: {{}}|n
         |n
         Examples:|n
         - Add a local directory with a VOC-like dataset:|n
@@ -102,6 +105,8 @@ def get_sensitive_args():
 
 @scoped
 def add_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
+
     # Workaround. Required positionals consume positionals from the end
     args._positionals += join_cli_args(args, "path", "extra_args")
 

--- a/src/datumaro/cli/commands/require_project/modification/create.py
+++ b/src/datumaro/cli/commands/require_project/modification/create.py
@@ -13,12 +13,14 @@ from datumaro.util.os_util import rmtree
 from ....util import MultilineFormatter
 from ....util.errors import CliException
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Create empty project",
-        description="""
-        Create an empty Datumaro project. A project is required for the most of
+        help=f"{deprecated} Create empty project",
+        description=f"""
+        {deprecated} Create an empty Datumaro project. A project is required for the most of
         Datumaro functionality.|n
         |n
         Examples:|n
@@ -55,6 +57,7 @@ def get_sensitive_args():
 
 
 def create_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     project_dir = osp.abspath(args.dst_dir)
 
     existing_project_dir = Project.find_project_dir(project_dir)

--- a/src/datumaro/cli/commands/require_project/modification/export.py
+++ b/src/datumaro/cli/commands/require_project/modification/export.py
@@ -23,13 +23,16 @@ __all__ = [
 ]
 
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
+
 def build_parser(parser_ctor=argparse.ArgumentParser):
     builtins = sorted(DEFAULT_ENVIRONMENT.exporters)
 
     parser = parser_ctor(
-        help="Export project",
-        description="""
-        Exports a project in some format.|n
+        help=f"{deprecated} Export project",
+        description=f"""
+        {deprecated} Exports a project in some format.|n
         |n
         Each dataset format has its own export
         options, which are passed after the '--' separator (see examples),
@@ -50,7 +53,7 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         Check the "plugins" section of the developer guide for information
         about plugin implementation.|n
         |n
-        List of builtin dataset formats: {}|n
+        List of builtin dataset formats: {{}}|n
         |n
         The command can only be applied to a project build target, a stage
         or the combined 'project' target, in which case all the targets will
@@ -121,6 +124,7 @@ def get_sensitive_args():
 
 @scoped
 def export_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     has_sep = "--" in args._positionals
     if has_sep:
         pos = args._positionals.index("--")

--- a/src/datumaro/cli/commands/require_project/modification/import_.py
+++ b/src/datumaro/cli/commands/require_project/modification/import_.py
@@ -20,14 +20,17 @@ __all__ = [
 ]
 
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
+
 def build_parser(parser_ctor=argparse.ArgumentParser):
     env = DEFAULT_ENVIRONMENT
     builtins = sorted(set(env.extractors) | set(env.importers))
 
     parser = parser_ctor(
-        help="Import dataset to project",
-        description="""
-        Imports a data source to a project. A data source is a dataset
+        help=f"{deprecated} Import dataset to project",
+        description=f"""
+        {deprecated} Imports a data source to a project. A data source is a dataset
         in a supported format (check 'formats' section below).|n
         |n
         Currently, only local paths to sources are supported.|n
@@ -46,7 +49,7 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         Each dataset format has its own import options, which are passed
         after the '--' separator (see examples), pass '-- -h' for more info.|n
         |n
-        Builtin formats: {}|n
+        Builtin formats: {{}}|n
         |n
         Examples:|n
         - Add a local directory with a VOC-like dataset:|n
@@ -108,6 +111,7 @@ def get_sensitive_args():
 
 @scoped
 def import_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     # Workaround. Required positionals consume positionals from the end
     args._positionals += join_cli_args(args, "url", "extra_args")
 

--- a/src/datumaro/cli/commands/require_project/modification/remove.py
+++ b/src/datumaro/cli/commands/require_project/modification/remove.py
@@ -16,9 +16,13 @@ __all__ = [
 ]
 
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
+
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Remove source from project", description="Remove a source from a project"
+        help=f"{deprecated} Remove source from project",
+        description=f"{deprecated} Remove a source from a project",
     )
 
     parser.add_argument("names", nargs="+", help="Names of the sources to be removed")
@@ -53,6 +57,7 @@ def get_sensitive_args():
 
 @scoped
 def remove_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     project = scope_add(load_project(args.project_dir))
 
     if not args.names:

--- a/src/datumaro/cli/commands/require_project/versioning/checkout.py
+++ b/src/datumaro/cli/commands/require_project/versioning/checkout.py
@@ -3,18 +3,21 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import logging as log
 
 from datumaro.util.scope import scope_add, scoped
 
 from ....util import MultilineFormatter
 from ....util.project import load_project
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Navigate to a revision",
-        description="""
-        Command forms:|n
+        help=f"{deprecated} Navigate to a revision",
+        description=f"""
+        {deprecated} Command forms:|n
         1) %(prog)s <revision>|n
         2) %(prog)s [--] <source1> ...|n
         3) %(prog)s <revision> [--] <source1> <source2> ...|n
@@ -72,6 +75,7 @@ def get_sensitive_args():
 
 @scoped
 def checkout_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     has_sep = "--" in args._positionals
     if has_sep:
         pos = args._positionals.index("--")

--- a/src/datumaro/cli/commands/require_project/versioning/commit.py
+++ b/src/datumaro/cli/commands/require_project/versioning/commit.py
@@ -3,18 +3,21 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import logging as log
 
 from datumaro.util.scope import scope_add, scoped
 
 from ....util import MultilineFormatter
 from ....util.project import load_project
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Create a revision",
-        description="""
-        Creates a new revision from the current state of the working directory.|n
+        help=f"{deprecated} Create a revision",
+        description=f"""
+        {deprecated} Creates a new revision from the current state of the working directory.|n
         |n
         Examples:|n
         - Create a revision:|n
@@ -62,6 +65,7 @@ def get_sensitive_args():
 
 @scoped
 def commit_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     project = scope_add(load_project(args.project_dir))
 
     old_tree = project.head

--- a/src/datumaro/cli/commands/require_project/versioning/info.py
+++ b/src/datumaro/cli/commands/require_project/versioning/info.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import logging as log
 import os.path as osp
 
 from datumaro.util.scope import scope_add, scoped
@@ -10,12 +11,14 @@ from datumaro.util.scope import scope_add, scoped
 from ....util import MultilineFormatter
 from ....util.project import load_project
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Get project info",
-        description="""
-        Outputs project info - information about plugins,
+        help=f"{deprecated} Get project info",
+        description=f"""
+        {deprecated} Outputs project info - information about plugins,
         sources, build tree, models and revisions.|n
         |n
         Examples:|n
@@ -50,6 +53,7 @@ def get_sensitive_args():
 
 @scoped
 def info_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     project = scope_add(load_project(args.project_dir))
     rev = project.get_rev(args.revision)
     env = rev.env

--- a/src/datumaro/cli/commands/require_project/versioning/log.py
+++ b/src/datumaro/cli/commands/require_project/versioning/log.py
@@ -3,14 +3,17 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import logging as log
 
 from datumaro.util.scope import scope_add, scoped
 
 from ....util.project import load_project
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
-    parser = parser_ctor(description="Prints project history.")
+    parser = parser_ctor(description=f"{deprecated} Prints project history.")
 
     parser.add_argument(
         "-n",
@@ -40,6 +43,7 @@ def get_sensitive_args():
 
 @scoped
 def log_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     project = scope_add(load_project(args.project_dir))
 
     revisions = project.history(args.max_count)

--- a/src/datumaro/cli/commands/require_project/versioning/status.py
+++ b/src/datumaro/cli/commands/require_project/versioning/status.py
@@ -3,18 +3,21 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import logging as log
 
 from datumaro.cli.util import MultilineFormatter
 from datumaro.util.scope import scope_add, scoped
 
 from ....util.project import load_project
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
 
 def build_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Prints project status.",
-        description="""
-        This command prints the summary of the project changes between
+        help=f"{deprecated} Prints project status.",
+        description=f"""
+        {deprecated} This command prints the summary of the project changes between
         the working tree of a project and its HEAD revision.
         """,
         formatter_class=MultilineFormatter,
@@ -41,6 +44,7 @@ def get_sensitive_args():
 
 @scoped
 def status_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     project = scope_add(load_project(args.project_dir))
 
     statuses = project.status()

--- a/src/datumaro/cli/contexts/model.py
+++ b/src/datumaro/cli/contexts/model.py
@@ -21,18 +21,20 @@ from ..util.project import (
     parse_full_revpath,
 )
 
+deprecated = "[DEPRECATED, will be removed in 1.12]"
+
 
 def build_add_parser(parser_ctor=argparse.ArgumentParser):
     builtins = sorted(Environment().launchers)
 
     parser = parser_ctor(
-        help="Add model to project",
-        description="""
-        Adds an executable model into a project. A model requires
+        help=f"{deprecated} Add model to project",
+        description=f"""
+        { deprecated } Adds an executable model into a project. A model requires
         a launcher to be executed. Each launcher has its own options, which
         are passed after the '--' separator, pass '-- -h' for more info.
         |n
-        List of builtin launchers: {}|n
+        List of builtin launchers: {{}}|n
         |n
         Examples:|n
         - Add an OpenVINO model into a project:|n
@@ -81,6 +83,7 @@ def get_add_sensitive_args():
 
 @scoped
 def add_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     show_plugin_help = "-h" in args.extra_args or "--help" in args.extra_args
 
     project = None
@@ -140,7 +143,8 @@ def add_command(args):
 
 def build_remove_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Remove model from project", description="Remove a model from a project"
+        help=f"{deprecated} Remove model from project",
+        description=f"{deprecated } Remove a model from a project",
     )
 
     parser.add_argument("name", help="Name of the model to be removed")
@@ -166,6 +170,7 @@ def get_remove_sensitive_args():
 
 @scoped
 def remove_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     project = scope_add(load_project(args.project_dir))
 
     project.remove_model(args.name)
@@ -178,9 +183,9 @@ def remove_command(args):
 
 def build_run_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Launches model inference",
-        description="""
-        Launches model inference on a dataset.|n
+        help=f"{deprecated} Launches model inference",
+        description=f"""
+        { deprecated } Launches model inference on a dataset.|n
         |n
         Target dataset is specified by a revpath. The full syntax is:|n
         - Dataset paths:|n
@@ -235,6 +240,7 @@ def get_run_sensitive_args():
 
 @scoped
 def run_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     dst_dir = args.dst_dir
     if dst_dir:
         if not args.overwrite and osp.isdir(dst_dir) and os.listdir(dst_dir):
@@ -262,8 +268,8 @@ def run_command(args):
 
 def build_info_parser(parser_ctor=argparse.ArgumentParser):
     parser = parser_ctor(
-        help="Print model information in this project",
-        description="Print model information in this project",
+        help=f"{deprecated} Print model information in this project",
+        description=f"{deprecated } Print model information in this project",
         formatter_class=MultilineFormatter,
     )
 
@@ -291,6 +297,7 @@ def get_info_sensitive_args():
 
 @scoped
 def info_command(args):
+    log.warning("This command is deprecated and will be removed in Datumaro 1.12")
     project = scope_add(load_project(args.project_dir))
 
     if args.name:

--- a/src/datumaro/components/project.py
+++ b/src/datumaro/components/project.py
@@ -283,6 +283,7 @@ class _DataSourceBase(CrudProxy[Source]):
         self._data.remove(name)
 
 
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class ProjectSources(_DataSourceBase):
     def __init__(self, tree: Tree):
         super().__init__(tree, "sources")
@@ -382,6 +383,7 @@ class Pipeline:
         return pipeline
 
 
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class ProjectBuilder:
     def __init__(self, project: Project, tree: Tree):
         self._project = project
@@ -760,6 +762,7 @@ class ProjectBuilder:
         return missing_sources, work_dir_hashes
 
 
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class ProjectBuildTargets(CrudProxy[BuildTarget]):
     MAIN_TARGET = "project"
     BASE_STAGE = "root"
@@ -1593,6 +1596,7 @@ Revision = NewType("Revision", str)  # a commit hash or a named reference
 ObjectId = NewType("ObjectId", str)  # a commit or an object hash
 
 
+@deprecated(deprecated_version="1.11", removed_version="1.12")
 class Project:
     @staticmethod
     def find_project_dir(path: str) -> Optional[str]:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This PR adds deprecation notices in the documentation of several commands that were missing them. It also ensures that the deprecation notice is also printed when running the command.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
