### PR TITLE
Add polygons and mask fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This release streamlines Datumaro by removing a number of lesser-used features, 
 
 ### New features
 - Experimental dataset class
-  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>)
+  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>, <https://github.com/open-edge-platform/datumaro/pull/1868>)
 
 ### Enhancements
 - Mark several dependencies as optional

--- a/src/datumaro/experimental/converters.py
+++ b/src/datumaro/experimental/converters.py
@@ -358,7 +358,7 @@ class BBoxCoordinateConverter(Converter):
         return result_df
 
 
-@converter
+@converter(lazy=True)
 class PolygonToMaskConverter(Converter):
     """
     Converts polygon annotations to rasterized masks.

--- a/src/datumaro/experimental/converters.py
+++ b/src/datumaro/experimental/converters.py
@@ -11,12 +11,22 @@ multi-field transformations.
 
 from typing import Any, Callable
 
+import cv2
 import numpy as np
 import polars as pl
 from PIL import Image
 
 from .converter_registry import AttributeSpec, Converter, converter
-from .fields import BBoxField, ImageField, ImagePathField
+from .fields import (
+    BBoxField,
+    ImageField,
+    ImageInfoField,
+    ImagePathField,
+    LabelField,
+    MaskField,
+    PolygonField,
+)
+from .type_registry import polars_to_numpy_dtype
 
 
 @converter
@@ -346,3 +356,134 @@ class BBoxCoordinateConverter(Converter):
         result_df = result_df.drop([temp_width_col, temp_height_col])
 
         return result_df
+
+
+@converter
+class PolygonToMaskConverter(Converter):
+    """
+    Converts polygon annotations to rasterized masks.
+
+    Transforms polygon coordinates into binary or indexed masks using
+    OpenCV contour filling for efficient rasterization.
+    """
+
+    input_polygon: AttributeSpec[PolygonField]
+    input_labels: AttributeSpec[LabelField]
+    image_info: AttributeSpec[ImageInfoField]
+    output_mask: AttributeSpec[MaskField]
+
+    # Configuration options
+    background_index: int = 0  # Background value
+
+    def filter_output_spec(self) -> bool:
+        """
+        Configure mask output specification.
+
+        Returns:
+            True if the converter should be applied, False otherwise
+        """
+        # Configure output for mask format
+        self.output_mask = AttributeSpec(
+            name=self.output_mask.name,
+            field=MaskField(
+                semantic=self.input_polygon.field.semantic,
+                dtype=self.output_mask.field.dtype,
+            ),
+        )
+
+        return True
+
+    def convert(self, df: pl.DataFrame) -> pl.DataFrame:
+        """
+        Rasterize polygon coordinates into indexed masks.
+
+        Args:
+            df: DataFrame with polygon coordinates, labels, and image info
+
+        Returns:
+            DataFrame with mask data in output column
+        """
+        input_column_name = self.input_polygon.name
+        labels_column_name = self.input_labels.name
+        image_info_column_name = self.image_info.name
+        output_column_name = self.output_mask.name
+        output_shape_column_name = self.output_mask.name + "_shape"
+
+        def polygons_to_mask(
+            polygons_data: list, labels_data: list, img_info: dict
+        ) -> tuple[list[int], list[int]]:
+            """Rasterize polygons into indexed mask using OpenCV contour filling."""
+            # Extract image dimensions
+            image_width = img_info["width"]
+            image_height = img_info["height"]
+
+            # Initialize mask with background index
+            numpy_dtype = polars_to_numpy_dtype(self.output_mask.field.dtype)
+            mask = np.full(
+                shape=(image_height, image_width),
+                fill_value=self.background_index,
+                dtype=numpy_dtype,
+            )
+
+            # Rasterize each polygon
+            for i, polygon_data in enumerate(polygons_data):
+                coords = polygon_data.to_numpy()
+                class_index = labels_data[i]
+
+                # Denormalize coordinates if needed
+                if self.input_polygon.field.normalize:
+                    coords = coords.copy()
+                    coords[:, 0] *= image_width
+                    coords[:, 1] *= image_height
+
+                # Convert to OpenCV contour format
+                contour = coords.astype(np.int32)
+
+                # Fill polygon with class index
+                cv2.drawContours(
+                    mask,
+                    [contour],
+                    0,
+                    int(class_index),
+                    thickness=cv2.FILLED,
+                )
+
+            return mask.reshape(-1), [image_height, image_width]
+
+        # Apply conversion using map_batches
+        def apply_conversion_batch(batch_df: pl.DataFrame) -> pl.DataFrame:
+            """Apply polygon-to-mask conversion for a batch."""
+            batch_polygons = batch_df.struct["polygons"]
+            batch_labels = batch_df.struct["labels"]
+            batch_img_infos = batch_df.struct["img_info"]
+
+            results_batch_polygons = []
+            results_batch_shape = []
+            for polygons, labels, img_infos in zip(batch_polygons, batch_labels, batch_img_infos):
+                mask_data, shape_data = polygons_to_mask(polygons, labels, img_infos)
+                results_batch_polygons.append(pl.Series(mask_data))
+                results_batch_shape.append(shape_data)
+
+            return pl.struct(
+                pl.Series(results_batch_polygons).alias("mask"),
+                pl.Series(results_batch_shape, dtype=pl.List(pl.Int32)).alias("shape"),
+                eager=True,
+            )
+
+        mask_data = pl.struct(
+            [
+                pl.col(input_column_name).alias("polygons"),
+                pl.col(labels_column_name).alias("labels"),
+                pl.col(image_info_column_name).alias("img_info"),
+            ]
+        ).map_batches(
+            apply_conversion_batch,
+            return_dtype=pl.Struct({"mask": pl.List(pl.UInt8), "shape": pl.List(pl.Int32)}),
+        )
+
+        return df.with_columns(
+            [
+                mask_data.struct.field("mask").alias(output_column_name),
+                mask_data.struct.field("shape").alias(output_shape_column_name),
+            ]
+        )

--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -353,8 +353,7 @@ def convert_numpy_object_array_to_series(data: np.ndarray) -> pl.Series:
     """
     if data.dtype == object:
         return pl.Series([convert_numpy_object_array_to_series(elem) for elem in data])
-    else:
-        return pl.Series(data)
+    return pl.Series(data)
 
 
 @dataclass(frozen=True)

--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -316,7 +316,7 @@ def label_field(
     return LabelField(semantic=semantic, dtype=dtype, multi_label=multi_label, is_list=is_list)
 
 
-def convert_numpy_object_array_to_series(data):
+def convert_numpy_object_array_to_series(data: np.ndarray) -> pl.Series:
     """
     Convert ragged numpy object arrays to Polars Series recursively.
 
@@ -351,7 +351,7 @@ def convert_numpy_object_array_to_series(data):
                 [6 7 8 9]
         ]
     """
-    if data.dtype == "O":
+    if data.dtype == object:
         return pl.Series([convert_numpy_object_array_to_series(elem) for elem in data])
     else:
         return pl.Series(data)

--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -262,22 +262,32 @@ class LabelField(Field):
     semantic: Semantic
     dtype: Any
     multi_label: bool = False  # Flag to indicate if this field should handle multi-labels
+    is_list: bool = False
+
+    @property
+    def _pl_type(self) -> pl.DataType:
+        pl_type = self.dtype
+        if self.multi_label:
+            pl_type = pl.List(pl_type)
+        if self.is_list:
+            pl_type = pl.List(pl_type)
+        return pl_type
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         """Generate schema based on whether this is single or multi-label."""
-        if self.multi_label:
-            return {name: pl.List(self.dtype)}
-        return {name: self.dtype}
+        return {name: self._pl_type}
 
     def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
         """Convert label(s) to Polars format for single or multi-label cases."""
+        pl_type = self._pl_type
+
         if value is None:
-            return {name: pl.Series(name, [None], dtype=self.dtype)}
+            return {name: pl.Series(name, [None], dtype=pl_type)}
 
         if self.multi_label:
             return {name: pl.Series(name, [to_numpy(value)], dtype=pl.List(self.dtype))}
 
-        return {name: pl.Series(name, [value], dtype=self.dtype)}
+        return {name: pl.Series(name, [value], dtype=pl_type)}
 
     def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type[T]) -> T:
         """Reconstruct label(s) from Polars data."""
