### PR TITLE
Automatically infer categories when converting schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This release streamlines Datumaro by removing a number of lesser-used features, 
 
 ### New features
 - Experimental dataset class
-  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>, <https://github.com/open-edge-platform/datumaro/pull/1868>)
+  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>, <https://github.com/open-edge-platform/datumaro/pull/1868>, <https://github.com/open-edge-platform/datumaro/pull/1876>)
 
 ### Enhancements
 - Mark several dependencies as optional

--- a/src/datumaro/experimental/categories.py
+++ b/src/datumaro/experimental/categories.py
@@ -185,6 +185,7 @@ class MaskCategories(Categories):
     Describes a color map for segmentation masks.
     """
 
+    labels: List[str] = field(default_factory=list)
     colormap: Colormap = field(default_factory=Colormap)
 
     @classmethod

--- a/src/datumaro/experimental/converter_registry.py
+++ b/src/datumaro/experimental/converter_registry.py
@@ -19,6 +19,7 @@ from functools import cache
 from typing import (
     Any,
     Callable,
+    Dict,
     Generic,
     List,
     NamedTuple,
@@ -35,6 +36,7 @@ from typing import (
 import polars as pl
 from typing_extensions import cast, dataclass_transform
 
+from .categories import Categories
 from .schema import Field, Schema, Semantic
 
 TField = TypeVar("TField", bound=Field)
@@ -66,10 +68,12 @@ class AttributeSpec(Generic[TField]):
     Attributes:
         name: The attribute name
         field: The field type specification
+        categories: Optional categories information (e.g., LabelCategories, MaskCategories)
     """
 
     name: str
     field: TField
+    categories: Optional[Categories] = None
 
 
 @dataclass_transform()
@@ -560,17 +564,21 @@ def _get_applicable_converters(
                 target_attr_spec = target_state.field_to_attr_spec[field_type]
                 output_name = target_attr_spec.name
                 output_field = target_attr_spec.field
+                output_categories = target_attr_spec.categories
             else:
                 # The field does not exist, use a temporary name
                 output_name = field_type.__name__.lower()
                 # and create a new instance of the field
                 output_field = field_type(semantic=semantic)
+                output_categories = None
 
             # Add the iteration count at the end to ensure uniqueness
             # and avoid any conflict with existing attribute names
             output_name = f"{output_name}_temp_{iteration}"
 
-            output_attr_spec = AttributeSpec(name=output_name, field=output_field)
+            output_attr_spec = AttributeSpec(
+                name=output_name, field=output_field, categories=output_categories
+            )
             converter_kwargs[attr_name] = output_attr_spec
 
         # Create converter instance with all AttributeSpec instances as kwargs
@@ -615,7 +623,9 @@ def _group_fields_by_semantic(schema: Schema) -> dict[Semantic, _SchemaState]:
         semantic = attr_info.annotation.semantic
 
         field_type = type(attr_info.annotation)
-        attr_spec = AttributeSpec(name=attr_name, field=attr_info.annotation)
+        attr_spec = AttributeSpec(
+            name=attr_name, field=attr_info.annotation, categories=attr_info.categories
+        )
         groups[semantic][field_type] = attr_spec
 
     # Convert to SchemaState objects
@@ -627,7 +637,7 @@ def _group_fields_by_semantic(schema: Schema) -> dict[Semantic, _SchemaState]:
 
 def _create_post_processing_for_semantic(
     final_state: _SchemaState, target_state: _SchemaState
-) -> List[Converter]:
+) -> Tuple[List[Converter], _SchemaState]:
     """
     Create post-processing converters for a single semantic group.
 
@@ -636,7 +646,8 @@ def _create_post_processing_for_semantic(
         target_state: Target state for this semantic group
 
     Returns:
-        List of post-processing converters (usually just one AttributeRemapperConverter)
+        Tuple of (list of post-processing converters, updated_state_after_processing)
+        where updated_state_after_processing reflects the state after renaming/deletion
     """
     # Build attribute mappings: include only attributes that should be kept
     attr_mappings = []
