### PR TITLE
Add support for encoded images stored as bytes

### DIFF
--- a/src/datumaro/experimental/converter_registry.py
+++ b/src/datumaro/experimental/converter_registry.py
@@ -518,7 +518,7 @@ def _heuristic_cost(current_state: _SchemaState, target_state: _SchemaState) -> 
 
 
 def _get_applicable_converters(
-    state: _SchemaState, target_state: _SchemaState, iteration: int = 0
+    semantic: Semantic, state: _SchemaState, target_state: _SchemaState, iteration: int = 0
 ) -> List[Tuple[Converter, _SchemaState]]:
     """Get all converters that can be applied to the current state along with their resulting states."""
     applicable: List[Tuple[Converter, _SchemaState]] = []
@@ -564,7 +564,7 @@ def _get_applicable_converters(
                 # The field does not exist, use a temporary name
                 output_name = field_type.__name__.lower()
                 # and create a new instance of the field
-                output_field = field_type()
+                output_field = field_type(semantic=semantic)
 
             # Add the iteration count at the end to ensure uniqueness
             # and avoid any conflict with existing attribute names
@@ -717,6 +717,7 @@ def _find_conversion_path_for_semantic(
 
         # Explore neighbors
         for converter, new_state in _get_applicable_converters(
+            semantic,
             current_node.state,
             target_state,
             current_node.g_cost,

--- a/src/datumaro/experimental/converters.py
+++ b/src/datumaro/experimental/converters.py
@@ -19,7 +19,9 @@ from PIL import Image
 from .converter_registry import AttributeSpec, Converter, converter
 from .fields import (
     BBoxField,
+    ImageBytesField,
     ImageField,
+    ImageInfo,
     ImageInfoField,
     ImagePathField,
     LabelField,
@@ -167,6 +169,7 @@ class ImagePathToImageConverter(Converter):
 
     input_path: AttributeSpec[ImagePathField]
     output_image: AttributeSpec[ImageField]
+    output_info: AttributeSpec[ImageInfoField]
 
     def filter_output_spec(self) -> bool:
         """Configure output image specification based on input."""
@@ -179,24 +182,33 @@ class ImagePathToImageConverter(Converter):
                 format="RGB",  # Default to RGB format
             ),
         )
+        # Configure output info specification
+        self.output_info = AttributeSpec(
+            name=self.output_info.name,
+            field=ImageInfoField(
+                semantic=self.input_path.field.semantic,
+            ),
+        )
         return True
 
     def convert(self, df: pl.DataFrame) -> pl.DataFrame:
         """
-        Convert image paths to loaded image tensors.
+        Convert image paths to loaded image tensors and image info.
 
         Args:
             df: DataFrame containing image path column
 
         Returns:
-            DataFrame with loaded image data and shape information
+            DataFrame with loaded image data, shape information, and image info
         """
         input_col = self.input_path.name
         output_col = self.output_image.name
+        output_info_col = self.output_info.name
 
         # Load images from paths
         image_data: list[Any] = []
         image_shapes: list[list[int]] = []
+        image_infos: list[ImageInfo] = []
 
         for path in df[input_col]:
             # Load image using PIL
@@ -210,12 +222,99 @@ class ImagePathToImageConverter(Converter):
                 image_data.append(img_array.flatten().tolist())
                 image_shapes.append(list(img_array.shape))
 
+                # Create image info with just width and height
+                image_infos.append(ImageInfo(width=img_array.shape[1], height=img_array.shape[0]))
+
         # Create output DataFrame
         result_df = df.clone()
         result_df = result_df.with_columns(
             [
                 pl.Series(output_col, image_data),
                 pl.Series(output_col + "_shape", image_shapes),
+                pl.Series(output_info_col, image_infos),
+            ]
+        )
+
+        return result_df
+
+
+@converter(lazy=True)
+class ImageBytesToImageConverter(Converter):
+    """
+    Lazy converter that decodes images from byte data.
+
+    This converter takes encoded image bytes (PNG, JPEG, BMP, etc.) and decodes
+    them to tensor format. It's marked as lazy to defer the expensive decoding
+    operation until the data is actually accessed.
+    """
+
+    input_bytes: AttributeSpec[ImageBytesField]
+    output_image: AttributeSpec[ImageField]
+    output_info: AttributeSpec[ImageInfoField]
+
+    def filter_output_spec(self) -> bool:
+        """Configure output image specification based on input."""
+        # Configure output specification with default RGB format
+        self.output_image = AttributeSpec(
+            name=self.output_image.name,
+            field=ImageField(
+                semantic=self.input_bytes.field.semantic,
+                dtype=pl.UInt8,  # Default to UInt8 for decoded images
+                format="RGB",  # Default to RGB format
+            ),
+        )
+        # Configure output info specification
+        self.output_info = AttributeSpec(
+            name=self.output_info.name,
+            field=ImageInfoField(
+                semantic=self.input_bytes.field.semantic,
+            ),
+        )
+        return True
+
+    def convert(self, df: pl.DataFrame) -> pl.DataFrame:
+        """
+        Convert image bytes to decoded image tensors and image info.
+
+        Args:
+            df: DataFrame containing image bytes column
+
+        Returns:
+            DataFrame with decoded image data, shape information, and image info
+        """
+        input_col = self.input_bytes.name
+        output_col = self.output_image.name
+        output_info_col = self.output_info.name
+
+        # Decode images from bytes
+        image_data: list[np.ndarray] = []
+        image_shapes: list[list[int]] = []
+        image_infos: list[ImageInfo] = []
+
+        for image_bytes in df[input_col]:
+            # Decode image using PIL
+            from io import BytesIO
+
+            with Image.open(BytesIO(image_bytes)) as img:
+                # Convert to RGB if needed
+                if img.mode != "RGB":
+                    img = img.convert("RGB")
+
+                # Convert to numpy array
+                img_array = np.array(img, dtype=np.uint8)
+                image_data.append(img_array.reshape(-1))
+                image_shapes.append(list(img_array.shape))
+
+                # Create image info with just width and height
+                image_infos.append(ImageInfo(width=img_array.shape[1], height=img_array.shape[0]))
+
+        # Create output DataFrame
+        result_df = df.clone()
+        result_df = result_df.with_columns(
+            [
+                pl.Series(output_col, image_data),
+                pl.Series(output_col + "_shape", image_shapes),
+                pl.Series(output_info_col, image_infos),
             ]
         )
 

--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -10,15 +10,20 @@ learning and computer vision applications.
 """
 
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any, Optional, TypeVar, Union
 
 import numpy as np
 import polars as pl
+from typing_extensions import TypeAlias
+
+from datumaro.util.image import decode_image, encode_image
 
 from .schema import Field, Semantic
 from .type_registry import from_polars_data, to_numpy
 
 T = TypeVar("T")
+
+PolarsDataType: TypeAlias = Union[type[pl.DataType], pl.DataType]
 
 
 @dataclass(frozen=True)
@@ -35,7 +40,7 @@ class TensorField(Field):
     """
 
     semantic: Semantic
-    dtype: Any
+    dtype: PolarsDataType = pl.UInt8()
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         """Generate Polars schema with separate columns for data and shape."""
@@ -83,7 +88,22 @@ class ImageField(TensorField):
         format: Image color format (e.g., "RGB", "BGR", "RGBA")
     """
 
-    format: str
+    format: str = "RGB"
+
+    def convert_to_image_bytes_field(
+        self, encoding_format: Optional[str] = None
+    ) -> "ImageBytesField":
+        """
+        Convert this ImageField to an ImageBytesField.
+
+        Args:
+            encoding_format: Image encoding format for bytes storage. If None,
+                           uses auto-detection/PNG default.
+
+        Returns:
+            ImageBytesField instance with the same semantic tags
+        """
+        return ImageBytesField(semantic=self.semantic, format=encoding_format)
 
 
 def image_field(dtype: Any, format: str = "RGB", semantic: Semantic = Semantic.Default) -> Any:
@@ -102,6 +122,134 @@ def image_field(dtype: Any, format: str = "RGB", semantic: Semantic = Semantic.D
 
 
 @dataclass(frozen=True)
+class ImageBytesField(Field):
+    """
+    Represents an image field stored as bytes data.
+
+    This field stores image data as encoded bytes (PNG, JPEG, BMP, etc.) and
+    provides conversion capabilities to decode them into numpy arrays or encode
+    numpy arrays into bytes format.
+
+    Attributes:
+        semantic: Semantic tags describing the image's purpose
+        format: Image encoding format (e.g., "PNG", "JPEG", "BMP"). If None,
+                auto-detects format when decoding or defaults to PNG when encoding.
+    """
+
+    semantic: Semantic
+    format: Optional[str] = None
+
+    # Format detection magic numbers (similar to ImageFromBytes)
+    _FORMAT_MAGICS = (
+        (b"\x89PNG\r\n\x1a\n", "PNG"),
+        (b"\xff\xd8\xff", "JPEG"),
+        (b"BM", "BMP"),
+    )
+
+    def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
+        """Generate schema for image bytes as binary data."""
+        return {name: pl.Binary()}
+
+    def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
+        """Convert image data to bytes and store in Polars series."""
+        if isinstance(value, bytes):
+            # Already bytes, store directly
+            bytes_data = value
+        elif isinstance(value, np.ndarray):
+            # Encode numpy array to bytes using specified format or default to PNG
+            encoding_format = self.format or "PNG"
+            ext = f".{encoding_format.lower()}"
+            bytes_data = encode_image(value, ext)
+        elif hasattr(value, "data") and isinstance(value.data, bytes):
+            # Handle ImageFromBytes-like objects
+            bytes_data = value.data
+        elif hasattr(value, "data") and isinstance(value.data, np.ndarray):
+            # Handle Image objects with numpy data
+            encoding_format = self.format or "PNG"
+            ext = f".{encoding_format.lower()}"
+            bytes_data = encode_image(value.data, ext)
+        else:
+            raise TypeError(f"Unsupported type for ImageBytesField: {type(value)}")
+
+        return {name: pl.Series(name, [bytes_data])}
+
+    def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type[T]) -> T:
+        """Reconstruct image from bytes data."""
+        bytes_data = df[name][row_index]
+
+        if target_type is bytes:
+            return bytes_data  # type: ignore
+        elif target_type is np.ndarray or hasattr(target_type, "__origin__"):
+            # If format is None, try to auto-detect format from bytes
+            if self.format is None:
+                detected_format = self._guess_format(bytes_data)
+                if detected_format is None:
+                    # If detection fails, still try to decode (decode_image handles various formats)
+                    pass
+
+            # Decode bytes to numpy array
+            return decode_image(bytes_data)  # type: ignore
+        else:
+            return from_polars_data(bytes_data, target_type)  # type: ignore
+
+    @classmethod
+    def _guess_format(cls, data: bytes) -> Optional[str]:
+        """Guess image format from bytes magic numbers."""
+        return next(
+            (fmt for magic, fmt in cls._FORMAT_MAGICS if data.startswith(magic)),
+            None,
+        )
+
+    def get_effective_format(self, data: Optional[bytes] = None) -> str:
+        """
+        Get the effective format for this field.
+
+        Args:
+            data: Optional bytes data to auto-detect format from
+
+        Returns:
+            The format to use - either the specified format, auto-detected format, or PNG as default
+        """
+        if self.format is not None:
+            return self.format
+
+        if data is not None:
+            detected = self._guess_format(data)
+            if detected is not None:
+                return detected
+
+        # Default to PNG if no format specified and no detection possible
+        return "PNG"
+
+    def convert_to_image_field(self, dtype: Any = pl.UInt8()) -> "ImageField":
+        """
+        Convert this ImageBytesField to an ImageField.
+
+        Args:
+            dtype: Polars data type for the resulting tensor field
+
+        Returns:
+            ImageField instance with the same semantic tags
+        """
+        return ImageField(semantic=self.semantic, dtype=dtype, format="RGB")
+
+
+def image_bytes_field(format: Optional[str] = None, semantic: Semantic = Semantic.Default) -> Any:
+    """
+    Create an ImageBytesField instance with the specified parameters.
+
+    Args:
+        format: Image encoding format (e.g., "PNG", "JPEG", "BMP"). If None,
+                auto-detects format when decoding or defaults to PNG when encoding.
+        semantic: Semantic tags describing the image's purpose (optional)
+
+    Returns:
+        ImageBytesField instance configured with the given parameters
+    """
+    return ImageBytesField(semantic=semantic, format=format)
+
+
+@dataclass(frozen=True)
 class BBoxField(Field):
     """
     Represents a bounding box field with format and normalization options.
@@ -117,9 +265,9 @@ class BBoxField(Field):
     """
 
     semantic: Semantic
-    dtype: Any
-    format: str
-    normalize: bool
+    dtype: PolarsDataType = pl.Float32()
+    format: str = "x1y1x2y2"
+    normalize: bool = False
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         """Generate schema for bounding box as list of 4-element arrays."""
@@ -260,7 +408,7 @@ class LabelField(Field):
     """
 
     semantic: Semantic
-    dtype: Any
+    dtype: PolarsDataType = pl.UInt8()
     multi_label: bool = False  # Flag to indicate if this field should handle multi-labels
     is_list: bool = False
 
@@ -373,9 +521,9 @@ class PolygonField(Field):
     """
 
     semantic: Semantic
-    dtype: Any
-    format: str
-    normalize: bool
+    dtype: PolarsDataType = pl.Float32()
+    format: str = "xy"
+    normalize: bool = False
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         """Generate schema for polygon as list of coordinate values."""
@@ -431,7 +579,7 @@ class MaskField(Field):
     """
 
     semantic: Semantic
-    dtype: Any
+    dtype: PolarsDataType = pl.UInt8()
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         """Generate Polars schema with separate columns for data and shape."""

--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -10,13 +10,11 @@ learning and computer vision applications.
 """
 
 from dataclasses import dataclass
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 import numpy as np
 import polars as pl
 from typing_extensions import TypeAlias
-
-from datumaro.util.image import decode_image, encode_image
 
 from .schema import Field, Semantic
 from .type_registry import from_polars_data, to_numpy
@@ -90,21 +88,6 @@ class ImageField(TensorField):
 
     format: str = "RGB"
 
-    def convert_to_image_bytes_field(
-        self, encoding_format: Optional[str] = None
-    ) -> "ImageBytesField":
-        """
-        Convert this ImageField to an ImageBytesField.
-
-        Args:
-            encoding_format: Image encoding format for bytes storage. If None,
-                           uses auto-detection/PNG default.
-
-        Returns:
-            ImageBytesField instance with the same semantic tags
-        """
-        return ImageBytesField(semantic=self.semantic, format=encoding_format)
-
 
 def image_field(dtype: Any, format: str = "RGB", semantic: Semantic = Semantic.Default) -> Any:
     """
@@ -137,14 +120,6 @@ class ImageBytesField(Field):
     """
 
     semantic: Semantic
-    format: Optional[str] = None
-
-    # Format detection magic numbers (similar to ImageFromBytes)
-    _FORMAT_MAGICS = (
-        (b"\x89PNG\r\n\x1a\n", "PNG"),
-        (b"\xff\xd8\xff", "JPEG"),
-        (b"BM", "BMP"),
-    )
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         """Generate schema for image bytes as binary data."""
@@ -152,101 +127,26 @@ class ImageBytesField(Field):
 
     def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
         """Convert image data to bytes and store in Polars series."""
-        if isinstance(value, bytes):
-            # Already bytes, store directly
-            bytes_data = value
-        elif isinstance(value, np.ndarray):
-            # Encode numpy array to bytes using specified format or default to PNG
-            encoding_format = self.format or "PNG"
-            ext = f".{encoding_format.lower()}"
-            bytes_data = encode_image(value, ext)
-        elif hasattr(value, "data") and isinstance(value.data, bytes):
-            # Handle ImageFromBytes-like objects
-            bytes_data = value.data
-        elif hasattr(value, "data") and isinstance(value.data, np.ndarray):
-            # Handle Image objects with numpy data
-            encoding_format = self.format or "PNG"
-            ext = f".{encoding_format.lower()}"
-            bytes_data = encode_image(value.data, ext)
-        else:
-            raise TypeError(f"Unsupported type for ImageBytesField: {type(value)}")
-
-        return {name: pl.Series(name, [bytes_data])}
+        numpy_value = to_numpy(value, pl.Binary)
+        return {name: pl.Series(name, [bytes(numpy_value)])}
 
     def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type[T]) -> T:
         """Reconstruct image from bytes data."""
         bytes_data = df[name][row_index]
-
-        if target_type is bytes:
-            return bytes_data  # type: ignore
-        elif target_type is np.ndarray or hasattr(target_type, "__origin__"):
-            # If format is None, try to auto-detect format from bytes
-            if self.format is None:
-                detected_format = self._guess_format(bytes_data)
-                if detected_format is None:
-                    # If detection fails, still try to decode (decode_image handles various formats)
-                    pass
-
-            # Decode bytes to numpy array
-            return decode_image(bytes_data)  # type: ignore
-        else:
-            return from_polars_data(bytes_data, target_type)  # type: ignore
-
-    @classmethod
-    def _guess_format(cls, data: bytes) -> Optional[str]:
-        """Guess image format from bytes magic numbers."""
-        return next(
-            (fmt for magic, fmt in cls._FORMAT_MAGICS if data.startswith(magic)),
-            None,
-        )
-
-    def get_effective_format(self, data: Optional[bytes] = None) -> str:
-        """
-        Get the effective format for this field.
-
-        Args:
-            data: Optional bytes data to auto-detect format from
-
-        Returns:
-            The format to use - either the specified format, auto-detected format, or PNG as default
-        """
-        if self.format is not None:
-            return self.format
-
-        if data is not None:
-            detected = self._guess_format(data)
-            if detected is not None:
-                return detected
-
-        # Default to PNG if no format specified and no detection possible
-        return "PNG"
-
-    def convert_to_image_field(self, dtype: Any = pl.UInt8()) -> "ImageField":
-        """
-        Convert this ImageBytesField to an ImageField.
-
-        Args:
-            dtype: Polars data type for the resulting tensor field
-
-        Returns:
-            ImageField instance with the same semantic tags
-        """
-        return ImageField(semantic=self.semantic, dtype=dtype, format="RGB")
+        return from_polars_data(bytes_data, target_type)  # type: ignore
 
 
-def image_bytes_field(format: Optional[str] = None, semantic: Semantic = Semantic.Default) -> Any:
+def image_bytes_field(semantic: Semantic = Semantic.Default) -> Any:
     """
     Create an ImageBytesField instance with the specified parameters.
 
     Args:
-        format: Image encoding format (e.g., "PNG", "JPEG", "BMP"). If None,
-                auto-detects format when decoding or defaults to PNG when encoding.
         semantic: Semantic tags describing the image's purpose (optional)
 
     Returns:
         ImageBytesField instance configured with the given parameters
     """
-    return ImageBytesField(semantic=semantic, format=format)
+    return ImageBytesField(semantic=semantic)
 
 
 @dataclass(frozen=True)

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -11,7 +11,7 @@ experimental dataset format with automatic schema inference and type conversion.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Type, cast
+from typing import Any, Optional, Type, cast
 
 import numpy as np
 import polars as pl
@@ -19,15 +19,18 @@ import polars as pl
 from datumaro.components.annotation import Annotation, AnnotationType, Bbox, Polygon
 from datumaro.components.dataset import Dataset as LegacyDataset
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
-from datumaro.components.media import FromFileMixin, Image, MediaElement
+from datumaro.components.media import FromDataMixin, FromFileMixin, Image, MediaElement
 
 from .dataset import Dataset, Sample
 from .fields import (
     BBoxField,
+    ImageInfo,
     ImagePathField,
     LabelField,
     PolygonField,
     bbox_field,
+    image_bytes_field,
+    image_info_field,
     image_path_field,
     label_field,
     polygon_field,
@@ -37,6 +40,18 @@ from .schema import AttributeInfo, Schema
 
 class ForwardMediaConverter(ABC):
     """Base class for forward media type converters."""
+
+    @classmethod
+    @abstractmethod
+    def get_supported_media_types(cls) -> list[Type[MediaElement[Any]]]:
+        """Return list of media types this converter can handle."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def create(cls, dataset: LegacyDataset) -> "ForwardMediaConverter | None":
+        """Create converter instance if dataset is supported, None otherwise."""
+        pass
 
     @abstractmethod
     def get_schema_attributes(self) -> dict[str, AttributeInfo]:
@@ -80,15 +95,14 @@ class ForwardAnnotationConverter(ABC):
 
 
 # Global registries
-_media_converters: dict[Type[MediaElement[Any]], ForwardMediaConverter] = {}
+_media_converter_classes: dict[Type[MediaElement[Any]], Type[ForwardMediaConverter]] = {}
 _annotation_converters: dict[AnnotationType, Type[ForwardAnnotationConverter]] = {}
 
 
-def register_forward_media_converter(
-    media_type: Type[MediaElement[Any]], converter: ForwardMediaConverter
-) -> None:
-    """Register a forward converter for a media type."""
-    _media_converters[media_type] = converter
+def register_forward_media_converter(converter_class: Type[ForwardMediaConverter]) -> None:
+    """Register a forward converter class for media types it supports."""
+    for media_type in converter_class.get_supported_media_types():
+        _media_converter_classes[media_type] = converter_class
 
 
 def register_forward_annotation_converter(
@@ -99,12 +113,17 @@ def register_forward_annotation_converter(
     _annotation_converters[annotation_type] = converter_class
 
 
-def get_forward_media_converter(media_type: Type[MediaElement[Any]]) -> ForwardMediaConverter:
-    """Get forward converter for a media type."""
-    for registered_type, converter in _media_converters.items():
-        if issubclass(media_type, registered_type):
-            return converter
-    raise ValueError(f"No converter registered for media type: {media_type}")
+def get_forward_media_converter(dataset: LegacyDataset) -> ForwardMediaConverter | None:
+    """Get forward converter for a dataset by trying registered converters."""
+    # Get the dataset's media type
+    media_type = cast(Type[MediaElement[Any]], dataset.media_type())
+
+    # Try converter registered for this specific media type
+    if media_type in _media_converter_classes:
+        converter_class = _media_converter_classes[media_type]
+        return converter_class.create(dataset)
+
+    return None
 
 
 def get_forward_annotation_converter(
@@ -118,20 +137,82 @@ def get_forward_annotation_converter(
 
 
 class ForwardImageMediaConverter(ForwardMediaConverter):
-    """Forward converter for Image media type."""
+    """Forward converter for Image media type supporting both file paths and byte data."""
+
+    def __init__(self, media_mixin: type, has_image_info: bool):
+        """Initialize converter with format preference and image info availability."""
+        self.media_mixin = media_mixin
+        self.has_image_info = has_image_info
+
+    @classmethod
+    def get_supported_media_types(cls) -> list[Type[MediaElement[Any]]]:
+        """Return list of media types this converter can handle."""
+        return [Image]
+
+    @classmethod
+    def create(cls, dataset: LegacyDataset) -> "ForwardImageMediaConverter | None":
+        """Create converter instance, detecting whether to use paths or bytes."""
+        found_media_type: Optional[type] = None
+        has_image_info = True  # Assume all images have size until proven otherwise
+
+        for item in dataset:
+            if isinstance(item.media, Image):
+                media_type = type(item.media)
+                if found_media_type is not None and media_type != found_media_type:
+                    raise ValueError(
+                        f"The dataset has a mix of different image media types: "
+                        f"{found_media_type} and {media_type}. This is not supported by the converter."
+                    )
+
+                found_media_type = media_type
+
+                # Check if this image has size info
+                if not item.media.has_size:
+                    has_image_info = False
+
+        if found_media_type is None:
+            return None
+
+        if issubclass(found_media_type, FromDataMixin):
+            media_mixin = FromDataMixin
+        elif issubclass(found_media_type, FromFileMixin):
+            media_mixin = FromFileMixin
+        else:
+            raise ValueError(f"Unknown media mixin for {found_media_type}.")
+
+        return cls(media_mixin=media_mixin, has_image_info=has_image_info)
 
     def get_schema_attributes(self) -> dict[str, AttributeInfo]:
-        return {"image_path": AttributeInfo(type=str, annotation=image_path_field())}
+        attributes: dict[str, AttributeInfo] = {}
+
+        if self.media_mixin == FromDataMixin:
+            attributes["image_bytes"] = AttributeInfo(type=bytes, annotation=image_bytes_field())
+        elif self.media_mixin == FromFileMixin:
+            attributes["image_path"] = AttributeInfo(type=str, annotation=image_path_field())
+        else:
+            raise RuntimeError(f"Media mixin not implemented: {self.media_mixin}")
+
+        # Add image info field if all images have size
+        if self.has_image_info:
+            attributes["image_info"] = AttributeInfo(type=ImageInfo, annotation=image_info_field())
+
+        return attributes
 
     def convert_item_media(self, item: DatasetItem) -> dict[str, Any]:
         result: dict[str, Any] = {}
 
         if isinstance(item.media, Image):  # pyright: ignore[reportUnknownMemberType]
-            if isinstance(item.media, FromFileMixin):
-                # Handle image path
+            if self.media_mixin == FromDataMixin:
+                result["image_bytes"] = item.media.data
+            elif self.media_mixin == FromFileMixin:
                 result["image_path"] = item.media.path
             else:
-                raise ValueError(f"Unsupported media type for Image: {type(item.media)}")
+                raise RuntimeError(f"Media mixin not implemented: {self.media_mixin}")
+
+            # Add image info if available
+            if self.has_image_info and item.media.has_size:
+                height, width = item.media.size  # size returns (H, W)
+                result["image_info"] = ImageInfo(width=width, height=height)
 
         return result
 
@@ -283,7 +364,7 @@ def register_builtin_forward_converters():
     """Register built-in forward converters for common types."""
 
     # Media converters
-    register_forward_media_converter(Image, ForwardImageMediaConverter())
+    register_forward_media_converter(ForwardImageMediaConverter)
 
     # Annotation converters
     register_forward_annotation_converter(ForwardBboxAnnotationConverter)
@@ -312,9 +393,6 @@ def analyze_legacy_dataset(legacy_dataset: LegacyDataset) -> AnalysisResult:
         AnalysisResult containing the inferred schema and converters
     """
     categories = legacy_dataset.categories()
-    media_type = cast(
-        Type[MediaElement[Any]], legacy_dataset.media_type()
-    )  # pyright: ignore[reportUnknownMemberType]
     ann_types = legacy_dataset.ann_types()
 
     attributes: dict[str, AttributeInfo] = {}
@@ -322,12 +400,9 @@ def analyze_legacy_dataset(legacy_dataset: LegacyDataset) -> AnalysisResult:
     ann_converters: dict[AnnotationType, ForwardAnnotationConverter] = {}
 
     # Get media attributes from converter
-    try:
-        media_converter = get_forward_media_converter(media_type)
+    media_converter = get_forward_media_converter(legacy_dataset)
+    if media_converter is not None:
         attributes.update(media_converter.get_schema_attributes())
-    except ValueError:
-        # No converter for this media type - skip
-        pass
 
     # Get annotation attributes from converters for each annotation type in the dataset
     for ann_type in ann_types:

--- a/src/datumaro/experimental/type_registry.py
+++ b/src/datumaro/experimental/type_registry.py
@@ -57,6 +57,8 @@ def polars_to_numpy_dtype(polars_dtype: pl.DataType) -> np.dtype[Any]:
         return np.dtype(np.uint64)
     elif polars_dtype == pl.Boolean:
         return np.dtype(np.bool_)
+    elif polars_dtype == pl.Binary:
+        return np.dtype(np.bytes_)
     else:
         raise TypeError(f"No NumPy dtype mapping for Polars dtype: {polars_dtype}")
 
@@ -64,6 +66,7 @@ def polars_to_numpy_dtype(polars_dtype: pl.DataType) -> np.dtype[Any]:
 # Type conversion registry - extensible at runtime
 _to_numpy_converters: dict[type, Callable[[Any], np.ndarray[Any, Any]]] = {
     np.ndarray: lambda x: x,
+    bytes: lambda x: np.array(x),
 }
 
 _from_polars_converters: dict[type, Callable[[Any], Any]] = {
@@ -71,6 +74,7 @@ _from_polars_converters: dict[type, Callable[[Any], Any]] = {
     int: lambda x: int(x),
     float: lambda x: float(x),
     str: lambda x: str(x),
+    bytes: lambda x: bytes(x),
 }
 
 

--- a/tests/unit/experimental/test_converters.py
+++ b/tests/unit/experimental/test_converters.py
@@ -20,6 +20,7 @@ from datumaro.experimental.converter_registry import (
 )
 from datumaro.experimental.converters import (
     BBoxCoordinateConverter,
+    ImageBytesToImageConverter,
     ImagePathToImageConverter,
     PolygonToMaskConverter,
     RGBToBGRConverter,
@@ -28,6 +29,7 @@ from datumaro.experimental.converters import (
 from datumaro.experimental.fields import (
     BBoxField,
     Field,
+    ImageBytesField,
     ImageField,
     ImageInfoField,
     ImagePathField,
@@ -221,6 +223,7 @@ def test_image_path_to_image_converter():
         # Set up converter attributes
         input_field = ImagePathField(semantic=Semantic.Default)
         output_field = ImageField(dtype=pl.UInt8, format="RGB", semantic=Semantic.Default)
+        output_info_field = ImageInfoField(semantic=Semantic.Default)
 
         setattr(
             converter_instance,
@@ -232,6 +235,11 @@ def test_image_path_to_image_converter():
             "output_image",
             AttributeSpec(name="image", field=output_field),
         )
+        setattr(
+            converter_instance,
+            "output_info",
+            AttributeSpec(name="image_info", field=output_info_field),
+        )
 
         # Test filter - should return True for path->image conversion
         assert converter_instance.filter_output_spec() is True
@@ -241,10 +249,83 @@ def test_image_path_to_image_converter():
 
         assert "image" in result_df.columns
         assert "image_shape" in result_df.columns
+        assert "image_info" in result_df.columns
 
         # Check that image was loaded correctly
         result_shape = list(result_df["image_shape"][0])
         assert result_shape == [50, 75, 3]  # height, width, channels
+
+        # Check that image info was created correctly (only width and height)
+        image_info = result_df["image_info"][0]
+        assert "width" in image_info
+        assert "height" in image_info
+        assert image_info["width"] == 75  # width
+        assert image_info["height"] == 50  # height
+
+
+def test_image_bytes_to_image_converter():
+    """Test ImageBytesToImageConverter functionality."""
+    import numpy as np
+
+    from datumaro.util.image import encode_image
+
+    converter_instance = ImageBytesToImageConverter()  # type: ignore[call-arg]
+
+    # Create test image data
+    test_image = np.random.randint(0, 256, (32, 48, 3), dtype=np.uint8)
+    image_bytes = encode_image(test_image, ".png")
+
+    # Create test data
+    df = pl.DataFrame({"image_bytes": [image_bytes]})
+
+    # Set up converter attributes
+    from datumaro.experimental.fields import image_bytes_field
+
+    input_field = ImageBytesField(semantic=Semantic.Default)
+    output_field = ImageField(dtype=pl.UInt8, format="RGB", semantic=Semantic.Default)
+    output_info_field = ImageInfoField(semantic=Semantic.Default)
+
+    setattr(
+        converter_instance,
+        "input_bytes",
+        AttributeSpec(name="image_bytes", field=input_field),
+    )
+    setattr(
+        converter_instance,
+        "output_image",
+        AttributeSpec(name="image", field=output_field),
+    )
+    setattr(
+        converter_instance,
+        "output_info",
+        AttributeSpec(name="image_info", field=output_info_field),
+    )
+
+    # Test filter - should return True for bytes->image conversion
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    assert "image" in result_df.columns
+    assert "image_shape" in result_df.columns
+    assert "image_info" in result_df.columns
+
+    # Check that image was loaded correctly
+    result_shape = tuple(result_df["image_shape"][0])
+    assert result_shape == (32, 48, 3)  # height, width, channels
+
+    # Check that image info was created correctly (only width and height)
+    image_info = result_df["image_info"][0]
+    assert "width" in image_info
+    assert "height" in image_info
+    assert image_info["width"] == 48  # width
+    assert image_info["height"] == 32  # height
+
+    # Check that the actual image data is correct (approximately, since PNG compression may cause slight differences)
+    result_image = result_df["image"][0].to_numpy().reshape(result_shape)
+    assert result_image.shape == test_image.shape
+    assert result_image.dtype == np.uint8
 
 
 def test_find_conversion_path():

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -12,10 +12,13 @@ from typing_extensions import Annotated
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories, Polygon
 from datumaro.components.dataset import Dataset as LegacyDataset
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
-from datumaro.components.media import Image, ImageFromFile, Video
+from datumaro.components.media import Image, ImageFromFile, MediaElement, Video
 from datumaro.experimental.dataset import Dataset, Sample
 from datumaro.experimental.fields import (
+    ImageInfo,
     bbox_field,
+    image_bytes_field,
+    image_info_field,
     image_path_field,
     label_field,
     polygon_field,
@@ -38,11 +41,18 @@ from datumaro.experimental.legacy import (
     register_forward_media_converter,
 )
 from datumaro.experimental.schema import AttributeInfo, Schema
+from datumaro.util.image import encode_image
 
 
 def test_image_media_converter_get_schema_attributes():
     """Test schema attribute generation for images."""
-    converter = ForwardImageMediaConverter()
+    # Create a simple dataset with file-based images to get the converter
+    items = [DatasetItem(id="test", media=Image.from_file("/path/to/image.jpg"))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+
     attributes = converter.get_schema_attributes()
 
     assert "image_path" in attributes
@@ -51,7 +61,12 @@ def test_image_media_converter_get_schema_attributes():
 
 def test_image_media_converter_convert_item_media_with_path_and_size():
     """Test media conversion with path and size."""
-    converter = ForwardImageMediaConverter()
+    # Create a dataset to get the converter
+    items = [DatasetItem(id="test", media=Image.from_file("/path/to/image.jpg"))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
 
     image_media = Image.from_file(
         "/path/to/image.jpg", size=(480, 640)
@@ -65,7 +80,12 @@ def test_image_media_converter_convert_item_media_with_path_and_size():
 
 def test_image_media_converter_convert_item_media_with_path_only():
     """Test media conversion with only path."""
-    converter = ForwardImageMediaConverter()
+    # Create a dataset to get the converter
+    items = [DatasetItem(id="test", media=Image.from_file("/path/to/image.jpg"))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
 
     image_media = Image.from_file("/path/to/image.jpg")  # pyright: ignore[reportUnknownMemberType]
 
@@ -77,11 +97,289 @@ def test_image_media_converter_convert_item_media_with_path_only():
 
 def test_image_media_converter_convert_item_media_no_media():
     """Test media conversion with no media."""
-    converter = ForwardImageMediaConverter()
+    # Create a dataset to get the converter
+    items = [DatasetItem(id="test", media=Image.from_file("/path/to/image.jpg"))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+
     item = DatasetItem(id="test", media=None)
     result = converter.convert_item_media(item)
 
     assert result == {}
+
+
+def test_image_bytes_media_converter_get_schema_attributes():
+    """Test schema attribute generation for image bytes."""
+    # Create test image data
+    test_image = np.random.randint(0, 256, (32, 32, 3), dtype=np.uint8)
+    image_bytes = encode_image(test_image, ".png")
+
+    # Create a dataset with ImageFromBytes media
+    items = [DatasetItem(id="test", media=Image.from_bytes(image_bytes))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+
+    attributes = converter.get_schema_attributes()
+
+    assert "image_bytes" in attributes
+    assert attributes["image_bytes"].type == bytes
+
+
+def test_image_bytes_media_converter_convert_item_media():
+    """Test media conversion with image bytes."""
+    # Create test image data
+    test_image = np.random.randint(0, 256, (32, 32, 3), dtype=np.uint8)
+    image_bytes = encode_image(test_image, ".png")
+
+    # Create a dataset to get the converter
+    items = [DatasetItem(id="test", media=Image.from_bytes(image_bytes))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+
+    image_media = Image.from_bytes(image_bytes)
+    item = DatasetItem(id="test", media=image_media)
+    result = converter.convert_item_media(item)
+
+    assert "image_bytes" in result
+    assert isinstance(result["image_bytes"], (bytes, np.ndarray))
+
+
+def test_image_bytes_media_converter_convert_item_media_with_numpy():
+    """Test media conversion with numpy-based image."""
+    # Create test image data
+    test_image = np.random.randint(0, 256, (32, 32, 3), dtype=np.uint8)
+
+    # Create a dataset with ImageFromNumpy media
+    items = [DatasetItem(id="test", media=Image.from_numpy(test_image))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+
+    image_media = Image.from_numpy(test_image)
+    item = DatasetItem(id="test", media=image_media)
+    result = converter.convert_item_media(item)
+
+    assert "image_bytes" in result
+    assert isinstance(result["image_bytes"], np.ndarray)
+    np.testing.assert_array_equal(result["image_bytes"], test_image)
+
+
+def test_unified_image_converter_handles_file_based_images():
+    """Test that the unified ForwardImageMediaConverter handles file-based images."""
+    # Create a dataset with file-based images
+    items = [DatasetItem(id="test", media=Image.from_file("/path/to/image.jpg"))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+
+    # Should generate image_path attributes for file-based images
+    attributes = converter.get_schema_attributes()
+    assert "image_path" in attributes
+
+
+def test_unified_image_converter_handles_data_based_images():
+    """Test that the unified ForwardImageMediaConverter handles data-based images."""
+    # Create test image data
+    test_image = np.random.randint(0, 256, (32, 32, 3), dtype=np.uint8)
+    image_bytes = encode_image(test_image, ".png")
+
+    # Create a dataset with data-based images
+    items = [DatasetItem(id="test", media=Image.from_bytes(image_bytes))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+
+    # Should generate image_bytes attributes for data-based images
+    attributes = converter.get_schema_attributes()
+    assert "image_bytes" in attributes
+
+
+def test_image_converter_with_size_info_includes_image_info_field():
+    """Test that ForwardImageMediaConverter includes ImageInfoField when all images have size."""
+    # Create images with size information
+    items = [
+        DatasetItem(id="test1", media=Image.from_file("/path/to/image1.jpg", size=(480, 640))),
+        DatasetItem(id="test2", media=Image.from_file("/path/to/image2.jpg", size=(720, 1280))),
+    ]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+    assert converter.has_image_info is True
+
+    # Should include both image_path and image_info attributes
+    attributes = converter.get_schema_attributes()
+    assert "image_path" in attributes
+    assert "image_info" in attributes
+    assert attributes["image_info"].type == ImageInfo
+
+
+def test_image_converter_without_size_info_excludes_image_info_field():
+    """Test that ForwardImageMediaConverter excludes ImageInfoField when images don't have size."""
+    # Create images without size information
+    items = [
+        DatasetItem(id="test1", media=Image.from_file("/path/to/image1.jpg")),
+        DatasetItem(id="test2", media=Image.from_file("/path/to/image2.jpg")),
+    ]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+    assert converter.has_image_info is False
+
+    # Should only include image_path attribute, not image_info
+    attributes = converter.get_schema_attributes()
+    assert "image_path" in attributes
+    assert "image_info" not in attributes
+
+
+def test_image_converter_mixed_size_info_excludes_image_info_field():
+    """Test that ForwardImageMediaConverter excludes ImageInfoField when some images lack size."""
+    # Create mixed dataset - some images with size, some without
+    items = [
+        DatasetItem(id="test1", media=Image.from_file("/path/to/image1.jpg", size=(480, 640))),
+        DatasetItem(id="test2", media=Image.from_file("/path/to/image2.jpg")),  # No size
+    ]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+    assert converter.has_image_info is False
+
+    # Should only include image_path attribute, not image_info
+    attributes = converter.get_schema_attributes()
+    assert "image_path" in attributes
+    assert "image_info" not in attributes
+
+
+def test_image_converter_converts_size_info():
+    """Test that ForwardImageMediaConverter properly converts size information."""
+    # Create images with size information
+    items = [DatasetItem(id="test", media=Image.from_file("/path/to/image.jpg", size=(480, 640)))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+    assert converter.has_image_info is True
+
+    # Test conversion
+    image_media = Image.from_file("/path/to/image.jpg", size=(480, 640))
+    item = DatasetItem(id="test", media=image_media)
+    result = converter.convert_item_media(item)
+
+    assert "image_path" in result
+    assert "image_info" in result
+    assert result["image_path"] == "/path/to/image.jpg"
+    assert isinstance(result["image_info"], ImageInfo)
+    assert result["image_info"].width == 640
+    assert result["image_info"].height == 480
+
+
+def test_image_converter_bytes_with_size_info():
+    """Test ForwardImageMediaConverter with image bytes that have size information."""
+    # Create test image data with size
+    test_image = np.random.randint(0, 256, (64, 128, 3), dtype=np.uint8)
+    image_bytes = encode_image(test_image, ".png")
+
+    # Create images from bytes - they should have size info when loaded
+    items = [DatasetItem(id="test", media=Image.from_bytes(image_bytes))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    converter = ForwardImageMediaConverter.create(dataset)
+    assert converter is not None
+
+    # Test conversion - the exact behavior depends on whether from_bytes has size info
+    image_media = Image.from_bytes(image_bytes)
+    item = DatasetItem(id="test", media=image_media)
+    result = converter.convert_item_media(item)
+
+    assert "image_bytes" in result
+
+    # If the image has size info, it should be included
+    if converter.has_image_info and image_media.has_size:
+        assert "image_info" in result
+        assert isinstance(result["image_info"], ImageInfo)
+        # Note: Image size is (H, W) but ImageInfo expects (width, height)
+        height, width = image_media.size
+        assert result["image_info"].width == width
+        assert result["image_info"].height == height
+
+
+def test_convert_from_legacy_with_image_bytes():
+    """Test full conversion pipeline with ImageFromData images."""
+    # Create test images
+    test_image1 = np.random.randint(0, 256, (32, 32, 3), dtype=np.uint8)
+    test_image2 = np.random.randint(0, 256, (64, 64, 3), dtype=np.uint8)
+
+    # Encode images as bytes
+    image_bytes1 = encode_image(test_image1, ".png")
+    image_bytes2 = encode_image(test_image2, ".jpg")
+
+    # Create dataset items with ImageFromBytes media
+    items = [
+        DatasetItem(id="item1", media=Image.from_bytes(image_bytes1), annotations=[]),
+        DatasetItem(id="item2", media=Image.from_bytes(image_bytes2), annotations=[]),
+    ]
+
+    # Create legacy dataset
+    legacy_dataset = LegacyDataset.from_iterable(items)
+
+    # Convert to experimental format
+    experimental_dataset = convert_from_legacy(legacy_dataset)
+
+    # Verify conversion
+    assert "image_bytes" in experimental_dataset.schema.attributes
+    assert "image_path" not in experimental_dataset.schema.attributes
+
+    # Verify samples
+    assert len(experimental_dataset) == 2
+
+    sample1 = experimental_dataset[0]
+    sample2 = experimental_dataset[1]
+
+    # Check that image_bytes are present
+    assert hasattr(sample1, "image_bytes")
+    assert hasattr(sample2, "image_bytes")
+
+
+def test_convert_from_legacy_with_image_paths():
+    """Test that file-based images still use ImagePathField correctly."""
+    # Create dataset items with ImageFromFile media
+    items = [
+        DatasetItem(id="item1", media=Image.from_file("test1.jpg"), annotations=[]),
+        DatasetItem(id="item2", media=Image.from_file("test2.png"), annotations=[]),
+    ]
+
+    # Create legacy dataset
+    legacy_dataset = LegacyDataset.from_iterable(items)
+
+    # Convert to experimental format
+    experimental_dataset = convert_from_legacy(legacy_dataset)
+
+    # Verify conversion
+    assert "image_path" in experimental_dataset.schema.attributes
+    assert "image_bytes" not in experimental_dataset.schema.attributes
+
+    # Verify samples
+    assert len(experimental_dataset) == 2
+
+    sample1 = experimental_dataset[0]
+    sample2 = experimental_dataset[1]
+
+    # Check that image_path are present
+    assert hasattr(sample1, "image_path")
+    assert hasattr(sample2, "image_path")
+    assert sample1.image_path == "test1.jpg"
+    assert sample2.image_path == "test2.png"
 
 
 def test_bbox_annotation_converter_get_schema_attributes():
@@ -173,11 +471,15 @@ def test_bbox_annotation_converter_convert_annotations_empty_list():
 
 def test_register_and_get_media_converter():
     """Test media converter registration and retrieval."""
-    converter = ForwardImageMediaConverter()
-    register_forward_media_converter(Image, converter)
+    register_forward_media_converter(ForwardImageMediaConverter)
 
-    retrieved = get_forward_media_converter(Image)
-    assert retrieved is converter
+    # Create a dataset with file-based images
+    items = [DatasetItem(id="test", media=Image.from_file("/path/to/image.jpg"))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    retrieved = get_forward_media_converter(dataset)
+    assert retrieved is not None
+    assert isinstance(retrieved, ForwardImageMediaConverter)
 
 
 def test_register_and_get_annotation_converter():
@@ -191,10 +493,13 @@ def test_register_and_get_annotation_converter():
 
 
 def test_get_nonexistent_media_converter():
-    """Test getting converter for unregistered media type."""
+    """Test getting converter for unsupported dataset."""
+    # Create a dataset with Video media (not supported by current converters)
+    items = [DatasetItem(id="test", media=Video("/path/to/video.mp4"))]
+    dataset = LegacyDataset.from_iterable(items, media_type=Video)
 
-    with pytest.raises(ValueError, match="No converter registered for media type"):
-        get_forward_media_converter(Video)
+    retrieved = get_forward_media_converter(dataset)
+    assert retrieved is None
 
 
 def test_get_nonexistent_annotation_converter():
@@ -278,7 +583,8 @@ def test_analyze_unknown_annotation_type():
 
         # Should skip unknown annotation type
         assert "image_path" in analysis_result.schema.attributes
-        assert len(analysis_result.schema.attributes) == 1  # Only image_path field
+        assert "image_info" in analysis_result.schema.attributes
+        assert len(analysis_result.schema.attributes) == 2  # Only image_path and image_info field
 
 
 def test_convert_simple_bbox_dataset():
@@ -369,7 +675,12 @@ def test_convert_image_only_dataset():
 
 def test_builtin_converters_registration():
     """Test that built-in converters are registered on import."""
-    image_converter = get_forward_media_converter(Image)
+    # Create a dataset with file-based images
+    items = [DatasetItem(id="test", media=Image.from_file("/path/to/image.jpg"))]
+    dataset = LegacyDataset.from_iterable(items)
+
+    image_converter = get_forward_media_converter(dataset)
+    assert image_converter is not None
     assert isinstance(image_converter, ForwardImageMediaConverter)
 
     categories: CategoriesInfo = {}

--- a/tests/unit/experimental/test_schema.py
+++ b/tests/unit/experimental/test_schema.py
@@ -11,6 +11,7 @@ import pytest
 from datumaro.experimental.dataset import Sample
 from datumaro.experimental.fields import (
     BBoxField,
+    ImageBytesField,
     ImageField,
     ImageInfo,
     ImageInfoField,
@@ -18,6 +19,7 @@ from datumaro.experimental.fields import (
     PolygonField,
     TensorField,
     bbox_field,
+    image_bytes_field,
     image_field,
     image_info_field,
     image_path_field,
@@ -25,6 +27,7 @@ from datumaro.experimental.fields import (
     tensor_field,
 )
 from datumaro.experimental.schema import AttributeInfo, Schema, Semantic
+from datumaro.util.image import decode_image, encode_image
 
 
 def test_tensor_field_creation():
@@ -83,6 +86,193 @@ def test_image_field_polars_schema():
 
     expected = {"image": pl.List(pl.UInt8()), "image_shape": pl.List(pl.Int32())}
     assert schema == expected
+
+
+def test_image_bytes_field_creation():
+    """Test ImageBytesField creation and properties."""
+    field = image_bytes_field(format="PNG", semantic=Semantic.Left)
+
+    assert isinstance(field, ImageBytesField)
+    assert field.format == "PNG"
+    assert field.semantic == Semantic.Left
+
+
+def test_image_bytes_field_creation_with_optional_format():
+    """Test ImageBytesField creation with optional format."""
+    field = image_bytes_field(format=None, semantic=Semantic.Default)
+
+    assert isinstance(field, ImageBytesField)
+    assert field.format is None
+    assert field.semantic == Semantic.Default
+
+    # Test factory function default
+    field_default = image_bytes_field()
+    assert field_default.format is None
+
+
+def test_image_bytes_field_effective_format():
+    """Test ImageBytesField effective format detection."""
+    field = image_bytes_field(format=None)
+    test_image = np.random.randint(0, 256, (8, 8, 3), dtype=np.uint8)
+
+    # Test with different formats
+    png_bytes = encode_image(test_image, ".png")
+    jpeg_bytes = encode_image(test_image, ".jpg")
+
+    # Test effective format with data
+    assert field.get_effective_format(png_bytes) == "PNG"
+    assert field.get_effective_format(jpeg_bytes) == "JPEG"
+    assert field.get_effective_format() == "PNG"  # Default when no data
+
+    # Test with explicit format
+    field_explicit = image_bytes_field(format="JPEG")
+    assert (
+        field_explicit.get_effective_format(png_bytes) == "JPEG"
+    )  # Uses explicit format even with PNG data
+
+
+def test_image_bytes_field_polars_schema():
+    """Test ImageBytesField Polars schema generation."""
+    field = image_bytes_field(format="PNG")
+    schema = field.to_polars_schema("image_bytes")
+
+    expected = {"image_bytes": pl.Binary()}
+    assert schema == expected
+
+
+def test_image_bytes_field_polars_conversion_with_numpy():
+    """Test ImageBytesField to/from Polars conversion with numpy arrays."""
+    field = image_bytes_field(format="PNG")
+    test_image = np.random.randint(0, 256, (32, 32, 3), dtype=np.uint8)
+
+    # Test to_polars with numpy array
+    polars_data = field.to_polars("image_bytes", test_image)
+    assert "image_bytes" in polars_data
+    assert isinstance(polars_data["image_bytes"][0], bytes)
+    assert len(polars_data["image_bytes"][0]) > 0
+
+    # Create DataFrame and test from_polars
+    df = pl.DataFrame(polars_data)
+    reconstructed = field.from_polars("image_bytes", 0, df, np.ndarray)
+
+    assert isinstance(reconstructed, np.ndarray)
+    assert reconstructed.shape == test_image.shape
+    assert np.allclose(reconstructed, test_image)
+
+
+def test_image_bytes_field_polars_conversion_with_bytes():
+    """Test ImageBytesField to/from Polars conversion with direct bytes."""
+    field = image_bytes_field(format="JPEG")
+    test_image = np.random.randint(0, 256, (16, 16, 3), dtype=np.uint8)
+    image_bytes = encode_image(test_image, ".jpg")
+    decoded_test_image = decode_image(image_bytes)
+
+    # Test to_polars with bytes
+    polars_data = field.to_polars("image_bytes", image_bytes)
+    assert "image_bytes" in polars_data
+    assert polars_data["image_bytes"][0] == image_bytes
+
+    # Create DataFrame and test from_polars
+    df = pl.DataFrame(polars_data)
+    reconstructed = field.from_polars("image_bytes", 0, df, np.ndarray)
+
+    assert isinstance(reconstructed, np.ndarray)
+    assert reconstructed.shape == test_image.shape
+    assert np.all(reconstructed == decoded_test_image)
+
+
+def test_image_bytes_field_auto_detection():
+    """Test ImageBytesField with auto-detection (format=None)."""
+    field = image_bytes_field(format=None)  # Auto-detection enabled
+    test_image = np.random.randint(0, 256, (16, 16, 3), dtype=np.uint8)
+
+    # Test with PNG bytes
+    png_bytes = encode_image(test_image, ".png")
+    polars_data = field.to_polars("image_bytes", png_bytes)
+    df = pl.DataFrame(polars_data)
+    reconstructed = field.from_polars("image_bytes", 0, df, np.ndarray)
+
+    assert isinstance(reconstructed, np.ndarray)
+    assert reconstructed.shape == test_image.shape
+    assert np.allclose(reconstructed, test_image)
+
+    # Test with numpy array (should default to PNG when encoding)
+    polars_data_numpy = field.to_polars("image_bytes", test_image)
+    df_numpy = pl.DataFrame(polars_data_numpy)
+    reconstructed_numpy = field.from_polars("image_bytes", 0, df_numpy, np.ndarray)
+
+    assert isinstance(reconstructed_numpy, np.ndarray)
+    assert reconstructed_numpy.shape == test_image.shape
+    assert np.allclose(reconstructed_numpy, test_image)
+
+
+def test_image_bytes_field_format_detection():
+    """Test ImageBytesField format detection."""
+    field = image_bytes_field()
+    test_image = np.random.randint(0, 256, (8, 8, 3), dtype=np.uint8)
+
+    # Test PNG detection
+    png_bytes = encode_image(test_image, ".png")
+    detected_format = field._guess_format(png_bytes)
+    assert detected_format == "PNG"
+
+    # Test JPEG detection
+    jpeg_bytes = encode_image(test_image, ".jpg")
+    detected_format = field._guess_format(jpeg_bytes)
+    assert detected_format == "JPEG"
+
+    # Test BMP detection
+    bmp_bytes = encode_image(test_image, ".bmp")
+    detected_format = field._guess_format(bmp_bytes)
+    assert detected_format == "BMP"
+
+    # Test unknown format
+    unknown_bytes = b"unknown_image_data"
+    detected_format = field._guess_format(unknown_bytes)
+    assert detected_format is None
+
+
+def test_image_bytes_field_converters():
+    """Test converters between ImageField and ImageBytesField."""
+    # Test ImageField to ImageBytesField conversion
+    image_field_instance = image_field(dtype=pl.UInt8(), format="RGB")
+    bytes_field_instance = image_field_instance.convert_to_image_bytes_field("JPEG")
+
+    assert isinstance(bytes_field_instance, ImageBytesField)
+    assert bytes_field_instance.format == "JPEG"
+    assert bytes_field_instance.semantic == image_field_instance.semantic
+
+    # Test ImageField to ImageBytesField conversion with None format
+    bytes_field_auto = image_field_instance.convert_to_image_bytes_field(None)
+    assert isinstance(bytes_field_auto, ImageBytesField)
+    assert bytes_field_auto.format is None
+    assert bytes_field_auto.semantic == image_field_instance.semantic
+
+    # Test ImageBytesField to ImageField conversion
+    bytes_field_instance2 = image_bytes_field(format="PNG", semantic=Semantic.Left)
+    image_field_instance2 = bytes_field_instance2.convert_to_image_field(pl.Float32())
+
+    assert isinstance(image_field_instance2, ImageField)
+    assert image_field_instance2.dtype == pl.Float32()
+    assert image_field_instance2.format == "RGB"
+    assert image_field_instance2.semantic == Semantic.Left
+
+    # Test ImageBytesField to ImageField conversion with None format
+    bytes_field_auto2 = image_bytes_field(format=None, semantic=Semantic.Right)
+    image_field_auto = bytes_field_auto2.convert_to_image_field(pl.Int32())
+
+    assert isinstance(image_field_auto, ImageField)
+    assert image_field_auto.dtype == pl.Int32()
+    assert image_field_auto.format == "RGB"
+    assert image_field_auto.semantic == Semantic.Right
+
+
+def test_image_bytes_field_unsupported_type():
+    """Test ImageBytesField with unsupported input type."""
+    field = image_bytes_field()
+
+    with pytest.raises(TypeError, match="Unsupported type for ImageBytesField"):
+        field.to_polars("image_bytes", "invalid_string_input")
 
 
 def test_bbox_field_creation():

--- a/tests/unit/experimental/test_schema.py
+++ b/tests/unit/experimental/test_schema.py
@@ -90,50 +90,15 @@ def test_image_field_polars_schema():
 
 def test_image_bytes_field_creation():
     """Test ImageBytesField creation and properties."""
-    field = image_bytes_field(format="PNG", semantic=Semantic.Left)
+    field = image_bytes_field(semantic=Semantic.Left)
 
     assert isinstance(field, ImageBytesField)
-    assert field.format == "PNG"
     assert field.semantic == Semantic.Left
-
-
-def test_image_bytes_field_creation_with_optional_format():
-    """Test ImageBytesField creation with optional format."""
-    field = image_bytes_field(format=None, semantic=Semantic.Default)
-
-    assert isinstance(field, ImageBytesField)
-    assert field.format is None
-    assert field.semantic == Semantic.Default
-
-    # Test factory function default
-    field_default = image_bytes_field()
-    assert field_default.format is None
-
-
-def test_image_bytes_field_effective_format():
-    """Test ImageBytesField effective format detection."""
-    field = image_bytes_field(format=None)
-    test_image = np.random.randint(0, 256, (8, 8, 3), dtype=np.uint8)
-
-    # Test with different formats
-    png_bytes = encode_image(test_image, ".png")
-    jpeg_bytes = encode_image(test_image, ".jpg")
-
-    # Test effective format with data
-    assert field.get_effective_format(png_bytes) == "PNG"
-    assert field.get_effective_format(jpeg_bytes) == "JPEG"
-    assert field.get_effective_format() == "PNG"  # Default when no data
-
-    # Test with explicit format
-    field_explicit = image_bytes_field(format="JPEG")
-    assert (
-        field_explicit.get_effective_format(png_bytes) == "JPEG"
-    )  # Uses explicit format even with PNG data
 
 
 def test_image_bytes_field_polars_schema():
     """Test ImageBytesField Polars schema generation."""
-    field = image_bytes_field(format="PNG")
+    field = image_bytes_field()
     schema = field.to_polars_schema("image_bytes")
 
     expected = {"image_bytes": pl.Binary()}
@@ -142,11 +107,11 @@ def test_image_bytes_field_polars_schema():
 
 def test_image_bytes_field_polars_conversion_with_numpy():
     """Test ImageBytesField to/from Polars conversion with numpy arrays."""
-    field = image_bytes_field(format="PNG")
-    test_image = np.random.randint(0, 256, (32, 32, 3), dtype=np.uint8)
+    field = image_bytes_field()
+    image_bytes = np.array(np.random.bytes(30))
 
     # Test to_polars with numpy array
-    polars_data = field.to_polars("image_bytes", test_image)
+    polars_data = field.to_polars("image_bytes", image_bytes)
     assert "image_bytes" in polars_data
     assert isinstance(polars_data["image_bytes"][0], bytes)
     assert len(polars_data["image_bytes"][0]) > 0
@@ -156,16 +121,13 @@ def test_image_bytes_field_polars_conversion_with_numpy():
     reconstructed = field.from_polars("image_bytes", 0, df, np.ndarray)
 
     assert isinstance(reconstructed, np.ndarray)
-    assert reconstructed.shape == test_image.shape
-    assert np.allclose(reconstructed, test_image)
+    assert np.all(reconstructed == image_bytes)
 
 
 def test_image_bytes_field_polars_conversion_with_bytes():
     """Test ImageBytesField to/from Polars conversion with direct bytes."""
-    field = image_bytes_field(format="JPEG")
-    test_image = np.random.randint(0, 256, (16, 16, 3), dtype=np.uint8)
-    image_bytes = encode_image(test_image, ".jpg")
-    decoded_test_image = decode_image(image_bytes)
+    field = image_bytes_field()
+    image_bytes = np.array(np.random.bytes(30))
 
     # Test to_polars with bytes
     polars_data = field.to_polars("image_bytes", image_bytes)
@@ -174,105 +136,10 @@ def test_image_bytes_field_polars_conversion_with_bytes():
 
     # Create DataFrame and test from_polars
     df = pl.DataFrame(polars_data)
-    reconstructed = field.from_polars("image_bytes", 0, df, np.ndarray)
+    reconstructed = field.from_polars("image_bytes", 0, df, bytes)
 
-    assert isinstance(reconstructed, np.ndarray)
-    assert reconstructed.shape == test_image.shape
-    assert np.all(reconstructed == decoded_test_image)
-
-
-def test_image_bytes_field_auto_detection():
-    """Test ImageBytesField with auto-detection (format=None)."""
-    field = image_bytes_field(format=None)  # Auto-detection enabled
-    test_image = np.random.randint(0, 256, (16, 16, 3), dtype=np.uint8)
-
-    # Test with PNG bytes
-    png_bytes = encode_image(test_image, ".png")
-    polars_data = field.to_polars("image_bytes", png_bytes)
-    df = pl.DataFrame(polars_data)
-    reconstructed = field.from_polars("image_bytes", 0, df, np.ndarray)
-
-    assert isinstance(reconstructed, np.ndarray)
-    assert reconstructed.shape == test_image.shape
-    assert np.allclose(reconstructed, test_image)
-
-    # Test with numpy array (should default to PNG when encoding)
-    polars_data_numpy = field.to_polars("image_bytes", test_image)
-    df_numpy = pl.DataFrame(polars_data_numpy)
-    reconstructed_numpy = field.from_polars("image_bytes", 0, df_numpy, np.ndarray)
-
-    assert isinstance(reconstructed_numpy, np.ndarray)
-    assert reconstructed_numpy.shape == test_image.shape
-    assert np.allclose(reconstructed_numpy, test_image)
-
-
-def test_image_bytes_field_format_detection():
-    """Test ImageBytesField format detection."""
-    field = image_bytes_field()
-    test_image = np.random.randint(0, 256, (8, 8, 3), dtype=np.uint8)
-
-    # Test PNG detection
-    png_bytes = encode_image(test_image, ".png")
-    detected_format = field._guess_format(png_bytes)
-    assert detected_format == "PNG"
-
-    # Test JPEG detection
-    jpeg_bytes = encode_image(test_image, ".jpg")
-    detected_format = field._guess_format(jpeg_bytes)
-    assert detected_format == "JPEG"
-
-    # Test BMP detection
-    bmp_bytes = encode_image(test_image, ".bmp")
-    detected_format = field._guess_format(bmp_bytes)
-    assert detected_format == "BMP"
-
-    # Test unknown format
-    unknown_bytes = b"unknown_image_data"
-    detected_format = field._guess_format(unknown_bytes)
-    assert detected_format is None
-
-
-def test_image_bytes_field_converters():
-    """Test converters between ImageField and ImageBytesField."""
-    # Test ImageField to ImageBytesField conversion
-    image_field_instance = image_field(dtype=pl.UInt8(), format="RGB")
-    bytes_field_instance = image_field_instance.convert_to_image_bytes_field("JPEG")
-
-    assert isinstance(bytes_field_instance, ImageBytesField)
-    assert bytes_field_instance.format == "JPEG"
-    assert bytes_field_instance.semantic == image_field_instance.semantic
-
-    # Test ImageField to ImageBytesField conversion with None format
-    bytes_field_auto = image_field_instance.convert_to_image_bytes_field(None)
-    assert isinstance(bytes_field_auto, ImageBytesField)
-    assert bytes_field_auto.format is None
-    assert bytes_field_auto.semantic == image_field_instance.semantic
-
-    # Test ImageBytesField to ImageField conversion
-    bytes_field_instance2 = image_bytes_field(format="PNG", semantic=Semantic.Left)
-    image_field_instance2 = bytes_field_instance2.convert_to_image_field(pl.Float32())
-
-    assert isinstance(image_field_instance2, ImageField)
-    assert image_field_instance2.dtype == pl.Float32()
-    assert image_field_instance2.format == "RGB"
-    assert image_field_instance2.semantic == Semantic.Left
-
-    # Test ImageBytesField to ImageField conversion with None format
-    bytes_field_auto2 = image_bytes_field(format=None, semantic=Semantic.Right)
-    image_field_auto = bytes_field_auto2.convert_to_image_field(pl.Int32())
-
-    assert isinstance(image_field_auto, ImageField)
-    assert image_field_auto.dtype == pl.Int32()
-    assert image_field_auto.format == "RGB"
-    assert image_field_auto.semantic == Semantic.Right
-
-
-def test_image_bytes_field_unsupported_type():
-    """Test ImageBytesField with unsupported input type."""
-    field = image_bytes_field()
-
-    with pytest.raises(TypeError, match="Unsupported type for ImageBytesField"):
-        field.to_polars("image_bytes", "invalid_string_input")
+    assert isinstance(reconstructed, bytes)
+    assert reconstructed == image_bytes
 
 
 def test_bbox_field_creation():


### PR DESCRIPTION
This pull request introduces support for handling images as encoded bytes throughout the experimental API, adds new converters for image bytes, and refactors field classes to improve type safety and default values. The default values are needed to allow the schema converter to automatically create new fields. It also updates the legacy converter registration mechanism for greater flexibility. The most important changes are grouped below:

**Image bytes support and converters**

* Added the `ImageBytesField` class to represent images as encoded bytes, with conversion methods to and from tensor format and auto-detection of image format. Also added the `image_bytes_field` factory function. (`src/datumaro/experimental/fields.py`)
* Implemented `ImageBytesToImageConverter`, a lazy converter for decoding image bytes to tensors and extracting image info, and updated `ImagePathToImageConverter` to also output image info. (`src/datumaro/experimental/converters.py`) [[1]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3R172) [[2]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3R185-R211) [[3]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3R225-R317)

**Field class improvements**

* Refactored field classes (`TensorField`, `BBoxField`, `PolygonField`, `MaskField`, `LabelField`) to use type-safe default values for `dtype`, `format`, and `normalize`, improving consistency and reducing boilerplate. (`src/datumaro/experimental/fields.py`) [[1]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7L38-R43) [[2]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7L120-R270) [[3]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7L376-R526) [[4]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7L434-R582) [[5]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7L263-R411)
* Added conversion methods between `ImageField` and `ImageBytesField` for seamless transformation between tensor and bytes representations. (`src/datumaro/experimental/fields.py`) [[1]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7L86-R106) [[2]](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7R124-R251)

**Converter registry and semantic propagation**

* Updated converter registry logic so that converter provides the semantic tag when instantiating new fields. Before, it was crashing due to missing parameters when creating a field. (`src/datumaro/experimental/converter_registry.py`) [[1]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L521-R521) [[2]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L567-R567) [[3]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41R720)

**Legacy API and converter registration**

* Refactored the legacy media converter registration to use converter classes instead of instances, allowing for dynamic creation and support for multiple media types per converter. (`src/datumaro/experimental/legacy.py`) [[1]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5R44-R55) [[2]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L83-R105) [[3]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L102-R126)
* Updated legacy imports and converter logic to support new image field types and info. (`src/datumaro/experimental/legacy.py`)

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
