### PR TITLE
Bump version of pyo3 to 0.25.1

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 derive_more = "0.99.17"
-pyo3 = "0.19.2"
+pyo3 = "0.25.1"
 serde = { version = "1.0.180", features = ["derive"] }
 serde_json = "1.0.104"
 strum = { version = "0.25", features = ["derive"] }

--- a/rust/src/coco_page_mapper.rs
+++ b/rust/src/coco_page_mapper.rs
@@ -198,7 +198,8 @@ impl CocoPageMapper {
             self.mapper
                 .get_anns_dict(img_id, &mut self.reader)?
                 .iter()
-                .map(|child| convert_to_py_object(child, py).unwrap()),
+                .map(|child| convert_to_py_object(child, py))
+                .collect::<PyResult<Vec<_>>>()?,
         )?;
         Ok(anns_list.into())
     }

--- a/rust/src/coco_page_mapper.rs
+++ b/rust/src/coco_page_mapper.rs
@@ -17,16 +17,12 @@ use pyo3::{prelude::*, types::PyList};
 use std::{fs::File, io::BufReader, path::Path};
 
 #[derive(EnumString, Debug)]
+#[strum(ascii_case_insensitive, serialize_all = "snake_case")]
 enum CocoJsonSection {
-    #[strum(ascii_case_insensitive)]
     Licenses(JsonDict),
-    #[strum(ascii_case_insensitive)]
     Info(JsonDict),
-    #[strum(ascii_case_insensitive)]
     Categories(JsonDict),
-    #[strum(ascii_case_insensitive)]
     Images(ImgPageMap<i64>),
-    #[strum(ascii_case_insensitive)]
     Annotations(AnnPageMap),
 }
 

