### PR TITLE
Fix dependencies for the stability tests

### DIFF
--- a/.github/workflows/weekly_check.yml
+++ b/.github/workflows/weekly_check.yml
@@ -1,11 +1,5 @@
 name: Weekly Stability Test
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
   workflow_dispatch: # run on request (no need for PR)
   schedule:
     # every 7PM on Sunday

--- a/.github/workflows/weekly_check.yml
+++ b/.github/workflows/weekly_check.yml
@@ -1,5 +1,11 @@
 name: Weekly Stability Test
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   workflow_dispatch: # run on request (no need for PR)
   schedule:
     # every 7PM on Sunday

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ This release streamlines Datumaro by removing a number of lesser-used features, 
 
 ### Enhancements
 - Mark several dependencies as optional
-  (<https://github.com/open-edge-platform/datumaro/pull/1849>)
+  (<https://github.com/open-edge-platform/datumaro/pull/1849>, <https://github.com/open-edge-platform/datumaro/pull/1862>)
 - Removal of unneeded dependencies
   (<https://github.com/open-edge-platform/datumaro/pull/1837>)
 - Documentation tidy-up

--- a/tox.ini
+++ b/tox.ini
@@ -111,6 +111,7 @@ extras =
     tf: ["tf", "cli"]
     tfds: ["tfds", "cli"]
     torch: ["torch", "cli"]
+    cli
 allowlist_externals =
     bash
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,8 @@ commands =
 deps=
     {[testenv]deps}
     atheris
+extras =
+    cli: cli
 allowlist_externals =
     bash
 commands_pre =
@@ -105,7 +107,6 @@ commands =
 deps =
     {[testenv:fuzzing]deps}
 extras =
-    default: default
     tf: tf
     tfds: tfds
     torch: torch

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ deps=
     {[testenv]deps}
     atheris
 extras =
-    cli: cli
+    cli
 allowlist_externals =
     bash
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -108,9 +108,9 @@ deps =
     {[testenv:fuzzing]deps}
 extras =
     default: cli
-    tf: tf cli
-    tfds: tfds cli
-    torch: torch cli
+    tf: [tf, cli]
+    tfds: [tfds, cli]
+    torch: [torch, cli]
 allowlist_externals =
     bash
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -107,9 +107,10 @@ commands =
 deps =
     {[testenv:fuzzing]deps}
 extras =
-    tf: tf
-    tfds: tfds
-    torch: torch
+    default: cli
+    tf: tf cli
+    tfds: tfds cli
+    torch: torch cli
 allowlist_externals =
     bash
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -108,9 +108,9 @@ deps =
     {[testenv:fuzzing]deps}
 extras =
     default: cli
-    tf: [tf, cli]
-    tfds: [tfds, cli]
-    torch: [torch, cli]
+    tf: ["tf", "cli"]
+    tfds: ["tfds", "cli"]
+    torch: ["torch", "cli"]
 allowlist_externals =
     bash
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -107,10 +107,9 @@ commands =
 deps =
     {[testenv:fuzzing]deps}
 extras =
-    default: cli
-    tf: ["tf", "cli"]
-    tfds: ["tfds", "cli"]
-    torch: ["torch", "cli"]
+    tf: tf
+    tfds: tfds
+    torch: torch
     cli
 allowlist_externals =
     bash


### PR DESCRIPTION
This pull request updates the `tox.ini` configuration to install the CLI in CLI-based testing environments. This fixes the weekly stability tests which were broken since we made CLI dependencies optional.

Configuration updates for CLI support:

* Added `cli` to the `extras` list in the main test environment, enabling CLI-specific dependencies for general testing.
* Added `cli` to the `extras` list in the `fuzzing` test environment, ensuring CLI dependencies are available for fuzzing tests.
 
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [x] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
