### PR TITLE
Implement conversion to the experimental Dataset format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 - Experimental dataset class
-  (<https://github.com/open-edge-platform/datumaro/pull/1807>)
+  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>)
 
 ## Q3 2025 Release 1.11.1
 

--- a/src/datumaro/components/dataset_storage.py
+++ b/src/datumaro/components/dataset_storage.py
@@ -434,6 +434,7 @@ class DatasetStorage(IDataset):
         return self._media_type
 
     def ann_types(self) -> Set[AnnotationType]:
+        self.init_cache()
         return self._ann_types
 
     def put(self, item: DatasetItem) -> None:

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -198,6 +198,22 @@ class Dataset(Generic[DType]):
         for i in range(len(self)):
             yield self[i]
 
+    def __delitem__(self, row_idx: int):
+        """
+        Delete a sample from the dataset at the specified index.
+
+        Args:
+            row_idx: The index of the sample to delete
+
+        Raises:
+            IndexError: If the row index is out of bounds
+        """
+        if row_idx < 0 or row_idx >= len(self.df):
+            raise IndexError("Row index out of bounds.")
+
+        # Create a filter to exclude the row at the specified index
+        self.df = self.df.with_row_index().filter(pl.col("index") != row_idx).drop("index")
+
     def __setitem__(self, row_idx: int, sample: DType):
         """
         Update the dataset at the specified index with the given sample.

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -179,6 +179,25 @@ class Dataset(Generic[DType]):
 
         return self._dtype(**attributes)
 
+    def __len__(self) -> int:
+        """
+        Return the number of samples in the dataset.
+
+        Returns:
+            The number of samples (rows) in the dataset
+        """
+        return len(self.df)
+
+    def __iter__(self):
+        """
+        Return an iterator over the samples in the dataset.
+
+        Yields:
+            Sample instances from the dataset in order
+        """
+        for i in range(len(self)):
+            yield self[i]
+
     def __setitem__(self, row_idx: int, sample: DType):
         """
         Update the dataset at the specified index with the given sample.

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -1,0 +1,268 @@
+# Copyright (C) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+"""
+Legacy dataset conversion functionality.
+
+This module provides functionality to convert legacy Datumaro datasets to the new
+experimental dataset format with automatic schema inference and type conversion.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Type, cast
+
+import numpy as np
+import polars as pl
+
+from datumaro.components.annotation import Annotation, AnnotationType, Bbox
+from datumaro.components.dataset import Dataset as LegacyDataset
+from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
+from datumaro.components.media import FromFileMixin, Image, MediaElement
+
+from .dataset import Dataset, Sample
+from .fields import bbox_field, image_path_field, tensor_field
+from .schema import AttributeInfo, Schema
+
+
+class MediaConverter(ABC):
+    """Base class for media type converters."""
+
+    @abstractmethod
+    def get_schema_attributes(self) -> dict[str, AttributeInfo]:
+        """Return schema attributes for this media type."""
+        pass
+
+    @abstractmethod
+    def convert_item_media(self, item: DatasetItem) -> dict[str, Any]:
+        """Convert media from a DatasetItem to experimental format."""
+        pass
+
+
+class AnnotationConverter(ABC):
+    """Base class for annotation type converters."""
+
+    @abstractmethod
+    def get_schema_attributes(self, categories: CategoriesInfo) -> dict[str, AttributeInfo]:
+        """Return schema attributes for this annotation type."""
+        pass
+
+    @abstractmethod
+    def convert_annotations(
+        self, annotations: list[Annotation], item: DatasetItem
+    ) -> dict[str, Any]:
+        """Convert annotations of this type to experimental format."""
+        pass
+
+
+# Global registries
+_media_converters: dict[Type[MediaElement[Any]], MediaConverter] = {}
+_annotation_converters: dict[AnnotationType, AnnotationConverter] = {}
+
+
+def register_media_converter(
+    media_type: Type[MediaElement[Any]], converter: MediaConverter
+) -> None:
+    """Register a converter for a media type."""
+    _media_converters[media_type] = converter
+
+
+def register_annotation_converter(
+    annotation_type: AnnotationType, converter: AnnotationConverter
+) -> None:
+    """Register a converter for an annotation type."""
+    _annotation_converters[annotation_type] = converter
+
+
+def get_media_converter(media_type: Type[MediaElement[Any]]) -> MediaConverter:
+    """Get converter for a media type."""
+    for registered_type, converter in _media_converters.items():
+        if issubclass(media_type, registered_type):
+            return converter
+    raise ValueError(f"No converter registered for media type: {media_type}")
+
+
+def get_annotation_converter(annotation_type: AnnotationType) -> AnnotationConverter:
+    """Get converter for an annotation type."""
+    if annotation_type not in _annotation_converters:
+        raise ValueError(f"No converter registered for annotation type: {annotation_type}")
+    return _annotation_converters[annotation_type]
+
+
+class ImageMediaConverter(MediaConverter):
+    """Converter for Image media type."""
+
+    def get_schema_attributes(self) -> dict[str, AttributeInfo]:
+        return {"image_path": AttributeInfo(type=str, annotation=image_path_field())}
+
+    def convert_item_media(self, item: DatasetItem) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+
+        if isinstance(item.media, Image):  # pyright: ignore[reportUnknownMemberType]
+            if isinstance(item.media, FromFileMixin):
+                # Handle image path
+                result["image_path"] = item.media.path
+            else:
+                raise ValueError(f"Unsupported media type for Image: {type(item.media)}")
+
+        return result
+
+
+class BboxAnnotationConverter(AnnotationConverter):
+    """Converter for Bbox annotations."""
+
+    def get_schema_attributes(self, categories: CategoriesInfo) -> dict[str, AttributeInfo]:
+        return {
+            "bboxes": AttributeInfo(
+                type=np.ndarray, annotation=bbox_field(dtype=pl.Float32, format="x1y1x2y2")
+            ),
+            "bbox_labels": AttributeInfo(type=np.ndarray, annotation=tensor_field(dtype=pl.Int32)),
+        }
+
+    def convert_annotations(
+        self, annotations: list[Annotation], item: DatasetItem
+    ) -> dict[str, Any]:
+        bboxes: list[list[float]] = []
+        labels: list[int | None] = []
+
+        for ann in annotations:
+            if isinstance(ann, Bbox):
+                # Convert from x,y,w,h to x1,y1,x2,y2 format
+                bboxes.append([ann.x, ann.y, ann.x + ann.w, ann.y + ann.h])
+                labels.append(ann.label)
+
+        # Ensure proper shapes for empty arrays
+        bboxes_array = np.array(bboxes, dtype=np.float32)
+        if bboxes_array.shape == (0,):
+            bboxes_array = bboxes_array.reshape(0, 4)
+
+        return {"bboxes": bboxes_array, "bbox_labels": np.array(labels, dtype=np.int32)}
+
+
+def register_builtin_converters():
+    """Register built-in converters for common types."""
+
+    # Media converters
+    register_media_converter(Image, ImageMediaConverter())
+
+    # Annotation converters
+    register_annotation_converter(AnnotationType.bbox, BboxAnnotationConverter())
+
+
+from dataclasses import dataclass
+
+
+@dataclass
+class AnalysisResult:
+    """Result of legacy dataset analysis."""
+
+    schema: Schema
+    media_converter: MediaConverter | None
+    ann_converters: dict[AnnotationType, AnnotationConverter]
+
+
+def analyze_legacy_dataset(legacy_dataset: LegacyDataset) -> AnalysisResult:
+    """Analyze legacy dataset and generate schema using registered converters.
+
+    Args:
+        legacy_dataset: The legacy Datumaro dataset to analyze
+
+    Returns:
+        AnalysisResult containing the inferred schema and converters
+    """
+    categories = legacy_dataset.categories()
+    media_type = cast(
+        Type[MediaElement[Any]], legacy_dataset.media_type()
+    )  # pyright: ignore[reportUnknownMemberType]
+    ann_types = legacy_dataset.ann_types()
+
+    attributes: dict[str, AttributeInfo] = {}
+    media_converter: MediaConverter | None = None
+    ann_converters: dict[AnnotationType, AnnotationConverter] = {}
+
+    # Get media attributes from converter
+    try:
+        media_converter = get_media_converter(media_type)
+        attributes.update(media_converter.get_schema_attributes())
+    except ValueError:
+        # No converter for this media type - skip
+        media_converter = None
+
+    # Get annotation attributes from converters
+    for ann_type in ann_types:
+        try:
+            ann_converter = get_annotation_converter(ann_type)
+            ann_converters[ann_type] = ann_converter
+            attributes.update(ann_converter.get_schema_attributes(categories))
+        except ValueError:
+            # No converter for this annotation type - skip
+            continue
+
+    schema = Schema(attributes=attributes)
+    return AnalysisResult(
+        schema=schema, media_converter=media_converter, ann_converters=ann_converters
+    )
+
+
+def _convert_legacy_item(item: DatasetItem, analysis_result: AnalysisResult) -> dict[str, Any]:
+    """Convert item using converters from analysis result."""
+
+    attributes: dict[str, Any] = {}
+
+    # Convert media using the analyzed converter
+    if analysis_result.media_converter:
+        attributes.update(analysis_result.media_converter.convert_item_media(item))
+
+    # Group annotations by type
+    annotations_by_type: dict[AnnotationType, list[Annotation]] = {}
+    for ann in item.annotations:
+        ann_type = ann.type
+        if ann_type not in annotations_by_type:
+            annotations_by_type[ann_type] = []
+        annotations_by_type[ann_type].append(ann)
+
+    # Convert each annotation type using the analyzed converters
+    for ann_type, anns in annotations_by_type.items():
+        if ann_type in analysis_result.ann_converters:
+            ann_converter = analysis_result.ann_converters[ann_type]
+            attributes.update(ann_converter.convert_annotations(anns, item))
+
+    return attributes
+
+
+def convert_from_legacy(legacy_dataset: LegacyDataset) -> Dataset[Sample]:
+    """Convert legacy dataset to experimental format with automatic schema inference.
+
+    Args:
+        legacy_dataset: The legacy Datumaro dataset to convert
+
+    Returns:
+        A new experimental Dataset with inferred schema and converted data
+
+    Example:
+        >>> legacy_ds = Dataset.import_from("path/to/coco", "coco")
+        >>> experimental_ds = convert_from_legacy(legacy_ds)
+        >>> sample = experimental_ds[0]
+        >>> print(sample.image_path)
+        >>> print(sample.bboxes.shape)
+    """
+
+    # Step 1: Analyze dataset to infer schema
+    analysis_result = analyze_legacy_dataset(legacy_dataset)
+
+    # Step 2: Create experimental dataset with inferred schema
+    experimental_dataset = Dataset(analysis_result.schema)
+
+    # Step 3: Convert all items
+    for legacy_item in legacy_dataset:
+        # Convert legacy item to experimental sample
+        sample_data = _convert_legacy_item(legacy_item, analysis_result)
+
+        # Create sample and add to dataset
+        sample = Sample(**sample_data)
+        experimental_dataset.append(sample)
+
+    return experimental_dataset
+
+
+# Auto-register built-in converters when module is imported
+register_builtin_converters()

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -322,3 +322,110 @@ def test_dataset_lazy_converters_property():
     assert isinstance(lazy_converters, list)
     # Initially should be empty
     assert len(lazy_converters) == 0