@@ -662,14 +673,30 @@ def _create_post_processing_for_semantic(
 
     # Create a single remapper converter that handles both renaming and deletion
     if converter_needed:
-        return [AttributeRemapperConverter(attr_mappings=attr_mappings)]
+        # Create the updated state after processing by applying the attr_mappings to final_state
+        # This preserves the categories from final_state but with the target names/structure
+        updated_field_to_attr_spec = {}
 
-    return []
+        for final_attr_spec, target_attr_spec in attr_mappings:
+            # Use the target name and field type, but preserve categories from final state
+            updated_field_to_attr_spec[type(target_attr_spec.field)] = AttributeSpec(
+                name=target_attr_spec.name,
+                field=target_attr_spec.field,
+                categories=final_attr_spec.categories,  # Preserve inferred categories
+            )
+
+        updated_state_after_processing = _SchemaState(updated_field_to_attr_spec)
+        return [
+            AttributeRemapperConverter(attr_mappings=attr_mappings)
+        ], updated_state_after_processing
+
+    # No converter needed, return the final state as-is
+    return [], final_state
 
 
 def _find_conversion_path_for_semantic(
     start_state: _SchemaState, target_state: _SchemaState, semantic: Semantic
-) -> List[Converter]:
+) -> Tuple[List[Converter], _SchemaState]:
     """
     Find conversion path for fields with a specific semantic tag.
 
@@ -679,7 +706,7 @@ def _find_conversion_path_for_semantic(
         semantic: The semantic tag being processed
 
     Returns:
-        List of converters needed for this semantic group
+        Tuple of (list of converters needed for this semantic group, updated target state)
 
     Raises:
         ConversionError: If no conversion path is found for this semantic
@@ -712,8 +739,10 @@ def _find_conversion_path_for_semantic(
         # Check if we've reached the goal - all target fields must match exactly
         if _heuristic_cost(current_node.state, target_state) == 0:
             # Add post-processing converters for final renaming and deletion
-            post_processing = _create_post_processing_for_semantic(current_node.state, target_state)
-            return current_node.path + post_processing
+            post_processing, final_state = _create_post_processing_for_semantic(
+                current_node.state, target_state
+            )
+            return current_node.path + post_processing, final_state
 
         # Explore neighbors
         for converter, new_state in _get_applicable_converters(
@@ -744,7 +773,9 @@ def _find_conversion_path_for_semantic(
     )
 
 
-def find_conversion_path(from_schema: Schema, to_schema: Schema) -> ConversionPaths:
+def find_conversion_path(
+    from_schema: Schema, to_schema: Schema
+) -> Tuple[ConversionPaths, Dict[str, Categories]]:
     """
     Find an optimal sequence of converters using A* search, grouped by semantic.
 
@@ -756,7 +787,8 @@ def find_conversion_path(from_schema: Schema, to_schema: Schema) -> ConversionPa
         to_schema: Target schema
 
     Returns:
-        ConversionPaths with separated batch and lazy converter lists
+        Tuple of (ConversionPaths with separated batch and lazy converter lists,
+                 dictionary of attribute names to inferred categories)
 
     Raises:
         ConversionError: If no conversion path is found
@@ -776,9 +808,12 @@ def find_conversion_path(from_schema: Schema, to_schema: Schema) -> ConversionPa
         start_state = start_groups.get(semantic, _SchemaState({}))
 
         # Find conversion path for this semantic group
