### PR TITLE
Add support for attribute renaming/deletion in the schema conversion

### DIFF
--- a/src/datumaro/experimental/converter_registry.py
+++ b/src/datumaro/experimental/converter_registry.py
@@ -317,6 +317,65 @@ class ConversionError(Exception):
     pass
 
 
+class AttributeRemapperConverter(Converter):
+    """
+    Special converter for renaming/selecting attributes and dropping others.
+
+    This converter is not registered with the converter registry but is used
+    internally by find_conversion_path when attributes need to be renamed or deleted.
+    It uses .select() to only keep the specified attributes with their new names,
+    effectively handling both renaming and deletion in a single operation.
+    """
+
+    def __init__(self, attr_map: dict[str, str]):
+        """
+        Initialize the converter with a mapping of old to new names.
+
+        Args:
+            attr_map: Dictionary mapping old attribute names to new names.
+                          Only attributes in this mapping will be kept in the output.
+        """
+        self.attr_map = attr_map
+        super().__init__()
+
+    @classmethod
+    def get_from_types(cls) -> dict[str, type[Field]]:
+        """Override to return empty dict since inputs are dynamic."""
+        return {}
+
+    @classmethod
+    def get_to_types(cls) -> dict[str, type[Field]]:
+        """Override to return empty dict since outputs are dynamic."""
+        return {}
+
+    def convert(self, df: pl.DataFrame) -> pl.DataFrame:
+        """
+        Select and rename columns according to attr_map.
+        Columns not in the mapping are dropped.
+
+        Args:
+            df: Input DataFrame
+
+        Returns:
+            DataFrame with only the selected/renamed columns
+        """
+        # Build selection expressions for all columns we want to keep
+        select_exprs = {}
+
+        for old_name, new_name in self.attr_map.items():
+            select_exprs[new_name] = pl.col(old_name)
+
+        return df.select(**select_exprs)
+
+    def filter_output_spec(self) -> bool:
+        """Always return True as renaming is always applicable."""
+        return True
+
+    def get_output_attr_specs(self) -> List[AttributeSpec[Field]]:
+        """Override to return empty list since outputs are handled dynamically."""
+        return []
+
+
 @dataclass(frozen=True)
 class _SchemaState:
     """Represents a schema state during A* search."""
@@ -326,13 +385,29 @@ class _SchemaState:
     ]  # Map field types to their AttributeSpec
 
     def __hash__(self):
-        # Hash the items of the dict as a frozenset for immutability
-        return hash(frozenset(self.field_to_attr_spec.items()))
+        # Hash only field types and their properties, not names
+        field_items = []
+        for field_type, attr_spec in self.field_to_attr_spec.items():
+            # Hash field type and field properties, but not the attribute name
+            field_items.append((field_type, attr_spec.field))
+        return hash(tuple(field_items))
 
     def __eq__(self, other: object) -> bool:
