### PR TITLE
In setup.py, use the license attribute instead of a license classifier.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,9 +75,9 @@ setuptools.setup(
     url="https://github.com/open-edge-platform/datumaro",
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src", include=["datumaro*"]),
+    license="MIT",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "MIT",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9",


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

Fix for license issue when uploading package to Pypi:
https://github.com/open-edge-platform/datumaro/actions/runs/16367098878/job/46247126228

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