+
+
+def test_dataset_len():
+    """Test __len__ method returns correct dataset size."""
+
+    class TestSample(Sample):
+        image: np.ndarray[Any, Any] = image_field(dtype=pl.UInt8, format="RGB")
+        bbox: np.ndarray[Any, Any] = bbox_field(dtype=pl.Float32, normalize=False)
+        image_info: ImageInfo = image_info_field()
+
+    dataset = Dataset(TestSample)
+
+    # Initially empty
+    assert len(dataset) == 0
+
+    # Add one sample
+    sample1 = TestSample(
+        image=np.array([[[255, 0, 0]], [[0, 255, 0]]], dtype=np.uint8),
+        bbox=np.array([[0.1, 0.2, 0.3, 0.4]], dtype=np.float32),
+        image_info=ImageInfo(width=1, height=2),
+    )
+    dataset.append(sample1)
+    assert len(dataset) == 1
+
+    # Add second sample
+    sample2 = TestSample(
+        image=np.array([[[0, 0, 255]], [[255, 255, 0]]], dtype=np.uint8),
+        bbox=np.array([[0.5, 0.6, 0.7, 0.8]], dtype=np.float32),
+        image_info=ImageInfo(width=1, height=2),
+    )
+    dataset.append(sample2)
+    assert len(dataset) == 2
+
+    # Add third sample
+    sample3 = TestSample(
+        image=np.array([[[128, 64, 192]], [[96, 160, 32]]], dtype=np.uint8),
+        bbox=np.array([[0.9, 0.8, 0.7, 0.6]], dtype=np.float32),
+        image_info=ImageInfo(width=1, height=2),
+    )
+    dataset.append(sample3)
+    assert len(dataset) == 3
+
+    # Verify len() returns the same as len(dataset.df)
+    assert len(dataset) == len(dataset.df)
+
+
+def test_dataset_iter():
+    """Test __iter__ method allows iteration over dataset samples."""
+
+    class TestSample(Sample):
+        image: np.ndarray[Any, Any] = image_field(dtype=pl.UInt8, format="RGB")
+        bbox: np.ndarray[Any, Any] = bbox_field(dtype=pl.Float32, normalize=False)
+        image_info: ImageInfo = image_info_field()
+
+    dataset = Dataset(TestSample)
+
+    # Create sample data for testing
+    samples = [
+        TestSample(
+            image=np.array([[[255, 0, 0]], [[0, 255, 0]]], dtype=np.uint8),
+            bbox=np.array([[0.1, 0.2, 0.3, 0.4]], dtype=np.float32),
+            image_info=ImageInfo(width=1, height=2),
+        ),
+        TestSample(
+            image=np.array([[[0, 0, 255]], [[255, 255, 0]]], dtype=np.uint8),
+            bbox=np.array([[0.5, 0.6, 0.7, 0.8]], dtype=np.float32),
+            image_info=ImageInfo(width=2, height=3),
+        ),
+        TestSample(
+            image=np.array([[[128, 64, 192]], [[96, 160, 32]]], dtype=np.uint8),
+            bbox=np.array([[0.9, 0.8, 0.7, 0.6]], dtype=np.float32),
+            image_info=ImageInfo(width=3, height=4),
+        ),
+    ]
+
+    # Add samples to dataset
+    for sample in samples:
+        dataset.append(sample)
+
+    # Test iteration with for loop
+    iterated_samples: list[TestSample] = []
+    for sample in dataset:
+        iterated_samples.append(sample)
+
+    # Verify we got all samples
+    assert len(iterated_samples) == len(samples)
+
+    # Verify each sample matches what we expect
+    for original, iterated in zip(samples, iterated_samples):
+        assert isinstance(iterated, TestSample)
+        np.testing.assert_array_equal(iterated.bbox, original.bbox)
+        assert iterated.image_info.width == original.image_info.width
+        assert iterated.image_info.height == original.image_info.height
+
+    # Test iteration with list comprehension
+    list_samples = [sample for sample in dataset]
+    assert len(list_samples) == 3
+
+    # Test iteration is consistent (calling iterator multiple times)
+    first_iteration = list(dataset)
+    second_iteration = list(dataset)
+    assert len(first_iteration) == len(second_iteration)
+
+    # Test empty dataset iteration
+    empty_dataset = Dataset(TestSample)
+    empty_list = list(empty_dataset)
+    assert len(empty_list) == 0

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import numpy as np
 import polars as pl