-        return (
-            isinstance(other, _SchemaState) and self.field_to_attr_spec == other.field_to_attr_spec
-        )
+        if not isinstance(other, _SchemaState):
+            return False
+
+        # Compare only field types and their properties, not names
+        if set(self.field_to_attr_spec.keys()) != set(other.field_to_attr_spec.keys()):
+            return False
+
+        for field_type in self.field_to_attr_spec.keys():
+            if (
+                self.field_to_attr_spec[field_type].field
+                != other.field_to_attr_spec[field_type].field
+            ):
+                return False
+
+        return True
 
     def get_attr_spec_for_field_type(
         self, field_type: Type[Field]
@@ -367,6 +442,8 @@ def _heuristic_cost(current_state: _SchemaState, target_state: _SchemaState) -> 
     This counts both:
     1. Missing field types that need to be created
     2. Field differences where the type exists but properties differ (dtype, format, semantic, etc.)
+
+    Note: Attribute names are ignored in the heuristic as they can be fixed in post-processing.
     """
     cost = 0
 
@@ -383,7 +460,7 @@ def _heuristic_cost(current_state: _SchemaState, target_state: _SchemaState) -> 
         current_attr_spec = current_state.field_to_attr_spec[field_type]
         target_attr_spec = target_state.field_to_attr_spec[field_type]
 
-        # Compare field properties - if they differ, we need conversion
+        # Compare field properties (ignoring names) - if they differ, we need conversion
         if current_attr_spec.field != target_attr_spec.field:
             cost += 1
 
@@ -391,7 +468,7 @@ def _heuristic_cost(current_state: _SchemaState, target_state: _SchemaState) -> 
 
 
 def _get_applicable_converters(
-    state: _SchemaState, target_state: _SchemaState
+    state: _SchemaState, target_state: _SchemaState, iteration: int = 0
 ) -> List[Tuple[Converter, _SchemaState]]:
     """Get all converters that can be applied to the current state along with their resulting states."""
     applicable: List[Tuple[Converter, _SchemaState]] = []
@@ -402,18 +479,22 @@ def _get_applicable_converters(
     for converter_class in ConverterRegistry.list_converters():
         # Check if all required input types are available
         from_types = converter_class.get_from_types()
-        if (
-            not all(field_type in available_field_types for field_type in from_types.values())
-            and len(from_types) > 0
-        ):
-            continue
 
         # Collect available input AttributeSpec instances
-        from_attr_specs: List[AttributeSpec[Field]] = []
-        for field_type in from_types.values():
-            if field_type in available_field_types:
-                attr_spec = state.field_to_attr_spec[field_type]
-                from_attr_specs.append(attr_spec)
+        converter_kwargs = {}
+        all_inputs_available = True
+        for attr_name, field_type in from_types.items():
+            if field_type not in available_field_types:
+                all_inputs_available = False
+                break
+
+            # Add the input attribute to kwargs for the converter constructor
+            attr_spec = state.field_to_attr_spec[field_type]
+            converter_kwargs[attr_name] = attr_spec
+
+        # Check if we have the required input types
+        if not all_inputs_available:
+            continue
 
         # Collect desired output AttributeSpec instances
         to_types = converter_class.get_to_types()
@@ -423,50 +504,24 @@ def _get_applicable_converters(
                 attr_spec = target_state.field_to_attr_spec[field_type]
                 to_attr_specs.append(attr_spec)
 
-        # Initialize the converter with AttributeSpec instances
-        # Check if we have the required input types
-        if len(from_attr_specs) < len(from_types):
-            continue
-
-        # Create a mapping from input types to input specs
-        input_type_to_spec = {}
-        for attr_spec in from_attr_specs:
-            field_type = type(attr_spec.field)
-            input_type_to_spec[field_type] = attr_spec
-
-        # Verify all required input types are available
-        all_inputs_available = True
-        converter_kwargs = {}
-        for attr_name, field_type in from_types.items():
-            if field_type not in input_type_to_spec:
-                all_inputs_available = False
-                break
-            # Add the input attribute to kwargs for the converter constructor
-            converter_kwargs[attr_name] = input_type_to_spec[field_type]
-
-        if not all_inputs_available:
-            continue
-
-        # Create output AttributeSpec instances and add to kwargs
-        output_attr_specs: List[AttributeSpec[Field]] = []
-        for i, (attr_name, field_type) in enumerate(to_types.items()):
-            # Create a default output AttributeSpec
-            # Use desired target name if specified, otherwise generate default
-            if i < len(to_attr_specs):
-                output_name = to_attr_specs[i].name
-                # Optionally use the target field if it matches the type
-                if isinstance(to_attr_specs[i].field, field_type):
-                    output_field = to_attr_specs[i].field
-                else:
-                    output_field = field_type()
+        for attr_name, field_type in to_types.items():
+            # First, check if target state has a matching field type and use its name/field
+            if field_type in target_state.field_to_attr_spec:
+                target_attr_spec = target_state.field_to_attr_spec[field_type]
+                output_name = target_attr_spec.name
+                output_field = target_attr_spec.field
             else:
-                field_hash = abs(hash(str(field_type))) % 10000
-                output_name = f"{field_type.__name__.lower()}_{field_hash}"
+                # The field does not exist, use a temporary name
+                output_name = field_type.__name__.lower()
+                # and create a new instance of the field
                 output_field = field_type()
+
+            # Add the iteration count at the end to ensure uniqueness
+            # and avoid any conflict with existing attribute names
+            output_name = f"{output_name}_temp_{iteration}"
 
             output_attr_spec = AttributeSpec(name=output_name, field=output_field)
             converter_kwargs[attr_name] = output_attr_spec
-            output_attr_specs.append(output_attr_spec)
 
         # Create converter instance with all AttributeSpec instances as kwargs
         converter_instance = converter_class(**converter_kwargs)
@@ -520,6 +575,56 @@ def _group_fields_by_semantic(schema: Schema) -> dict[Semantic, _SchemaState]:
     }
 
 
+def _create_post_processing_for_semantic(
+    final_state: _SchemaState, target_state: _SchemaState
+) -> List[Converter]:
+    """
+    Create post-processing converters for a single semantic group.
+
+    Args:
+        final_state: Final state reached after conversions
+        target_state: Target state for this semantic group
+
+    Returns:
+        List of post-processing converters (usually just one AttributeRemapperConverter)
+    """
+    # Build rename mapping: include only attributes that should be kept
+    attr_map = {}
+
+    # Determine if a converter is needed (i.e. at least one attribute has been renamed or deleted)
+    converter_needed = False
+
+    for field_type, target_attr_spec in target_state.field_to_attr_spec.items():
+        if field_type in final_state.field_to_attr_spec:
+            final_attr_spec = final_state.field_to_attr_spec[field_type]
+
+            if final_attr_spec.name != target_attr_spec.name:
+                converter_needed = True
+
+            # Get all column names for this field using to_polars_schema
+            final_columns = list(
+                final_attr_spec.field.to_polars_schema(final_attr_spec.name).keys()
+            )
+            target_columns = list(
+                target_attr_spec.field.to_polars_schema(target_attr_spec.name).keys()
+            )
+
+            # Map each column from final to target
+            for final_col, target_col in zip(final_columns, target_columns):
+                attr_map[final_col] = target_col
+
+    for field_type, final_attr_spec in final_state.field_to_attr_spec.items():
+        if field_type not in target_state.field_to_attr_spec:
+            # If the field is not in the target state, it should be deleted
+            converter_needed = True
+
+    # Create a single rename converter that handles both renaming and deletion
+    if converter_needed:
+        return [AttributeRemapperConverter(attr_map=attr_map)]
+
+    return []
+
+
 def _find_conversion_path_for_semantic(
     start_state: _SchemaState, target_state: _SchemaState, semantic: Semantic
 ) -> List[Converter]:
@@ -537,9 +642,9 @@ def _find_conversion_path_for_semantic(
     Raises:
         ConversionError: If no conversion path is found for this semantic
     """
-    # If we already have all required fields, no conversion needed
+    # If we already have all required fields, check if we need renaming/deletion
     if start_state == target_state:
-        return []
+        return _create_post_processing_for_semantic(start_state, target_state)
 
     # Initialize A* search
     open_set: List[_SearchNode] = []
@@ -564,12 +669,15 @@ def _find_conversion_path_for_semantic(
 
         # Check if we've reached the goal - all target fields must match exactly
         if _heuristic_cost(current_node.state, target_state) == 0:
-            return current_node.path
+            # Add post-processing converters for final renaming and deletion
+            post_processing = _create_post_processing_for_semantic(current_node.state, target_state)
+            return current_node.path + post_processing
 
         # Explore neighbors
         for converter, new_state in _get_applicable_converters(
             current_node.state,
             target_state,
+            current_node.g_cost,
         ):
             if new_state in closed_set:
                 continue

--- a/src/datumaro/experimental/converter_registry.py
+++ b/src/datumaro/experimental/converter_registry.py
@@ -185,6 +185,24 @@ class Converter(ABC):
         # Subclasses should override for sophisticated filtering
         return True
 
+    def get_input_attr_specs(self) -> List[AttributeSpec[Field]]:
+        """
+        Get the current input AttributeSpec instances from input_* attributes.
+
+        Returns:
+            List of input AttributeSpec instances currently configured on the converter
+        """
+        input_attr_specs: List[AttributeSpec[Field]] = []
+
+        # Get the input attribute names from class type hints
+        from_types = self.get_from_types()
+
+        for attr_name in from_types.keys():
+            attr_spec = cast(AttributeSpec[Field], getattr(self, attr_name))
+            input_attr_specs.append(attr_spec)
+
+        return input_attr_specs
+
     def get_output_attr_specs(self) -> List[AttributeSpec[Field]]:
         """
         Get the current output AttributeSpec instances from output_* attributes.
@@ -327,30 +345,66 @@ class AttributeRemapperConverter(Converter):
     effectively handling both renaming and deletion in a single operation.
     """
 
-    def __init__(self, attr_map: dict[str, str]):
+    def __init__(self, attr_mappings: list[tuple[AttributeSpec, AttributeSpec]]):
         """
-        Initialize the converter with a mapping of old to new names.
+        Initialize the converter with a list of attribute mappings.
 
         Args:
-            attr_map: Dictionary mapping old attribute names to new names.
-                          Only attributes in this mapping will be kept in the output.
+            attr_mappings: List of tuples (from_attr_spec, to_attr_spec) defining
+                          the attribute transformations. Only attributes in this
+                          list will be kept in the output.
         """
-        self.attr_map = attr_map
+        self.attr_mappings = attr_mappings
+
+        # Calculate column mapping from attribute mappings
+        self.column_map = {}
+        for from_attr, to_attr in attr_mappings:
+            # Get all column names for this field using to_polars_schema
+            from_columns = list(from_attr.field.to_polars_schema(from_attr.name).keys())
+            to_columns = list(to_attr.field.to_polars_schema(to_attr.name).keys())
+
+            # Map each column from source to target
+            for from_col, to_col in zip(from_columns, to_columns):
+                self.column_map[from_col] = to_col
+
+        # Dynamically set input_* and output_* attributes for get_from_types/get_to_types
+        for i, (from_attr, to_attr) in enumerate(attr_mappings):
+            setattr(self, f"input_{i}", from_attr)
+            setattr(self, f"output_{i}", to_attr)
+
         super().__init__()
 
-    @classmethod
-    def get_from_types(cls) -> dict[str, type[Field]]:
-        """Override to return empty dict since inputs are dynamic."""
-        return {}
+    @cache
+    def get_from_types(self) -> dict[str, Type[Field]]:
+        """
+        Extract input field types from input_* class attributes.
 
-    @classmethod
-    def get_to_types(cls) -> dict[str, type[Field]]:
-        """Override to return empty dict since outputs are dynamic."""
-        return {}
+        Returns:
+            Dictionary mapping input attribute names to their Field types
+        """
+        from_types: dict[str, Type[Field]] = {}
+        for i, (input_spec, _) in enumerate(self.attr_mappings):
+            from_types[f"input_{i}"] = type(input_spec.field)
+
+        return from_types
+
+    @cache
+    def get_to_types(self) -> dict[str, Type[Field]]:
+        """
+        Extract output field types from output_* class attributes.
+
+        Returns:
+            Dictionary mapping output attribute names to their Field types
+        """
+        to_types: dict[str, Type[Field]] = {}
+        for i, (_, output_spec) in enumerate(self.attr_mappings):
+            to_types[f"output_{i}"] = type(output_spec.field)
+
+        return to_types
 
     def convert(self, df: pl.DataFrame) -> pl.DataFrame:
         """
-        Select and rename columns according to attr_map.
+        Select and rename columns according to column_map.
         Columns not in the mapping are dropped.
 
         Args:
@@ -362,7 +416,7 @@ class AttributeRemapperConverter(Converter):
         # Build selection expressions for all columns we want to keep
         select_exprs = {}
 
-        for old_name, new_name in self.attr_map.items():
+        for old_name, new_name in self.column_map.items():
             select_exprs[new_name] = pl.col(old_name)
 
         return df.select(**select_exprs)
@@ -370,10 +424,6 @@ class AttributeRemapperConverter(Converter):
     def filter_output_spec(self) -> bool:
         """Always return True as renaming is always applicable."""
         return True
-
-    def get_output_attr_specs(self) -> List[AttributeSpec[Field]]:
-        """Override to return empty list since outputs are handled dynamically."""
-        return []
 
 
 @dataclass(frozen=True)
@@ -588,8 +638,8 @@ def _create_post_processing_for_semantic(
     Returns:
         List of post-processing converters (usually just one AttributeRemapperConverter)
     """
-    # Build rename mapping: include only attributes that should be kept
-    attr_map = {}
+    # Build attribute mappings: include only attributes that should be kept
+    attr_mappings = []
 
     # Determine if a converter is needed (i.e. at least one attribute has been renamed or deleted)
     converter_needed = False
@@ -601,26 +651,18 @@ def _create_post_processing_for_semantic(
             if final_attr_spec.name != target_attr_spec.name:
                 converter_needed = True
 
-            # Get all column names for this field using to_polars_schema
-            final_columns = list(
-                final_attr_spec.field.to_polars_schema(final_attr_spec.name).keys()
-            )
-            target_columns = list(
-                target_attr_spec.field.to_polars_schema(target_attr_spec.name).keys()
-            )
+            # Add the mapping from final to target attribute spec
+            attr_mappings.append((final_attr_spec, target_attr_spec))
 
-            # Map each column from final to target
-            for final_col, target_col in zip(final_columns, target_columns):
-                attr_map[final_col] = target_col
-
+    # Check if any fields need to be deleted (exist in final but not in target)
     for field_type, final_attr_spec in final_state.field_to_attr_spec.items():
         if field_type not in target_state.field_to_attr_spec:
             # If the field is not in the target state, it should be deleted
             converter_needed = True
 
-    # Create a single rename converter that handles both renaming and deletion
+    # Create a single remapper converter that handles both renaming and deletion
     if converter_needed:
-        return [AttributeRemapperConverter(attr_map=attr_map)]
+        return [AttributeRemapperConverter(attr_mappings=attr_mappings)]
 
     return []
 
@@ -725,6 +767,8 @@ def find_conversion_path(from_schema: Schema, to_schema: Schema) -> ConversionPa
     # Collect all converters needed across all semantic groups
     all_converters: List[Converter] = []
 
+    attr_mappings = []
+
     # Process each semantic group in the target schema
     for semantic, target_state in target_groups.items():
         # Get corresponding source state for this semantic (if any)
@@ -735,7 +779,15 @@ def find_conversion_path(from_schema: Schema, to_schema: Schema) -> ConversionPa
             start_state, target_state, semantic
         )
 
+        # Merge all the attribute remappers into a single one. If any, the remapper is always the last step.
+        if semantic_converters and isinstance(semantic_converters[-1], AttributeRemapperConverter):
+            attr_mappings += semantic_converters[-1].attr_mappings
+            semantic_converters = semantic_converters[:-1]
+
         all_converters.extend(semantic_converters)
+
+    if attr_mappings:
+        all_converters.append(AttributeRemapperConverter(attr_mappings=attr_mappings))
 
     # Separate batch and lazy converters
     return _separate_batch_and_lazy_converters(all_converters)
@@ -761,40 +813,31 @@ def _separate_batch_and_lazy_converters(
     # Track which converters must be lazy
     lazy_indices: Set[int] = set()
 
-    # First pass: mark all intrinsically lazy converters
+    lazy_fields: dict[str, bool] = defaultdict(
+        bool
+    )  # Maps fields whether they were produced lazily
+
     for i, converter in enumerate(conversion_path):
+        lazy = False
+
         if converter.lazy:
+            # Mark all intrinsically lazy converters as lazy
+            lazy = True
+        else:
+            # Check whether the converter depends on a lazy converter
+            input_specs = converter.get_input_attr_specs()
+            for attr_spec in input_specs:
+                if attr_spec.name in lazy_fields:
+                    lazy = True
+                    break
+
+        if lazy:
             lazy_indices.add(i)
 
-    # Second pass: mark converters that depend on lazy converter outputs
-    # Build dependency graph
-    converter_outputs: dict[
-        Type[Field], int
-    ] = {}  # Maps field types to converter indices that produce them
-
-    for i, converter in enumerate(conversion_path):
-        output_specs = converter.get_output_attr_specs()
-        for attr_spec in output_specs:
-            field_type = type(attr_spec.field)
-            converter_outputs[field_type] = i
-
-    # Mark dependent converters as lazy
-    changed = True
-    while changed:
-        changed = False
-        for i, converter in enumerate(conversion_path):
-            if i in lazy_indices:
-                continue
-
-            # Check if this converter depends on any lazy converter output
-            from_types = converter.get_from_types()
-            for field_type in from_types.values():
-                if field_type in converter_outputs:
-                    producer_index: int = converter_outputs[field_type]
-                    if producer_index in lazy_indices and producer_index < i:
-                        lazy_indices.add(i)
-                        changed = True
-                        break
+            # Mark all output fields as lazy
+            output_specs = converter.get_output_attr_specs()
+            for attr_spec in output_specs:
+                lazy_fields[attr_spec.name] = True
 
     # Separate into batch and lazy lists
     batch_converters: List[Converter] = []

--- a/src/datumaro/experimental/converters.py
+++ b/src/datumaro/experimental/converters.py
@@ -67,6 +67,9 @@ class RGBToBGRConverter(Converter):
         input_column_name = self.input_image.name
         output_column_name = self.output_image.name
 
+        input_shape_column_name = self.input_image.name + "_shape"
+        output_shape_column_name = self.output_image.name + "_shape"
+
         def rgb_to_bgr(tensor_data: pl.Series) -> Any:
             """Convert RGB tensor data to BGR by reversing the channel order."""
             data = tensor_data.to_numpy().copy()
@@ -79,7 +82,8 @@ class RGBToBGRConverter(Converter):
         return df.with_columns(
             pl.col(input_column_name)
             .map_elements(rgb_to_bgr, return_dtype=dtype)
-            .alias(output_column_name)
+            .alias(output_column_name),
+            pl.col(input_shape_column_name).alias(output_shape_column_name),
         )
 
 
@@ -129,16 +133,15 @@ class UInt8ToFloat32Converter(Converter):
         input_column_name = self.input_image.name
         output_column_name = self.output_image.name
 
-        image_field = self.input_image.field
-        print(f"Converting dtype from: {image_field.dtype}")
-        print(f"Input attribute name: {self.input_image.name}")
-        print(f"Output attribute name: {self.output_image.name}")
+        input_shape_column_name = self.input_image.name + "_shape"
+        output_shape_column_name = self.output_image.name + "_shape"
 
         return df.with_columns(
             # Normalize UInt8 values (0-255) to Float32 (0.0-1.0)
             pl.col(input_column_name)
             .list.eval((pl.element() / 255.0).cast(self.output_image.field.dtype))
-            .alias(output_column_name)
+            .alias(output_column_name),
+            pl.col(input_shape_column_name).alias(output_shape_column_name),
         )
 
 

--- a/tests/unit/experimental/test_converters.py
+++ b/tests/unit/experimental/test_converters.py
@@ -944,9 +944,6 @@ def test_attribute_deletion():
     # Test the remapper converter functionality
     remapper_converter = path.batch_converters[0]
 
-    # Check that it only keeps the image attribute
-    assert remapper_converter.attr_map == {"image": "image", "image_shape": "image_shape"}
-
     # Create test DataFrame with both columns
     test_image = np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8)
     test_bbox = np.array([[10.0, 20.0, 30.0, 40.0]], dtype=np.float32)
@@ -1005,16 +1002,32 @@ def test_combined_rename_and_delete():
     assert isinstance(path.batch_converters[0], AttributeRemapperConverter)
     assert len(path.lazy_converters) == 0
 
-    # Check that the remapper mapping only includes the field we want to keep
+    # Check that the remapper handles the conversion correctly by testing on sample data
     remapper_converter = path.batch_converters[0]
-    assert remapper_converter.attr_map == {
-        "old_image": "new_image",
-        "old_image_shape": "new_image_shape",
-    }
+
+    # Create test DataFrame
+    test_df = pl.DataFrame(
+        {
+            "old_image": [[1, 2, 3, 4, 5, 6]],  # Sample image data
+            "old_image_shape": [[2, 3]],  # Sample shape data
+            "other_field": ["should_be_deleted"],  # Should be deleted
+        }
+    )
+
+    # Apply the converter
+    result_df = remapper_converter.convert(test_df)
+
+    # Check that only the renamed fields are present
+    expected_columns = {"new_image", "new_image_shape"}
+    assert set(result_df.columns) == expected_columns
+
+    # Check that data is preserved correctly
+    assert result_df["new_image"].to_list() == [[1, 2, 3, 4, 5, 6]]
+    assert result_df["new_image_shape"].to_list() == [[2, 3]]
 
 
 def test_attribute_remapping_converter():
-    """Test AttributeRenameConverter with multiple attributes."""
+    """Test AttributeRemapperConverter with multiple attributes."""
     import polars as pl
 
     # Create test DataFrame with multiple columns including auxiliary columns
@@ -1027,17 +1040,24 @@ def test_attribute_remapping_converter():
         }
     )
 