-        semantic_converters = _find_conversion_path_for_semantic(
+        semantic_converters, updated_target_state = _find_conversion_path_for_semantic(
             start_state, target_state, semantic
         )
+
+        # Update the target state with any inferred categories
+        target_groups[semantic] = updated_target_state
 
         # Merge all the attribute remappers into a single one. If any, the remapper is always the last step.
         if semantic_converters and isinstance(semantic_converters[-1], AttributeRemapperConverter):
@@ -790,8 +825,17 @@ def find_conversion_path(from_schema: Schema, to_schema: Schema) -> ConversionPa
     if attr_mappings:
         all_converters.append(AttributeRemapperConverter(attr_mappings=attr_mappings))
 
+    # Reconstruct the updated schema with inferred categories
+    inferred_categories: dict[str, Categories] = {}
+    for semantic, updated_target_state in target_groups.items():
+        for attr_spec in updated_target_state.field_to_attr_spec.values():
+            if attr_spec.categories is not None:
+                inferred_categories[attr_spec.name] = attr_spec.categories
+
     # Separate batch and lazy converters
-    return _separate_batch_and_lazy_converters(all_converters)
+    conversion_paths = _separate_batch_and_lazy_converters(all_converters)
+
+    return conversion_paths, inferred_categories
 
 
 def _separate_batch_and_lazy_converters(

--- a/src/datumaro/experimental/converters.py
+++ b/src/datumaro/experimental/converters.py
@@ -16,6 +16,9 @@ import numpy as np
 import polars as pl
 from PIL import Image
 
+from datumaro.util.mask_tools import generate_colormap
+
+from .categories import LabelCategories, MaskCategories, RgbColor
 from .converter_registry import AttributeSpec, Converter, converter
 from .fields import (
     BBoxField,
@@ -468,7 +471,7 @@ class PolygonToMaskConverter(Converter):
 
     input_polygon: AttributeSpec[PolygonField]
     input_labels: AttributeSpec[LabelField]
-    image_info: AttributeSpec[ImageInfoField]
+    input_image_info: AttributeSpec[ImageInfoField]
     output_mask: AttributeSpec[MaskField]
 
     # Configuration options
@@ -481,6 +484,27 @@ class PolygonToMaskConverter(Converter):
         Returns:
             True if the converter should be applied, False otherwise
         """
+
+        # Copy label categories and create mask categories
+        mask_categories = None
+        if self.input_labels.categories is not None:
+            # Create mask categories based on label categories
+            if isinstance(self.input_labels.categories, LabelCategories):
+                # Create a colormap for mask categories
+                # Generate colors for all labels plus background
+                num_classes = len(self.input_labels.categories) + 1  # +1 for background
+                colormap_dict = generate_colormap(num_classes, include_background=True)
+
+                # Create mask categories with the generated colormap
+                mask_categories = MaskCategories()
+                for index, color in colormap_dict.items():
+                    if isinstance(color, tuple):
+                        mask_categories.colormap[index] = RgbColor(*color)
+                    else:
+                        mask_categories.colormap[index] = color
+
+                mask_categories.labels = ["background"] + self.input_labels.categories.labels
+
         # Configure output for mask format
         self.output_mask = AttributeSpec(
             name=self.output_mask.name,
@@ -488,6 +512,7 @@ class PolygonToMaskConverter(Converter):
                 semantic=self.input_polygon.field.semantic,
                 dtype=self.output_mask.field.dtype,
             ),
+            categories=mask_categories,
         )
 
         return True
@@ -504,14 +529,19 @@ class PolygonToMaskConverter(Converter):
         """
         input_column_name = self.input_polygon.name
         labels_column_name = self.input_labels.name
-        image_info_column_name = self.image_info.name
+        image_info_column_name = self.input_image_info.name
         output_column_name = self.output_mask.name
         output_shape_column_name = self.output_mask.name + "_shape"
 
         def polygons_to_mask(
             polygons_data: list, labels_data: list, img_info: dict
         ) -> tuple[list[int], list[int]]:
-            """Rasterize polygons into indexed mask using OpenCV contour filling."""
+            """Rasterize polygons into indexed mask using OpenCV contour filling.
+
+            The mask uses:
+            - Index 0: Background (empty areas)
+            - Index 1+: Polygon class labels (shifted by 1 to reserve 0 for background)
+            """
             # Extract image dimensions
             image_width = img_info["width"]
             image_height = img_info["height"]
@@ -538,12 +568,13 @@ class PolygonToMaskConverter(Converter):
                 # Convert to OpenCV contour format
                 contour = coords.astype(np.int32)
 
-                # Fill polygon with class index
+                # Fill polygon with class index + 1 (to reserve 0 for background)
+                # This means label 0 becomes mask index 1, label 1 becomes mask index 2, etc.
                 cv2.drawContours(
                     mask,
                     [contour],
                     0,
-                    int(class_index),
+                    int(class_index) + 1,  # +1 to shift labels and reserve 0 for background
                     thickness=cv2.FILLED,
                 )
 

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -46,6 +46,11 @@ class Sample:
         for key, value in kwargs.items():
             setattr(self, key, value)
 
+        self.__post_init__()
+
+    def __post_init__(self) -> None:
+        pass
+
     def __repr__(self):
         """Return a string representation of the sample."""
         fields = ", ".join(f"{key}={getattr(self, key)}" for key in self.__dict__)
@@ -318,16 +323,19 @@ class Dataset(Generic[DType]):
             return Dataset.from_dataframe(self.df, target_dtype_or_schema)
 
         # Find the optimal conversion path using A* search
-        conversion_paths = find_conversion_path(self._schema, target_schema)
+        conversion_paths, inferred_categories = find_conversion_path(self._schema, target_schema)
 
         # Apply batch converters immediately
         converted_df = self.df.clone()
         for converter in conversion_paths.batch_converters:
             converted_df = converter.convert(converted_df)
 
-        # Create new dataset with converted data and new schema using from_dataframe
+        # Create new dataset with converted data and inferred categories
         return Dataset.from_dataframe(
-            converted_df, target_dtype_or_schema, conversion_paths.lazy_converters
+            converted_df,
+            target_dtype_or_schema,
+            conversion_paths.lazy_converters,
+            categories=inferred_categories,
         )
 
 

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -16,11 +16,14 @@ from typing import Any, Optional, Type, cast
 import numpy as np
 import polars as pl
 
-from datumaro.components.annotation import Annotation, AnnotationType, Bbox, Polygon
+from datumaro.components.annotation import Annotation, AnnotationType, Bbox
+from datumaro.components.annotation import LabelCategories as LegacyLabelCategories
+from datumaro.components.annotation import Polygon
 from datumaro.components.dataset import Dataset as LegacyDataset
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
 from datumaro.components.media import FromDataMixin, FromFileMixin, Image, MediaElement
 
+from .categories import LabelCategories
 from .dataset import Dataset, Sample
 from .fields import (
     BBoxField,
@@ -232,17 +235,22 @@ class ForwardBboxAnnotationConverter(ForwardAnnotationConverter):
     ) -> "ForwardBboxAnnotationConverter | None":
         """Create converter instance for bbox annotations."""
         # Extract label categories if available
-        label_categories = categories.get(AnnotationType.label, None)
+        legacy_label_categories = categories.get(AnnotationType.label, None)
 
         bbox_attribute = AttributeInfo(type=np.ndarray, annotation=bbox_field(dtype=pl.Float32))
 
         bbox_labels_attribute = None
         # Only add bbox_labels if we have label categories
-        if label_categories is not None:
+        if legacy_label_categories is not None:
+            # Convert legacy label categories to new format
+            new_label_categories = LabelCategories()
+            for label_item in legacy_label_categories.items:
+                new_label_categories.add(label_item.name)
+
             bbox_labels_attribute = AttributeInfo(
                 type=np.ndarray,
                 annotation=label_field(dtype=pl.Int32, multi_label=False, is_list=True),
-                categories=label_categories,
+                categories=new_label_categories,
             )
 
         return cls(bbox_attribute=bbox_attribute, bbox_labels_attribute=bbox_labels_attribute)
@@ -300,7 +308,7 @@ class ForwardPolygonAnnotationConverter(ForwardAnnotationConverter):
     ) -> "ForwardPolygonAnnotationConverter | None":
         """Create converter instance for polygon annotations."""
         # Extract label categories if available
-        label_categories = categories.get(AnnotationType.label, None)
+        legacy_label_categories = categories.get(AnnotationType.label, None)
 
         polygon_attribute = AttributeInfo(
             type=np.ndarray, annotation=polygon_field(dtype=pl.Float32, format="xy")
@@ -308,11 +316,16 @@ class ForwardPolygonAnnotationConverter(ForwardAnnotationConverter):
 
         polygon_labels_attribute = None
         # Only add polygon_labels if we have label categories
-        if label_categories is not None:
+        if legacy_label_categories is not None:
+            # Convert legacy label categories to new format
+            new_label_categories = LabelCategories()
+            for label_item in legacy_label_categories.items:
+                new_label_categories.add(label_item.name)
+
             polygon_labels_attribute = AttributeInfo(
                 type=np.ndarray,
                 annotation=label_field(dtype=pl.Int32, multi_label=False, is_list=True),
-                categories=label_categories,
+                categories=new_label_categories,
             )
 
         return cls(
@@ -624,7 +637,6 @@ class BackwardBboxAnnotationConverter(BackwardAnnotationConverter):
 
     def infer_categories(self, experimental_dataset: Dataset[Sample]) -> CategoriesInfo:
         """Infer label categories from bbox_labels."""
-        from datumaro.components.annotation import LabelCategories
 
         # Collect all unique label IDs
         label_ids: set[int] = set()
@@ -636,7 +648,7 @@ class BackwardBboxAnnotationConverter(BackwardAnnotationConverter):
                         label_ids.add(int(label_id))
 
         # Create label categories
-        label_categories = LabelCategories()
+        label_categories = LegacyLabelCategories()
         for label_id in sorted(label_ids):
             label_categories.add(f"class_{label_id}")
 
@@ -697,7 +709,6 @@ class BackwardPolygonAnnotationConverter(BackwardAnnotationConverter):
 
     def infer_categories(self, experimental_dataset: Dataset[Sample]) -> CategoriesInfo:
         """Infer label categories from polygon_labels."""
-        from datumaro.components.annotation import LabelCategories
 
         if self.polygon_labels_attr is None:
             return {}
@@ -712,7 +723,7 @@ class BackwardPolygonAnnotationConverter(BackwardAnnotationConverter):
                         label_ids.add(int(label_id))
 
         # Create label categories
-        label_categories = LabelCategories()
+        label_categories = LegacyLabelCategories()
         for label_id in sorted(label_ids):
             label_categories.add(f"class_{label_id}")
 

--- a/tests/unit/experimental/test_converters.py
+++ b/tests/unit/experimental/test_converters.py
@@ -9,6 +9,7 @@ import numpy as np
 import polars as pl
 import pytest
 
+from datumaro.experimental.categories import LabelCategories, MaskCategories
 from datumaro.experimental.converter_registry import (
     AttributeRemapperConverter,
     AttributeSpec,
@@ -349,7 +350,7 @@ def test_find_conversion_path():
     )
 
     # This should find a conversion path (UInt8 -> Float32)
-    path = find_conversion_path(source_schema, target_schema)
+    path, _ = find_conversion_path(source_schema, target_schema)
     assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is UInt8ToFloat32Converter
     assert type(path.batch_converters[1]) is AttributeRemapperConverter
@@ -381,7 +382,7 @@ def test_convert_dataframe():
     )
 
     # Get conversion path and apply it manually
-    conversion_paths = find_conversion_path(source_schema, target_schema)
+    conversion_paths, _ = find_conversion_path(source_schema, target_schema)
 
     # Apply batch converters first
     result_df = df
@@ -480,7 +481,7 @@ def test_multiple_converter_chaining():
     # 2. UInt8 -> Float32 (dtype)
     # 3. absolute -> normalized bbox (with image as auxiliary)
 
-    path = find_conversion_path(source_schema, target_schema)
+    path, _ = find_conversion_path(source_schema, target_schema)
     # If successful, should have multiple steps
     assert len(path.batch_converters) == 4
     assert type(path.batch_converters[0]) is BBoxCoordinateConverter
@@ -544,7 +545,7 @@ def test_astar_direct_conversion():
     )
 
     # Test finding conversion path
-    path = find_conversion_path(from_schema, to_schema)
+    path, _ = find_conversion_path(from_schema, to_schema)
     assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is ExtractImageSizeConverter
     assert type(path.batch_converters[1]) is AttributeRemapperConverter
@@ -648,7 +649,7 @@ def test_astar_chained_conversion():
     )
 
     # Test finding conversion path
-    path = find_conversion_path(from_schema, to_schema)
+    path, _ = find_conversion_path(from_schema, to_schema)
     # Should need 2 converters: ImageField -> ImageSizeField, then NormalizedBbox -> AbsoluteBbox
     assert len(path.batch_converters) == 3
     assert type(path.batch_converters[0]) is ExtractImageSizeChainConverter
@@ -675,7 +676,7 @@ def test_astar_no_conversion_needed():
         }
     )
 