@@ -286,7 +296,10 @@ class LabelField(Field):
 
 
 def label_field(
-    dtype: Any = pl.Int32(), semantic: Semantic = Semantic.Default, multi_label: bool = False
+    dtype: Any = pl.Int32(),
+    semantic: Semantic = Semantic.Default,
+    multi_label: bool = False,
+    is_list: bool = False,
 ) -> Any:
     """
     Create a LabelField instance with the specified parameters.
@@ -295,8 +308,161 @@ def label_field(
         dtype: Polars data type for label values (defaults to pl.Int32())
         semantic: Semantic tags describing the label purpose (optional)
         multi_label: Whether this field should handle multiple labels (defaults to False)
+        is_list: Whether this field should be treated as a list type (defaults to False)
 
     Returns:
         LabelField instance configured with the given parameters
     """
-    return LabelField(semantic=semantic, dtype=dtype, multi_label=multi_label)
+    return LabelField(semantic=semantic, dtype=dtype, multi_label=multi_label, is_list=is_list)
+
+
+def convert_numpy_object_array_to_series(data):
+    """
+    Convert ragged numpy object arrays to Polars Series recursively.
+
+    Handles nested object arrays containing variable-length lists.
+
+    Example:
+        >>> import numpy as np
+        >>> ragged = np.array([
+        ...     np.array([1, 2, 3]),
+        ...     np.array([4, 5]),
+        ...     np.array([6, 7, 8, 9])
+        ... ], dtype=object)
+        >>> series = convert_numpy_object_array_to_series(ragged)
+        >>> print(series)
+        shape: (3,)
+        Series: '' [list[i64]]
+        [
+                [1, 2, 3]
+                [4, 5]
+                [6, 7, … 9]
+        ]
+
+        # Compare with direct conversion which results
+        # into an object Series instead of a list Series:
+        >>> direct = pl.Series(ragged)
+        >>> print(direct)
+        shape: (3,)
+        Series: '' [o][object]
+        [
+                [1 2 3]
+                [4 5]
+                [6 7 8 9]
+        ]
+    """
+    if data.dtype == "O":
+        return pl.Series([convert_numpy_object_array_to_series(elem) for elem in data])
+    else:
+        return pl.Series(data)
+
+
+@dataclass(frozen=True)
+class PolygonField(Field):
+    """
+    Represents a polygon field with format and normalization options.
+
+    Handles polygon data with support for different coordinate formats
+    and optional normalization to [0,1] range. Polygons are stored as
+    variable-length lists of coordinate pairs.
+
+    Attributes:
+        semantic: Semantic tags describing the polygon purpose
+        dtype: Polars data type for coordinate values
+        format: Coordinate format (e.g., "xy", "yx")
+        normalize: Whether coordinates are normalized to [0,1] range
+    """
+
+    semantic: Semantic
+    dtype: Any
+    format: str
+    normalize: bool
+
+    def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
+        """Generate schema for polygon as list of coordinate values."""
+        return {name: pl.List(pl.List(pl.Array(self.dtype, 2)))}
+
+    def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
+        """Convert polygon tensor to Polars list format."""
+        numpy_value = to_numpy(value, self.dtype)
+
+        series = convert_numpy_object_array_to_series(numpy_value)
+
+        return {name: pl.Series(name, [series], dtype=pl.List(pl.List(pl.Array(self.dtype, 2))))}
+
+    def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type[T]) -> T:
+        """Reconstruct polygon tensor from Polars data."""
+        polars_data = df[name][row_index]
+        return from_polars_data(polars_data, target_type)  # type: ignore
+
+
+def polygon_field(
+    dtype: Any,
+    format: str = "xy",
+    normalize: bool = False,
+    semantic: Semantic = Semantic.Default,
+) -> Any:
+    """
+    Create a PolygonField instance with the specified parameters.
+
+    Args:
+        dtype: Polars data type for coordinate values
+        format: Coordinate format (defaults to "xy")
+        normalize: Whether coordinates are normalized (defaults to False)
+        semantic: Semantic tags describing the polygon purpose (optional)
+
+    Returns:
+        PolygonField instance configured with the given parameters
+    """
+    return PolygonField(semantic=semantic, dtype=dtype, format=format, normalize=normalize)
+
+
+@dataclass(frozen=True)
+class MaskField(Field):
+    """
+    Represents a mask tensor field for binary or indexed segmentation masks.
+
+    Similar to TensorField but specialized for masks: handles single-channel
+    2D arrays with no color format specification. Uses uint8 as the default
+    data type suitable for binary masks, class masks, or instance masks.
+
+    Attributes:
+        semantic: Semantic tags describing the mask purpose
+        dtype: Polars data type for mask values (defaults to uint8)
+    """
+
+    semantic: Semantic
+    dtype: Any
+
+    def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
+        """Generate Polars schema with separate columns for data and shape."""
+        return {name: pl.List(self.dtype), name + "_shape": pl.List(pl.Int32())}
+
+    def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
+        """Convert mask tensor to flattened data and shape information."""
+        numpy_value = to_numpy(value, self.dtype)
+        return {
+            name: pl.Series(name, [numpy_value.reshape(-1)]),
+            name + "_shape": pl.Series(name + "_shape", [numpy_value.shape]),
+        }
+
+    def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type[T]) -> T:
+        """Reconstruct mask tensor from flattened data using stored shape."""
+        flat_data = df[name][row_index]
+        shape = df[name + "_shape"][row_index]
+        numpy_data = np.array(flat_data).reshape(shape)
+        return from_polars_data(numpy_data, target_type)  # type: ignore
+
+
+def mask_field(dtype: Any = pl.UInt8(), semantic: Semantic = Semantic.Default) -> Any:
+    """
+    Create a MaskField instance with the specified parameters.
+
+    Args:
+        dtype: Polars data type for mask values (defaults to pl.UInt8())
+        semantic: Semantic tags describing the mask purpose (optional)
+
+    Returns:
+        MaskField instance configured with the given parameters
+    """
+    return MaskField(semantic=semantic, dtype=dtype)

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -16,7 +16,7 @@ from typing import Any, Type, cast
 import numpy as np
 import polars as pl
 
-from datumaro.components.annotation import Annotation, AnnotationType, Bbox
+from datumaro.components.annotation import Annotation, AnnotationType, Bbox, Polygon
 from datumaro.components.dataset import Dataset as LegacyDataset
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
 from datumaro.components.media import FromFileMixin, Image, MediaElement
@@ -25,10 +25,12 @@ from .dataset import Dataset, Sample
 from .fields import (
     BBoxField,
     ImagePathField,
-    TensorField,
+    LabelField,
+    PolygonField,
     bbox_field,
     image_path_field,
-    tensor_field,
+    label_field,
+    polygon_field,
 )
 from .schema import AttributeInfo, Schema
 
@@ -50,8 +52,22 @@ class ForwardMediaConverter(ABC):
 class ForwardAnnotationConverter(ABC):
     """Base class for forward annotation type converters."""
 
+    @classmethod
     @abstractmethod