-    # Create rename mapping
-    attr_map = {"old_image": "new_image", "old_bbox": "new_bbox"}
+    # Create attribute mappings using AttributeSpec
+    from_image_attr = AttributeSpec(name="old_image", field=image_field(dtype=pl.Int32()))
+    to_image_attr = AttributeSpec(name="new_image", field=image_field(dtype=pl.Int32()))
+
+    from_bbox_attr = AttributeSpec(name="old_bbox", field=bbox_field(dtype=pl.Int32()))
+    to_bbox_attr = AttributeSpec(name="new_bbox", field=bbox_field(dtype=pl.Int32()))
+
+    attr_mappings = [(from_image_attr, to_image_attr), (from_bbox_attr, to_bbox_attr)]
 
     # Create and apply converter
-    converter = AttributeRemapperConverter(attr_map=attr_map)
+    converter = AttributeRemapperConverter(attr_mappings=attr_mappings)
     result_df = converter.convert(df)
 
-    # Check that columns were remapped correctly
-    expected_columns = {"new_image", "new_bbox"}
+    # Check that columns were remapped correctly (should only have remapped columns)
+    expected_columns = {"new_image", "new_image_shape", "new_bbox"}
     assert set(result_df.columns) == expected_columns
 
     # Check that data is preserved
     assert result_df["new_image"].to_list() == [[1, 2, 3]]
