### PR TITLE
Reduce coverage of test_vis_gallery to only label visualisation.

### DIFF
--- a/tests/unit/test_visualizer.py
+++ b/tests/unit/test_visualizer.py
@@ -196,10 +196,6 @@ class PointsVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     def test_vis_one_sample(self):
         self._test_vis_one_sample("_draw_points", check_z_order=True)
 
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_vis_gallery(self):
-        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
-
 
 class MaskVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
@@ -229,10 +225,6 @@ class MaskVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_one_sample(self):
         self._test_vis_one_sample("_draw_mask", check_z_order=True)
-
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_vis_gallery(self):
-        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
 class PolygonVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
@@ -264,10 +256,6 @@ class PolygonVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     def test_vis_one_sample(self):
         self._test_vis_one_sample("_draw_polygon", check_z_order=True)
 
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_vis_gallery(self):
-        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
-
 
 class PolyLineVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
@@ -297,10 +285,6 @@ class PolyLineVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_one_sample(self):
         self._test_vis_one_sample("_draw_polygon", check_z_order=True)
-
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_vis_gallery(self):
-        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
 class BboxVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
@@ -335,10 +319,6 @@ class BboxVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     def test_vis_one_sample(self):
         self._test_vis_one_sample("_draw_bbox")
 
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_vis_gallery(self):
-        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
-
 
 class CaptionVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
@@ -366,10 +346,6 @@ class CaptionVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     def test_vis_one_sample(self):
         self._test_vis_one_sample("_draw_caption", check_z_order=False)
 
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_vis_gallery(self):
-        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
-
 
 class SuperResolutionVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
@@ -396,10 +372,6 @@ class SuperResolutionVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     def test_vis_one_sample(self):
         self._test_vis_one_sample("_draw_super_resolution_annotation", check_z_order=False)
 
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_vis_gallery(self):
-        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
-
 
 class DepthVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
@@ -425,10 +397,6 @@ class DepthVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_vis_one_sample(self):
         self._test_vis_one_sample("_draw_depth_annotation", check_z_order=False)
-
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_vis_gallery(self):
-        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
 
 class EllipseVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
@@ -463,15 +431,29 @@ class EllipseVisualizerTest(TestCaseClosePltFigure, VisualizerTestBase):
     def test_vis_one_sample(self):
         self._test_vis_one_sample("_draw_ellipse")
 
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_vis_gallery(self):
-        self._test_vis_gallery(self.DEFAULT_GRID_SIZE_TEST_CASES)
 
-
-class UnsupportedTypeTest(LabelVisualizerTest):
+class UnsupportedTypeTest(TestCaseClosePltFigure, VisualizerTestBase):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
+        cls.subset = "train"
+        cls.items = [
+            DatasetItem(
+                "image_%03d" % img_idx,
+                subset=cls.subset,
+                media=Image.from_numpy(data=np.ones((4, 6, 3))),
+                annotations=[
+                    Label(
+                        label=label_idx,
+                        id=img_idx * img_idx + label_idx,
+                        group=1,
+                        attributes={},
+                    )
+                    for label_idx in range(img_idx)
+                ],
+            )
+            for img_idx in range(1, 6)
+        ]
+        cls.dataset = Dataset.from_iterable(cls.items)
 
         for item in cls.dataset:
             item.annotations.append(HashKey(np.ones(96).astype(np.uint8)))


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

Reduce coverage of test_vis_gallery to only label visualisation.

Running this test for every annotation type is very expensive. By calling it only for one annotation type, we can reduce the running time of the overall test suite by more than half.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