--- a/rust/src/coco_page_mapper.rs
+++ b/rust/src/coco_page_mapper.rs
@@ -19,15 +19,15 @@ use std::{fs::File, io::BufReader, path::Path};
 #[derive(EnumString, Debug)]
 enum CocoJsonSection {
     #[strum(ascii_case_insensitive)]
-    LICENSES(JsonDict),
+    Licenses(JsonDict),
     #[strum(ascii_case_insensitive)]
-    INFO(JsonDict),
+    Info(JsonDict),
     #[strum(ascii_case_insensitive)]
-    CATEGORIES(JsonDict),
+    Categories(JsonDict),
     #[strum(ascii_case_insensitive)]
-    IMAGES(ImgPageMap<i64>),
+    Images(ImgPageMap<i64>),
     #[strum(ascii_case_insensitive)]
-    ANNOTATIONS(AnnPageMap),
+    Annotations(AnnPageMap),
 }
 
 impl ParsedJsonSection for CocoJsonSection {
@@ -43,25 +43,25 @@ impl ParsedJsonSection for CocoJsonSection {
                     }
                 }
                 match curr_key {
-                    CocoJsonSection::LICENSES(_) => {
+                    CocoJsonSection::Licenses(_) => {
                         let v = parse_serde_json_value(reader)?;
-                        Ok(Box::new(CocoJsonSection::LICENSES(v)))
+                        Ok(Box::new(CocoJsonSection::Licenses(v)))
                     }
-                    CocoJsonSection::INFO(_) => {
+                    CocoJsonSection::Info(_) => {
                         let v = parse_serde_json_value(reader)?;
-                        Ok(Box::new(CocoJsonSection::INFO(v)))
+                        Ok(Box::new(CocoJsonSection::Info(v)))
                     }
-                    CocoJsonSection::CATEGORIES(_) => {
+                    CocoJsonSection::Categories(_) => {
                         let v = parse_serde_json_value(reader)?;
-                        Ok(Box::new(CocoJsonSection::CATEGORIES(v)))
+                        Ok(Box::new(CocoJsonSection::Categories(v)))
                     }
-                    CocoJsonSection::IMAGES(_) => {
+                    CocoJsonSection::Images(_) => {
                         let v = ImgPageMap::from_reader(reader)?;
-                        Ok(Box::new(CocoJsonSection::IMAGES(v)))
+                        Ok(Box::new(CocoJsonSection::Images(v)))
                     }
-                    CocoJsonSection::ANNOTATIONS(_) => {
+                    CocoJsonSection::Annotations(_) => {
                         let v = AnnPageMap::from_reader(reader)?;
-                        Ok(Box::new(CocoJsonSection::ANNOTATIONS(v)))
+                        Ok(Box::new(CocoJsonSection::Annotations(v)))
                     }
                 }
             }
@@ -123,19 +123,19 @@ impl CocoPageMapperImpl {
 
         for section in sections {
             match *section {
-                CocoJsonSection::LICENSES(v) => {
+                CocoJsonSection::Licenses(v) => {
                     licenses = Some(v);
                 }
-                CocoJsonSection::INFO(v) => {
+                CocoJsonSection::Info(v) => {
                     info = Some(v);
                 }
-                CocoJsonSection::CATEGORIES(v) => {
+                CocoJsonSection::Categories(v) => {
                     categories = Some(v);
                 }
-                CocoJsonSection::IMAGES(v) => {
+                CocoJsonSection::Images(v) => {
                     images = Some(v);
                 }
-                CocoJsonSection::ANNOTATIONS(v) => {
+                CocoJsonSection::Annotations(v) => {
                     annotations = Some(v);
                 }
             }
@@ -199,7 +199,7 @@ impl CocoPageMapper {
                 .get_anns_dict(img_id, &mut self.reader)?
                 .iter()
                 .map(|child| convert_to_py_object(child, py).unwrap()),
-        );
+        )?;
         Ok(anns_list.into())
     }
 

--- a/rust/src/datum_page_mapper.rs
+++ b/rust/src/datum_page_mapper.rs
@@ -18,16 +18,12 @@ use crate::{
 use pyo3::prelude::*;
 use serde_json::json;
 #[derive(EnumString, Debug)]
+#[strum(ascii_case_insensitive, serialize_all = "snake_case")]
 pub enum DatumJsonSection {
-    #[strum(ascii_case_insensitive)]
     DmFormatVersion(String),
-    #[strum(ascii_case_insensitive)]
     MediaType(i64),
-    #[strum(ascii_case_insensitive)]
     Infos(JsonDict),
-    #[strum(ascii_case_insensitive)]
     Categories(JsonDict),
-    #[strum(ascii_case_insensitive)]
     Items(ImgPageMap<String>),
 }
 

--- a/rust/src/datum_page_mapper.rs
+++ b/rust/src/datum_page_mapper.rs
@@ -20,15 +20,15 @@ use serde_json::json;
 #[derive(EnumString, Debug)]
 pub enum DatumJsonSection {
     #[strum(ascii_case_insensitive)]
-    DM_FORMAT_VERSION(String),
+    DmFormatVersion(String),
     #[strum(ascii_case_insensitive)]
-    MEDIA_TYPE(i64),
+    MediaType(i64),
     #[strum(ascii_case_insensitive)]
-    INFOS(JsonDict),
+    Infos(JsonDict),
     #[strum(ascii_case_insensitive)]
-    CATEGORIES(JsonDict),
+    Categories(JsonDict),
     #[strum(ascii_case_insensitive)]
-    ITEMS(ImgPageMap<String>),
+    Items(ImgPageMap<String>),
 }
 
 impl ParsedJsonSection for DatumJsonSection {
@@ -44,32 +44,32 @@ impl ParsedJsonSection for DatumJsonSection {
                     }
                 }
                 match curr_key {
-                    DatumJsonSection::DM_FORMAT_VERSION(_) => {
+                    DatumJsonSection::DmFormatVersion(_) => {
                         let v = parse_serde_json_value(reader)?
                             .as_str()
                             .ok_or(invalid_data(
                                 "Cannot parse datumaro format version from the json file",
                             ))?
                             .to_string();
-                        Ok(Box::new(DatumJsonSection::DM_FORMAT_VERSION(v)))
+                        Ok(Box::new(DatumJsonSection::DmFormatVersion(v)))
                     }
-                    DatumJsonSection::MEDIA_TYPE(_) => {
+                    DatumJsonSection::MediaType(_) => {
                         let v = parse_serde_json_value(reader)?
                             .as_i64()
                             .ok_or(invalid_data("Cannot parse media type from the json file"))?;
-                        Ok(Box::new(DatumJsonSection::MEDIA_TYPE(v)))
+                        Ok(Box::new(DatumJsonSection::MediaType(v)))
                     }
-                    DatumJsonSection::INFOS(_) => {
+                    DatumJsonSection::Infos(_) => {
                         let v = parse_serde_json_value(reader)?;
-                        Ok(Box::new(DatumJsonSection::INFOS(v)))
+                        Ok(Box::new(DatumJsonSection::Infos(v)))
                     }
-                    DatumJsonSection::CATEGORIES(_) => {
+                    DatumJsonSection::Categories(_) => {
                         let v = parse_serde_json_value(reader)?;
-                        Ok(Box::new(DatumJsonSection::CATEGORIES(v)))
+                        Ok(Box::new(DatumJsonSection::Categories(v)))
                     }
-                    DatumJsonSection::ITEMS(_) => {
+                    DatumJsonSection::Items(_) => {
                         let v = ImgPageMap::from_reader(reader)?;
-                        Ok(Box::new(DatumJsonSection::ITEMS(v)))
+                        Ok(Box::new(DatumJsonSection::Items(v)))
                     }
                 }
             }
@@ -128,19 +128,19 @@ impl DatumPageMapperImpl {
 
         for section in sections {
             match *section {
-                DatumJsonSection::DM_FORMAT_VERSION(v) => {
+                DatumJsonSection::DmFormatVersion(v) => {
                     dm_format_version = Some(v);
                 }
-                DatumJsonSection::MEDIA_TYPE(v) => {
+                DatumJsonSection::MediaType(v) => {
                     media_type = Some(v);
                 }
-                DatumJsonSection::INFOS(v) => {
+                DatumJsonSection::Infos(v) => {
                     infos = Some(v);
                 }
-                DatumJsonSection::CATEGORIES(v) => {
+                DatumJsonSection::Categories(v) => {
                     categories = Some(v);
                 }
-                DatumJsonSection::ITEMS(v) => {
+                DatumJsonSection::Items(v) => {
                     items = Some(v);
                 }
             }

--- a/rust/src/json_section_page_mapper.rs
+++ b/rust/src/json_section_page_mapper.rs
@@ -6,13 +6,14 @@ use crate::{
     page_mapper::{JsonPageMapper, ParsedJsonSection},
     utils::read_skipping_ws,
 };
-use pyo3::{prelude::*, types::PyDict};
+use pyo3::{prelude::*, IntoPyObjectExt};
 use std::{
     collections::HashMap,
     fs::File,
     io::{self, BufReader, Read, Seek},
     path::Path,
 };
+
 
 #[derive(Debug)]
 pub struct JsonSection {
@@ -192,7 +193,7 @@ impl JsonSectionPageMapper {
             })
             .collect();
 
-        Ok(dict.into_py(self_.py()))
+        Ok(dict.into_py_any(self_.py()).unwrap())
     }
 
     fn __len__(&self) -> PyResult<usize> {

--- a/rust/src/json_section_page_mapper.rs
+++ b/rust/src/json_section_page_mapper.rs
@@ -193,7 +193,7 @@ impl JsonSectionPageMapper {
             })
             .collect();
 
-        Ok(dict.into_py_any(self_.py()).unwrap())
+        Ok(dict.into_py_any(self_.py())?)
     }
 
     fn __len__(&self) -> PyResult<usize> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -9,6 +9,7 @@ mod page_mapper;
 mod page_maps;
 mod utils;
 use pyo3::prelude::*;
+use pyo3::types::PyModule;
 
 use crate::coco_page_mapper::CocoPageMapper;
 use crate::datum_page_mapper::DatumPageMapper;
@@ -17,10 +18,9 @@ use crate::json_section_page_mapper::JsonSectionPageMapper;
 /// Datumaro Rust API
 #[pymodule]
 #[pyo3(name = "rust_api")]
-fn rust_api(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn rust_api(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<CocoPageMapper>()?;
     m.add_class::<DatumPageMapper>()?;
     m.add_class::<JsonSectionPageMapper>()?;
-
     Ok(())
 }

--- a/rust/src/page_maps.rs
+++ b/rust/src/page_maps.rs
@@ -112,7 +112,7 @@ where
                     let mut stream = de.into_iter::<HashMap<String, serde_json::Value>>();
                     let offset = curr_pos + stream.byte_offset() as u64;
 
-                    match stream.next().unwrap() {
+                    match stream.next().ok_or_else(|| stream_error("Unexpected end of stream", offset))? {
                         Ok(parsed_map) => {
                             let id = ItemPageMapKeyTrait::get_id(parsed_map, offset)?;
 
@@ -248,7 +248,7 @@ impl AnnPageMap {
                     let mut stream = de.into_iter::<HashMap<String, serde_json::Value>>();
                     let offset = curr_pos + stream.byte_offset() as u64;
 
-                    match stream.next().unwrap() {
+                    match stream.next().ok_or_else(|| stream_error("Unexpected end of stream", offset))? {
                         Ok(parsed_map) => {
                             let ann_id = if let Some(v) = parsed_map.get("id") {
                                 v.as_i64().ok_or(stream_error(

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -61,7 +61,7 @@ pub fn parse_serde_json_value(
 ) -> Result<serde_json::Value, io::Error> {
     let de = serde_json::Deserializer::from_reader(reader);
     let mut stream = de.into_iter::<serde_json::Value>();
-    match stream.next().unwrap() {
+    match stream.next().ok_or_else(|| invalid_data("Unexpected end of stream"))? {
         Ok(x) => Ok(x),
         Err(e) => {
             let cur_pos = stream.byte_offset();
@@ -84,7 +84,7 @@ pub fn convert_to_py_object(value: &serde_json::Value, py: Python<'_>) -> PyResu
     if value.is_array() {
         let list = PyList::empty(py);
 
-        for child in value.as_array().unwrap() {
+        for child in value.as_array().ok_or_else(|| PyValueError::new_err("Expected array"))? {
             list.append(convert_to_py_object(child, py)?)?;
         }
 
@@ -92,22 +92,22 @@ pub fn convert_to_py_object(value: &serde_json::Value, py: Python<'_>) -> PyResu
     } else if value.is_object() {
         let dict = PyDict::new(py);
 
-        for (key, child) in value.as_object().unwrap().iter() {
+        for (key, child) in value.as_object().ok_or_else(|| PyValueError::new_err("Expected object"))?.iter() {
             let child = convert_to_py_object(child, py)?;
             dict.set_item(key, child)?;
         }
 
         return Ok(dict.into());
     } else if value.is_boolean() {
-        return Ok(value.as_bool().unwrap().into_py_any(py).unwrap());
+        return Ok(value.as_bool().ok_or_else(|| PyValueError::new_err("Expected boolean"))?.into_py_any(py)?);
     } else if value.is_f64() {
-        return Ok(value.as_f64().unwrap().into_py_any(py).unwrap());
+        return Ok(value.as_f64().ok_or_else(|| PyValueError::new_err("Expected f64"))?.into_py_any(py)?);
     } else if value.is_i64() {
-        return Ok(value.as_i64().unwrap().into_py_any(py).unwrap());
+        return Ok(value.as_i64().ok_or_else(|| PyValueError::new_err("Expected i64"))?.into_py_any(py)?);
     } else if value.is_u64() {
-        return Ok(value.as_u64().unwrap().into_py_any(py).unwrap());
+        return Ok(value.as_u64().ok_or_else(|| PyValueError::new_err("Expected u64"))?.into_py_any(py)?);
     } else if value.is_string() {
-        return Ok(value.as_str().unwrap().into_py_any(py).unwrap());
+        return Ok(value.as_str().ok_or_else(|| PyValueError::new_err("Expected string"))?.into_py_any(py)?);
     } else if value.is_null() {
         return Ok(py.None());
     } else {

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -6,7 +6,8 @@ use std::io::{self};
 use pyo3::{
     exceptions::PyValueError,
     prelude::*,
-    types::{PyBool, PyDict, PyFloat, PyList, PyUnicode},
+    types::{PyDict, PyList},
+    IntoPyObjectExt,
 };
 use serde::de::{IgnoredAny, Deserialize};
 use serde_json::{self, Deserializer};
@@ -98,15 +99,15 @@ pub fn convert_to_py_object(value: &serde_json::Value, py: Python<'_>) -> PyResu
 
         return Ok(dict.into());
     } else if value.is_boolean() {
-        return Ok(PyBool::new(py, value.as_bool().unwrap()).into());
+        return Ok(value.as_bool().unwrap().into_py_any(py).unwrap());
     } else if value.is_f64() {
-        return Ok(PyFloat::new(py, value.as_f64().unwrap()).into());
+        return Ok(value.as_f64().unwrap().into_py_any(py).unwrap());
     } else if value.is_i64() {
-        return Ok(value.as_i64().unwrap().to_object(py));
+        return Ok(value.as_i64().unwrap().into_py_any(py).unwrap());
     } else if value.is_u64() {
-        return Ok(value.as_u64().unwrap().to_object(py));
+        return Ok(value.as_u64().unwrap().into_py_any(py).unwrap());
     } else if value.is_string() {
-        return Ok(PyUnicode::new(py, value.as_str().unwrap()).into());
+        return Ok(value.as_str().unwrap().into_py_any(py).unwrap());
     } else if value.is_null() {
         return Ok(py.None());
     } else {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

Bump the version of pyo3 to 0.25.1. There were numerous breaking changes in pyo3 which makes the changes non-straightforward.

Background reading on the issue with into_py/to_object:
https://github.com/pyo3/pyo3/releases?page=2
https://pyo3.rs/v0.23.0/migration.html
https://github.com/PyO3/pyo3/discussions/4857

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