+    assert result_df["new_image_shape"].to_list() == [[3]]
     assert result_df["new_bbox"].to_list() == [[[1, 2, 3, 4]]]

--- a/tests/unit/experimental/test_converters.py
+++ b/tests/unit/experimental/test_converters.py
@@ -10,6 +10,7 @@ import polars as pl
 import pytest
 
 from datumaro.experimental.converter_registry import (
+    AttributeRemapperConverter,
     AttributeSpec,
     ConversionError,
     Converter,
@@ -30,6 +31,7 @@ from datumaro.experimental.fields import (
     ImagePathField,
     bbox_field,
     image_field,
+    image_info_field,
 )
 from datumaro.experimental.schema import AttributeInfo, Schema, Semantic
 
@@ -262,8 +264,9 @@ def test_find_conversion_path():
 
     # This should find a conversion path (UInt8 -> Float32)
     path = find_conversion_path(source_schema, target_schema)
-    assert len(path.batch_converters) == 1
+    assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is UInt8ToFloat32Converter
+    assert type(path.batch_converters[1]) is AttributeRemapperConverter
 
 
 def test_convert_dataframe():
@@ -393,10 +396,11 @@ def test_multiple_converter_chaining():
 
     path = find_conversion_path(source_schema, target_schema)
     # If successful, should have multiple steps
-    assert len(path.batch_converters) == 3
+    assert len(path.batch_converters) == 4
     assert type(path.batch_converters[0]) is BBoxCoordinateConverter
     assert type(path.batch_converters[1]) is RGBToBGRConverter
     assert type(path.batch_converters[2]) is UInt8ToFloat32Converter
+    assert type(path.batch_converters[3]) is AttributeRemapperConverter
 
 
 def test_astar_direct_conversion():
@@ -455,8 +459,9 @@ def test_astar_direct_conversion():
 
     # Test finding conversion path
     path = find_conversion_path(from_schema, to_schema)
-    assert len(path.batch_converters) == 1
+    assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is ExtractImageSizeConverter
+    assert type(path.batch_converters[1]) is AttributeRemapperConverter
     assert path.lazy_converters == []
 
 
@@ -559,9 +564,10 @@ def test_astar_chained_conversion():
     # Test finding conversion path
     path = find_conversion_path(from_schema, to_schema)
     # Should need 2 converters: ImageField -> ImageSizeField, then NormalizedBbox -> AbsoluteBbox
-    assert len(path.batch_converters) == 2
+    assert len(path.batch_converters) == 3
     assert type(path.batch_converters[0]) is ExtractImageSizeChainConverter
     assert type(path.batch_converters[1]) is NormalizeToAbsoluteBboxConverter
+    assert type(path.batch_converters[2]) is AttributeRemapperConverter
     assert len(path.lazy_converters) == 0
 
 
@@ -698,8 +704,9 @@ def test_optimal_path_selection():
     )
 
     path = find_conversion_path(from_schema, to_schema)
