### PR TITLE
Keep NDR and remove deprecation notice

### DIFF
--- a/src/datumaro/plugins/ndr.py
+++ b/src/datumaro/plugins/ndr.py
@@ -13,7 +13,6 @@ from datumaro.components.cli_plugin import CliPlugin
 from datumaro.components.dataset_base import DEFAULT_SUBSET_NAME
 from datumaro.components.transformer import Transform
 from datumaro.util import parse_str_enum_value
-from datumaro.util.deprecation import deprecated
 
 
 class Algorithm(Enum):
@@ -31,7 +30,6 @@ class UnderSamplingMethod(Enum):
     inverse = auto()
 
 
-@deprecated(deprecated_version="1.11", removed_version="1.12")
 class NDR(Transform, CliPlugin):
     """
     Removes near-duplicated images in subset|n


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

This PR removes the deprecation notice on the NDR class because the NDR code is self-contained and quite useful. It does not have any dependency on inference.

NDR was exposed via in the CLI via the prune action which was removed. We can perhaps think about adding again a prune method focused on NDR.

Part of https://github.com/open-edge-platform/datumaro/issues/1809.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