-    path = find_conversion_path(schema, schema)
+    path, _ = find_conversion_path(schema, schema)
     total_converters = len(path.batch_converters) + len(path.lazy_converters)
     assert (
         total_converters == 0
@@ -789,7 +790,7 @@ def test_optimal_path_selection():
         }
     )
 
-    path = find_conversion_path(from_schema, to_schema)
+    path, _ = find_conversion_path(from_schema, to_schema)
     assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is AToCDirectConverter
     assert type(path.batch_converters[1]) is AttributeRemapperConverter
@@ -825,7 +826,7 @@ def test_generator_converter():
         }
     )
 
-    path = find_conversion_path(from_schema, to_schema)
+    path, _ = find_conversion_path(from_schema, to_schema)
     assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is GenerateBConverter
     assert type(path.batch_converters[1]) is AttributeRemapperConverter
@@ -884,7 +885,7 @@ def test_multiple_output_converter():
         }
     )
 
-    path = find_conversion_path(from_schema, to_schema)
+    path, _ = find_conversion_path(from_schema, to_schema)
     assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is AToMultiConverter
     assert type(path.batch_converters[1]) is AttributeRemapperConverter
@@ -936,7 +937,7 @@ def test_partial_schema_matching():
         }
     )
 
-    path = find_conversion_path(from_schema, to_schema)
+    path, _ = find_conversion_path(from_schema, to_schema)
     assert len(path.batch_converters) == 2
     assert type(path.batch_converters[0]) is AToCPartialConverter
     assert type(path.batch_converters[1]) is AttributeRemapperConverter