-    assert len(path.batch_converters) == 1
+    assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is AToCDirectConverter
+    assert type(path.batch_converters[1]) is AttributeRemapperConverter
     assert len(path.lazy_converters) == 0
 
 
@@ -733,8 +740,9 @@ def test_generator_converter():
     )
 
     path = find_conversion_path(from_schema, to_schema)
-    assert len(path.batch_converters) == 1
+    assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is GenerateBConverter
+    assert type(path.batch_converters[1]) is AttributeRemapperConverter
     assert len(path.lazy_converters) == 0
 
 
@@ -791,8 +799,9 @@ def test_multiple_output_converter():
     )
 
     path = find_conversion_path(from_schema, to_schema)
-    assert len(path.batch_converters) == 1
+    assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is AToMultiConverter
+    assert type(path.batch_converters[1]) is AttributeRemapperConverter
     assert len(path.lazy_converters) == 0
 
 
@@ -842,6 +851,193 @@ def test_partial_schema_matching():
     )
 
     path = find_conversion_path(from_schema, to_schema)
-    assert len(path.batch_converters) == 1
+    assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is AToCPartialConverter
+    assert type(path.batch_converters[1]) is AttributeRemapperConverter
     assert len(path.lazy_converters) == 0
+
+
+def test_attribute_renaming():
+    """Test attribute renaming functionality using special converters."""
+
+    # Create source schema with an image field named "input_image"
+    source_schema = Schema(
+        {
+            "input_image": AttributeInfo(
+                type=str, annotation=image_field(dtype=pl.UInt8(), format="RGB")
+            ),
+        }
+    )
+
+    # Create target schema with the same field type but different name "output_image"
+    target_schema = Schema(
+        {
+            "output_image": AttributeInfo(
+                type=str, annotation=image_field(dtype=pl.UInt8(), format="RGB")
+            ),
+        }
+    )
+
+    # Find conversion path - should include a remapper converter
+    path = find_conversion_path(source_schema, target_schema)
+
+    # Should have exactly one batch converter for renaming
+    assert len(path.batch_converters) == 1
+    assert isinstance(path.batch_converters[0], AttributeRemapperConverter)
+    assert len(path.lazy_converters) == 0
+
+    # Test the remapper converter functionality
+    remapper_converter = path.batch_converters[0]
+
+    # Create test DataFrame with the source column
+    test_data = np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8)
+    df = pl.DataFrame(
+        {"input_image": [test_data.flatten()], "input_image_shape": [test_data.shape]}
+    )
+
+    # Apply the remapper converter
+    result_df = remapper_converter.convert(df)
+
+    # Check that columns were renamed correctly
+    assert "output_image" in result_df.columns
+    assert "output_image_shape" in result_df.columns
+    assert "input_image" not in result_df.columns
+    assert "input_image_shape" not in result_df.columns
+
+    # Check that data was preserved
+    assert result_df["output_image"][0].to_list() == test_data.flatten().tolist()
+    assert result_df["output_image_shape"][0].to_list() == list(test_data.shape)
+
+
+def test_attribute_deletion():
+    """Test attribute deletion functionality using AttributeRenameConverter."""
+
+    # Create source schema with two fields
+    source_schema = Schema(
+        {
+            "image": AttributeInfo(
+                type=str, annotation=image_field(dtype=pl.UInt8(), format="RGB")
+            ),
+            "bbox": AttributeInfo(
+                type=str, annotation=bbox_field(dtype=pl.Float32(), format="x1y1x2y2")
+            ),
+        }
+    )
+
+    # Create target schema with only the image field (bbox should be deleted)
+    target_schema = Schema(
+        {
+            "image": AttributeInfo(
+                type=str, annotation=image_field(dtype=pl.UInt8(), format="RGB")
+            ),
+        }
+    )
+
+    # Find conversion path - should include a remapper converter that only keeps image
+    path = find_conversion_path(source_schema, target_schema)
+
+    # Should have exactly one batch converter for selection/deletion
+    assert len(path.batch_converters) == 1
+    assert isinstance(path.batch_converters[0], AttributeRemapperConverter)
+    assert len(path.lazy_converters) == 0
+
+    # Test the remapper converter functionality
+    remapper_converter = path.batch_converters[0]
+
+    # Check that it only keeps the image attribute
+    assert remapper_converter.attr_map == {"image": "image", "image_shape": "image_shape"}
+
+    # Create test DataFrame with both columns
+    test_image = np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8)
+    test_bbox = np.array([[10.0, 20.0, 30.0, 40.0]], dtype=np.float32)
+
+    df = pl.DataFrame(
+        {
+            "image": test_image.reshape(1, -1),
+            "image_shape": [list(test_image.shape)],
+            "bbox": test_bbox.reshape(1, -1, 4),
+        }
+    )
+
+    # Apply the remapper converter
+    result_df = remapper_converter.convert(df)
+
+    # Check that bbox column was removed but image columns remain
+    assert "image" in result_df.columns
+    assert "image_shape" in result_df.columns
+    assert "bbox" not in result_df.columns
+
+    # Check that image data was preserved
+    assert result_df["image"][0].to_list() == test_image.flatten().tolist()
+    assert result_df["image_shape"][0].to_list() == list(test_image.shape)
+
+
+def test_combined_rename_and_delete():
+    """Test scenario with both renaming and deletion operations."""
+
+    # Create source schema with three fields
+    source_schema = Schema(
+        {
+            "old_image": AttributeInfo(
+                type=str, annotation=image_field(dtype=pl.UInt8(), format="RGB")
+            ),
+            "bbox": AttributeInfo(
+                type=str, annotation=bbox_field(dtype=pl.Float32(), format="x1y1x2y2")
+            ),
+            "extra_field": AttributeInfo(type=str, annotation=image_info_field()),
+        }
+    )
+
+    # Create target schema with renamed image and no bbox or extra_field
+    target_schema = Schema(
+        {
+            "new_image": AttributeInfo(
+                type=str, annotation=image_field(dtype=pl.UInt8(), format="RGB")
+            ),
+        }
+    )
+
+    # Find conversion path - should include a single remapper converter that handles both operations
+    path = find_conversion_path(source_schema, target_schema)
+
+    # Should have exactly one batch converter that handles both renaming and deletion
+    assert len(path.batch_converters) == 1
+    assert isinstance(path.batch_converters[0], AttributeRemapperConverter)
+    assert len(path.lazy_converters) == 0
+
+    # Check that the remapper mapping only includes the field we want to keep
+    remapper_converter = path.batch_converters[0]
+    assert remapper_converter.attr_map == {
+        "old_image": "new_image",
+        "old_image_shape": "new_image_shape",
+    }
+
+
+def test_attribute_remapping_converter():
+    """Test AttributeRenameConverter with multiple attributes."""
+    import polars as pl
+
+    # Create test DataFrame with multiple columns including auxiliary columns
+    df = pl.DataFrame(
+        {
+            "old_image": [[1, 2, 3]],
+            "old_image_shape": [[3]],
+            "old_bbox": [[[1, 2, 3, 4]]],
+            "other_field": ["test"],
+        }
+    )
+
+    # Create rename mapping
+    attr_map = {"old_image": "new_image", "old_bbox": "new_bbox"}
+
+    # Create and apply converter
+    converter = AttributeRemapperConverter(attr_map=attr_map)
+    result_df = converter.convert(df)
+
+    # Check that columns were remapped correctly
+    expected_columns = {"new_image", "new_bbox"}
+    assert set(result_df.columns) == expected_columns
+
+    # Check that data is preserved
+    assert result_df["new_image"].to_list() == [[1, 2, 3]]
+    assert result_df["new_bbox"].to_list() == [[[1, 2, 3, 4]]]