-    def get_schema_attributes(self, categories: CategoriesInfo) -> dict[str, AttributeInfo]:
+    def create_from_categories(
+        cls, categories: CategoriesInfo
+    ) -> "ForwardAnnotationConverter | None":
+        """Create converter instance if categories support this annotation type."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_annotation_type(cls) -> AnnotationType:
+        """Get the annotation type this converter handles."""
+        pass
+
+    @abstractmethod
+    def get_schema_attributes(self) -> dict[str, AttributeInfo]:
         """Return schema attributes for this annotation type."""
         pass
 
@@ -65,7 +81,7 @@ class ForwardAnnotationConverter(ABC):
 
 # Global registries
 _media_converters: dict[Type[MediaElement[Any]], ForwardMediaConverter] = {}
-_annotation_converters: dict[AnnotationType, ForwardAnnotationConverter] = {}
+_annotation_converters: dict[AnnotationType, Type[ForwardAnnotationConverter]] = {}
 
 
 def register_forward_media_converter(
@@ -76,10 +92,11 @@ def register_forward_media_converter(
 
 
 def register_forward_annotation_converter(
-    annotation_type: AnnotationType, converter: ForwardAnnotationConverter
+    converter_class: Type[ForwardAnnotationConverter],
 ) -> None:
-    """Register a forward converter for an annotation type."""
-    _annotation_converters[annotation_type] = converter
+    """Register a forward converter class for an annotation type."""
+    annotation_type = converter_class.get_annotation_type()
+    _annotation_converters[annotation_type] = converter_class
 
 
 def get_forward_media_converter(media_type: Type[MediaElement[Any]]) -> ForwardMediaConverter:
@@ -90,11 +107,14 @@ def get_forward_media_converter(media_type: Type[MediaElement[Any]]) -> ForwardM
     raise ValueError(f"No converter registered for media type: {media_type}")
 
 
-def get_forward_annotation_converter(annotation_type: AnnotationType) -> ForwardAnnotationConverter:
-    """Get forward converter for an annotation type."""
+def get_forward_annotation_converter(
+    annotation_type: AnnotationType, categories: CategoriesInfo
+) -> ForwardAnnotationConverter | None:
+    """Get forward converter for an annotation type that can handle the given categories."""
     if annotation_type not in _annotation_converters:
-        raise ValueError(f"No converter registered for annotation type: {annotation_type}")
-    return _annotation_converters[annotation_type]
+        return None
+    converter_class = _annotation_converters[annotation_type]
+    return converter_class.create_from_categories(categories)
 
 
 class ForwardImageMediaConverter(ForwardMediaConverter):
@@ -119,13 +139,42 @@ class ForwardImageMediaConverter(ForwardMediaConverter):
 class ForwardBboxAnnotationConverter(ForwardAnnotationConverter):
     """Forward converter for Bbox annotations."""
 
-    def get_schema_attributes(self, categories: CategoriesInfo) -> dict[str, AttributeInfo]:
-        return {
-            "bboxes": AttributeInfo(
-                type=np.ndarray, annotation=bbox_field(dtype=pl.Float32, format="x1y1x2y2")
-            ),
-            "bbox_labels": AttributeInfo(type=np.ndarray, annotation=tensor_field(dtype=pl.Int32)),
-        }
+    def __init__(self, bbox_attribute: AttributeInfo, bbox_labels_attribute: AttributeInfo | None):
+        """Initialize with bbox attributes and label attribute name."""
+        super().__init__()
+        self.bbox_attribute = bbox_attribute
+        self.bbox_labels_attribute = bbox_labels_attribute
+
+    @classmethod
+    def create_from_categories(
+        cls, categories: CategoriesInfo
+    ) -> "ForwardBboxAnnotationConverter | None":
+        """Create converter instance for bbox annotations."""
+        # Extract label categories if available
+        label_categories = categories.get(AnnotationType.label, None)
+
+        bbox_attribute = AttributeInfo(type=np.ndarray, annotation=bbox_field(dtype=pl.Float32))
+
+        bbox_labels_attribute = None
+        # Only add bbox_labels if we have label categories
+        if label_categories is not None:
+            bbox_labels_attribute = AttributeInfo(
+                type=np.ndarray,
+                annotation=label_field(dtype=pl.Int32, multi_label=False, is_list=True),
+                categories=label_categories,
+            )
+
+        return cls(bbox_attribute=bbox_attribute, bbox_labels_attribute=bbox_labels_attribute)
+
+    @classmethod
+    def get_annotation_type(cls) -> AnnotationType:
+        return AnnotationType.bbox
+
+    def get_schema_attributes(self) -> dict[str, AttributeInfo]:
+        attributes = {"bboxes": self.bbox_attribute}
+        if self.bbox_labels_attribute is not None:
+            attributes["bbox_labels"] = self.bbox_labels_attribute
+        return attributes
 
     def convert_annotations(
         self, annotations: list[Annotation], item: DatasetItem
@@ -144,7 +193,90 @@ class ForwardBboxAnnotationConverter(ForwardAnnotationConverter):
         if bboxes_array.shape == (0,):
             bboxes_array = bboxes_array.reshape(0, 4)
 
-        return {"bboxes": bboxes_array, "bbox_labels": np.array(labels, dtype=np.int32)}
+        result = {"bboxes": bboxes_array}
+
+        # Only add bbox_labels if we have label categories
+        if self.bbox_labels_attribute is not None:
+            result["bbox_labels"] = np.array(labels, dtype=np.int32)
+
+        return result
+
+
+class ForwardPolygonAnnotationConverter(ForwardAnnotationConverter):
+    """Forward converter for Polygon annotations."""
+
+    def __init__(
+        self, polygon_attribute: AttributeInfo, polygon_labels_attribute: AttributeInfo | None
+    ):
+        """Initialize with polygon attributes and label attribute."""
+        super().__init__()
+        self.polygon_attribute = polygon_attribute
+        self.polygon_labels_attribute = polygon_labels_attribute
+
+    @classmethod
+    def create_from_categories(
+        cls, categories: CategoriesInfo
+    ) -> "ForwardPolygonAnnotationConverter | None":
+        """Create converter instance for polygon annotations."""
+        # Extract label categories if available
+        label_categories = categories.get(AnnotationType.label, None)
+
+        polygon_attribute = AttributeInfo(
+            type=np.ndarray, annotation=polygon_field(dtype=pl.Float32, format="xy")
+        )
+
+        polygon_labels_attribute = None
+        # Only add polygon_labels if we have label categories
+        if label_categories is not None:
+            polygon_labels_attribute = AttributeInfo(
+                type=np.ndarray,
+                annotation=label_field(dtype=pl.Int32, multi_label=False, is_list=True),
+                categories=label_categories,
+            )
+
+        return cls(
+            polygon_attribute=polygon_attribute, polygon_labels_attribute=polygon_labels_attribute
+        )
+
+    @classmethod
+    def get_annotation_type(cls) -> AnnotationType:
+        return AnnotationType.polygon
+
+    def get_schema_attributes(self) -> dict[str, AttributeInfo]:
+        attributes = {"polygons": self.polygon_attribute}
+        if self.polygon_labels_attribute is not None:
+            attributes["polygon_labels"] = self.polygon_labels_attribute
+        return attributes
+
+    def convert_annotations(
+        self, annotations: list[Annotation], item: DatasetItem
+    ) -> dict[str, Any]:
+        polygons: list[list[float]] = []
+        labels: list[int | None] = []
+
+        for ann in annotations:
+            if isinstance(ann, Polygon):
+                # Points are stored as flat coordinates in Polygon
+                # ann.points in the format [x1,y1,x2,y2,...] format
+                polygons.append(np.array(ann.points).reshape(-1, 2))
+                labels.append(ann.label)
+
+        # Convert to numpy array - polygons is a list of variable-length coordinate lists
+        # We'll store it as a ragged array (object dtype to handle different lengths)
+
+        # When using np.array, there is a corner case for the case where len(polygons) == 1 where
+        # Numpy creates a 2D array of objects instead of a 1D array of objects.
+        # We may be able to solve this in the upcoming version of Numpy with the argument ndmax.
+        # In the meantime, create an empty array, then assign to avoid the corner case
+        polygons_array = np.empty((len(polygons),), dtype=object)
+        polygons_array[:] = polygons
+        result = {"polygons": polygons_array}
+
+        # Only add polygon_labels if we have label categories
+        if self.polygon_labels_attribute is not None:
+            result["polygon_labels"] = np.array(labels, dtype=np.int32)
+
+        return result
 
 
 def register_builtin_forward_converters():
@@ -154,7 +286,8 @@ def register_builtin_forward_converters():
     register_forward_media_converter(Image, ForwardImageMediaConverter())
 
     # Annotation converters
-    register_forward_annotation_converter(AnnotationType.bbox, ForwardBboxAnnotationConverter())
+    register_forward_annotation_converter(ForwardBboxAnnotationConverter)
+    register_forward_annotation_converter(ForwardPolygonAnnotationConverter)
 
 
 from dataclasses import dataclass
@@ -196,15 +329,12 @@ def analyze_legacy_dataset(legacy_dataset: LegacyDataset) -> AnalysisResult:
         # No converter for this media type - skip
         pass
 
-    # Get annotation attributes from converters
+    # Get annotation attributes from converters for each annotation type in the dataset
     for ann_type in ann_types:
-        try:
-            ann_converter = get_forward_annotation_converter(ann_type)
-            ann_converters[ann_type] = ann_converter
-            attributes.update(ann_converter.get_schema_attributes(categories))
-        except ValueError:
-            # No converter for this annotation type - skip
-            continue
+        converter = get_forward_annotation_converter(ann_type, categories)
+        if converter is not None:
+            ann_converters[ann_type] = converter
+            attributes.update(converter.get_schema_attributes())
 
     schema = Schema(attributes=attributes)
     return AnalysisResult(
@@ -381,11 +511,9 @@ class BackwardBboxAnnotationConverter(BackwardAnnotationConverter):
                 bboxes_attr = attr_name
                 break
 
-        # Find bbox_labels field (look for tensor field with 'bbox_labels' in name or similar pattern)
+        # Find bbox_labels field (look for label field with 'bbox_labels' in name or similar pattern)
         for attr_name, attr_info in schema.attributes.items():
-            if isinstance(attr_info.annotation, TensorField) and (
-                "bbox_label" in attr_name.lower() or "label" in attr_name.lower()
-            ):
+            if isinstance(attr_info.annotation, LabelField):
                 bbox_labels_attr = attr_name
                 break
 
@@ -429,6 +557,82 @@ class BackwardBboxAnnotationConverter(BackwardAnnotationConverter):
             bbox_labels = getattr(sample, self.bbox_labels_attr, None)
             if bbox_labels is not None:
                 for label_id in bbox_labels:
+                    if label_id is not None:
+                        label_ids.add(int(label_id))
+
+        # Create label categories
+        label_categories = LabelCategories()
+        for label_id in sorted(label_ids):
+            label_categories.add(f"class_{label_id}")
+
+        return {AnnotationType.label: label_categories}
+
+
+class BackwardPolygonAnnotationConverter(BackwardAnnotationConverter):
+    """Backward converter for Polygon annotations."""
+
+    def __init__(self, polygons_attr: str, polygon_labels_attr: str | None):
+        """Initialize with the names of the polygon-related attributes."""
+        self.polygons_attr = polygons_attr
+        self.polygon_labels_attr = polygon_labels_attr
+
+    @classmethod
+    def create_from_schema(cls, schema: Schema) -> "BackwardPolygonAnnotationConverter | None":
+        """Create converter instance if schema contains polygon-related fields."""
+        polygons_attr = None
+        polygon_labels_attr = None
+
+        # Find polygon field
+        for attr_name, attr_info in schema.attributes.items():
+            if isinstance(attr_info.annotation, PolygonField):
+                polygons_attr = attr_name
+                break
+
+        # Find polygon_labels field
+        for attr_name, attr_info in schema.attributes.items():
+            if isinstance(attr_info.annotation, LabelField):
+                polygon_labels_attr = attr_name
+                break
+
+        if polygons_attr:
+            return cls(polygons_attr=polygons_attr, polygon_labels_attr=polygon_labels_attr)
+        return None
+
+    def get_annotation_type(self) -> AnnotationType:
+        return AnnotationType.polygon
+
+    def convert_to_legacy_annotations(
+        self, sample: Sample, categories: CategoriesInfo
+    ) -> list[Annotation]:
+        """Convert polygons and polygon_labels back to legacy Polygon annotations."""
+        polygons = getattr(sample, self.polygons_attr)
+        polygon_labels = (
+            getattr(sample, self.polygon_labels_attr) if self.polygon_labels_attr else None
+        )
+
+        annotations: list[Annotation] = []
+        for i in range(len(polygons)):
+            flat_coords = polygons[i].reshape(-1)
+            label = int(polygon_labels[i]) if polygon_labels is not None else None
+
+            polygon = Polygon(points=flat_coords, label=label)
+            annotations.append(polygon)
+
+        return annotations
+
+    def infer_categories(self, experimental_dataset: Dataset[Sample]) -> CategoriesInfo:
+        """Infer label categories from polygon_labels."""
+        from datumaro.components.annotation import LabelCategories
+
+        if self.polygon_labels_attr is None:
+            return {}
+
+        # Collect all unique label IDs
+        label_ids: set[int] = set()
+        for sample in experimental_dataset:
+            polygon_labels = getattr(sample, self.polygon_labels_attr, None)
+            if polygon_labels is not None:
+                for label_id in polygon_labels:
                     if label_id is not None:
                         label_ids.add(int(label_id))
 
@@ -567,6 +771,7 @@ def register_builtin_backward_converters():
 
     # Register backward annotation converters
     register_backward_annotation_converter(BackwardBboxAnnotationConverter)
+    register_backward_annotation_converter(BackwardPolygonAnnotationConverter)
 
 
 # Auto-register built-in converters when module is imported

--- a/src/datumaro/experimental/type_registry.py
+++ b/src/datumaro/experimental/type_registry.py
@@ -131,8 +131,10 @@ def to_numpy(value: Any, dtype: Any = None) -> np.ndarray[Any, Any]:
 
         # Apply dtype conversion if specified
         if dtype is not None:
-            if numpy_value.dtype == "O":
-                nested_func = np.vectorize(lambda x: to_numpy(x, dtype), otypes="O")
+            if numpy_value.dtype == object:
+                nested_func = np.vectorize(
+                    lambda x: to_numpy(x, dtype), otypes=numpy_value.dtype.char
+                )
                 numpy_value = nested_func(numpy_value)
             else:
                 target_numpy_dtype = polars_to_numpy_dtype(dtype)

--- a/src/datumaro/experimental/type_registry.py
+++ b/src/datumaro/experimental/type_registry.py
@@ -16,6 +16,51 @@ from typing import Any, Callable, Union
 import numpy as np
 import polars as pl
 
+
+def polars_to_numpy_dtype(polars_dtype: pl.DataType) -> np.dtype[Any]:
+    """Convert a Polars dtype to the corresponding NumPy dtype.
+
+    Args:
+        polars_dtype: Polars data type to convert
+
+    Returns:
+        Corresponding NumPy dtype
+
+    Raises:
+        TypeError: If no mapping exists for the given Polars dtype
+
+    Example:
+        >>> numpy_dtype = polars_to_numpy_dtype(pl.Float32)
+        >>> numpy_dtype == np.float32
+        True
+    """
+    # Basic numeric types
+    if polars_dtype == pl.Float32:
+        return np.dtype(np.float32)
+    elif polars_dtype == pl.Float64:
+        return np.dtype(np.float64)
+    elif polars_dtype == pl.Int8:
+        return np.dtype(np.int8)
+    elif polars_dtype == pl.Int16:
+        return np.dtype(np.int16)
+    elif polars_dtype == pl.Int32:
+        return np.dtype(np.int32)
+    elif polars_dtype == pl.Int64:
+        return np.dtype(np.int64)
+    elif polars_dtype == pl.UInt8:
+        return np.dtype(np.uint8)
+    elif polars_dtype == pl.UInt16:
+        return np.dtype(np.uint16)
+    elif polars_dtype == pl.UInt32:
+        return np.dtype(np.uint32)
+    elif polars_dtype == pl.UInt64:
+        return np.dtype(np.uint64)
+    elif polars_dtype == pl.Boolean:
+        return np.dtype(np.bool_)
+    else:
+        raise TypeError(f"No NumPy dtype mapping for Polars dtype: {polars_dtype}")
+
+
 # Type conversion registry - extensible at runtime
 _to_numpy_converters: dict[type, Callable[[Any], np.ndarray[Any, Any]]] = {
     np.ndarray: lambda x: x,
@@ -86,14 +131,12 @@ def to_numpy(value: Any, dtype: Any = None) -> np.ndarray[Any, Any]:
 
         # Apply dtype conversion if specified
         if dtype is not None:
-            if dtype == pl.Float32:
-                numpy_value = numpy_value.astype(np.float32)
-            elif dtype == pl.Float64:
-                numpy_value = numpy_value.astype(np.float64)
-            elif dtype == pl.Int32:
-                numpy_value = numpy_value.astype(np.int32)
-            elif dtype == pl.Int64:
-                numpy_value = numpy_value.astype(np.int64)
+            if numpy_value.dtype == "O":
+                nested_func = np.vectorize(lambda x: to_numpy(x, dtype), otypes="O")
+                numpy_value = nested_func(numpy_value)
+            else:
+                target_numpy_dtype = polars_to_numpy_dtype(dtype)
+                numpy_value = numpy_value.astype(target_numpy_dtype)
 
         return numpy_value
 

--- a/tests/unit/experimental/test_converters.py
+++ b/tests/unit/experimental/test_converters.py
@@ -21,6 +21,7 @@ from datumaro.experimental.converter_registry import (
 from datumaro.experimental.converters import (
     BBoxCoordinateConverter,
     ImagePathToImageConverter,
+    PolygonToMaskConverter,
     RGBToBGRConverter,
     UInt8ToFloat32Converter,
 )
@@ -28,7 +29,11 @@ from datumaro.experimental.fields import (
     BBoxField,
     Field,
     ImageField,
+    ImageInfoField,
     ImagePathField,
+    LabelField,
+    MaskField,
+    PolygonField,
     bbox_field,
     image_field,
     image_info_field,
@@ -1061,3 +1066,160 @@ def test_attribute_remapping_converter():
     assert result_df["new_image"].to_list() == [[1, 2, 3]]
     assert result_df["new_image_shape"].to_list() == [[3]]
     assert result_df["new_bbox"].to_list() == [[[1, 2, 3, 4]]]
+
+
+def test_polygon_to_mask_converter():
+    """Test conversion from polygon coordinates to mask format."""
+    converter_instance = PolygonToMaskConverter()  # type: ignore[call-arg]
+
+    # Create test data with polygon coordinates and labels
+    # Triangle polygon: (10,10) -> (30,10) -> (20,30) -> (10,10)
+    polygon_coords1 = [[10.0, 10.0], [30.0, 10.0], [20.0, 30.0]]
+
+    # Rectangle polygon: (40,40) -> (60,40) -> (60,60) -> (40,60) -> (40,40)
+    polygon_coords2 = [[40.0, 40.0], [60.0, 40.0], [60.0, 60.0], [40.0, 60.0], [40.0, 40.0]]
+
+    # Pentagon polygon: (70,10) -> (85,5) -> (90,20) -> (80,35) -> (65,25)
+    polygon_coords3 = [[70.0, 10.0], [85.0, 5.0], [90.0, 20.0], [80.0, 35.0], [65.0, 25.0]]
+
+    polygon_series = pl.Series(
+        [polygon_coords1, polygon_coords2, polygon_coords3], dtype=pl.List(pl.Array(pl.Float32, 2))
+    )
+
+    df = pl.DataFrame(
+        {
+            "polygons": [polygon_series],  # List of three polygons
+            "labels": [[1, 2, 3]],  # Corresponding labels for each polygon
+            "image_info": [{"width": 100, "height": 100}],  # Image dimensions
+        }
+    )
+
+    # Set up converter attributes
+    input_polygon_field = PolygonField(
+        dtype=pl.Float32, format="xy", normalize=False, semantic=Semantic.Default
+    )
+    input_labels_field = LabelField(dtype=pl.Int32, semantic=Semantic.Default, multi_label=True)
+    image_info_field = ImageInfoField(semantic=Semantic.Default)
+    output_mask_field = MaskField(dtype=pl.UInt8, semantic=Semantic.Default)
+
+    setattr(
+        converter_instance,
+        "input_polygon",
+        AttributeSpec(name="polygons", field=input_polygon_field),
+    )
+    setattr(
+        converter_instance,
+        "input_labels",
+        AttributeSpec(name="labels", field=input_labels_field),
+    )
+    setattr(
+        converter_instance,
+        "image_info",
+        AttributeSpec(name="image_info", field=image_info_field),
+    )
+    setattr(
+        converter_instance,
+        "output_mask",
+        AttributeSpec(name="mask", field=output_mask_field),
+    )
+
+    # Test filter - should return True when we have valid input
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    # Check that mask column was created
+    assert "mask" in result_df.columns
+    assert "mask_shape" in result_df.columns
+
+    # Get the mask data and reshape it
+    mask_data = np.array(result_df["mask"][0])
+    mask_shape = result_df["mask_shape"][0]
+    mask = mask_data.reshape(mask_shape)
+
+    # Check mask properties
+    assert mask.shape == (100, 100)  # Should match image dimensions
+    assert mask.dtype == np.uint8
+
+    # Check that polygons were filled with correct labels
+    # Triangle should have label 1, rectangle should have label 2, pentagon should have label 3
+    # Background should be 0
+
+    # Check that triangle area has label 1
+    assert mask[15, 20] == 1  # Point inside triangle
+
+    # Check that rectangle area has label 2
+    assert mask[50, 50] == 2  # Point inside rectangle
+
+    # Check that pentagon area has label 3
+    assert mask[20, 75] == 3  # Point inside pentagon
+
+    # Check background area has label 0
+    assert mask[5, 5] == 0  # Point outside all polygons
+    assert mask[95, 95] == 0  # Another background point
+
+    # Check that mask contains the expected label values
+    unique_labels = np.unique(mask)
+    assert 0 in unique_labels  # Background
+    assert 1 in unique_labels  # First polygon label (triangle)
+    assert 2 in unique_labels  # Second polygon label (rectangle)
+    assert 3 in unique_labels  # Third polygon label (pentagon)
+
+
+def test_polygon_to_mask_converter_normalized():
+    """Test conversion with normalized polygon coordinates."""
+    converter_instance = PolygonToMaskConverter()  # type: ignore[call-arg]
+
+    # Create test data with normalized coordinates (0.0 to 1.0 range)
+    # Small triangle in normalized coordinates
+    polygon_coords = [[0.1, 0.1], [0.3, 0.1], [0.2, 0.3]]  # Normalized coordinates
+    polygon_series = pl.Series([polygon_coords], dtype=pl.List(pl.Array(pl.Float32, 2)))
+
+    df = pl.DataFrame(
+        {
+            "polygons": [polygon_series],
+            "labels": [[5]],  # Label 5 for this polygon
+            "image_info": [{"width": 100, "height": 100}],
+        }
+    )
+
+    # Set up converter attributes with normalization enabled
+    input_polygon_field = PolygonField(
+        dtype=pl.Float32,
+        format="xy",
+        normalize=True,  # Enable normalization
+        semantic=Semantic.Default,
+    )
+    input_labels_field = LabelField(dtype=pl.Int32, semantic=Semantic.Default, multi_label=True)
+    image_info_field = ImageInfoField(semantic=Semantic.Default)
+    output_mask_field = MaskField(dtype=pl.UInt8, semantic=Semantic.Default)
+
+    setattr(
+        converter_instance,
+        "input_polygon",
+        AttributeSpec(name="polygons", field=input_polygon_field),
+    )
+    setattr(
+        converter_instance, "input_labels", AttributeSpec(name="labels", field=input_labels_field)
+    )
+    setattr(
+        converter_instance, "image_info", AttributeSpec(name="image_info", field=image_info_field)
+    )
+    setattr(converter_instance, "output_mask", AttributeSpec(name="mask", field=output_mask_field))
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    # Get the mask and check it
+    mask_data = np.array(result_df["mask"][0])
+    mask_shape = result_df["mask_shape"][0]
+    mask = mask_data.reshape(mask_shape)
+
+    # Check that polygon was filled with label 5
+    # Normalized coordinates should be scaled: 0.2 * 100 = 20, 0.1 * 100 = 10, etc.
+    assert mask[15, 20] == 5  # Point inside the scaled triangle
+    assert mask[5, 5] == 0  # Background point
+
+    # Verify the label is present in the mask
+    assert 5 in np.unique(mask)

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -9,17 +9,25 @@ import polars as pl
 import pytest
 from typing_extensions import Annotated
 
-from datumaro.components.annotation import AnnotationType, Bbox
+from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories, Polygon
 from datumaro.components.dataset import Dataset as LegacyDataset
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
-from datumaro.components.media import Image, ImageFromFile
+from datumaro.components.media import Image, ImageFromFile, Video
 from datumaro.experimental.dataset import Dataset, Sample
-from datumaro.experimental.fields import bbox_field, image_path_field, tensor_field
+from datumaro.experimental.fields import (
+    bbox_field,
+    image_path_field,
+    label_field,
+    polygon_field,
+    tensor_field,
+)
 from datumaro.experimental.legacy import (
     BackwardBboxAnnotationConverter,
     BackwardImageMediaConverter,
+    BackwardPolygonAnnotationConverter,
     ForwardBboxAnnotationConverter,
     ForwardImageMediaConverter,
+    ForwardPolygonAnnotationConverter,
     analyze_experimental_dataset,
     analyze_legacy_dataset,
     convert_from_legacy,
@@ -29,6 +37,7 @@ from datumaro.experimental.legacy import (
     register_forward_annotation_converter,
     register_forward_media_converter,
 )
+from datumaro.experimental.schema import AttributeInfo, Schema
 
 
 def test_image_media_converter_get_schema_attributes():
@@ -77,20 +86,28 @@ def test_image_media_converter_convert_item_media_no_media():
 
 def test_bbox_annotation_converter_get_schema_attributes():
     """Test schema attribute generation for bboxes."""
-    converter = ForwardBboxAnnotationConverter()
     categories: CategoriesInfo = {}  # Empty categories
+    converter = ForwardBboxAnnotationConverter.create_from_categories(categories)
+    assert converter is not None
 
-    attributes = converter.get_schema_attributes(categories)
+    attributes = converter.get_schema_attributes()
 
     assert "bboxes" in attributes
-    assert "bbox_labels" in attributes
+    # bbox_labels should not be present when there are no label categories
+    assert "bbox_labels" not in attributes
     assert attributes["bboxes"].type == np.ndarray
-    assert attributes["bbox_labels"].type == np.ndarray
 
 
 def test_bbox_annotation_converter_convert_annotations_single_bbox():
     """Test conversion of single bbox annotation."""
-    converter = ForwardBboxAnnotationConverter()
+
+    # Create categories with labels to test with labels
+    label_categories = LabelCategories()
+    label_categories.add("class_1")
+    categories: CategoriesInfo = {AnnotationType.label: label_categories}
+
+    converter = ForwardBboxAnnotationConverter.create_from_categories(categories)
+    assert converter is not None
 
     bbox = Bbox(10, 20, 30, 40, label=1)  # x=10, y=20, w=30, h=40
     item = DatasetItem(id="test")
@@ -106,7 +123,15 @@ def test_bbox_annotation_converter_convert_annotations_single_bbox():
 
 def test_bbox_annotation_converter_convert_annotations_multiple_bboxes():
     """Test conversion of multiple bbox annotations."""
-    converter = ForwardBboxAnnotationConverter()
+
+    # Create categories with labels
+    label_categories = LabelCategories()
+    label_categories.add("class_1")
+    label_categories.add("class_2")
+    categories: CategoriesInfo = {AnnotationType.label: label_categories}
+
+    converter = ForwardBboxAnnotationConverter.create_from_categories(categories)
+    assert converter is not None
 
     bbox1 = Bbox(10, 20, 30, 40, label=1)
     bbox2 = Bbox(50, 60, 70, 80, label=2)
@@ -129,7 +154,9 @@ def test_bbox_annotation_converter_convert_annotations_multiple_bboxes():
 
 def test_bbox_annotation_converter_convert_annotations_empty_list():
     """Test conversion of empty annotation list."""
-    converter = ForwardBboxAnnotationConverter()
+    categories: CategoriesInfo = {}  # Empty categories
+    converter = ForwardBboxAnnotationConverter.create_from_categories(categories)
+    assert converter is not None
     item = DatasetItem(id="test")
 
     result = converter.convert_annotations([], item)
@@ -137,8 +164,8 @@ def test_bbox_annotation_converter_convert_annotations_empty_list():
     # Empty arrays with proper shapes
     assert result["bboxes"].shape == (0, 4)
     assert result["bboxes"].dtype == np.float32
-    assert result["bbox_labels"].shape == (0,)
-    assert result["bbox_labels"].dtype == np.int32
+    # No bbox_labels should be present when there are no categories
+    assert "bbox_labels" not in result
 
 
 # Converter registry tests
@@ -155,16 +182,16 @@ def test_register_and_get_media_converter():
 
 def test_register_and_get_annotation_converter():
     """Test annotation converter registration and retrieval."""
-    converter = ForwardBboxAnnotationConverter()
-    register_forward_annotation_converter(AnnotationType.bbox, converter)
+    register_forward_annotation_converter(ForwardBboxAnnotationConverter)
 
-    retrieved = get_forward_annotation_converter(AnnotationType.bbox)
-    assert retrieved is converter
+    categories: CategoriesInfo = {}
+    retrieved = get_forward_annotation_converter(AnnotationType.bbox, categories)
+    assert retrieved is not None
+    assert isinstance(retrieved, ForwardBboxAnnotationConverter)
 
 
 def test_get_nonexistent_media_converter():
     """Test getting converter for unregistered media type."""
-    from datumaro.components.media import Video
 
     with pytest.raises(ValueError, match="No converter registered for media type"):
         get_forward_media_converter(Video)
@@ -172,8 +199,9 @@ def test_get_nonexistent_media_converter():
 
 def test_get_nonexistent_annotation_converter():
     """Test getting converter for unregistered annotation type."""
-    with pytest.raises(ValueError, match="No converter registered for annotation type"):
-        get_forward_annotation_converter(AnnotationType.polygon)
+    categories: CategoriesInfo = {}
+    converter = get_forward_annotation_converter(AnnotationType.unknown, categories)
+    assert converter is None
 
 
 def test_analyze_image_and_bbox_dataset():
@@ -188,8 +216,15 @@ def test_analyze_image_and_bbox_dataset():
         bbox = Bbox(10, 20, 30, 40, label=1)
         item = DatasetItem(id="item1", media=image_media, annotations=[bbox])
 
+        # Create dataset with label categories
+        label_categories = LabelCategories()
+        label_categories.add("background")
+        label_categories.add("class_1")
+
         dataset = LegacyDataset.from_iterable(
-            [item], ann_types={AnnotationType.bbox}
+            [item],
+            ann_types={AnnotationType.bbox},
+            categories={AnnotationType.label: label_categories},
         )  # pyright: ignore[reportUnknownMemberType]
 
         analysis_result = analyze_legacy_dataset(dataset)
@@ -226,19 +261,18 @@ def test_analyze_unknown_annotation_type():
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
 
-        # Polygon annotation (not registered)
-        from datumaro.components.annotation import Polygon
-
         image_path = str(temp_path / "image1.jpg")
         image_media = Image.from_file(
             image_path, size=(480, 640)
         )  # pyright: ignore[reportUnknownMemberType]
-        polygon = Polygon([10, 20, 30, 40, 50, 60], label=1)
-        item = DatasetItem(id="item1", media=image_media, annotations=[polygon])
 
-        dataset = LegacyDataset.from_iterable(
-            [item], ann_types={AnnotationType.polygon}
-        )  # pyright: ignore[reportUnknownMemberType]
+        class UnknownAnnotation(Bbox):
+            _type = AnnotationType.unknown
+
+        bbox = UnknownAnnotation(10, 20, 30, 40, label=1)
+        item = DatasetItem(id="item1", media=image_media, annotations=[bbox])
+
+        dataset = LegacyDataset.from_iterable([item])  # pyright: ignore[reportUnknownMemberType]
 
         analysis_result = analyze_legacy_dataset(dataset)
 
@@ -262,8 +296,16 @@ def test_convert_simple_bbox_dataset():
 
         item1 = DatasetItem(id="item1", media=image_media, annotations=[bbox1, bbox2])
 
+        # Create dataset with label categories so bbox_labels will be present
+        label_categories = LabelCategories()
+        label_categories.add("background")
+        label_categories.add("class_1")
+        label_categories.add("class_2")
+
         dataset = LegacyDataset.from_iterable(
-            [item1], ann_types={AnnotationType.bbox}
+            [item1],
+            ann_types={AnnotationType.bbox},
+            categories={AnnotationType.label: label_categories},
         )  # pyright: ignore[reportUnknownMemberType]
 
         # Convert dataset
@@ -330,7 +372,9 @@ def test_builtin_converters_registration():
     image_converter = get_forward_media_converter(Image)
     assert isinstance(image_converter, ForwardImageMediaConverter)
 
-    bbox_converter = get_forward_annotation_converter(AnnotationType.bbox)
+    categories: CategoriesInfo = {}
+    bbox_converter = get_forward_annotation_converter(AnnotationType.bbox, categories)
+    assert bbox_converter is not None
     assert isinstance(bbox_converter, ForwardBboxAnnotationConverter)
 
 
@@ -340,7 +384,9 @@ class DetectionSample(Sample):
     bboxes: Annotated[
         np.ndarray[Any, np.dtype[np.float32]], bbox_field(dtype=pl.Float32, format="x1y1x2y2")
     ]
-    bbox_labels: Annotated[np.ndarray[Any, np.dtype[np.int32]], tensor_field(dtype=pl.Int32)]
+    bbox_labels: Annotated[
+        np.ndarray[Any, np.dtype[np.int32]], label_field(dtype=pl.Int32, multi_label=True)
+    ]
 
 
 def test_convert_to_legacy_simple():
@@ -443,8 +489,6 @@ def test_backward_image_media_converter_create_from_schema():
 
 def test_backward_image_media_converter_create_from_schema_no_image_field():
     """Test BackwardImageMediaConverter with schema that has no image field."""
-    from datumaro.experimental.fields import tensor_field
-    from datumaro.experimental.schema import AttributeInfo, Schema
 
     # Create schema without image_path field
     schema = Schema(
@@ -498,8 +542,6 @@ def test_backward_bbox_annotation_converter_create_from_schema():
 
 def test_backward_bbox_annotation_converter_create_from_schema_missing_fields():
     """Test BackwardBboxAnnotationConverter with incomplete schema."""
-    from datumaro.experimental.fields import image_path_field
-    from datumaro.experimental.schema import AttributeInfo, Schema
 
     # Create schema without bbox fields
     schema = Schema(
@@ -638,7 +680,6 @@ def test_analyze_experimental_dataset():
 
 def test_analyze_experimental_dataset_no_compatible_converters():
     """Test analysis with dataset that has no compatible backward converters."""
-    from datumaro.experimental.fields import tensor_field
 
     # Create a custom sample type without image_path or bbox fields
     class CustomSample(Sample):
@@ -663,7 +704,6 @@ def test_analyze_experimental_dataset_no_compatible_converters():
 
 def test_convert_to_legacy_with_only_images():
     """Test convert_to_legacy with dataset containing only images."""
-    from datumaro.experimental.fields import image_path_field
 
     # Define schema with only image_path
     class ImageOnlySample(Sample):
@@ -698,3 +738,255 @@ def test_convert_to_legacy_with_only_images():
     assert isinstance(second_item_media, ImageFromFile)
     assert second_item_media.path == "/path/to/image2.jpg"
     assert len(second_item.annotations) == 0
+
+
+def test_forward_polygon_annotation_converter_get_schema_attributes():
+    """Test schema attribute generation for polygons."""
+    categories: CategoriesInfo = {}  # Empty categories
+    converter = ForwardPolygonAnnotationConverter.create_from_categories(categories)
+    assert converter is not None
+    attributes = converter.get_schema_attributes()
+
+    assert "polygons" in attributes
+    # polygon_labels should not be present when there are no label categories
+    assert "polygon_labels" not in attributes
+    assert attributes["polygons"].type == np.ndarray
+
+
+def test_forward_polygon_annotation_converter_convert_annotations():
+    """Test polygon annotation conversion."""
+
+    # Create categories with labels
+    label_categories = LabelCategories()
+    label_categories.add("class_1")
+    label_categories.add("class_2")
+    categories: CategoriesInfo = {AnnotationType.label: label_categories}
+
+    converter = ForwardPolygonAnnotationConverter.create_from_categories(categories)
+    assert converter is not None
+
+    # Create polygon annotations with flat coordinates
+    triangle = Polygon(points=[0, 0, 10, 0, 5, 10], label=1)  # Triangle as flat list
+    rectangle = Polygon(points=[20, 20, 30, 20, 30, 30, 20, 30], label=2)  # Rectangle as flat list
+
+    annotations = [triangle, rectangle]
+    item = DatasetItem(id="test")
+
+    result = converter.convert_annotations(annotations, item)
+
+    assert "polygons" in result
+    assert "polygon_labels" in result
+
+    # Check polygon data
+    polygons = result["polygons"]
+    assert len(polygons) == 2
+
+    # First polygon (triangle): [0,0,10,0,5,10] -> [0,0,10,0,5,10]
+    assert np.all(polygons[0] == [[0, 0], [10, 0], [5, 10]])
+
+    # Second polygon (rectangle): [20,20,30,20,30,30,20,30] -> [20,20,30,20,30,30,20,30]
+    assert np.all(polygons[1] == [[20, 20], [30, 20], [30, 30], [20, 30]])
+
+    # Check labels
+    labels = result["polygon_labels"]
+    assert len(labels) == 2
+    assert labels[0] == 1
+    assert labels[1] == 2
+
+
+def test_backward_polygon_annotation_converter_create_from_schema():
+    """Test BackwardPolygonAnnotationConverter schema detection."""
+
+    # Create schema with polygon fields
+    schema = Schema(
+        attributes={
+            "polygons": AttributeInfo(type=list, annotation=polygon_field(dtype=pl.Float32)),
+            "polygon_labels": AttributeInfo(
+                type=np.ndarray, annotation=label_field(dtype=pl.Int32, multi_label=True)
+            ),
+        }
+    )
+
+    converter = BackwardPolygonAnnotationConverter.create_from_schema(schema)
+    assert converter is not None
+    assert converter.polygons_attr == "polygons"
+    assert converter.polygon_labels_attr == "polygon_labels"
+
+
+def test_backward_polygon_annotation_converter_convert_to_legacy():
+    """Test conversion from experimental to legacy polygon annotations."""
+    converter = BackwardPolygonAnnotationConverter("polygons", "polygon_labels")
+
+    # Create sample with polygon data
+    class TestSample(Sample):
+        pass
+
+    sample = TestSample()
+    # Simulate polygon data: triangle and rectangle
+    sample.polygons = np.array(
+        [
+            np.array([[0, 0], [10, 0], [5, 10]], dtype=np.float32),
+            np.array([[20, 20], [30, 20], [30, 30], [20, 30]], dtype=np.float32),
+        ],
+        dtype=object,
+    )
+    sample.polygon_labels = np.array([1, 2], dtype=np.int32)
+
+    categories: CategoriesInfo = {}
+    result = converter.convert_to_legacy_annotations(sample, categories)
+
+    assert len(result) == 2
+
+    # Check first polygon (triangle)
+    poly1 = result[0]
+    assert isinstance(poly1, Polygon)
+    assert poly1.points == [0.0, 0.0, 10.0, 0.0, 5.0, 10.0]  # Flat coordinate format
+    assert poly1.label == 1
+
+    # Check second polygon (rectangle)
+    poly2 = result[1]
+    assert isinstance(poly2, Polygon)
+    assert poly2.points == [
+        20.0,
+        20.0,
+        30.0,
+        20.0,
+        30.0,
+        30.0,
+        20.0,
+        30.0,
+    ]  # Flat coordinate format
+    assert poly2.label == 2
+
+
+def test_polygon_conversion_with_labels():
+    """Test polygon conversion between legacy and experimental formats with label categories."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create an image file for the test
+        image_path = str(temp_path / "image1.jpg")
+        image_media = Image.from_file(
+            image_path, size=(480, 640)
+        )  # pyright: ignore[reportUnknownMemberType]
+
+        # Create polygon annotations with different shapes
+        triangle = Polygon(points=[10, 20, 30, 25, 20, 40], label=1)  # Triangle
+        rectangle = Polygon(points=[50, 60, 80, 60, 80, 90, 50, 90], label=2)  # Rectangle
+
+        item = DatasetItem(id="polygon_test", media=image_media, annotations=[triangle, rectangle])
+
+        # Create label categories
+
+        label_categories = LabelCategories()
+        label_categories.add("background")
+        label_categories.add("triangle_class")
+        label_categories.add("rectangle_class")
+
+        # Create legacy dataset with categories
+        legacy_dataset = LegacyDataset.from_iterable(
+            [item],
+            ann_types={AnnotationType.polygon},
+            categories={AnnotationType.label: label_categories},
+        )  # pyright: ignore[reportUnknownMemberType]
+
+        # Convert to experimental format
+        experimental_dataset = convert_from_legacy(legacy_dataset)
+
+        # Verify experimental dataset structure
+        assert len(experimental_dataset) == 1
+        exp_sample = experimental_dataset[0]
+
+        # Check that polygons and polygon_labels are present
+        assert hasattr(exp_sample, "polygons")
+        assert hasattr(exp_sample, "polygon_labels")
+
+        # Check polygon data
+        assert len(exp_sample.polygons) == 2
+        assert np.all(exp_sample.polygons[0] == [[10, 20], [30, 25], [20, 40]])  # Triangle
+        assert np.all(
+            exp_sample.polygons[1] == [[50, 60], [80, 60], [80, 90], [50, 90]]
+        )  # Rectangle
+
+        # Check labels
+        np.testing.assert_array_equal(exp_sample.polygon_labels, [1, 2])
+
+        # Convert back to legacy format
+        restored_legacy_dataset = convert_to_legacy(experimental_dataset)
+
+        # Verify restored dataset
+        restored_items = list(restored_legacy_dataset)
+        assert len(restored_items) == 1
+
+        restored_item = restored_items[0]
+        assert len(restored_item.annotations) == 2
+
+        # Check restored polygons
+        polygon_anns = [ann for ann in restored_item.annotations if isinstance(ann, Polygon)]
+        assert len(polygon_anns) == 2
+
+        # Sort by label for consistent comparison
+        polygon_anns.sort(key=lambda x: x.label)
+
+        # Verify triangle
+        assert polygon_anns[0].points == [10, 20, 30, 25, 20, 40]
+        assert polygon_anns[0].label == 1
+
+        # Verify rectangle
+        assert polygon_anns[1].points == [50, 60, 80, 60, 80, 90, 50, 90]
+        assert polygon_anns[1].label == 2
+
+
+def test_polygon_conversion_without_labels():
+    """Test polygon conversion when no label categories are present."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create an image file for the test
+        image_path = str(temp_path / "image1.jpg")
+        image_media = Image.from_file(
+            image_path, size=(480, 640)
+        )  # pyright: ignore[reportUnknownMemberType]
+
+        # Create polygon annotation without label categories
+        triangle = Polygon(points=[10, 20, 30, 25, 20, 40])  # No label
+
+        item = DatasetItem(id="polygon_no_labels", media=image_media, annotations=[triangle])
+
+        # Create legacy dataset without label categories
+        legacy_dataset = LegacyDataset.from_iterable(
+            [item], ann_types={AnnotationType.polygon}
+        )  # pyright: ignore[reportUnknownMemberType]
+
+        # Convert to experimental format
+        experimental_dataset = convert_from_legacy(legacy_dataset)
+
+        # Verify experimental dataset structure
+        assert len(experimental_dataset) == 1
+        exp_sample = experimental_dataset[0]
+
+        # Check that polygons is present but polygon_labels is not
+        assert hasattr(exp_sample, "polygons")
+        assert not hasattr(exp_sample, "polygon_labels")
+
+        # Check polygon data
+        assert len(exp_sample.polygons) == 1
+        assert np.all(exp_sample.polygons[0] == [[10, 20], [30, 25], [20, 40]])
+
+        # Convert back to legacy format
+        restored_legacy_dataset = convert_to_legacy(experimental_dataset)
+
+        # Verify restored dataset
+        restored_items = list(restored_legacy_dataset)
+        assert len(restored_items) == 1
+
+        restored_item = restored_items[0]
+        assert len(restored_item.annotations) == 1
+
+        # Check restored polygon
+        polygon_anns = [ann for ann in restored_item.annotations if isinstance(ann, Polygon)]
+        assert len(polygon_anns) == 1
+
+        restored_polygon = polygon_anns[0]
+        assert restored_polygon.points == [10, 20, 30, 25, 20, 40]
+        assert restored_polygon.label is None

--- a/tests/unit/experimental/test_schema.py
+++ b/tests/unit/experimental/test_schema.py
@@ -15,11 +15,13 @@ from datumaro.experimental.fields import (
     ImageInfo,
     ImageInfoField,
     ImagePathField,
+    PolygonField,
     TensorField,
     bbox_field,
     image_field,
     image_info_field,
     image_path_field,
+    polygon_field,
     tensor_field,
 )
 from datumaro.experimental.schema import AttributeInfo, Schema, Semantic
@@ -292,3 +294,56 @@ def test_schema_duplicate_field_type_assertion():
     assert len(schema.attributes) == 2
     assert "left_image" in schema.attributes
     assert "right_image" in schema.attributes
+
+
+def test_polygon_field_creation():
+    """Test PolygonField creation and properties."""
+    field = polygon_field(dtype=pl.Float32, format="xy", normalize=True, semantic=Semantic.Default)
+
+    assert isinstance(field, PolygonField)
+    assert field.dtype == pl.Float32
+    assert field.format == "xy"
+    assert field.normalize is True
+    assert field.semantic == Semantic.Default
+
+
+def test_polygon_field_creation_defaults():
+    """Test PolygonField creation with default values."""
+    field = polygon_field(dtype=pl.Float32)
+
+    assert isinstance(field, PolygonField)
+    assert field.dtype == pl.Float32
+    assert field.format == "xy"  # Default format
+    assert field.normalize is False  # Default normalization
+    assert field.semantic == Semantic.Default  # Default semantic
+
+
+def test_polygon_field_polars_schema():
+    """Test PolygonField Polars schema generation."""
+    field = polygon_field(dtype=pl.Float32)
+    schema = field.to_polars_schema("polygon")
+
+    expected = {"polygon": pl.List(pl.List(pl.Array(pl.Float32, 2)))}
+    assert schema == expected
+
+
+def test_polygon_field_polars_conversion():
+    """Test PolygonField to/from Polars conversion with simple polygon."""
+    field = cast(PolygonField, polygon_field(dtype=pl.Float32, normalize=False))
+    # Triangle: (0,0) -> (10,0) -> (5,10) -> (0,0)
+    test_polygon_1 = np.array([[0.0, 0.0], [10.0, 0.0], [5.0, 10.0]], dtype=np.float32)
+    test_polygon_2 = np.array([[2.0, 2.0], [10.0, 2.0], [5.0, 10.0], [6.0, 11.0]], dtype=np.float32)
+    polygons = np.array([test_polygon_1, test_polygon_2], dtype=object)
+
+    # Test to_polars
+    polars_data = field.to_polars("polygon", polygons)
+    assert "polygon" in polars_data
+    assert isinstance(polars_data["polygon"], pl.Series)
+
+    # Create DataFrame and test from_polars
+    df = pl.DataFrame(polars_data)
+    reconstructed = cast(np.ndarray[Any, Any], field.from_polars("polygon", 0, df, np.ndarray))
+
+    assert len(reconstructed) == 2
+    assert np.all(reconstructed[0] == test_polygon_1)
+    assert np.all(reconstructed[1] == test_polygon_2)


### PR DESCRIPTION
This pull request introduces polygon and mask annotations. It also extends the label annotation to allow list of labels which can be used alongside polygons or bounding boxes. The PR adds conversion between polygons and masks, as well as conversion between legacy polygon datasets and new dataset class; however, I haven’t implemented this conversion yet for masks.

### Polygon and Mask Annotation Support

* Added `PolygonField` and `MaskField` classes to `fields.py`, enabling robust representation and conversion of polygon and mask data, including normalization, format specification, and efficient serialization to Polars dataframes.
* Implemented `PolygonToMaskConverter` in `converters.py`, allowing conversion of polygon annotations to rasterized masks using OpenCV.

### Label Handling Improvements

* Enhanced `LabelField` to support both multi-label and list semantics via new `is_list` property, and updated serialization logic to accommodate these cases. The `label_field` factory now accepts `is_list` as a parameter. [[1]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7R265-R290) [[2]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7L289-R302) [[3]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7R311-R468)

### Converter Registration and Instantiation Refactor

* Refactored the annotation converter registry in `legacy.py` to store converter classes instead of instances, and introduced logic to instantiate converters based on dataset categories using a new `create_from_categories` class method. [[1]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L68-R84) [[2]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L79-R99) [[3]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L93-R117)
* Updated the `ForwardBboxAnnotationConverter` to use the new instantiation pattern, including conditional support for label categories and improved schema attribute handling.

### Legacy Compatibility and Imports

* Added `Polygon` to legacy annotation imports and updated usage to reflect new field and converter types for seamless integration with legacy datasets. [[1]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L19-R19) [[2]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L28-R33)

---

- Polygon and mask annotation support: [[1]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7R311-R468) [[2]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3R359-R489)
- Label handling improvements: [[1]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7R265-R290) [[2]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7L289-R302) [[3]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7R311-R468)
- Converter registration and instantiation refactor: [[1]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L68-R84) [[2]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L79-R99) [[3]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L93-R117)
- ForwardBboxAnnotationConverter update: [src/datumaro/experimental/legacy.pyL122-R177](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L122-R177)
- Legacy compatibility and imports: [[1]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L19-R19) [[2]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L28-R33)<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