@@ -965,7 +966,7 @@ def test_attribute_renaming():
     )
 
     # Find conversion path - should include a remapper converter
-    path = find_conversion_path(source_schema, target_schema)
+    path, _ = find_conversion_path(source_schema, target_schema)
 
     # Should have exactly one batch converter for renaming
     assert len(path.batch_converters) == 1
@@ -1020,7 +1021,7 @@ def test_attribute_deletion():
     )
 
     # Find conversion path - should include a remapper converter that only keeps image
-    path = find_conversion_path(source_schema, target_schema)
+    path, _ = find_conversion_path(source_schema, target_schema)
 
     # Should have exactly one batch converter for selection/deletion
     assert len(path.batch_converters) == 1
@@ -1081,7 +1082,7 @@ def test_combined_rename_and_delete():
     )
 
     # Find conversion path - should include a single remapper converter that handles both operations
-    path = find_conversion_path(source_schema, target_schema)
+    path, _ = find_conversion_path(source_schema, target_schema)
 
     # Should have exactly one batch converter that handles both renaming and deletion
     assert len(path.batch_converters) == 1
@@ -1170,7 +1171,7 @@ def test_polygon_to_mask_converter():
     df = pl.DataFrame(
         {
             "polygons": [polygon_series],  # List of three polygons
-            "labels": [[1, 2, 3]],  # Corresponding labels for each polygon
+            "labels": [[0, 1, 2]],  # Corresponding labels for each polygon
             "image_info": [{"width": 100, "height": 100}],  # Image dimensions
         }
     )
