### PR TITLE
Fix import of dataclass_transform in Python 3.9

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -32,10 +32,10 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-24.04", "windows-2022", "macos-15"]
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.9", "3.13"]
         include:
-          - python-version: "3.12"
-            tox-env-py: "312"
+          - python-version: "3.9"
+            tox-env-py: "39"
           - python-version: "3.13"
             tox-env-py: "313"
           - os: "ubuntu-24.04"

--- a/src/datumaro/components/hl_ops/__init__.py
+++ b/src/datumaro/components/hl_ops/__init__.py
@@ -295,7 +295,6 @@ class HLOps:
         return Dataset(source=merged, env=env)
 
     @staticmethod
-    @staticmethod
     @scoped
     def export(
         dataset: IDataset,

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -95,7 +95,9 @@ class Sample:
 
             # For Union types, keep the original annotation (the Union instance)
             # instead of the origin (which is just the UnionType class)
-            if isinstance(annotation, types.UnionType) or type_origin is Union:
+            if (
+                sys.version_info >= (3, 10) and isinstance(annotation, types.UnionType)
+            ) or type_origin is Union:
                 final_type = annotation
             else:
                 final_type = type_origin if type_origin is not None else annotation

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -18,13 +18,12 @@ from typing import (
     Type,
     Union,
     cast,
-    dataclass_transform,
     get_args,
     get_origin,
 )
 
 import polars as pl
-from typing_extensions import TypeGuard, TypeVar
+from typing_extensions import TypeGuard, TypeVar, dataclass_transform
 
 from .converter_registry import Converter, find_conversion_path
 from .schema import AttributeInfo, Field, Schema

--- a/src/datumaro/experimental/type_registry.py
+++ b/src/datumaro/experimental/type_registry.py
@@ -9,6 +9,7 @@ different tensor libraries (PyTorch, NumPy, JAX, TensorFlow, etc.) and Polars
 DataFrames. New types can be registered at runtime without modifying core code.
 """
 
+import sys
 import types
 from typing import Any, Callable, Union
 
@@ -129,7 +130,7 @@ def from_polars_data(polars_data: Any, target_type: type) -> Any:
     union_args = None
 
     # Check for types.UnionType (Python 3.10+ syntax: A | B)
-    if isinstance(target_type, types.UnionType):
+    if sys.version_info >= (3, 10) and isinstance(target_type, types.UnionType):
         is_union = True
         union_args = target_type.__args__
 

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -2,6 +2,7 @@
 Unit tests for Dataset class.
 """
 
+import sys
 from typing import Any
 
 import numpy as np
@@ -612,12 +613,14 @@ def test_union_type_handling():
 
     from datumaro.experimental.type_registry import from_polars_data
 
-    # Modern syntax
-    union_type_modern = torch.Tensor | np.ndarray
     polars_data = [1.0, 2.0, 3.0]
-    result = from_polars_data(polars_data, union_type_modern)
-    assert isinstance(result, torch.Tensor)
-    assert result.tolist() == [1.0, 2.0, 3.0]
+
+    # Modern syntax
+    if sys.version_info >= (3, 10):
+        union_type_modern = torch.Tensor | np.ndarray
+        result = from_polars_data(polars_data, union_type_modern)
+        assert isinstance(result, torch.Tensor)
+        assert result.tolist() == [1.0, 2.0, 3.0]
 
     # typing.Union syntax
     union_type_typing = Union[torch.Tensor, np.ndarray]

--- a/tests/unit/experimental/test_type_registry.py
+++ b/tests/unit/experimental/test_type_registry.py
@@ -4,6 +4,7 @@
 
 """Tests for the experimental type registry system."""
 
+import sys
 from typing import Union
 
 import numpy as np
@@ -56,10 +57,11 @@ def test_union_type_conversion():
     assert result.tolist() == [1.0, 2.0, 3.0]
 
     # Test modern syntax (Python 3.10+)
-    modern_union = torch.Tensor | np.ndarray
-    result = from_polars_data(data, modern_union)
-    assert isinstance(result, torch.Tensor)
-    assert result.tolist() == [1.0, 2.0, 3.0]
+    if sys.version_info >= (3, 10):
+        modern_union = torch.Tensor | np.ndarray
+        result = from_polars_data(data, modern_union)
+        assert isinstance(result, torch.Tensor)
+        assert result.tolist() == [1.0, 2.0, 3.0]
 
 
 def test_union_type_fallback_behavior():


### PR DESCRIPTION
This PR fixes a compatibility issue with Python 3.9. In addition, I updated the CI to check Python 3.9 instead of 3.12. We are already testing 3.13 which is very close to 3.12, so testing 3.12 is a bit redundant. Besides Python 3.9 support keeps breaking as it’s quite different from 3.12/3.13 so I think that testing it before merging PRs will help improve stability.

CI workflow updates:

* Updated the `python-version` matrix in `.github/workflows/pr_check.yml` to test against Python 3.9 and 3.13 instead of 3.12 and 3.13, and adjusted the corresponding `tox-env-py` values in the `include` section.

Python import correction:

* Changed the import of `dataclass_transform` in `src/datumaro/experimental/dataset.py` to use `typing_extensions` instead of `typing`, ensuring compatibility with older Python versions.
* Union types is only available in Python 3.10 and above so I disabled it in Python 3.9.

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