### PR DESCRIPTION
This pull request introduces a new post-processing step to the schema conversion logic in the converter registry, ensuring that attribute renaming and deletion are handled explicitly after all field-type conversions. The main change is the addition of the `AttributeRemapperConverter`, which is used internally to finalize attribute names and drop unused attributes, improving the correctness and flexibility of schema conversions. The conversion path finding logic and related tests have been updated to reflect this new step, and some minor improvements were made to the converter implementation details.

### Converter registry and path finding improvements

* Added `AttributeRemapperConverter`, a special converter that performs attribute renaming and selection (dropping others) as a post-processing step after field-type conversions. This converter is not registered globally but is used internally by the conversion path finder.
* Updated the A* search and conversion path logic to append an `AttributeRemapperConverter` when attribute names or the set of attributes do not match the target schema, ensuring that the output schema is correct. [[1]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L540-R647) [[2]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L567-R680)
* Modified `_SchemaState` equality and hashing to ignore attribute names, focusing only on field types and their properties, since renaming is now handled in post-processing.
* Improved `_get_applicable_converters` to simplify the logic and ensure uniqueness of temporary names during conversion steps. [[1]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L405-R497) [[2]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L426-L469)
* Updated the heuristic cost function to ignore attribute names, as they are now fixed in post-processing. [[1]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41R445-R446) [[2]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L386-R471)