@@ -1195,7 +1196,7 @@ def test_polygon_to_mask_converter():
     )
     setattr(
         converter_instance,
-        "image_info",
+        "input_image_info",
         AttributeSpec(name="image_info", field=image_info_field),
     )
     setattr(
@@ -1227,13 +1228,13 @@ def test_polygon_to_mask_converter():
     # Triangle should have label 1, rectangle should have label 2, pentagon should have label 3
     # Background should be 0
 
-    # Check that triangle area has label 1
+    # Check that triangle area has label 0 (stored as mask value 1)
     assert mask[15, 20] == 1  # Point inside triangle
 
-    # Check that rectangle area has label 2
+    # Check that rectangle area has label 1 (stored as mask value 2)
     assert mask[50, 50] == 2  # Point inside rectangle
 
-    # Check that pentagon area has label 3
+    # Check that pentagon area has label 2 (stored as mask value 3)
     assert mask[20, 75] == 3  # Point inside pentagon
 
     # Check background area has label 0
@@ -1285,7 +1286,9 @@ def test_polygon_to_mask_converter_normalized():
         converter_instance, "input_labels", AttributeSpec(name="labels", field=input_labels_field)
     )
     setattr(
-        converter_instance, "image_info", AttributeSpec(name="image_info", field=image_info_field)
+        converter_instance,
+        "input_image_info",
+        AttributeSpec(name="image_info", field=image_info_field),
     )
     setattr(converter_instance, "output_mask", AttributeSpec(name="mask", field=output_mask_field))
 
