### PR TITLE
Add support for Python 3.13 and MacOS

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -27,6 +27,8 @@ jobs:
             tox-env-py: "311"
           - python-version: "3.12"
             tox-env-py: "312"
+          - python-version: "3.13"
+            tox-env-py: "313"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/nightly_check.yml
+++ b/.github/workflows/nightly_check.yml
@@ -14,13 +14,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-24.04', 'windows-2022']
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        os: ['ubuntu-24.04', 'windows-2022', 'macos-15']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         include:
           - os: "ubuntu-24.04"
             tox-env-os: "lin"
           - os: "windows-2022"
             tox-env-os: "win"
+          - os: "macos-15"
+            tox-env-os: "mac"
           - python-version: "3.9"
             tox-env-py: "39"
           - python-version: "3.10"
@@ -29,6 +31,8 @@ jobs:
             tox-env-py: "311"
           - python-version: "3.12"
             tox-env-py: "312"
+          - python-version: "3.13"
+            tox-env-py: "313"
     name: nightly regression test (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==3.1.1
       - name: Build wheels
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.12
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -44,7 +44,7 @@ jobs:
         run: python -m pip install cibuildwheel==3.1.1
       - name: Build wheels
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.12
+          MACOSX_DEPLOYMENT_TARGET: 11.0
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -23,6 +23,31 @@ defaults:
   run:
     shell: bash
 jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['macos-15']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Installing python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.15.0
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-wheels_${{ matrix.os }}
+          path: ./wheelhouse/*.whl
   pr_test:
     if: |
       github.event.pull_request.draft == false &&

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: "3.11"
           cache: pip
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.15.0
+        run: python -m pip install cibuildwheel==3.1.1
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-15']
+        os: ['macos-13', 'macos-15']
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -31,15 +31,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-24.04", "windows-2022"]
-        python-version: ["3.12"]
+        os: ["ubuntu-24.04", "windows-2022", "macos-15"]
+        python-version: ["3.12", "3.13"]
         include:
           - python-version: "3.12"
             tox-env-py: "312"
+          - python-version: "3.13"
+            tox-env-py: "313"
           - os: "ubuntu-24.04"
             tox-env-os: "lin"
           - os: "windows-2022"
             tox-env-os: "win"
+          - os: "macos-15"
+            tox-env-os: "mac"
     name: pr test (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -23,33 +23,6 @@ defaults:
   run:
     shell: bash
 jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ['macos-13', 'macos-15']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-      - name: Installing python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.11"
-          cache: pip
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==3.1.1
-      - name: Build wheels
-        env:
-          MACOSX_DEPLOYMENT_TARGET: 11.0
-        run: python -m cibuildwheel --output-dir wheelhouse
-      - uses: actions/upload-artifact@v4
-        with:
-          name: artifact-wheels_${{ matrix.os }}
-          path: ./wheelhouse/*.whl
   pr_test:
     if: |
       github.event.pull_request.draft == false &&

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-24.04', 'windows-2022']
+        os: ['ubuntu-24.04', 'windows-2022', 'macos-15']
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-24.04', 'windows-2022', 'macos-15']
+        # macos-13 is used to build x86_64 MacOS binaries while macos-15 is used for arm64
+        os: ['ubuntu-24.04', 'windows-2022', 'macos-13', 'macos-15']
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==3.1.1
       - name: Build wheels
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.12
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -31,7 +31,7 @@ jobs:
         run: python -m pip install cibuildwheel==3.1.1
       - name: Build wheels
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.12
+          MACOSX_DEPLOYMENT_TARGET: 11.0
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.11"
           cache: pip
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.15.0
+        run: python -m pip install cibuildwheel==3.1.1
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump version of NumPy and OpenVINO
   (<https://github.com/open-edge-platform/datumaro/pull/1803>)
+- Support for Python 3.13 and MacOS
+  (<https://github.com/open-edge-platform/datumaro/pull/1804>)
 
 ## Q3 2025 Release 1.11.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ omit = [
 
 [tool.cibuildwheel]
 # reference docs - https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-build = "cp39-*_x86_64 cp310-*_x86_64 cp311-*_x86_64 cp312-*_x86_64 cp313-*_x86_64 cp39-*_amd64 cp310-*_amd64 cp311-*_amd64 cp312-*_amd64 cp313-*_amd64"
+build = "cp39-*_x86_64 cp310-*_x86_64 cp311-*_x86_64 cp312-*_x86_64 cp313-*_x86_64 cp39-*_amd64 cp310-*_amd64 cp311-*_amd64 cp312-*_amd64 cp313-*_amd64 cp39-*_arm64 cp310-*_arm64 cp311-*_arm64 cp312-*_arm64 cp313-*_arm64"
 
 [tool.cibuildwheel.linux]
 before-all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ omit = [
 
 [tool.cibuildwheel]
 # reference docs - https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-build = "cp39-*_x86_64 cp310-*_x86_64 cp311-*_x86_64 cp312-*_x86_64 cp39-*_amd64 cp310-*_amd64 cp311-*_amd64 cp312-*_amd64"
-skip = "*macos*"
+build = "cp39-*_x86_64 cp310-*_x86_64 cp311-*_x86_64 cp312-*_x86_64 cp313-*_x86_64 cp39-*_amd64 cp310-*_amd64 cp311-*_amd64 cp312-*_amd64 cp313-*_amd64"
 
 [tool.cibuildwheel.linux]
 before-all = [

--- a/src/datumaro/plugins/framework_converter.py
+++ b/src/datumaro/plugins/framework_converter.py
@@ -229,15 +229,15 @@ try:
 
             return output_dict
 
-        def create(self) -> 'tf.data.Dataset':
+        def create(self) -> "tf.data.Dataset":
             tf_dataset = tf.data.Dataset.range(len(self.dataset)).map(self._process_item)
             tf_dataset = tf_dataset
             return tf_dataset
 
-        def repeat(self, count=None) -> 'tf.data.Dataset':
+        def repeat(self, count=None) -> "tf.data.Dataset":
             return self.create().repeat(count)
 
-        def batch(self, batch_size, drop_remainder=False) -> 'tf.data.Dataset':
+        def batch(self, batch_size, drop_remainder=False) -> "tf.data.Dataset":
             return self.create().batch(batch_size, drop_remainder=drop_remainder)
 
 except ImportError:

--- a/src/datumaro/plugins/framework_converter.py
+++ b/src/datumaro/plugins/framework_converter.py
@@ -229,15 +229,15 @@ try:
 
             return output_dict
 
-        def create(self) -> tf.data.Dataset:
+        def create(self) -> 'tf.data.Dataset':
             tf_dataset = tf.data.Dataset.range(len(self.dataset)).map(self._process_item)
             tf_dataset = tf_dataset
             return tf_dataset
 
-        def repeat(self, count=None) -> tf.data.Dataset:
+        def repeat(self, count=None) -> 'tf.data.Dataset':
             return self.create().repeat(count)
 
-        def batch(self, batch_size, drop_remainder=False) -> tf.data.Dataset:
+        def batch(self, batch_size, drop_remainder=False) -> 'tf.data.Dataset':
             return self.create().batch(batch_size, drop_remainder=drop_remainder)
 
 except ImportError:

--- a/tests/unit/data_formats/test_roboflow.py
+++ b/tests/unit/data_formats/test_roboflow.py
@@ -13,10 +13,6 @@ from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.environment import DEFAULT_ENVIRONMENT
 from datumaro.components.importer import Importer
 from datumaro.components.media import Image
-from datumaro.plugins.data_formats.roboflow.base_tfrecord import (
-    RoboflowTfrecordBase,
-    RoboflowTfrecordImporter,
-)
 from datumaro.plugins.data_formats.roboflow.importer import (
     RoboflowCocoImporter,
     RoboflowCreateMlImporter,
@@ -37,6 +33,15 @@ except ImportError:
     TF_AVAILABLE = False
 else:
     TF_AVAILABLE = True
+
+if TF_AVAILABLE:
+    from datumaro.plugins.data_formats.roboflow.base_tfrecord import (
+        RoboflowTfrecordBase,
+        RoboflowTfrecordImporter,
+    )
+else:
+    RoboflowTfrecordBase = None
+    RoboflowTfrecordImporter = None
 
 
 DUMMY_DATASET_COCO_DIR = get_test_asset_path("roboflow_dataset", "coco")

--- a/tests/unit/test_framework_converter.py
+++ b/tests/unit/test_framework_converter.py
@@ -240,16 +240,20 @@ class FrameworkConverterFactoryTest(TestCase):
         with self.assertRaises(ValueError):
             FrameworkConverterFactory.create_converter("invalid_framework")
 
-    @skipIf(TORCH_AVAILABLE, reason="PyTorch is installed")
-    def test_create_converter_torch_importerror(self):
-        with self.assertRaises(ImportError):
-            _ = FrameworkConverterFactory.create_converter("torch")
 
-    @skipIf(TF_AVAILABLE, reason="Tensorflow is installed")
-    def test_create_converter_tf_importerror(self):
-        with self.assertRaises(ImportError):
-            _ = FrameworkConverterFactory.create_converter("tf")
+def _tf_tensor_spec(shape, dtype, name=None):
+    return tf.TensorSpec(shape=shape, dtype=dtype, name=name) if TF_AVAILABLE else ""
 
+
+def _tf_int32():
+    return tf.int32 if TF_AVAILABLE else ""
+
+
+def _tf_float32():
+    return tf.float32 if TF_AVAILABLE else ""
+
+def _transforms_to_tensor():
+    return transforms.ToTensor() if TORCH_AVAILABLE else ""
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
 class MultiframeworkConverterTest:
@@ -345,7 +349,7 @@ class MultiframeworkConverterTest:
             (
                 "train",
                 "semantic_segmentation",
-                {"transform": transforms.ToTensor()},
+                {"transform": _transforms_to_tensor()},
             ),
         ],
     )
@@ -601,8 +605,8 @@ class MultiframeworkConverterTest:
                 "classification",
                 {
                     "output_signature": {
-                        "image": tf.TensorSpec(shape=(None, None, None), dtype=tf.int32),
-                        "label": tf.TensorSpec(shape=(), dtype=tf.int32),
+                        "image": _tf_tensor_spec(shape=(None, None, None), dtype=_tf_int32()),
+                        "label": _tf_tensor_spec(shape=(), dtype=_tf_int32()),
                     }
                 },
             ),
@@ -611,8 +615,8 @@ class MultiframeworkConverterTest:
                 "multilabel_classification",
                 {
                     "output_signature": {
-                        "image": tf.TensorSpec(shape=(None, None, None), dtype=tf.int32),
-                        "label": tf.TensorSpec(shape=(None,), dtype=tf.int32),
+                        "image": _tf_tensor_spec(shape=(None, None, None), dtype=_tf_int32()),
+                        "label": _tf_tensor_spec(shape=(None,), dtype=_tf_int32()),
                     }
                 },
             ),
@@ -621,9 +625,9 @@ class MultiframeworkConverterTest:
                 "detection",
                 {
                     "output_signature": {
-                        "image": tf.TensorSpec(shape=(None, None, None), dtype=tf.int32),
-                        "bbox": tf.TensorSpec(shape=(None, 4), dtype=tf.float32, name="points"),
-                        "category_id": tf.TensorSpec(shape=(None,), dtype=tf.int32, name="label"),
+                        "image": _tf_tensor_spec(shape=(None, None, None), dtype=_tf_int32()),
+                        "bbox": _tf_tensor_spec(shape=(None, 4), dtype=_tf_float32(), name="points"),
+                        "category_id": _tf_tensor_spec(shape=(None,), dtype=_tf_int32(), name="label"),
                     }
                 },
             ),
@@ -632,11 +636,11 @@ class MultiframeworkConverterTest:
                 "instance_segmentation",
                 {
                     "output_signature": {
-                        "image": tf.TensorSpec(shape=(None, None, None), dtype=tf.int32),
-                        "polygon": tf.TensorSpec(
-                            shape=(None, None), dtype=tf.float32, name="points"
+                        "image": _tf_tensor_spec(shape=(None, None, None), dtype=_tf_int32()),
+                        "polygon": _tf_tensor_spec(
+                            shape=(None, None), dtype=_tf_float32(), name="points"
                         ),
-                        "category_id": tf.TensorSpec(shape=(None,), dtype=tf.int32, name="label"),
+                        "category_id": _tf_tensor_spec(shape=(None,), dtype=_tf_int32(), name="label"),
                     }
                 },
             ),
@@ -645,8 +649,8 @@ class MultiframeworkConverterTest:
                 "semantic_segmentation",
                 {
                     "output_signature": {
-                        "image": tf.TensorSpec(shape=(None, None, None), dtype=tf.int32),
-                        "label": tf.TensorSpec(shape=(None, None), dtype=tf.int32),
+                        "image": _tf_tensor_spec(shape=(None, None, None), dtype=_tf_int32()),
+                        "label": _tf_tensor_spec(shape=(None, None), dtype=_tf_int32()),
                     }
                 },
             ),
@@ -721,17 +725,17 @@ class MultiframeworkConverterTest:
                 "train",
                 "classification",
                 {
-                    "image": tf.TensorSpec(shape=(None, None, None), dtype=tf.int32),
-                    "label": tf.TensorSpec(shape=(), dtype=tf.int32),
+                    "image": _tf_tensor_spec(shape=(None, None, None), dtype=_tf_int32()),
+                    "label": _tf_tensor_spec(shape=(), dtype=_tf_int32()),
                 },
             ),
             (
                 "val",
                 "detection",
                 {
-                    "image": tf.TensorSpec(shape=(None, None, None), dtype=tf.int32),
-                    "bbox": tf.TensorSpec(shape=(None, 4), dtype=tf.float32, name="points"),
-                    "category_id": tf.TensorSpec(shape=(None,), dtype=tf.int32, name="label"),
+                    "image": _tf_tensor_spec(shape=(None, None, None), dtype=_tf_int32()),
+                    "bbox": _tf_tensor_spec(shape=(None, 4), dtype=_tf_float32(), name="points"),
+                    "category_id": _tf_tensor_spec(shape=(None,), dtype=_tf_int32(), name="label"),
                 },
             ),
         ],
@@ -781,17 +785,17 @@ class MultiframeworkConverterTest:
                 "train",
                 "classification",
                 {
-                    "image": tf.TensorSpec(shape=(None, None, None), dtype=tf.int32),
-                    "label": tf.TensorSpec(shape=(), dtype=tf.int32),
+                    "image": _tf_tensor_spec(shape=(None, None, None), dtype=_tf_int32()),
+                    "label": _tf_tensor_spec(shape=(), dtype=_tf_int32()),
                 },
             ),
             (
                 "val",
                 "detection",
                 {
-                    "image": tf.TensorSpec(shape=(None, None, None), dtype=tf.int32),
-                    "bbox": tf.TensorSpec(shape=(None, 4), dtype=tf.float32, name="points"),
-                    "category_id": tf.TensorSpec(shape=(None,), dtype=tf.int32, name="label"),
+                    "image": _tf_tensor_spec(shape=(None, None, None), dtype=_tf_int32()),
+                    "bbox": _tf_tensor_spec(shape=(None, 4), dtype=_tf_float32(), name="points"),
+                    "category_id": _tf_tensor_spec(shape=(None,), dtype=_tf_int32(), name="label"),
                 },
             ),
         ],
@@ -907,16 +911,6 @@ class MultiframeworkConverterTest:
             ):
                 assert tf.reduce_all(tf_item[0] == dm_item["image"])
                 assert tf.reduce_all(tf_item[1] == dm_item["label"])
-
-    @pytest.mark.skipif(TORCH_AVAILABLE, reason="PyTorch is installed")
-    def test_torch_dataset_import(self):
-        with pytest.raises(ImportError):
-            from datumaro.plugins.framework_converter import DmTorchDataset
-
-    @pytest.mark.skipif(TF_AVAILABLE, reason="Tensorflow is installed")
-    def test_tf_dataset_import(self):
-        with pytest.raises(ImportError):
-            from datumaro.plugins.framework_converter import DmTfDataset
 
     @pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is not installed")
     def test_missing_tokenizer(self, fxt_tabular_label_dataset, fxt_text_example):

--- a/tests/unit/test_framework_converter.py
+++ b/tests/unit/test_framework_converter.py
@@ -252,8 +252,10 @@ def _tf_int32():
 def _tf_float32():
     return tf.float32 if TF_AVAILABLE else ""
 
+
 def _transforms_to_tensor():
     return transforms.ToTensor() if TORCH_AVAILABLE else ""
+
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
 class MultiframeworkConverterTest:
@@ -626,8 +628,12 @@ class MultiframeworkConverterTest:
                 {
                     "output_signature": {
                         "image": _tf_tensor_spec(shape=(None, None, None), dtype=_tf_int32()),
-                        "bbox": _tf_tensor_spec(shape=(None, 4), dtype=_tf_float32(), name="points"),
-                        "category_id": _tf_tensor_spec(shape=(None,), dtype=_tf_int32(), name="label"),
+                        "bbox": _tf_tensor_spec(
+                            shape=(None, 4), dtype=_tf_float32(), name="points"
+                        ),
+                        "category_id": _tf_tensor_spec(
+                            shape=(None,), dtype=_tf_int32(), name="label"
+                        ),
                     }
                 },
             ),
@@ -640,7 +646,9 @@ class MultiframeworkConverterTest:
                         "polygon": _tf_tensor_spec(
                             shape=(None, None), dtype=_tf_float32(), name="points"
                         ),
-                        "category_id": _tf_tensor_spec(shape=(None,), dtype=_tf_int32(), name="label"),
+                        "category_id": _tf_tensor_spec(
+                            shape=(None,), dtype=_tf_int32(), name="label"
+                        ),
                     }
                 },
             ),

--- a/tests/unit/test_video.py
+++ b/tests/unit/test_video.py
@@ -4,6 +4,7 @@
 
 import filecmp
 import os.path as osp
+import sys
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -266,6 +267,10 @@ class ProjectTest:
 
         assert not osp.exists(osp.join(project_dir, "src"))
 
+    @pytest.mark.xfail(
+        sys.platform == "win32",
+        reason="failing due to a file because it is being used by another process",
+    )
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     @scoped
     def test_can_release_resources_on_checkout(self, test_dir):

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands =
     rm {toxworkdir}/requirements.txt
 
 
-[testenv:tests-py{39,310,311,312}-{lin,win}]
+[testenv:tests-py{39,310,311,312,313}-{lin,win,mac}]
 commands =
     python -m pytest -v --csv={toxworkdir}/results-{envname}.csv {posargs:tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,9 @@ deps =
     -r{toxinidir}/tests/requirements.txt
 extras =
     default
-    tests-py{39,310,311,312}-{lin,win,mac}: tf
-    tests-py{39,310,311,312}-{lin,win,mac}: tfds
+    # Exclude Tensorflow from Python 3.13 as it is not supported yet
+    tests-py{39,310,311}-{lin,win,mac}: tf
+    tests-py{39,310,311}-{lin,win,mac}: tfds
     torch
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ deps =
     -r{toxinidir}/tests/requirements.txt
 extras =
     default
-    tf
-    tfds
+    tests-py{39,310,311,312}-{lin,win,mac}: tf
+    tests-py{39,310,311,312}-{lin,win,mac}: tfds
     torch
 
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This PR adds support for Python 3.13 and MacOS. No changes to Datumaro itself but I had to disable the tensorflow tests for Python 3.13 since Tensorflow doesn’t suport 3.13 yet.

In theory, the tests already had support for running without Tensorflow and PyTorch; however, in practice, I found a few issues especially with parameterised test. So I have addressed those issues.

I have disabled the test test_can_release_resources_on_checkout on Windows because it is failing with Python 3.13 and the tested feature is already deprecated.

Resolves #1755

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
