### PR TITLE
Update specs.json and fix typing with older Python versions

### DIFF
--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: MIT
 
 from functools import cache
-from typing import Any, Generic, List, Sequence, Type, TypeGuard, Union, cast, get_args, get_origin
+from typing import Any, Generic, List, Sequence, Type, Union, cast, get_args, get_origin
 
 import polars as pl
-from typing_extensions import Annotated, TypeVar, dataclass_transform
+from typing_extensions import Annotated, TypeGuard, TypeVar, dataclass_transform
 
 from .converter_registry import Converter, find_conversion_path
 from .schema import AttributeInfo, Field, Schema

--- a/src/datumaro/plugins/specs.json
+++ b/src/datumaro/plugins/specs.json
@@ -1173,27 +1173,6 @@
     "plugin_type": "DatasetBase"
   },
   {
-    "import_path": "datumaro.plugins.data_formats.roboflow.base_tfrecord.RoboflowTfrecordBase",
-    "plugin_name": "roboflow_tfrecord",
-    "plugin_type": "DatasetBase",
-    "extra_deps": [
-      "tensorflow"
-    ]
-  },
-  {
-    "import_path": "datumaro.plugins.data_formats.roboflow.base_tfrecord.RoboflowTfrecordImporter",
-    "plugin_name": "roboflow_tfrecord",
-    "plugin_type": "Importer",
-    "extra_deps": [
-      "tensorflow"
-    ],
-    "metadata": {
-      "file_extensions": [
-        ".tfrecord"
-      ]
-    }
-  },
-  {
     "import_path": "datumaro.plugins.data_formats.roboflow.importer.RoboflowCocoImporter",
     "plugin_name": "roboflow_coco",
     "plugin_type": "Importer",
@@ -1357,35 +1336,6 @@
         ".csv"
       ]
     }
-  },
-  {
-    "import_path": "datumaro.plugins.data_formats.tf_detection_api.base.TfDetectionApiBase",
-    "plugin_name": "tf_detection_api",
-    "plugin_type": "DatasetBase",
-    "extra_deps": [
-      "tensorflow"
-    ]
-  },
-  {
-    "import_path": "datumaro.plugins.data_formats.tf_detection_api.base.TfDetectionApiImporter",
-    "plugin_name": "tf_detection_api",
-    "plugin_type": "Importer",
-    "extra_deps": [
-      "tensorflow"
-    ],
-    "metadata": {
-      "file_extensions": [
-        ".tfrecord"
-      ]
-    }
-  },
-  {
-    "import_path": "datumaro.plugins.data_formats.tf_detection_api.exporter.TfDetectionApiExporter",
-    "plugin_name": "tf_detection_api",
-    "plugin_type": "Exporter",
-    "extra_deps": [
-      "tensorflow"
-    ]
   },
   {
     "import_path": "datumaro.plugins.data_formats.vgg_face2.VggFace2Base",
@@ -1716,11 +1666,6 @@
     }
   },
   {
-    "import_path": "datumaro.plugins.explorer.ExplorerLauncher",
-    "plugin_name": "explorer",
-    "plugin_type": "Launcher"
-  },
-  {
     "import_path": "datumaro.plugins.inference_server_plugin.base.LauncherForDedicatedInferenceServer",
     "plugin_name": "launcher_for_dedicated_inference_server",
     "plugin_type": "Launcher"
@@ -1893,11 +1838,6 @@
   {
     "import_path": "datumaro.plugins.transforms.RemoveAnnotations",
     "plugin_name": "remove_annotations",
-    "plugin_type": "Transform"
-  },
-  {
-    "import_path": "datumaro.plugins.transforms.PseudoLabeling",
-    "plugin_name": "pseudo_labeling",
     "plugin_type": "Transform"
   },
   {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

The specs.json was not updated in the recent PRs causing the test tests/unit/test_environment.py::EnvironmentTest::test_equivalance to fail. Also the typing.TypeGuard is not available in older versions of Python, thus updating to use the definition from typing_extensions instead.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