@@ -1297,10 +1300,74 @@ def test_polygon_to_mask_converter_normalized():
     mask_shape = result_df["mask_shape"][0]
     mask = mask_data.reshape(mask_shape)
 
-    # Check that polygon was filled with label 5
+    # Check that polygon was filled with label 5 (stored as mask value 6)
     # Normalized coordinates should be scaled: 0.2 * 100 = 20, 0.1 * 100 = 10, etc.
-    assert mask[15, 20] == 5  # Point inside the scaled triangle
+    assert mask[15, 20] == 6  # Point inside the scaled triangle (5+1=6)
     assert mask[5, 5] == 0  # Background point
 
-    # Verify the label is present in the mask
-    assert 5 in np.unique(mask)
+
+def test_find_conversion_path_inferred_categories():
+    """Test that find_conversion_path returns inferred categories."""
+
+    # Create test data for polygon to mask conversion
+    df = pl.DataFrame(
+        {
+            "polygons": [[[10, 20, 30, 25, 20, 40]]],  # Triangle coordinates
+            "labels": [[2]],  # Label 2
+            "image_info": [{"width": 100, "height": 100}],
+        },
+        schema=pl.Schema(
+            {
+                "polygons": pl.List(pl.List(pl.Float32)),
+                "labels": pl.List(pl.Int32),
+                "image_info": pl.Struct({"width": pl.Int32, "height": pl.Int32}),
+            }
+        ),
+    )
+
+    # Create source schema with label categories
+    label_categories = LabelCategories(labels=["cat", "dog", "bird"])
+    source_schema = Schema(
+        attributes={
+            "polygons": AttributeInfo(
+                type=list,
+                annotation=PolygonField(dtype=pl.Float32, semantic=Semantic.Default),
+                categories=None,
+            ),
+            "labels": AttributeInfo(
+                type=list,
+                annotation=LabelField(semantic=Semantic.Default),
+                categories=label_categories,
+            ),
+            "image_info": AttributeInfo(
+                type=dict, annotation=ImageInfoField(semantic=Semantic.Default)
+            ),
+        }
+    )
+
+    # Create target schema (polygon to mask conversion)
+    target_schema = Schema(
+        attributes={
+            "mask": AttributeInfo(
+                type=np.ndarray, annotation=MaskField(dtype=pl.UInt8, semantic=Semantic.Default)
+            )
+        }
+    )
+
+    # Get conversion path and check inferred categories
+    conversion_paths, inferred_categories = find_conversion_path(source_schema, target_schema)
+
+    # Should have converters for polygon to mask conversion
+    total_converters = len(conversion_paths.batch_converters) + len(
+        conversion_paths.lazy_converters
+    )
+    assert total_converters > 0
+
+    # Check that mask categories were inferred
+    assert "mask" in inferred_categories
+    mask_categories = inferred_categories["mask"]
+    assert isinstance(mask_categories, MaskCategories)
+
+    # Check that the mask categories include background + original labels
+    expected_labels = ["background", "cat", "dog", "bird"]
+    assert mask_categories.labels == expected_labels


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of category information (such as label and mask categories) during schema conversion and mask generation in the Datumaro experimental pipeline. The changes ensure that inferred categories are correctly propagated through converters and available in the resulting dataset, improving interoperability and downstream usage. Additionally, update the polygon-to-mask converter to create the mask categories. Also, add support in the Sample class for an optional __post_init__ method.