### Converter implementation details

* Minor changes to image converters to handle shape column renaming consistently, reflecting the new attribute remapping logic. [[1]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3R70-R72) [[2]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3L82-R86) [[3]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3L132-R144)

### Testing updates

* Added `AttributeRemapperConverter` to the test imports and updated all relevant tests to expect an additional converter in the conversion path, verifying that attribute remapping is performed as a final step. [[1]](diffhunk://#diff-f7d8d115b4530c510a92b0dbc1a1174ca351f0c2767fd8137a2da599fff8b484R13) [[2]](diffhunk://#diff-f7d8d115b4530c510a92b0dbc1a1174ca351f0c2767fd8137a2da599fff8b484R34) [[3]](diffhunk://#diff-f7d8d115b4530c510a92b0dbc1a1174ca351f0c2767fd8137a2da599fff8b484L265-R269) [[4]](diffhunk://#diff-f7d8d115b4530c510a92b0dbc1a1174ca351f0c2767fd8137a2da599fff8b484L396-R403) [[5]](diffhunk://#diff-f7d8d115b4530c510a92b0dbc1a1174ca351f0c2767fd8137a2da599fff8b484L458-R464) [[6]](diffhunk://#diff-f7d8d115b4530c510a92b0dbc1a1174ca351f0c2767fd8137a2da599fff8b484L562-R570) [[7]](diffhunk://#diff-f7d8d115b4530c510a92b0dbc1a1174ca351f0c2767fd8137a2da599fff8b484L701-R709) [[8]](diffhunk://#diff-f7d8d115b4530c510a92b0dbc1a1174ca351f0c2767fd8137a2da599fff8b484L736-R745) [[9]](diffhunk://#diff-f7d8d115b4530c510a92b0dbc1a1174ca351f0c2767fd8137a2da599fff8b484L794-R804)<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/open-edge-platform/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
