### PR TITLE
Add conversion back from the experimental to the legacy dataset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 - Experimental dataset class
-  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>)
+  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>)
 
 ## Q3 2025 Release 1.11.1
 

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -20,12 +20,19 @@ from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
 from datumaro.components.media import FromFileMixin, Image, MediaElement
 
 from .dataset import Dataset, Sample
-from .fields import bbox_field, image_path_field, tensor_field
+from .fields import (
+    BBoxField,
+    ImagePathField,
+    TensorField,
+    bbox_field,
+    image_path_field,
+    tensor_field,
+)
 from .schema import AttributeInfo, Schema
 
 
-class MediaConverter(ABC):
-    """Base class for media type converters."""
+class ForwardMediaConverter(ABC):
+    """Base class for forward media type converters."""
 
     @abstractmethod
     def get_schema_attributes(self) -> dict[str, AttributeInfo]:
@@ -38,8 +45,8 @@ class MediaConverter(ABC):
         pass
 
 
-class AnnotationConverter(ABC):
-    """Base class for annotation type converters."""
+class ForwardAnnotationConverter(ABC):
+    """Base class for forward annotation type converters."""
 
     @abstractmethod
     def get_schema_attributes(self, categories: CategoriesInfo) -> dict[str, AttributeInfo]:
@@ -55,41 +62,41 @@ class AnnotationConverter(ABC):
 
 
 # Global registries
