### PR TITLE
Upgrade Numpy and OpenVINO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Q3 2025 Release 1.11.1
+
+### Enhancements
+
+- Bump version of NumPy and OpenVINO
+
 ## Q3 2025 Release 1.11.0
 
 This release includes a significant number of deprecations in the CLI and API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements
 
 - Bump version of NumPy and OpenVINO
+  (<https://github.com/open-edge-platform/datumaro/pull/1803>)
 
 ## Q3 2025 Release 1.11.0
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 -r ../requirements-default.txt
 -r ../requirements-dev.txt
 
-opencv-python-headless==4.11.0.86
+opencv-python-headless>=4.11.0.86
 
 # docs
 markupsafe==3.0.2

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -6,7 +6,7 @@ lxml<6,>=5.2.0
 matplotlib>=3.3.1
 networkx>=2.6
 nibabel>=3.2.1
-numpy>=2.2.4
+numpy>=2.0.4,<2.2.0
 orjson==3.10.18
 Pillow>=10.3.0
 ruamel.yaml>=0.17.0
@@ -34,7 +34,7 @@ requests
 pandas>=1.4.0
 
 # OpenVINO
-openvino>=2023.2.0
+openvino>=2025.2.0
 tokenizers
 
 # Encryption

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -6,7 +6,7 @@ lxml<6,>=5.2.0
 matplotlib>=3.3.1
 networkx>=2.6
 nibabel>=3.2.1
-numpy<2,>=1.23.4
+numpy>=2.2.4
 orjson==3.10.18
 Pillow>=10.3.0
 ruamel.yaml>=0.17.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -2,21 +2,20 @@ attrs>=21.3.0
 defusedxml>=0.7.0
 h5py>=2.10.0
 imagesize>=1.4.1
-lxml<6,>=5.2.0
+lxml<7,>=5.2.0
 matplotlib>=3.3.1
 networkx>=2.6
 nibabel>=3.2.1
 numpy>=2.0.4,<2.2.0
-orjson==3.10.18
+orjson>=3.10.0
 Pillow>=10.3.0
 ruamel.yaml>=0.17.0
 shapely>=1.7
 typing_extensions>=3.7.4.3
 tqdm
 
-pycocotools>=2.0.4; platform_system != "Windows" or python_version >= '3.9'
+pycocotools>=2.0.4
 
-pycocotools-windows; platform_system == "Windows" and python_version < '3.9'
 PyYAML==6.0.2
 
 # 2.3 has an unlisted dependency on PyTorch, which we don't need

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -6,7 +6,7 @@ lxml<7,>=5.2.0
 matplotlib>=3.3.1
 networkx>=2.6
 nibabel>=3.2.1
-numpy>=2.0.4,<2.2.0
+numpy>=1.23.4,<2.2.0
 orjson>=3.10.0
 Pillow>=10.3.0
 ruamel.yaml>=0.17.0
@@ -33,7 +33,7 @@ requests
 pandas>=1.4.0
 
 # OpenVINO
-openvino>=2025.2.0
+openvino>=2023.2.0
 tokenizers
 
 # Encryption

--- a/requirements-default.txt
+++ b/requirements-default.txt
@@ -1,4 +1,3 @@
 dvc==3.49.0 # fix version to avoid some import issues
-fsspec <= 2022.11.0; python_version < '3.8'
 GitPython>=3.1.18,!=3.1.25 # https://github.com/open-edge-platform/datumaro/issues/612
 openvino-telemetry>=2022.1.0

--- a/requirements-default.txt
+++ b/requirements-default.txt
@@ -2,4 +2,3 @@ dvc==3.49.0 # fix version to avoid some import issues
 fsspec <= 2022.11.0; python_version < '3.8'
 GitPython>=3.1.18,!=3.1.25 # https://github.com/open-edge-platform/datumaro/issues/612
 openvino-telemetry>=2022.1.0
-openvino-dev>=2023.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -r requirements-core.txt
 -r requirements-default.txt
 
-opencv-python-headless==4.11.0.86
+opencv-python-headless>=4.11.0.86

--- a/src/datumaro/components/algorithms/rise.py
+++ b/src/datumaro/components/algorithms/rise.py
@@ -47,7 +47,7 @@ class RISE:
 
     def generate_masks(self, image_size):
         cell_size = np.ceil(np.array(image_size) / self.mask_size).astype(np.int8)
-        up_size = tuple([(self.mask_size + 1) * cs for cs in cell_size])
+        up_size = tuple([(self.mask_size + 1) * int(cs) for cs in cell_size])
 
         grid = np.random.rand(self.num_masks, self.mask_size, self.mask_size) < self.prob
         grid = grid.astype("float32")

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -498,7 +498,7 @@ class RleMask(Mask):
 
     def __eq__(self, other):
         if not isinstance(other, __class__):
-            return False
+            return super().__eq__(other)
         return self.rle == other.rle
 
 

--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -271,8 +271,6 @@ class HashKey(Annotation):
             raise ValueError(value)
 
     def __eq__(self, other):
-        if not super().__eq__(other):
-            return False
         if not isinstance(other, __class__):
             return False
         return np.array_equal(self.hash_key, other.hash_key)
@@ -285,8 +283,6 @@ class FeatureVector(Annotation):
     vector: np.ndarray = field(validator=attr.validators.instance_of(np.ndarray))
 
     def __eq__(self, other):
-        if not super().__eq__(other):
-            return False
         if not isinstance(other, __class__):
             return False
         return np.array_equal(self.hash_key, other.hash_key)
@@ -340,8 +336,6 @@ class MaskCategories(Categories):
         return len(self.colormap)
 
     def __eq__(self, other):
-        if not super().__eq__(other):
-            return False
         if not isinstance(other, __class__):
             return False
         for label_id, my_color in self.colormap.items():
@@ -456,8 +450,6 @@ class Mask(Annotation):
         return paint_mask(self.as_class_mask(), colormap)
 
     def __eq__(self, other):
-        if not super().__eq__(other):
-            return False
         if not isinstance(other, __class__):
             return False
         return (
@@ -506,7 +498,7 @@ class RleMask(Mask):
 
     def __eq__(self, other):
         if not isinstance(other, __class__):
-            return super().__eq__(other)
+            return False
         return self.rle == other.rle
 
 
@@ -1813,8 +1805,6 @@ class _ImageAnnotation(Annotation):
     image: Image = field()
 
     def __eq__(self, other):
-        if not super().__eq__(other):
-            return False
         if not isinstance(other, __class__):
             return False
         return np.array_equal(self.image, other.image)
@@ -2054,8 +2044,6 @@ class TabularCategories(Categories):
         return iter(self.items)
 
     def __eq__(self, other) -> bool:
-        if not super().__eq__(other):
-            return False
         if not isinstance(other, __class__):
             return False
         return self.items == other.items

--- a/src/datumaro/components/merge/intersect_merge.py
+++ b/src/datumaro/components/merge/intersect_merge.py
@@ -94,7 +94,7 @@ class IntersectMerge(Merger):
     def __init__(self, **options):
         super().__init__(**options)
 
-    @attrs(repr_ns="IntersectMerge", kw_only=True)
+    @attrs(kw_only=True)
     class Conf:
         """
         Parameters

--- a/src/datumaro/plugins/data_formats/coco/exporter.py
+++ b/src/datumaro/plugins/data_formats/coco/exporter.py
@@ -12,6 +12,7 @@ from io import BufferedWriter
 from itertools import chain, groupby
 from typing import Dict, List, Optional, Type, Union
 
+import numpy as np
 import pycocotools.mask as mask_utils
 from json_stream.writer import streamable_dict, streamable_list
 
@@ -466,6 +467,8 @@ class _InstancesExporter(_TaskExporter):
             else:
                 rles = mask_utils.merge(rles)
             area = mask_utils.area(rles)
+            if isinstance(area, np.ndarray):
+                area = area[0]
         else:
             _, _, w, h = bbox
             segmentation = []

--- a/src/datumaro/plugins/framework_converter.py
+++ b/src/datumaro/plugins/framework_converter.py
@@ -175,7 +175,8 @@ try:
                 image = np.expand_dims(image, axis=-1)
 
             if self.transform:
-                image = self.transform(image)
+                # Use image.copy() because PyTorch does not support non-writable tensors.
+                image = self.transform(image.copy())
 
             if self.target_transform:
                 label = self.target_transform(label)

--- a/src/datumaro/plugins/openvino_plugin/launcher.py
+++ b/src/datumaro/plugins/openvino_plugin/launcher.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, fields
 from typing import Dict, List, Optional
 
 import numpy as np
-from openvino.runtime import Core
+from openvino import Core
 from tqdm import tqdm
 
 from datumaro.components.abstracts.model_interpreter import LauncherInputType, ModelPred

--- a/src/datumaro/util/annotation_util.py
+++ b/src/datumaro/util/annotation_util.py
@@ -160,7 +160,10 @@ def segment_iou(a, b):
 
         a = _to_rle(a)
         b = _to_rle(b)
-    return float(mask_utils.iou(a, b, [not is_bbox]))
+    iou = mask_utils.iou(a, b, [not is_bbox])
+    if isinstance(iou, np.ndarray):
+        iou = iou[0, 0]
+    return float(iou)
 
 
 def PDJ(a, b, eps=None, ratio=0.05, bbox=None):

--- a/src/datumaro/util/mask_tools.py
+++ b/src/datumaro/util/mask_tools.py
@@ -106,7 +106,7 @@ def paint_mask(mask, colormap=None):
         map_fn = colormap
     else:
         map_fn = lambda c: colormap.get(c, (-1, -1, -1))
-    palette = np.array([map_fn(c)[::-1] for c in range(256)], dtype=np.uint8)
+    palette = np.mod([map_fn(c)[::-1] for c in range(256)], 256).astype(np.uint8)
 
     mask = mask.astype(np.uint8)
     painted_mask = palette[mask].reshape((*mask.shape[:2], 3))
@@ -121,7 +121,7 @@ def remap_mask(mask, map_fn):
     """
     check_is_mask(mask)
 
-    return np.array([map_fn(c) for c in range(256)], dtype=np.uint8)[mask]
+    return np.mod([map_fn(c) for c in range(256)], 256).astype(np.uint8)[mask]
 
 
 def make_index_mask(

--- a/src/datumaro/util/pickle_util.py
+++ b/src/datumaro/util/pickle_util.py
@@ -9,7 +9,10 @@ import numpy.core.multiarray
 
 class RestrictedUnpickler(pickle.Unpickler):
     def find_class(self, module, name):
-        if module == "numpy.core.multiarray" and name in PickleLoader.safe_numpy:
+        if (
+            module in ["numpy.core.multiarray", "numpy._core.multiarray"]
+            and name in PickleLoader.safe_numpy
+        ):
             return getattr(numpy.core.multiarray, name)
         elif module == "numpy" and name in PickleLoader.safe_numpy:
             return getattr(numpy, name)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

Resolves #1801 

This PR addresses deprecations and update the version of some dependencies, especially NumPy and OpenVINO:
* Fix underflows/overflows when converting data to/from Python unsigned int.
* Fix conversion of Numpy array to scalar
* Fix access to non-writeable Numpy array from PyTorch which is not supported by PyTorch
* Remove calls to inexistent `super().__eq__` which led to warnings
* Remove repr_ns parameter which is no longer needed and is deprecated by the attrs library
* Fixed OpenVINO imports

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