**Category propagation and schema conversion improvements:**

* The schema conversion process (`find_conversion_path` and related functions in `converter_registry.py`) now tracks and returns inferred categories for each attribute, ensuring that category metadata (like label and mask categories) is available in the converted dataset. The function signatures and return values were updated to include these inferred categories. [[1]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41R71-R76) [[2]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L630-R640) [[3]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L639-R650) [[4]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L665-R699) [[5]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L682-R709) [[6]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L715-R745) [[7]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L747-R778) [[8]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L759-R791) [[9]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41L779-R817) [[10]](diffhunk://#diff-4ac196ddc4dc8e6d33daf684ded18886ff8774fadb8b6cbd4bfa88ca424bb34fL321-R338)
* The dataset conversion logic (`convert_to_schema` in `dataset.py`) now passes inferred categories to the new dataset, ensuring that category metadata is preserved and accessible after conversion.

**Mask conversion and category generation enhancements:**

* The `PolygonToMaskConverter` now generates `MaskCategories` with a colormap that includes a reserved background index (0), and label indices are shifted accordingly. Mask categories are constructed from label categories, and the output mask specification includes this category metadata. [[1]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3L471-R474) [[2]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3R487-R515) [[3]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3L507-R544) [[4]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3L541-R577) [[5]](diffhunk://#diff-f0858b860d68536c04476766ef0512d873b7f7cc20dde377a42ec13a836d9622R188)
* The mask rasterization logic in `PolygonToMaskConverter` has been updated to always reserve index 0 for background, shifting polygon class indices by +1.

**Legacy compatibility:**

* The legacy conversion logic now converts legacy label categories to the new `LabelCategories` format before passing them to new converters, ensuring compatibility and consistency in category handling. [[1]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L19-R26) [[2]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L235-R253)

**General codebase improvements:**

* Added missing imports and type hints, and clarified code structure in several files to support the above changes. [[1]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41R22) [[2]](diffhunk://#diff-fb2a908f10fa67b50f19323df8324a854db0618c5c61595394aa828af411ca41R39) [[3]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3R19-R21) [[4]](diffhunk://#diff-4ac196ddc4dc8e6d33daf684ded18886ff8774fadb8b6cbd4bfa88ca424bb34fR49-R53)

These changes collectively improve category metadata handling and mask generation, making schema conversion more robust and datasets more informative for downstream tasks.

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