+import pytest
 
 from datumaro.experimental.dataset import (
     AttributeInfo,
@@ -355,17 +356,10 @@ def test_dataset_len():
     dataset.append(sample2)
     assert len(dataset) == 2
 
-    # Add third sample
-    sample3 = TestSample(
-        image=np.array([[[128, 64, 192]], [[96, 160, 32]]], dtype=np.uint8),
-        bbox=np.array([[0.9, 0.8, 0.7, 0.6]], dtype=np.float32),
-        image_info=ImageInfo(width=1, height=2),
-    )
-    dataset.append(sample3)
-    assert len(dataset) == 3
+    # Remove a sample
+    del dataset[0]
 
-    # Verify len() returns the same as len(dataset.df)
-    assert len(dataset) == len(dataset.df)
+    assert len(dataset) == 1
 
 
 def test_dataset_iter():
@@ -429,3 +423,80 @@ def test_dataset_iter():
     empty_dataset = Dataset(TestSample)
     empty_list = list(empty_dataset)
     assert len(empty_list) == 0
+
+
+def test_dataset_delitem():
+    """Test __delitem__ method allows deletion of dataset samples."""
+
+    class TestSample(Sample):
+        image: np.ndarray[Any, Any] = image_field(dtype=pl.UInt8, format="RGB")
+        bbox: np.ndarray[Any, Any] = bbox_field(dtype=pl.Float32, normalize=False)
+        image_info: ImageInfo = image_info_field()
+
+    dataset = Dataset(TestSample)
+
+    # Create and add sample data
+    samples = [
+        TestSample(
+            image=np.array([[[255, 0, 0]], [[0, 255, 0]]], dtype=np.uint8),
+            bbox=np.array([[0.1, 0.2, 0.3, 0.4]], dtype=np.float32),
+            image_info=ImageInfo(width=1, height=2),
+        ),
+        TestSample(
+            image=np.array([[[0, 0, 255]], [[255, 255, 0]]], dtype=np.uint8),
+            bbox=np.array([[0.5, 0.6, 0.7, 0.8]], dtype=np.float32),
+            image_info=ImageInfo(width=2, height=3),
+        ),
+        TestSample(
+            image=np.array([[[128, 64, 192]], [[96, 160, 32]]], dtype=np.uint8),
+            bbox=np.array([[0.9, 0.8, 0.7, 0.6]], dtype=np.float32),
+            image_info=ImageInfo(width=3, height=4),
+        ),
+    ]
+
+    # Add samples to dataset
+    for sample in samples:
+        dataset.append(sample)
+
+    # Initially should have 3 samples
+    assert len(dataset) == 3
+
+    # Delete middle sample (index 1)
+    del dataset[1]
+    assert len(dataset) == 2
+
+    # Verify remaining samples are correct (original indices 0 and 2)
+    remaining_sample_0 = dataset[0]
+    remaining_sample_1 = dataset[1]  # This was originally index 2
+
+    np.testing.assert_array_equal(remaining_sample_0.bbox, samples[0].bbox)
+    np.testing.assert_array_equal(remaining_sample_1.bbox, samples[2].bbox)
+    assert remaining_sample_0.image_info.width == 1
+    assert remaining_sample_1.image_info.width == 3
+
+    # Delete first sample (index 0)
+    del dataset[0]
+    assert len(dataset) == 1
+
+    # Only the original third sample should remain
+    last_sample = dataset[0]
+    np.testing.assert_array_equal(last_sample.bbox, samples[2].bbox)
+    assert last_sample.image_info.width == 3
+
+    # Delete last sample
+    del dataset[0]
+    assert len(dataset) == 0
+
+    # Test deleting from empty dataset should raise IndexError
+    with pytest.raises(IndexError, match="Row index out of bounds"):
+        del dataset[0]
+
+    # Test deleting with out-of-bounds indices
+    dataset.append(samples[0])  # Add one sample back
+    assert len(dataset) == 1
+
+    with pytest.raises(IndexError, match="Row index out of bounds"):
+        del dataset[1]  # Index 1 is out of bounds
+
+    with pytest.raises(IndexError, match="Row index out of bounds"):
+        del dataset[-1]  # Negative indices not supported

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -266,7 +266,7 @@ def test_convert_simple_bbox_dataset():
 
         # Check attributes
         assert hasattr(sample, "image_path")
-        assert getattr(sample, "image_path") == image_path
+        assert Path(getattr(sample, "image_path")) == Path(image_path)
         assert hasattr(sample, "bboxes")
         assert hasattr(sample, "bbox_labels")
 
@@ -311,7 +311,7 @@ def test_convert_image_only_dataset():
 
         # Should have image attributes only
         assert hasattr(sample, "image_path")
-        assert getattr(sample, "image_path") == image_path
+        assert Path(getattr(sample, "image_path")) == Path(image_path)
         assert not hasattr(sample, "bboxes")
         assert not hasattr(sample, "bbox_labels")
 

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -1,0 +1,325 @@
+"""Unit tests for legacy dataset conversion functionality."""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from datumaro.components.annotation import AnnotationType, Bbox
+from datumaro.components.dataset import Dataset as LegacyDataset
+from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
+from datumaro.components.media import Image
+from datumaro.experimental.legacy import (
+    BboxAnnotationConverter,
+    ImageMediaConverter,
+    analyze_legacy_dataset,
+    convert_from_legacy,
+    get_annotation_converter,
+    get_media_converter,
+    register_annotation_converter,
+    register_media_converter,
+)
+
+
+def test_image_media_converter_get_schema_attributes():
+    """Test schema attribute generation for images."""
+    converter = ImageMediaConverter()
+    attributes = converter.get_schema_attributes()
+
+    assert "image_path" in attributes
+    assert attributes["image_path"].type == str
+
+
+def test_image_media_converter_convert_item_media_with_path_and_size():
+    """Test media conversion with path and size."""
+    converter = ImageMediaConverter()
+
+    image_media = Image.from_file(
+        "/path/to/image.jpg", size=(480, 640)
+    )  # pyright: ignore[reportUnknownMemberType]
+
+    item = DatasetItem(id="test", media=image_media)
+    result = converter.convert_item_media(item)
+
+    assert result["image_path"] == "/path/to/image.jpg"
+
+
+def test_image_media_converter_convert_item_media_with_path_only():
+    """Test media conversion with only path."""
+    converter = ImageMediaConverter()
+
+    image_media = Image.from_file("/path/to/image.jpg")  # pyright: ignore[reportUnknownMemberType]
+
+    item = DatasetItem(id="test", media=image_media)
+    result = converter.convert_item_media(item)
+
+    assert result["image_path"] == "/path/to/image.jpg"
+
+
+def test_image_media_converter_convert_item_media_no_media():
+    """Test media conversion with no media."""
+    converter = ImageMediaConverter()
+    item = DatasetItem(id="test", media=None)
+    result = converter.convert_item_media(item)
+
+    assert result == {}
+
+
+def test_bbox_annotation_converter_get_schema_attributes():
+    """Test schema attribute generation for bboxes."""
+    converter = BboxAnnotationConverter()
+    categories: CategoriesInfo = {}  # Empty categories
+
+    attributes = converter.get_schema_attributes(categories)
+
+    assert "bboxes" in attributes
+    assert "bbox_labels" in attributes
+    assert attributes["bboxes"].type == np.ndarray
+    assert attributes["bbox_labels"].type == np.ndarray
+
+
+def test_bbox_annotation_converter_convert_annotations_single_bbox():
+    """Test conversion of single bbox annotation."""
+    converter = BboxAnnotationConverter()
+
+    bbox = Bbox(10, 20, 30, 40, label=1)  # x=10, y=20, w=30, h=40
+    item = DatasetItem(id="test")
+
+    result = converter.convert_annotations([bbox], item)
+
+    expected_bbox = np.array([[10, 20, 40, 60]], dtype=np.float32)  # x1,y1,x2,y2 format
+    expected_labels = np.array([1], dtype=np.int32)
+
+    np.testing.assert_array_equal(result["bboxes"], expected_bbox)
+    np.testing.assert_array_equal(result["bbox_labels"], expected_labels)
+
+
+def test_bbox_annotation_converter_convert_annotations_multiple_bboxes():
+    """Test conversion of multiple bbox annotations."""
+    converter = BboxAnnotationConverter()
+
+    bbox1 = Bbox(10, 20, 30, 40, label=1)
+    bbox2 = Bbox(50, 60, 70, 80, label=2)
+    item = DatasetItem(id="test")
+
+    result = converter.convert_annotations([bbox1, bbox2], item)
+
+    expected_bboxes = np.array(
+        [
+            [10, 20, 40, 60],  # x1,y1,x2,y2 for first bbox
+            [50, 60, 120, 140],  # x1,y1,x2,y2 for second bbox
+        ],
+        dtype=np.float32,
+    )
+    expected_labels = np.array([1, 2], dtype=np.int32)
+
+    np.testing.assert_array_equal(result["bboxes"], expected_bboxes)
+    np.testing.assert_array_equal(result["bbox_labels"], expected_labels)
+
+
+def test_bbox_annotation_converter_convert_annotations_empty_list():
+    """Test conversion of empty annotation list."""
+    converter = BboxAnnotationConverter()
+    item = DatasetItem(id="test")
+
+    result = converter.convert_annotations([], item)
+
+    # Empty arrays with proper shapes
+    assert result["bboxes"].shape == (0, 4)
+    assert result["bboxes"].dtype == np.float32
+    assert result["bbox_labels"].shape == (0,)
+    assert result["bbox_labels"].dtype == np.int32
+
+
+# Converter registry tests
+
+
+def test_register_and_get_media_converter():
+    """Test media converter registration and retrieval."""
+    converter = ImageMediaConverter()
+    register_media_converter(Image, converter)
+
+    retrieved = get_media_converter(Image)
+    assert retrieved is converter
+
+
+def test_register_and_get_annotation_converter():
+    """Test annotation converter registration and retrieval."""
+    converter = BboxAnnotationConverter()
+    register_annotation_converter(AnnotationType.bbox, converter)
+
+    retrieved = get_annotation_converter(AnnotationType.bbox)
+    assert retrieved is converter
+
+
+def test_get_nonexistent_media_converter():
+    """Test getting converter for unregistered media type."""
+    from datumaro.components.media import Video
+
+    with pytest.raises(ValueError, match="No converter registered for media type"):
+        get_media_converter(Video)
+
+
+def test_get_nonexistent_annotation_converter():
+    """Test getting converter for unregistered annotation type."""
+    with pytest.raises(ValueError, match="No converter registered for annotation type"):
+        get_annotation_converter(AnnotationType.polygon)
+
+
+def test_analyze_image_and_bbox_dataset():
+    """Test analysis of dataset with images and bboxes."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        image_path = str(temp_path / "image1.jpg")
+        image_media = Image.from_file(
+            image_path, size=(480, 640)
+        )  # pyright: ignore[reportUnknownMemberType]
+        bbox = Bbox(10, 20, 30, 40, label=1)
+        item = DatasetItem(id="item1", media=image_media, annotations=[bbox])
+
+        dataset = LegacyDataset.from_iterable(
+            [item], ann_types={AnnotationType.bbox}
+        )  # pyright: ignore[reportUnknownMemberType]
+
+        analysis_result = analyze_legacy_dataset(dataset)
+
+        # Should have image and bbox attributes
+        assert "image_path" in analysis_result.schema.attributes
+        assert "bboxes" in analysis_result.schema.attributes
+        assert "bbox_labels" in analysis_result.schema.attributes
+
+
+def test_analyze_image_only_dataset():
+    """Test analysis of dataset with only images."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        image_path = str(temp_path / "image1.jpg")
+        image_media = Image.from_file(
+            image_path, size=(480, 640)
+        )  # pyright: ignore[reportUnknownMemberType]
+        item = DatasetItem(id="item1", media=image_media, annotations=[])
+
+        dataset = LegacyDataset.from_iterable([item])  # pyright: ignore[reportUnknownMemberType]
+
+        analysis_result = analyze_legacy_dataset(dataset)
+
+        # Should have only image attributes
+        assert "image_path" in analysis_result.schema.attributes
+        assert "bboxes" not in analysis_result.schema.attributes
+        assert "bbox_labels" not in analysis_result.schema.attributes
+
+
+def test_analyze_unknown_annotation_type():
+    """Test analysis with unknown annotation type."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Polygon annotation (not registered)
+        from datumaro.components.annotation import Polygon
+
+        image_path = str(temp_path / "image1.jpg")
+        image_media = Image.from_file(
+            image_path, size=(480, 640)
+        )  # pyright: ignore[reportUnknownMemberType]
+        polygon = Polygon([10, 20, 30, 40, 50, 60], label=1)
+        item = DatasetItem(id="item1", media=image_media, annotations=[polygon])
+
+        dataset = LegacyDataset.from_iterable(
+            [item], ann_types={AnnotationType.polygon}
+        )  # pyright: ignore[reportUnknownMemberType]
+
+        analysis_result = analyze_legacy_dataset(dataset)
+
+        # Should skip unknown annotation type
+        assert "image_path" in analysis_result.schema.attributes
+        assert len(analysis_result.schema.attributes) == 1  # Only image_path field
+
+
+def test_convert_simple_bbox_dataset():
+    """Test conversion of a simple dataset with bboxes."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        image_path = str(temp_path / "image1.jpg")
+        image_media = Image.from_file(
+            image_path, size=(480, 640)
+        )  # pyright: ignore[reportUnknownMemberType]
+
+        bbox1 = Bbox(10, 20, 30, 40, label=1)
+        bbox2 = Bbox(50, 60, 70, 80, label=2)
+
+        item1 = DatasetItem(id="item1", media=image_media, annotations=[bbox1, bbox2])
+
+        dataset = LegacyDataset.from_iterable(
+            [item1], ann_types={AnnotationType.bbox}
+        )  # pyright: ignore[reportUnknownMemberType]
+
+        # Convert dataset
+        experimental_ds = convert_from_legacy(dataset)
+
+        assert len(experimental_ds.df) == 1
+
+        sample = experimental_ds[0]
+
+        # Check attributes
+        assert hasattr(sample, "image_path")
+        assert getattr(sample, "image_path") == image_path
+        assert hasattr(sample, "bboxes")
+        assert hasattr(sample, "bbox_labels")
+
+        expected_bboxes = np.array(
+            [
+                [10, 20, 40, 60],  # First bbox in x1,y1,x2,y2 format
+                [50, 60, 120, 140],  # Second bbox in x1,y1,x2,y2 format
+            ],
+            dtype=np.float32,
+        )
+        expected_labels = np.array([1, 2], dtype=np.int32)
+
+        np.testing.assert_array_equal(getattr(sample, "bboxes"), expected_bboxes)
+        np.testing.assert_array_equal(getattr(sample, "bbox_labels"), expected_labels)
+
+
+def test_convert_empty_dataset():
+    """Test conversion of empty dataset."""
+    dataset = LegacyDataset.from_iterable([])  # pyright: ignore[reportUnknownMemberType]
+
+    experimental_ds = convert_from_legacy(dataset)
+    assert len(experimental_ds.df) == 0
+
+
+def test_convert_image_only_dataset():
+    """Test conversion of dataset with only images, no annotations."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        image_path = str(temp_path / "image1.jpg")
+        image_media = Image.from_file(
+            image_path, size=(480, 640)
+        )  # pyright: ignore[reportUnknownMemberType]
+        item = DatasetItem(id="item1", media=image_media, annotations=[])
+
+        dataset = LegacyDataset.from_iterable([item])  # pyright: ignore[reportUnknownMemberType]
+
+        experimental_ds = convert_from_legacy(dataset)
+
+        assert len(experimental_ds.df) == 1
+        sample = experimental_ds[0]
+
+        # Should have image attributes only
+        assert hasattr(sample, "image_path")
+        assert getattr(sample, "image_path") == image_path
+        assert not hasattr(sample, "bboxes")
+        assert not hasattr(sample, "bbox_labels")
+
+
+def test_builtin_converters_registration():
+    """Test that built-in converters are registered on import."""
+    image_converter = get_media_converter(Image)
+    assert isinstance(image_converter, ImageMediaConverter)
+
+    bbox_converter = get_annotation_converter(AnnotationType.bbox)
+    assert isinstance(bbox_converter, BboxAnnotationConverter)

--- a/tests/unit/experimental/test_legacy_integration.py
+++ b/tests/unit/experimental/test_legacy_integration.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import os.path as osp
+import tempfile
+
+import numpy as np
+import pytest
+
+from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
+from datumaro.components.dataset import Dataset as LegacyDataset
+from datumaro.components.dataset_base import DatasetItem
+from datumaro.components.media import Image
+from datumaro.experimental.dataset import Dataset as ExperimentalDataset
+from datumaro.experimental.legacy import convert_from_legacy
+
+
+@pytest.fixture()
+def fxt_dataset() -> LegacyDataset:
+    h = w = 8
+    n_labels = 5
+    n_items = 5
+
+    return LegacyDataset.from_iterable(  # pyright: ignore[reportUnknownMemberType]
+        [
+            DatasetItem(
+                id=f"img_{item_id}",
+                subset=subset,
+                media=Image.from_numpy(  # pyright: ignore[reportUnknownMemberType]
+                    data=np.random.randint(0, 255, size=(h, w, 3), dtype=np.uint8), ext=".png"
+                ),
+                annotations=[
+                    Bbox(
+                        *np.random.randint(0, h, size=(4,)).tolist(),
+                        id=item_id,
+                        label=np.random.randint(0, n_labels),
+                        group=item_id,
+                        z_order=0,
+                        attributes={},
+                    )
+                ],
+            )
+            for subset in ["Test", "Train", "Validation"]
+            for item_id in range(n_items)
+        ],
+        categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                [f"label_{idx}" for idx in range(n_labels)]
+            )
+        },
+    )
+
+
+@pytest.mark.parametrize("input_format", ["coco", "yolo", "datumaro"], ids=lambda x: f"[if:{x}]")
+def test_object_detection(
+    fxt_dataset: LegacyDataset,
+    input_format: str,
+):
+    """Test converting legacy datasets from various formats to experimental format."""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Step 1: Export the fixture dataset to the specified format
+        src_dir = osp.join(temp_dir, "src")
+        fxt_dataset.export(
+            src_dir, format=input_format, save_media=True
+        )  # pyright: ignore[reportUnknownMemberType]
+
+        # Step 2: Import it back as a legacy dataset
+        legacy_dataset = LegacyDataset.import_from(
+            src_dir, format=input_format
+        )  # pyright: ignore[reportUnknownMemberType]
+
+        # Step 3: Convert to experimental format
+        experimental_dataset = convert_from_legacy(legacy_dataset)
+
+        # Step 4: Verify the conversion
+        assert isinstance(experimental_dataset, ExperimentalDataset)
+        assert len(experimental_dataset) == len(legacy_dataset)
+
+        # Verify schema attributes exist
+        schema = experimental_dataset.schema
+        assert "bboxes" in schema.attributes
+        assert "image_path" in schema.attributes
+        assert "bboxes" in schema.attributes
+        assert "bbox_labels" in schema.attributes
+
+        # Verify data conversion for first few samples
+        for legacy_item, experimental_sample in zip(legacy_dataset, experimental_dataset):
+            # Check image path is preserved
+            assert (
+                getattr(experimental_sample, "image_path") == legacy_item.media.path
+            )  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue, reportOptionalMemberAccess]
+
+            # Check bbox data
+            assert hasattr(experimental_sample, "bboxes")
+            assert hasattr(experimental_sample, "bbox_labels")
+
+            # Get bbox annotations from legacy item
+            bbox_anns = [ann for ann in legacy_item.annotations if isinstance(ann, Bbox)]
+            assert bbox_anns
+
+            # Verify bbox array shape and values
+            bboxes = getattr(experimental_sample, "bboxes")
+            labels = getattr(experimental_sample, "bbox_labels")
+
+            assert bboxes.shape[0] == len(bbox_anns)
+            assert bboxes.shape[1] == 4  # x1, y1, x2, y2
+            assert labels.shape[0] == len(bbox_anns)
+
+            # Verify first bbox conversion (x,y,w,h -> x1,y1,x2,y2)
+            first_bbox = bbox_anns[0]
+            expected_x1y1x2y2 = [
+                first_bbox.x,
+                first_bbox.y,
+                first_bbox.x + first_bbox.w,
+                first_bbox.y + first_bbox.h,
+            ]
+            np.testing.assert_array_almost_equal(bboxes[0], expected_x1y1x2y2)
+            assert labels[0] == first_bbox.label


### PR DESCRIPTION
### Summary

This PR implements the conversion from the legacy to the experimental Dataset class. I will implement the conversion back to the legacy class in a separate PR.

Misc fixes:
* Also implements `__len__`, `__delitem__` and `__iter__` in the Dataset class.
* Fix bug when fetching ann_types() before the cache is initialised.

The conversion works in two steps: the first step analyse the existing dataset and generate the schema for the new dataset. The second step actually converts the data.

I have defined MediaConverter and AnnotationConverter base class which can be extended to support new media/annotation types. This PR implements the conversion logic but the conversion for specific media/annotation type will be implemented later. 

Part of #1789

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