-_media_converters: dict[Type[MediaElement[Any]], MediaConverter] = {}
-_annotation_converters: dict[AnnotationType, AnnotationConverter] = {}
+_media_converters: dict[Type[MediaElement[Any]], ForwardMediaConverter] = {}
+_annotation_converters: dict[AnnotationType, ForwardAnnotationConverter] = {}
 
 
-def register_media_converter(
-    media_type: Type[MediaElement[Any]], converter: MediaConverter
+def register_forward_media_converter(
+    media_type: Type[MediaElement[Any]], converter: ForwardMediaConverter
 ) -> None:
-    """Register a converter for a media type."""
+    """Register a forward converter for a media type."""
     _media_converters[media_type] = converter
 
 
-def register_annotation_converter(
-    annotation_type: AnnotationType, converter: AnnotationConverter
+def register_forward_annotation_converter(
+    annotation_type: AnnotationType, converter: ForwardAnnotationConverter
 ) -> None:
-    """Register a converter for an annotation type."""
+    """Register a forward converter for an annotation type."""
     _annotation_converters[annotation_type] = converter
 
 
-def get_media_converter(media_type: Type[MediaElement[Any]]) -> MediaConverter:
-    """Get converter for a media type."""
+def get_forward_media_converter(media_type: Type[MediaElement[Any]]) -> ForwardMediaConverter:
+    """Get forward converter for a media type."""
     for registered_type, converter in _media_converters.items():
         if issubclass(media_type, registered_type):
             return converter
     raise ValueError(f"No converter registered for media type: {media_type}")
 
 
-def get_annotation_converter(annotation_type: AnnotationType) -> AnnotationConverter:
-    """Get converter for an annotation type."""
+def get_forward_annotation_converter(annotation_type: AnnotationType) -> ForwardAnnotationConverter:
+    """Get forward converter for an annotation type."""
     if annotation_type not in _annotation_converters:
         raise ValueError(f"No converter registered for annotation type: {annotation_type}")
     return _annotation_converters[annotation_type]
 
 
-class ImageMediaConverter(MediaConverter):
-    """Converter for Image media type."""
+class ForwardImageMediaConverter(ForwardMediaConverter):
+    """Forward converter for Image media type."""
 
     def get_schema_attributes(self) -> dict[str, AttributeInfo]:
         return {"image_path": AttributeInfo(type=str, annotation=image_path_field())}
@@ -107,8 +114,8 @@ class ImageMediaConverter(MediaConverter):
         return result
 
 
-class BboxAnnotationConverter(AnnotationConverter):
-    """Converter for Bbox annotations."""
+class ForwardBboxAnnotationConverter(ForwardAnnotationConverter):
+    """Forward converter for Bbox annotations."""
 
     def get_schema_attributes(self, categories: CategoriesInfo) -> dict[str, AttributeInfo]:
         return {
@@ -138,14 +145,14 @@ class BboxAnnotationConverter(AnnotationConverter):
         return {"bboxes": bboxes_array, "bbox_labels": np.array(labels, dtype=np.int32)}
 
 
-def register_builtin_converters():
-    """Register built-in converters for common types."""
+def register_builtin_forward_converters():
+    """Register built-in forward converters for common types."""
 
     # Media converters
-    register_media_converter(Image, ImageMediaConverter())
+    register_forward_media_converter(Image, ForwardImageMediaConverter())
 
     # Annotation converters
-    register_annotation_converter(AnnotationType.bbox, BboxAnnotationConverter())
+    register_forward_annotation_converter(AnnotationType.bbox, ForwardBboxAnnotationConverter())
 
 
 from dataclasses import dataclass
@@ -156,8 +163,8 @@ class AnalysisResult:
     """Result of legacy dataset analysis."""
 
     schema: Schema
-    media_converter: MediaConverter | None
-    ann_converters: dict[AnnotationType, AnnotationConverter]
+    media_converter: ForwardMediaConverter | None
+    ann_converters: dict[AnnotationType, ForwardAnnotationConverter]
 
 
 def analyze_legacy_dataset(legacy_dataset: LegacyDataset) -> AnalysisResult:
@@ -176,12 +183,12 @@ def analyze_legacy_dataset(legacy_dataset: LegacyDataset) -> AnalysisResult:
     ann_types = legacy_dataset.ann_types()
 
     attributes: dict[str, AttributeInfo] = {}
-    media_converter: MediaConverter | None = None
-    ann_converters: dict[AnnotationType, AnnotationConverter] = {}
+    media_converter: ForwardMediaConverter | None = None
+    ann_converters: dict[AnnotationType, ForwardAnnotationConverter] = {}
 
     # Get media attributes from converter
     try:
-        media_converter = get_media_converter(media_type)
+        media_converter = get_forward_media_converter(media_type)
         attributes.update(media_converter.get_schema_attributes())
     except ValueError:
         # No converter for this media type - skip
@@ -190,7 +197,7 @@ def analyze_legacy_dataset(legacy_dataset: LegacyDataset) -> AnalysisResult:
     # Get annotation attributes from converters
     for ann_type in ann_types:
         try:
-            ann_converter = get_annotation_converter(ann_type)
+            ann_converter = get_forward_annotation_converter(ann_type)
             ann_converters[ann_type] = ann_converter
             attributes.update(ann_converter.get_schema_attributes(categories))
         except ValueError:
@@ -264,5 +271,302 @@ def convert_from_legacy(legacy_dataset: LegacyDataset) -> Dataset[Sample]:
     return experimental_dataset
 
 
+class BackwardMediaConverter(ABC):
+    """Base class for backward media type converters."""
+
+    @classmethod
+    @abstractmethod
+    def create_from_schema(cls, schema: Schema) -> "BackwardMediaConverter | None":
+        """Create converter instance if schema is supported, None otherwise."""
+        pass
+
+    @abstractmethod
+    def get_media_type(self) -> Type[MediaElement[Any]]:
+        """Get the legacy media type this converter produces."""
+        pass
+
+    @abstractmethod
+    def convert_to_legacy_media(self, sample: Sample) -> MediaElement[Any]:
+        """Convert experimental sample media to legacy MediaElement."""
+        pass
+
+
+class BackwardAnnotationConverter(ABC):
+    """Base class for backward annotation type converters."""
+
+    @classmethod
+    @abstractmethod
+    def create_from_schema(cls, schema: Schema) -> "BackwardAnnotationConverter | None":
+        """Create converter instance if schema is supported, None otherwise."""
+        pass
+
+    @abstractmethod
+    def get_annotation_type(self) -> AnnotationType:
+        """Get the legacy annotation type this converter produces."""
+        pass
+
+    @abstractmethod
+    def infer_categories(self, experimental_dataset: Dataset[Sample]) -> CategoriesInfo:
+        """Infer legacy categories from experimental dataset."""
+        pass
+
+    @abstractmethod
+    def convert_to_legacy_annotations(
+        self, sample: Sample, categories: CategoriesInfo
+    ) -> list[Annotation]:
+        """Convert experimental sample annotations to legacy format."""
+        pass
+
+
+# Global registries for backward converters
+_backward_media_converter_classes: list[Type[BackwardMediaConverter]] = []
+_backward_annotation_converter_classes: list[Type[BackwardAnnotationConverter]] = []
+
+
+def register_backward_media_converter(converter_class: Type[BackwardMediaConverter]) -> None:
+    """Register a backward converter class for a media type."""
+    _backward_media_converter_classes.append(converter_class)
+
+
+def register_backward_annotation_converter(
+    converter_class: Type[BackwardAnnotationConverter],
+) -> None:
+    """Register a backward converter class for an annotation type."""
+    _backward_annotation_converter_classes.append(converter_class)
+
+
+class BackwardImageMediaConverter(BackwardMediaConverter):
+    """Backward converter for Image media type."""
+
+    def __init__(self, image_path_attr: str):
+        """Initialize with the name of the image path attribute."""
+        self.image_path_attr = image_path_attr
+
+    @classmethod
+    def create_from_schema(cls, schema: Schema) -> "BackwardImageMediaConverter | None":
+        """Create converter instance if schema contains image_path field."""
+        for attr_name, attr_info in schema.attributes.items():
+            if isinstance(attr_info.annotation, ImagePathField):
+                return cls(image_path_attr=attr_name)
+        return None
+
+    def get_media_type(self) -> Type[MediaElement[Any]]:
+        return Image
+
+    def convert_to_legacy_media(self, sample: Sample) -> MediaElement[Any]:
+        """Convert image_path back to Image MediaElement."""
+        image_path = getattr(sample, self.image_path_attr)
+        return Image.from_file(path=image_path)  # pyright: ignore[reportUnknownMemberType]
+
+
+class BackwardBboxAnnotationConverter(BackwardAnnotationConverter):
+    """Backward converter for Bbox annotations."""
+
+    def __init__(self, bboxes_attr: str, bbox_labels_attr: str):
+        """Initialize with the names of the bbox-related attributes."""
+        self.bboxes_attr = bboxes_attr
+        self.bbox_labels_attr = bbox_labels_attr
+
+    @classmethod
+    def create_from_schema(cls, schema: Schema) -> "BackwardBboxAnnotationConverter | None":
+        """Create converter instance if schema contains bbox-related fields."""
+        bboxes_attr = None
+        bbox_labels_attr = None
+
+        # Find bbox field
+        for attr_name, attr_info in schema.attributes.items():
+            if isinstance(attr_info.annotation, BBoxField):
+                bboxes_attr = attr_name
+                break
+
+        # Find bbox_labels field (look for tensor field with 'bbox_labels' in name or similar pattern)
+        for attr_name, attr_info in schema.attributes.items():
+            if isinstance(attr_info.annotation, TensorField) and (
+                "bbox_label" in attr_name.lower() or "label" in attr_name.lower()
+            ):
+                bbox_labels_attr = attr_name
+                break
+
+        if bboxes_attr and bbox_labels_attr:
+            return cls(bboxes_attr=bboxes_attr, bbox_labels_attr=bbox_labels_attr)
+        return None
+
+    def get_annotation_type(self) -> AnnotationType:
+        return AnnotationType.bbox
+
+    def convert_to_legacy_annotations(
+        self, sample: Sample, categories: CategoriesInfo
+    ) -> list[Annotation]:
+        """Convert bboxes and bbox_labels back to legacy Bbox annotations."""
+        bboxes = getattr(sample, self.bboxes_attr, None)
+        bbox_labels = getattr(sample, self.bbox_labels_attr, None)
+
+        if bboxes is None or bbox_labels is None:
+            return []
+
+        annotations: list[Annotation] = []
+        for i in range(len(bboxes)):
+            # Convert from x1,y1,x2,y2 back to x,y,w,h format
+            x1, y1, x2, y2 = bboxes[i]
+            x, y, w, h = x1, y1, x2 - x1, y2 - y1
+
+            label_id = int(bbox_labels[i]) if bbox_labels[i] is not None else None
+
+            bbox = Bbox(x=x, y=y, w=w, h=h, label=label_id)
+            annotations.append(bbox)
+
+        return annotations
+
+    def infer_categories(self, experimental_dataset: Dataset[Sample]) -> CategoriesInfo:
+        """Infer label categories from bbox_labels."""
+        from datumaro.components.annotation import LabelCategories
+
+        # Collect all unique label IDs
+        label_ids: set[int] = set()
+        for sample in experimental_dataset:
+            bbox_labels = getattr(sample, self.bbox_labels_attr, None)
+            if bbox_labels is not None:
+                for label_id in bbox_labels:
+                    if label_id is not None:
+                        label_ids.add(int(label_id))
+
+        # Create label categories
+        label_categories = LabelCategories()
+        for label_id in sorted(label_ids):
+            label_categories.add(f"class_{label_id}")
+
+        return {AnnotationType.label: label_categories}
+
+
+@dataclass
+class BackwardAnalysisResult:
+    """Result of experimental dataset analysis for backward conversion."""
+
+    media_type: Type[MediaElement[Any]] | None
+    ann_types: set[AnnotationType]
+    categories: CategoriesInfo
+    media_converter: BackwardMediaConverter | None
+    ann_converters: dict[AnnotationType, BackwardAnnotationConverter]
+
+
+def analyze_experimental_dataset(experimental_dataset: Dataset[Sample]) -> BackwardAnalysisResult:
+    """Analyze experimental dataset schema to determine legacy format.
+
+    Args:
+        experimental_dataset: The experimental dataset to analyze
+
+    Returns:
+        BackwardAnalysisResult containing legacy format information
+    """
+    schema = experimental_dataset.schema
+
+    # Find compatible media converter
+    media_converter: BackwardMediaConverter | None = None
+    media_type: Type[MediaElement[Any]] | None = None
+
+    for converter_class in _backward_media_converter_classes:
+        converter_instance = converter_class.create_from_schema(schema)
+        if converter_instance is not None:
+            media_converter = converter_instance
+            media_type = converter_instance.get_media_type()
+            break
+
+    # Find compatible annotation converters
+    ann_converters: dict[AnnotationType, BackwardAnnotationConverter] = {}
+    ann_types: set[AnnotationType] = set()
+    categories: CategoriesInfo = {}
+
+    for converter_class in _backward_annotation_converter_classes:
+        converter_instance = converter_class.create_from_schema(schema)
+        if converter_instance is not None:
+            ann_type = converter_instance.get_annotation_type()
+            ann_converters[ann_type] = converter_instance
+            ann_types.add(ann_type)
+
+            # Merge categories from this converter
+            converter_categories = converter_instance.infer_categories(experimental_dataset)
+            categories.update(converter_categories)
+
+    return BackwardAnalysisResult(
+        media_type=media_type,
+        ann_types=ann_types,
+        categories=categories,
+        media_converter=media_converter,
+        ann_converters=ann_converters,
+    )
+
+
+def _convert_experimental_item(
+    index: int, sample: Sample, backward_analysis: BackwardAnalysisResult
+) -> DatasetItem:
+    """Convert experimental sample to legacy DatasetItem."""
+
+    # Convert media
+    media: MediaElement[Any] | None = None
+    if backward_analysis.media_converter:
+        media = backward_analysis.media_converter.convert_to_legacy_media(sample)
+
+    # Convert annotations
+    annotations: list[Annotation] = []
+    for converter in backward_analysis.ann_converters.values():
+        ann_list = converter.convert_to_legacy_annotations(sample, backward_analysis.categories)
+        annotations.extend(ann_list)
+
+    item_id = str(index)
+
+    return DatasetItem(
+        id=item_id,
+        media=media,
+        annotations=annotations,
+        attributes={},  # Could be extended to convert attributes
+    )
+
+
+def convert_to_legacy(experimental_dataset: Dataset[Sample]) -> LegacyDataset:
+    """Convert experimental dataset to legacy format.
+
+    Args:
+        experimental_dataset: The experimental Dataset to convert
+
+    Returns:
+        A new legacy Datumaro Dataset with converted data
+
+    Example:
+        >>> experimental_ds = Dataset(MySchema)
+        >>> # ... add samples to experimental_ds
+        >>> legacy_ds = convert_to_legacy(experimental_ds)
+        >>> legacy_ds.export("output", "coco")
+    """
+
+    # Step 1: Analyze experimental dataset
+    backward_analysis = analyze_experimental_dataset(experimental_dataset)
+
+    # Step 2: Create legacy dataset items
+    legacy_items: list[DatasetItem] = []
+    for i, sample in enumerate(experimental_dataset):
+        legacy_item = _convert_experimental_item(i, sample, backward_analysis)
+        legacy_items.append(legacy_item)
+
+    # Step 3: Create legacy dataset
+    legacy_dataset = LegacyDataset.from_iterable(  # pyright: ignore[reportUnknownMemberType]
+        legacy_items,
+        categories=backward_analysis.categories,
+        media_type=backward_analysis.media_type or MediaElement,
+    )
+
+    return legacy_dataset
+
+
+def register_builtin_backward_converters():
+    """Register built-in backward converters."""
+
+    # Register backward media converters
+    register_backward_media_converter(BackwardImageMediaConverter)
+
+    # Register backward annotation converters
+    register_backward_annotation_converter(BackwardBboxAnnotationConverter)
+
+
 # Auto-register built-in converters when module is imported
-register_builtin_converters()
+register_builtin_forward_converters()
+register_builtin_backward_converters()

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -2,29 +2,38 @@
 
 import tempfile
 from pathlib import Path
+from typing import Any, cast
 
 import numpy as np
+import polars as pl
 import pytest
+from typing_extensions import Annotated
 
 from datumaro.components.annotation import AnnotationType, Bbox
 from datumaro.components.dataset import Dataset as LegacyDataset
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
-from datumaro.components.media import Image
+from datumaro.components.media import Image, ImageFromFile
+from datumaro.experimental.dataset import Dataset, Sample
+from datumaro.experimental.fields import bbox_field, image_path_field, tensor_field
 from datumaro.experimental.legacy import (
-    BboxAnnotationConverter,
-    ImageMediaConverter,
+    BackwardBboxAnnotationConverter,
+    BackwardImageMediaConverter,
+    ForwardBboxAnnotationConverter,
+    ForwardImageMediaConverter,
+    analyze_experimental_dataset,
     analyze_legacy_dataset,
     convert_from_legacy,
-    get_annotation_converter,
-    get_media_converter,
-    register_annotation_converter,
-    register_media_converter,
+    convert_to_legacy,
+    get_forward_annotation_converter,
+    get_forward_media_converter,
+    register_forward_annotation_converter,
+    register_forward_media_converter,
 )
 
 
 def test_image_media_converter_get_schema_attributes():
     """Test schema attribute generation for images."""
-    converter = ImageMediaConverter()
+    converter = ForwardImageMediaConverter()
     attributes = converter.get_schema_attributes()
 
     assert "image_path" in attributes
@@ -33,7 +42,7 @@ def test_image_media_converter_get_schema_attributes():
 
 def test_image_media_converter_convert_item_media_with_path_and_size():
     """Test media conversion with path and size."""
-    converter = ImageMediaConverter()
+    converter = ForwardImageMediaConverter()
 
     image_media = Image.from_file(
         "/path/to/image.jpg", size=(480, 640)
@@ -47,7 +56,7 @@ def test_image_media_converter_convert_item_media_with_path_and_size():
 
 def test_image_media_converter_convert_item_media_with_path_only():
     """Test media conversion with only path."""
-    converter = ImageMediaConverter()
+    converter = ForwardImageMediaConverter()
 
     image_media = Image.from_file("/path/to/image.jpg")  # pyright: ignore[reportUnknownMemberType]
 
@@ -59,7 +68,7 @@ def test_image_media_converter_convert_item_media_with_path_only():
 
 def test_image_media_converter_convert_item_media_no_media():
     """Test media conversion with no media."""
-    converter = ImageMediaConverter()
+    converter = ForwardImageMediaConverter()
     item = DatasetItem(id="test", media=None)
     result = converter.convert_item_media(item)
 
@@ -68,7 +77,7 @@ def test_image_media_converter_convert_item_media_no_media():
 
 def test_bbox_annotation_converter_get_schema_attributes():
     """Test schema attribute generation for bboxes."""
-    converter = BboxAnnotationConverter()
+    converter = ForwardBboxAnnotationConverter()
     categories: CategoriesInfo = {}  # Empty categories
 
     attributes = converter.get_schema_attributes(categories)
@@ -81,7 +90,7 @@ def test_bbox_annotation_converter_get_schema_attributes():
 
 def test_bbox_annotation_converter_convert_annotations_single_bbox():
     """Test conversion of single bbox annotation."""
-    converter = BboxAnnotationConverter()
+    converter = ForwardBboxAnnotationConverter()
 
     bbox = Bbox(10, 20, 30, 40, label=1)  # x=10, y=20, w=30, h=40
     item = DatasetItem(id="test")
@@ -97,7 +106,7 @@ def test_bbox_annotation_converter_convert_annotations_single_bbox():
 
 def test_bbox_annotation_converter_convert_annotations_multiple_bboxes():
     """Test conversion of multiple bbox annotations."""
-    converter = BboxAnnotationConverter()
+    converter = ForwardBboxAnnotationConverter()
 
     bbox1 = Bbox(10, 20, 30, 40, label=1)
     bbox2 = Bbox(50, 60, 70, 80, label=2)
@@ -120,7 +129,7 @@ def test_bbox_annotation_converter_convert_annotations_multiple_bboxes():
 
 def test_bbox_annotation_converter_convert_annotations_empty_list():
     """Test conversion of empty annotation list."""
-    converter = BboxAnnotationConverter()
+    converter = ForwardBboxAnnotationConverter()
     item = DatasetItem(id="test")
 
     result = converter.convert_annotations([], item)
@@ -137,19 +146,19 @@ def test_bbox_annotation_converter_convert_annotations_empty_list():
 
 def test_register_and_get_media_converter():
     """Test media converter registration and retrieval."""
-    converter = ImageMediaConverter()
-    register_media_converter(Image, converter)
+    converter = ForwardImageMediaConverter()
+    register_forward_media_converter(Image, converter)
 
-    retrieved = get_media_converter(Image)
+    retrieved = get_forward_media_converter(Image)
     assert retrieved is converter
 
 
 def test_register_and_get_annotation_converter():
     """Test annotation converter registration and retrieval."""
-    converter = BboxAnnotationConverter()
-    register_annotation_converter(AnnotationType.bbox, converter)
+    converter = ForwardBboxAnnotationConverter()
+    register_forward_annotation_converter(AnnotationType.bbox, converter)
 
-    retrieved = get_annotation_converter(AnnotationType.bbox)
+    retrieved = get_forward_annotation_converter(AnnotationType.bbox)
     assert retrieved is converter
 
 
@@ -158,13 +167,13 @@ def test_get_nonexistent_media_converter():
     from datumaro.components.media import Video
 
     with pytest.raises(ValueError, match="No converter registered for media type"):
-        get_media_converter(Video)
+        get_forward_media_converter(Video)
 
 
 def test_get_nonexistent_annotation_converter():
     """Test getting converter for unregistered annotation type."""
     with pytest.raises(ValueError, match="No converter registered for annotation type"):
-        get_annotation_converter(AnnotationType.polygon)
+        get_forward_annotation_converter(AnnotationType.polygon)
 
 
 def test_analyze_image_and_bbox_dataset():
@@ -318,8 +327,374 @@ def test_convert_image_only_dataset():
 
 def test_builtin_converters_registration():
     """Test that built-in converters are registered on import."""
-    image_converter = get_media_converter(Image)
-    assert isinstance(image_converter, ImageMediaConverter)
+    image_converter = get_forward_media_converter(Image)
+    assert isinstance(image_converter, ForwardImageMediaConverter)
 
-    bbox_converter = get_annotation_converter(AnnotationType.bbox)
-    assert isinstance(bbox_converter, BboxAnnotationConverter)
+    bbox_converter = get_forward_annotation_converter(AnnotationType.bbox)
+    assert isinstance(bbox_converter, ForwardBboxAnnotationConverter)
+
+
+# Define a sample schema for testing convert_to_legacy
+class DetectionSample(Sample):
+    image_path: Annotated[str, image_path_field()]
+    bboxes: Annotated[
+        np.ndarray[Any, np.dtype[np.float32]], bbox_field(dtype=pl.Float32, format="x1y1x2y2")
+    ]
+    bbox_labels: Annotated[np.ndarray[Any, np.dtype[np.int32]], tensor_field(dtype=pl.Int32)]
+
+
+def test_convert_to_legacy_simple():
+    """Test basic convert_to_legacy functionality."""
+    # Create experimental dataset with sample data
+    experimental_dataset = Dataset(DetectionSample)
+
+    # Add sample data
+    sample1 = DetectionSample(
+        image_path="/path/to/image1.jpg",
+        bboxes=np.array([[10, 20, 50, 60], [100, 120, 150, 160]], dtype=np.float32),
+        bbox_labels=np.array([0, 1], dtype=np.int32),
+    )
+
+    sample2 = DetectionSample(
+        image_path="/path/to/image2.jpg",
+        bboxes=np.array([[5, 15, 45, 55]], dtype=np.float32),
+        bbox_labels=np.array([1], dtype=np.int32),
+    )
+
+    experimental_dataset.append(sample1)
+    experimental_dataset.append(sample2)
+
+    # Convert to legacy format
+    legacy_dataset = convert_to_legacy(experimental_dataset)  # type: ignore
+
+    # Verify conversion
+    assert len(legacy_dataset) == 2
+
+    # Check first item
+    items = list(legacy_dataset)
+    first_item = items[0]
+
+    # Verify media
+    assert isinstance(first_item.media, Image)  # type: ignore[reportUnknownMemberType]
+    assert getattr(first_item.media, "path", None) == "/path/to/image1.jpg"
+
+    # Verify annotations
+    assert len(first_item.annotations) == 2
+
+    # Check first bbox: [10, 20, 50, 60] -> Bbox(x=10, y=20, w=40, h=40)
+    bbox1 = first_item.annotations[0]
+    assert isinstance(bbox1, Bbox)
+    assert bbox1.x == 10
+    assert bbox1.y == 20
+    assert bbox1.w == 40  # 50 - 10
+    assert bbox1.h == 40  # 60 - 20
+    assert bbox1.label == 0
+
+    # Check second bbox: [100, 120, 150, 160] -> Bbox(x=100, y=120, w=50, h=40)
+    bbox2 = first_item.annotations[1]
+    assert isinstance(bbox2, Bbox)
+    assert bbox2.x == 100
+    assert bbox2.y == 120
+    assert bbox2.w == 50  # 150 - 100
+    assert bbox2.h == 40  # 160 - 120
+    assert bbox2.label == 1
+
+    # Check second item
+    second_item = items[1]
+    second_item_media = cast(Any, second_item.media)  # pyright: ignore[reportUnknownMemberType]
+    assert isinstance(second_item_media, ImageFromFile)
+    assert second_item_media.path == "/path/to/image2.jpg"
+    assert len(second_item.annotations) == 1
+
+    # Check the bbox in second item: [5, 15, 45, 55] -> Bbox(x=5, y=15, w=40, h=40)
+    bbox3 = second_item.annotations[0]
+    assert isinstance(bbox3, Bbox)
+    assert bbox3.x == 5
+    assert bbox3.y == 15
+    assert bbox3.w == 40  # 45 - 5
+    assert bbox3.h == 40  # 55 - 15
+    assert bbox3.label == 1
+
+
+def test_convert_to_legacy_empty_dataset():
+    """Test convert_to_legacy with empty experimental dataset."""
+    experimental_dataset = Dataset(DetectionSample)
+
+    legacy_dataset = convert_to_legacy(experimental_dataset)  # type: ignore
+
+    assert len(legacy_dataset) == 0
+
+
+def test_backward_image_media_converter_create_from_schema():
+    """Test BackwardImageMediaConverter.create_from_schema method."""
+    # Create experimental dataset to get schema
+    experimental_dataset = Dataset(DetectionSample)
+    schema = experimental_dataset.schema
+
+    # Test that converter can be created from schema with image_path field
+    converter = BackwardImageMediaConverter.create_from_schema(schema)
+    assert converter is not None
+    assert isinstance(converter, BackwardImageMediaConverter)
+    assert converter.image_path_attr == "image_path"
+
+    # Test get_media_type
+    assert converter.get_media_type() == Image
+
+
+def test_backward_image_media_converter_create_from_schema_no_image_field():
+    """Test BackwardImageMediaConverter with schema that has no image field."""
+    from datumaro.experimental.fields import tensor_field
+    from datumaro.experimental.schema import AttributeInfo, Schema
+
+    # Create schema without image_path field
+    schema = Schema(
+        attributes={
+            "some_tensor": AttributeInfo(type=np.ndarray, annotation=tensor_field(dtype=pl.Float32))
+        }
+    )
+
+    converter = BackwardImageMediaConverter.create_from_schema(schema)
+    assert converter is None
+
+
+def test_backward_image_media_converter_convert_to_legacy_media():
+    """Test media conversion from experimental to legacy."""
+    experimental_dataset = Dataset(DetectionSample)
+    schema = experimental_dataset.schema
+
+    converter = BackwardImageMediaConverter.create_from_schema(schema)
+    assert converter is not None
+
+    # Create sample with image path
+    sample = DetectionSample(
+        image_path="/test/image.jpg",
+        bboxes=np.array([[1, 2, 3, 4]], dtype=np.float32),
+        bbox_labels=np.array([0], dtype=np.int32),
+    )
+
+    # Convert to legacy media
+    legacy_media = converter.convert_to_legacy_media(sample)
+
+    assert isinstance(legacy_media, Image)
+    assert getattr(legacy_media, "path", None) == "/test/image.jpg"
+
+
+def test_backward_bbox_annotation_converter_create_from_schema():
+    """Test BackwardBboxAnnotationConverter.create_from_schema method."""
+    # Create experimental dataset to get schema
+    experimental_dataset = Dataset(DetectionSample)
+    schema = experimental_dataset.schema
+
+    # Test that converter can be created from schema with bbox fields
+    converter = BackwardBboxAnnotationConverter.create_from_schema(schema)
+    assert converter is not None
+    assert isinstance(converter, BackwardBboxAnnotationConverter)
+    assert converter.bboxes_attr == "bboxes"
+    assert converter.bbox_labels_attr == "bbox_labels"
+
+    # Test get_annotation_type
+    assert converter.get_annotation_type() == AnnotationType.bbox
+
+
+def test_backward_bbox_annotation_converter_create_from_schema_missing_fields():
+    """Test BackwardBboxAnnotationConverter with incomplete schema."""
+    from datumaro.experimental.fields import image_path_field
+    from datumaro.experimental.schema import AttributeInfo, Schema
+
+    # Create schema without bbox fields
+    schema = Schema(
+        attributes={"image_path": AttributeInfo(type=str, annotation=image_path_field())}
+    )
+
+    converter = BackwardBboxAnnotationConverter.create_from_schema(schema)
+    assert converter is None
+
+
+def test_backward_bbox_annotation_converter_convert_to_legacy_annotations():
+    """Test annotation conversion from experimental to legacy."""
+    experimental_dataset = Dataset(DetectionSample)
+    schema = experimental_dataset.schema
+
+    converter = BackwardBboxAnnotationConverter.create_from_schema(schema)
+    assert converter is not None
+
+    # Create sample with bboxes
+    sample = DetectionSample(
+        image_path="/test/image.jpg",
+        bboxes=np.array([[10, 20, 50, 60], [100, 150, 200, 250]], dtype=np.float32),
+        bbox_labels=np.array([1, 2], dtype=np.int32),
+    )
+
+    # Convert to legacy annotations
+    categories: CategoriesInfo = {}  # Empty categories for this test
+    legacy_annotations = converter.convert_to_legacy_annotations(sample, categories)
+
+    assert len(legacy_annotations) == 2
+
+    # Check first bbox: [10, 20, 50, 60] -> Bbox(x=10, y=20, w=40, h=40)
+    bbox1 = legacy_annotations[0]
+    assert isinstance(bbox1, Bbox)
+    assert bbox1.x == 10
+    assert bbox1.y == 20
+    assert bbox1.w == 40  # 50 - 10
+    assert bbox1.h == 40  # 60 - 20
+    assert bbox1.label == 1
+
+    # Check second bbox: [100, 150, 200, 250] -> Bbox(x=100, y=150, w=100, h=100)
+    bbox2 = legacy_annotations[1]
+    assert isinstance(bbox2, Bbox)
+    assert bbox2.x == 100
+    assert bbox2.y == 150
+    assert bbox2.w == 100  # 200 - 100
+    assert bbox2.h == 100  # 250 - 150
+    assert bbox2.label == 2
+
+
+def test_backward_bbox_annotation_converter_convert_empty_annotations():
+    """Test bbox converter with empty arrays."""
+    experimental_dataset = Dataset(DetectionSample)
+    schema = experimental_dataset.schema
+
+    converter = BackwardBboxAnnotationConverter.create_from_schema(schema)
+    assert converter is not None
+
+    # Create sample with empty bboxes
+    sample = DetectionSample(
+        image_path="/test/image.jpg",
+        bboxes=np.array([], dtype=np.float32).reshape(0, 4),
+        bbox_labels=np.array([], dtype=np.int32),
+    )
+
+    # Convert to legacy annotations
+    categories: CategoriesInfo = {}
+    legacy_annotations = converter.convert_to_legacy_annotations(sample, categories)
+
+    assert len(legacy_annotations) == 0
+
+
+def test_backward_bbox_annotation_converter_infer_categories():
+    """Test category inference from experimental dataset."""
+    experimental_dataset = Dataset(DetectionSample)
+
+    # Add samples with different labels
+    sample1 = DetectionSample(
+        image_path="/test/image1.jpg",
+        bboxes=np.array([[10, 20, 50, 60]], dtype=np.float32),
+        bbox_labels=np.array([0], dtype=np.int32),
+    )
+
+    sample2 = DetectionSample(
+        image_path="/test/image2.jpg",
+        bboxes=np.array([[100, 150, 200, 250], [50, 75, 100, 125]], dtype=np.float32),
+        bbox_labels=np.array([2, 1], dtype=np.int32),
+    )
+
+    experimental_dataset.append(sample1)
+    experimental_dataset.append(sample2)
+
+    schema = experimental_dataset.schema
+    converter = BackwardBboxAnnotationConverter.create_from_schema(schema)
+    assert converter is not None
+
+    # Infer categories
+    categories = converter.infer_categories(experimental_dataset)  # type: ignore
+
+    # Should have label categories
+    assert AnnotationType.label in categories
+    # Basic check that categories were created - detailed verification is complex due to legacy types
+    assert categories[AnnotationType.label] is not None
+
+
+def test_analyze_experimental_dataset():
+    """Test analysis of experimental dataset for backward conversion."""
+    experimental_dataset = Dataset(DetectionSample)
+
+    # Add sample data
+    sample = DetectionSample(
+        image_path="/test/image.jpg",
+        bboxes=np.array([[10, 20, 50, 60]], dtype=np.float32),
+        bbox_labels=np.array([1], dtype=np.int32),
+    )
+    experimental_dataset.append(sample)
+
+    # Analyze dataset
+    analysis_result = analyze_experimental_dataset(experimental_dataset)  # type: ignore
+
+    # Check media type and converter
+    assert analysis_result.media_type == Image
+    assert analysis_result.media_converter is not None
+    assert isinstance(analysis_result.media_converter, BackwardImageMediaConverter)
+
+    # Check annotation types and converters
+    assert AnnotationType.bbox in analysis_result.ann_types
+    assert AnnotationType.bbox in analysis_result.ann_converters
+    assert isinstance(
+        analysis_result.ann_converters[AnnotationType.bbox], BackwardBboxAnnotationConverter
+    )
+
+    # Check categories
+    assert AnnotationType.label in analysis_result.categories
+
+
+def test_analyze_experimental_dataset_no_compatible_converters():
+    """Test analysis with dataset that has no compatible backward converters."""
+    from datumaro.experimental.fields import tensor_field
+
+    # Create a custom sample type without image_path or bbox fields
+    class CustomSample(Sample):
+        some_data: Annotated[np.ndarray[Any, np.dtype[np.float32]], tensor_field(dtype=pl.Float32)]
+
+    experimental_dataset = Dataset(CustomSample)
+
+    # Add sample
+    sample = CustomSample(some_data=np.array([1, 2, 3], dtype=np.float32))
+    experimental_dataset.append(sample)
+
+    # Analyze dataset
+    analysis_result = analyze_experimental_dataset(experimental_dataset)  # type: ignore
+
+    # Should have no compatible converters
+    assert analysis_result.media_type is None
+    assert analysis_result.media_converter is None
+    assert len(analysis_result.ann_types) == 0
+    assert len(analysis_result.ann_converters) == 0
+    assert len(analysis_result.categories) == 0
+
+
+def test_convert_to_legacy_with_only_images():
+    """Test convert_to_legacy with dataset containing only images."""
+    from datumaro.experimental.fields import image_path_field
+
+    # Define schema with only image_path
+    class ImageOnlySample(Sample):
+        image_path: Annotated[str, image_path_field()]
+
+    experimental_dataset = Dataset(ImageOnlySample)
+
+    # Add samples
+    sample1 = ImageOnlySample(image_path="/path/to/image1.jpg")
+    sample2 = ImageOnlySample(image_path="/path/to/image2.jpg")
+
+    experimental_dataset.append(sample1)
+    experimental_dataset.append(sample2)
+
+    # Convert to legacy
+    legacy_dataset = convert_to_legacy(experimental_dataset)  # type: ignore
+
+    assert len(legacy_dataset) == 2
+
+    items = list(legacy_dataset)
+
+    # Check first item
+    first_item = items[0]
+    first_item_media = cast(Any, first_item.media)  # pyright: ignore[reportUnknownMemberType]
+    assert isinstance(first_item_media, ImageFromFile)
+    assert first_item_media.path == "/path/to/image1.jpg"
+    assert len(first_item.annotations) == 0  # No annotations
+
+    # Check second item
+    second_item = items[1]
+    second_item_media = cast(Any, second_item.media)  # pyright: ignore[reportUnknownMemberType]
+    assert isinstance(second_item_media, ImageFromFile)
+    assert second_item_media.path == "/path/to/image2.jpg"
+    assert len(second_item.annotations) == 0

--- a/tests/unit/experimental/test_legacy_integration.py
+++ b/tests/unit/experimental/test_legacy_integration.py
@@ -4,6 +4,7 @@
 
 import os.path as osp
 import tempfile
+from typing import cast
 
 import numpy as np
 import pytest
@@ -11,9 +12,9 @@ import pytest
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.dataset import Dataset as LegacyDataset
 from datumaro.components.dataset_base import DatasetItem
-from datumaro.components.media import Image
+from datumaro.components.media import Image, ImageFromFile
 from datumaro.experimental.dataset import Dataset as ExperimentalDataset
-from datumaro.experimental.legacy import convert_from_legacy
+from datumaro.experimental.legacy import convert_from_legacy, convert_to_legacy
 
 
 @pytest.fixture()
@@ -118,3 +119,43 @@ def test_object_detection(
             ]
             np.testing.assert_array_almost_equal(bboxes[0], expected_x1y1x2y2)
             assert labels[0] == first_bbox.label
+
+        # Step 5: Test conversion back to legacy format
+        reconstructed_legacy_dataset = convert_to_legacy(experimental_dataset)  # type: ignore
+
+        # Step 6: Verify the round-trip conversion
+        assert isinstance(reconstructed_legacy_dataset, LegacyDataset)
+        assert len(reconstructed_legacy_dataset) == len(experimental_dataset)
+
+        # Verify data consistency in round-trip conversion
+        for original_item, reconstructed_item in zip(legacy_dataset, reconstructed_legacy_dataset):
+            # Check media paths are preserved
+            original_media = cast(
+                ImageFromFile, original_item.media
+            )  # pyright: ignore[reportUnknownMemberType]
+            reconstructed_media = cast(
+                ImageFromFile, reconstructed_item.media
+            )  # pyright: ignore[reportUnknownMemberType]
+            assert original_media.path == reconstructed_media.path
+
+            # Get bbox annotations from both datasets
+            original_bboxes = [ann for ann in original_item.annotations if isinstance(ann, Bbox)]
+            reconstructed_bboxes = [
+                ann for ann in reconstructed_item.annotations if isinstance(ann, Bbox)
+            ]
+
+            assert len(original_bboxes) == len(reconstructed_bboxes)
+
+            # Sort both lists by bbox coordinates for consistent comparison
+            original_bboxes_sorted = sorted(original_bboxes, key=lambda b: (b.x, b.y, b.w, b.h))
+            reconstructed_bboxes_sorted = sorted(
+                reconstructed_bboxes, key=lambda b: (b.x, b.y, b.w, b.h)
+            )
+
+            # Verify each bbox is preserved through round-trip conversion
+            for orig_bbox, recon_bbox in zip(original_bboxes_sorted, reconstructed_bboxes_sorted):
+                assert orig_bbox.x == recon_bbox.x
+                assert orig_bbox.y == recon_bbox.y
+                assert orig_bbox.w == recon_bbox.w
+                assert orig_bbox.h == recon_bbox.h
+                assert orig_bbox.label == recon_bbox.label


### PR DESCRIPTION
The approach is similar to #1810. The conversion works in two steps: the first step analyse the existing dataset and generate the media type, annotation type and categories for the new dataset. The second step actually converts the data.

I have defined BackwardMediaConverter and BackwardAnnotationConverter base class which can be extended to support new media/annotation types. This PR implements the conversion logic but the conversion for specific media/annotation type will be implemented later.

Follow-up from #1810. Fixes #1789

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
