### PR TITLE
Add support for instance segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This release streamlines Datumaro by removing a number of lesser-used features, 
 
 ### New features
 - Experimental dataset class
-  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>, <https://github.com/open-edge-platform/datumaro/pull/1868>, <https://github.com/open-edge-platform/datumaro/pull/1876>)
+  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>, <https://github.com/open-edge-platform/datumaro/pull/1868>, <https://github.com/open-edge-platform/datumaro/pull/1876>, <https://github.com/open-edge-platform/datumaro/pull/1877>)
 
 ### Enhancements
 - Mark several dependencies as optional

--- a/src/datumaro/experimental/converters.py
+++ b/src/datumaro/experimental/converters.py
@@ -27,6 +27,7 @@ from .fields import (
     ImageInfo,
     ImageInfoField,
     ImagePathField,
+    InstanceMaskField,
     LabelField,
     MaskField,
     PolygonField,
@@ -617,3 +618,214 @@ class PolygonToMaskConverter(Converter):
                 mask_data.struct.field("shape").alias(output_shape_column_name),
             ]
         )
+
+
+@converter(lazy=True)
+class PolygonToInstanceMaskConverter(Converter):
+    """
+    Converts polygon annotations to instance masks.
+
+    Transforms polygon coordinates into binary instance masks of shape (N, H, W)
+    where N is the number of instances. Each mask represents a single instance
+    without category information.
+    """
+
+    input_polygon: AttributeSpec[PolygonField]
+    input_image_info: AttributeSpec[ImageInfoField]
+    output_instance_mask: AttributeSpec[InstanceMaskField]
+
+    def filter_output_spec(self) -> bool:
+        """Configure output specification for instance mask format."""
+        # Configure output for instance mask format
+        self.output_instance_mask = AttributeSpec(
+            name=self.output_instance_mask.name,
+            field=InstanceMaskField(
+                semantic=self.input_polygon.field.semantic,
+                dtype=self.output_instance_mask.field.dtype,
+            ),
+        )
+        return True
+
+    def convert(self, df: pl.DataFrame) -> pl.DataFrame:
+        """
+        Rasterize polygon coordinates into instance masks.
+
+        Args:
+            df: DataFrame with polygon coordinates and image info
+
+        Returns:
+            DataFrame with instance mask data in output column
+        """
+        input_column_name = self.input_polygon.name
+        image_info_column_name = self.input_image_info.name
+        output_column_name = self.output_instance_mask.name
+        output_shape_column_name = self.output_instance_mask.name + "_shape"
+
+        def polygons_to_instance_masks(
+            polygons_data: list, img_info: dict
+        ) -> tuple[list[bool], list[int]]:
+            """Rasterize polygons into instance masks using OpenCV contour filling."""
+            # Extract image dimensions
+            image_width = img_info["width"]
+            image_height = img_info["height"]
+
+            # Convert dtype - use uint8 for OpenCV, then convert to bool
+            numpy_dtype = polars_to_numpy_dtype(self.output_instance_mask.field.dtype)
+
+            if len(polygons_data) == 0:
+                # No polygons, return empty mask with shape (0, H, W)
+                empty_mask = np.array([], dtype=numpy_dtype)
+                return empty_mask.tolist(), [0, image_height, image_width]
+
+            # Create instance masks for each polygon
+            instance_masks = []
+
+            for polygon_data in polygons_data:
+                coords = polygon_data.to_numpy()
+
+                # Initialize mask for this instance (use uint8 for OpenCV compatibility)
+                mask = np.zeros((image_height, image_width), dtype=np.uint8)
+
+                # Denormalize coordinates if needed
+                if self.input_polygon.field.normalize:
+                    coords = coords.copy()
+                    coords[:, 0] *= image_width
+                    coords[:, 1] *= image_height
+
+                # Convert to OpenCV contour format
+                contour = coords.astype(np.int32)
+
+                # Fill polygon with 1 for instance mask
+                cv2.drawContours(
+                    mask,
+                    [contour],
+                    0,
+                    1,  # Fill with 1 for binary instance mask
+                    thickness=cv2.FILLED,
+                )
+
+                # Convert to the target dtype (e.g., bool)
+                mask = mask.astype(numpy_dtype)
+                instance_masks.append(mask)
+
+            # Stack into (N, H, W) tensor
+            stacked_masks = np.stack(instance_masks, axis=0)
+            return stacked_masks.reshape(-1), list(stacked_masks.shape)
+
+        # Apply conversion using map_batches
+        def apply_conversion_batch(batch_df: pl.DataFrame, **kwargs) -> pl.DataFrame:
+            """Apply polygon-to-instance-mask conversion for a batch."""
+            batch_polygons = batch_df.struct["polygons"]
+            batch_img_infos = batch_df.struct["img_info"]
+
+            results_batch_mask = []
+            results_batch_shape = []
+
+            for polygons, img_info in zip(batch_polygons, batch_img_infos):
+                mask_data, shape_data = polygons_to_instance_masks(polygons, img_info)
+                results_batch_mask.append(pl.Series(mask_data))
+                results_batch_shape.append(shape_data)
+
+            return pl.struct(
+                pl.Series(results_batch_mask).alias("mask"),
+                pl.Series(results_batch_shape, dtype=pl.List(pl.Int32)).alias("shape"),
+                eager=True,
+            )
+
+        mask_data = pl.struct(
+            [
+                pl.col(input_column_name).alias("polygons"),
+                pl.col(image_info_column_name).alias("img_info"),
+            ]
+        ).map_batches(
+            apply_conversion_batch,
+            return_dtype=pl.Struct(
+                {"mask": pl.List(self.output_instance_mask.field.dtype), "shape": pl.List(pl.Int32)}
+            ),
+        )
+
+        return df.with_columns(
+            [
+                mask_data.struct.field("mask").alias(output_column_name),
+                mask_data.struct.field("shape").alias(output_shape_column_name),
+            ]
+        )
+
+
+@converter(lazy=True)
+class PolygonToBBoxConverter(Converter):
+    """
+    Converts polygon annotations to bounding boxes.
+
+    Extracts the bounding box coordinates that enclose each polygon.
+    """
+
+    input_polygon: AttributeSpec[PolygonField]
+    output_bbox: AttributeSpec[BBoxField]
+
+    def filter_output_spec(self) -> bool:
+        """Configure output specification for bounding box format."""
+        # Configure output for bbox format
+        self.output_bbox = AttributeSpec(
+            name=self.output_bbox.name,
+            field=BBoxField(
+                semantic=self.input_polygon.field.semantic,
+                dtype=self.input_polygon.field.dtype,
+                format=self.output_bbox.field.format,
+                normalize=self.input_polygon.field.normalize,  # Inherit normalization from polygon
+            ),
+        )
+        return True
+
+    def convert(self, df: pl.DataFrame) -> pl.DataFrame:
+        """
+        Extract bounding boxes from polygon coordinates.
+
+        Args:
+            df: DataFrame with polygon coordinates
+
+        Returns:
+            DataFrame with bounding box data in output column
+        """
+        input_column_name = self.input_polygon.name
+        output_column_name = self.output_bbox.name
+
+        df = df.with_columns(
+            pl.col(input_column_name)
+            .list.eval(
+                pl.concat_arr(
+                    [
+                        pl.element().list.eval(pl.element().arr.get(0)).list.min(),
+                        pl.element().list.eval(pl.element().arr.get(1)).list.min(),
+                        pl.element().list.eval(pl.element().arr.get(0)).list.max(),
+                        pl.element().list.eval(pl.element().arr.get(1)).list.max(),
+                    ]
+                )
+            )
+            .alias(output_column_name)
+        )
+
+        # Format according to output bbox format
+        if self.output_bbox.field.format == "x1y1x2y2":
+            # Already in this format
+            pass
+        elif self.output_bbox.field.format == "xywh":
+            df = df.with_columns(
+                pl.col(output_column_name).list.eval(
+                    pl.concat_arr(
+                        [
+                            pl.element().arr.get(0),
+                            pl.element().arr.get(1),
+                            pl.element().arr.get(2) - pl.element().arr.get(0),
+                            pl.element().arr.get(3) - pl.element().arr.get(1),
+                        ]
+                    )
+                )
+            )
+        else:
+            raise NotImplementedError(
+                f"This conversion is not yet implemented "
+                f"for the format {self.output_bbox.field.format}."
+            )
+
+        return df

--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -513,3 +513,54 @@ def mask_field(dtype: Any = pl.UInt8(), semantic: Semantic = Semantic.Default) -
         MaskField instance configured with the given parameters
     """
     return MaskField(semantic=semantic, dtype=dtype)
+
+
+@dataclass(frozen=True)
+class InstanceMaskField(Field):
+    """
+    Represents an instance mask tensor field for instance segmentation masks.
+
+    Handles 3D tensor data of shape (N, H, W) where N is the number of instances,
+    H and W are the mask height and width. Each mask is a binary mask representing
+    a single instance. Unlike MaskField, this does not contain category information.
+
+    Attributes:
+        semantic: Semantic tags describing the instance mask purpose
+        dtype: Polars data type for mask values (defaults to bool for binary masks)
+    """
+
+    semantic: Semantic
+    dtype: PolarsDataType = pl.Boolean()
+
+    def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
+        """Generate Polars schema with separate columns for data and shape."""
+        return {name: pl.List(self.dtype), name + "_shape": pl.List(pl.Int32())}
+
+    def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
+        """Convert instance mask tensor to flattened data and shape information."""
+        numpy_value = to_numpy(value, self.dtype)
+        return {
+            name: pl.Series(name, [numpy_value.reshape(-1)]),
+            name + "_shape": pl.Series(name + "_shape", [numpy_value.shape]),
+        }
+
+    def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type[T]) -> T:
+        """Reconstruct instance mask tensor from flattened data using stored shape."""
+        flat_data = df[name][row_index]
+        shape = df[name + "_shape"][row_index]
+        numpy_data = np.array(flat_data).reshape(shape)
+        return from_polars_data(numpy_data, target_type)  # type: ignore
+
+
+def instance_mask_field(dtype: Any = pl.Boolean(), semantic: Semantic = Semantic.Default) -> Any:
+    """
+    Create an InstanceMaskField instance with the specified parameters.
+
+    Args:
+        dtype: Polars data type for mask values (defaults to pl.Boolean())
+        semantic: Semantic tags describing the instance mask purpose (optional)
+
+    Returns:
+        InstanceMaskField instance configured with the given parameters
+    """
+    return InstanceMaskField(semantic=semantic, dtype=dtype)

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -249,7 +249,7 @@ class ForwardBboxAnnotationConverter(ForwardAnnotationConverter):
 
             bbox_labels_attribute = AttributeInfo(
                 type=np.ndarray,
-                annotation=label_field(dtype=pl.Int32, multi_label=False, is_list=True),
+                annotation=label_field(is_list=True),
                 categories=new_label_categories,
             )
 
@@ -324,7 +324,7 @@ class ForwardPolygonAnnotationConverter(ForwardAnnotationConverter):
 
             polygon_labels_attribute = AttributeInfo(
                 type=np.ndarray,
-                annotation=label_field(dtype=pl.Int32, multi_label=False, is_list=True),
+                annotation=label_field(is_list=True),
                 categories=new_label_categories,
             )
 

--- a/tests/unit/experimental/test_converters.py
+++ b/tests/unit/experimental/test_converters.py
@@ -23,6 +23,8 @@ from datumaro.experimental.converters import (
     BBoxCoordinateConverter,
     ImageBytesToImageConverter,
     ImagePathToImageConverter,
+    PolygonToBBoxConverter,
+    PolygonToInstanceMaskConverter,
     PolygonToMaskConverter,
     RGBToBGRConverter,
     UInt8ToFloat32Converter,
@@ -34,6 +36,7 @@ from datumaro.experimental.fields import (
     ImageField,
     ImageInfoField,
     ImagePathField,
+    InstanceMaskField,
     LabelField,
     MaskField,
     PolygonField,
@@ -1371,3 +1374,315 @@ def test_find_conversion_path_inferred_categories():
     # Check that the mask categories include background + original labels
     expected_labels = ["background", "cat", "dog", "bird"]
     assert mask_categories.labels == expected_labels
+
+
+def test_polygon_to_instance_mask_converter():
+    """Test conversion from polygon coordinates to instance mask format."""
+    # Create test data with triangle, rectangle, and pentagon polygons
+    polygon_coords1 = [[10.0, 10.0], [20.0, 10.0], [15.0, 20.0]]
+    polygon_coords2 = [[30.0, 30.0], [40.0, 30.0], [40.0, 40.0], [30.0, 40.0]]
+    polygon_coords3 = [[50.0, 50.0], [60.0, 50.0], [65.0, 60.0], [55.0, 70.0], [45.0, 60.0]]
+
+    polygon_series = pl.Series(
+        [polygon_coords1, polygon_coords2, polygon_coords3], dtype=pl.List(pl.Array(pl.Float32, 2))
+    )
+
+    df = pl.DataFrame(
+        {
+            "polygons": [polygon_series],
+            "image_info": [{"width": 100, "height": 100}],
+        }
+    )
+
+    # Create converter instance
+    converter_instance = PolygonToInstanceMaskConverter()
+
+    # Set up field specs
+    input_polygon_field = PolygonField(
+        dtype=pl.Float32, format="xy", normalize=False, semantic=Semantic.Default
+    )
+    image_info_field = ImageInfoField(semantic=Semantic.Default)
+    output_instance_mask_field = InstanceMaskField(dtype=pl.Boolean, semantic=Semantic.Default)
+
+    setattr(
+        converter_instance,
+        "input_polygon",
+        AttributeSpec(name="polygons", field=input_polygon_field),
+    )
+    setattr(
+        converter_instance,
+        "input_image_info",
+        AttributeSpec(name="image_info", field=image_info_field),
+    )
+    setattr(
+        converter_instance,
+        "output_instance_mask",
+        AttributeSpec(name="instance_mask", field=output_instance_mask_field),
+    )
+
+    # Test filter - should return True when we have valid input
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    # Check that instance mask column was created
+    assert "instance_mask" in result_df.columns
+    assert "instance_mask_shape" in result_df.columns
+
+    # Get the mask data and reshape it
+    mask_data = np.array(result_df["instance_mask"][0])
+    mask_shape = result_df["instance_mask_shape"][0]
+    masks = mask_data.reshape(mask_shape)
+
+    # Check mask properties
+    assert masks.shape == (3, 100, 100)  # 3 instances, 100x100 image
+    assert masks.dtype == bool
+
+    # Check that each instance is properly filled
+    # Triangle should be in first mask
+    assert masks[0, 15, 15] == True  # Point inside triangle
+    assert masks[0, 5, 5] == False  # Point outside triangle
+
+    # Rectangle should be in second mask
+    assert masks[1, 35, 35] == True  # Point inside rectangle
+    assert masks[1, 5, 5] == False  # Point outside rectangle
+
+    # Pentagon should be in third mask
+    assert masks[2, 55, 55] == True  # Point inside pentagon
+    assert masks[2, 5, 5] == False  # Point outside pentagon
+
+    # No overlap between instances
+    assert not np.any(masks[0] & masks[1])  # Triangle and rectangle don't overlap
+    assert not np.any(masks[0] & masks[2])  # Triangle and pentagon don't overlap
+    assert not np.any(masks[1] & masks[2])  # Rectangle and pentagon don't overlap
+
+
+def test_polygon_to_instance_mask_converter_normalized():
+    """Test conversion with normalized polygon coordinates."""
+    # Create test data with normalized coordinates (0-1 range)
+    polygon_coords1 = [[0.1, 0.1], [0.2, 0.1], [0.15, 0.2]]
+    polygon_coords2 = [[0.3, 0.3], [0.4, 0.3], [0.4, 0.4], [0.3, 0.4]]
+
+    polygon_series = pl.Series(
+        [polygon_coords1, polygon_coords2], dtype=pl.List(pl.Array(pl.Float32, 2))
+    )
+
+    df = pl.DataFrame(
+        {
+            "polygons": [polygon_series],
+            "image_info": [{"width": 100, "height": 100}],
+        }
+    )
+
+    # Create converter instance with normalized coordinates
+    converter_instance = PolygonToInstanceMaskConverter()
+
+    # Set up field specs
+    input_polygon_field = PolygonField(
+        dtype=pl.Float32, format="xy", normalize=True, semantic=Semantic.Default
+    )
+    image_info_field = ImageInfoField(semantic=Semantic.Default)
+    output_instance_mask_field = InstanceMaskField(dtype=pl.Boolean, semantic=Semantic.Default)
+
+    setattr(
+        converter_instance,
+        "input_polygon",
+        AttributeSpec(name="polygons", field=input_polygon_field),
+    )
+    setattr(
+        converter_instance,
+        "input_image_info",
+        AttributeSpec(name="image_info", field=image_info_field),
+    )
+    setattr(
+        converter_instance,
+        "output_instance_mask",
+        AttributeSpec(name="instance_mask", field=output_instance_mask_field),
+    )
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    # Get the mask and check it
+    mask_data = np.array(result_df["instance_mask"][0])
+    mask_shape = result_df["instance_mask_shape"][0]
+    masks = mask_data.reshape(mask_shape)
+
+    # Check mask properties
+    assert masks.shape == (2, 100, 100)
+
+    # Check that polygons were filled correctly after denormalization
+    # Triangle: 0.1 * 100 = 10, 0.2 * 100 = 20, etc.
+    assert masks[0, 15, 15] == True  # Point inside the scaled triangle
+    assert masks[0, 5, 5] == False  # Background point
+
+    # Rectangle: 0.3 * 100 = 30, 0.4 * 100 = 40, etc.
+    assert masks[1, 35, 35] == True  # Point inside the scaled rectangle
+    assert masks[1, 5, 5] == False  # Background point
+
+
+def test_polygon_to_bbox_converter():
+    """Test conversion from polygon coordinates to bounding box format."""
+    # Create test data with triangle and rectangle polygons
+    polygon_coords1 = [[10.0, 10.0], [20.0, 10.0], [15.0, 20.0]]
+    polygon_coords2 = [[30.0, 30.0], [40.0, 30.0], [40.0, 40.0], [30.0, 40.0]]
+
+    polygon_series = pl.Series(
+        [polygon_coords1, polygon_coords2], dtype=pl.List(pl.Array(pl.Float32, 2))
+    )
+
+    df = pl.DataFrame(
+        {
+            "polygons": [polygon_series],
+        }
+    )
+
+    # Create converter instance
+    converter_instance = PolygonToBBoxConverter()
+
+    # Set up field specs
+    input_polygon_field = PolygonField(
+        dtype=pl.Float32, format="xy", normalize=False, semantic=Semantic.Default
+    )
+    output_bbox_field = BBoxField(
+        dtype=pl.Float32, format="x1y1x2y2", normalize=False, semantic=Semantic.Default
+    )
+
+    setattr(
+        converter_instance,
+        "input_polygon",
+        AttributeSpec(name="polygons", field=input_polygon_field),
+    )
+    setattr(
+        converter_instance,
+        "output_bbox",
+        AttributeSpec(name="bboxes", field=output_bbox_field),
+    )
+
+    # Test filter - should return True when we have valid input
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    # Check that bbox column was created
+    assert "bboxes" in result_df.columns
+
+    # Get the bbox data
+    bboxes = result_df["bboxes"][0]
+
+    # Check that we have 2 bounding boxes (triangle and rectangle)
+    assert len(bboxes) == 2
+
+    # Check triangle bbox (x1y1x2y2 format)
+    triangle_bbox = bboxes[0]
+    assert triangle_bbox[0] == 10.0  # x1 (min x)
+    assert triangle_bbox[1] == 10.0  # y1 (min y)
+    assert triangle_bbox[2] == 20.0  # x2 (max x)
+    assert triangle_bbox[3] == 20.0  # y2 (max y)
+
+    # Check rectangle bbox
+    rectangle_bbox = bboxes[1]
+    assert rectangle_bbox[0] == 30.0  # x1
+    assert rectangle_bbox[1] == 30.0  # y1
+    assert rectangle_bbox[2] == 40.0  # x2
+    assert rectangle_bbox[3] == 40.0  # y2
+
+
+def test_polygon_to_bbox_converter_xywh():
+    """Test conversion to xywh bbox format."""
+    # Create test data with rectangle polygon
+    polygon_coords = [[30.0, 30.0], [40.0, 30.0], [40.0, 40.0], [30.0, 40.0]]
+
+    polygon_series = pl.Series([polygon_coords], dtype=pl.List(pl.Array(pl.Float32, 2)))
+
+    df = pl.DataFrame(
+        {
+            "polygons": [polygon_series],
+        }
+    )
+
+    # Create converter instance
+    converter_instance = PolygonToBBoxConverter()
+
+    # Set up field specs for xywh format
+    input_polygon_field = PolygonField(
+        dtype=pl.Float32, format="xy", normalize=False, semantic=Semantic.Default
+    )
+    output_bbox_field = BBoxField(
+        dtype=pl.Float32, format="xywh", normalize=False, semantic=Semantic.Default
+    )
+
+    setattr(
+        converter_instance,
+        "input_polygon",
+        AttributeSpec(name="polygons", field=input_polygon_field),
+    )
+    setattr(
+        converter_instance,
+        "output_bbox",
+        AttributeSpec(name="bboxes", field=output_bbox_field),
+    )
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    # Get the bbox data
+    bboxes = result_df["bboxes"][0]
+
+    # Check rectangle bbox in xywh format
+    rectangle_bbox = bboxes[0]
+    assert rectangle_bbox[0] == 30.0  # x (min x)
+    assert rectangle_bbox[1] == 30.0  # y (min y)
+    assert rectangle_bbox[2] == 10.0  # w (width)
+    assert rectangle_bbox[3] == 10.0  # h (height)
+
+
+def test_polygon_to_bbox_converter_normalized():
+    """Test conversion with normalized polygon coordinates."""
+    # Create test data with normalized coordinates (0-1 range)
+    polygon_coords = [[0.3, 0.3], [0.4, 0.3], [0.4, 0.4], [0.3, 0.4]]
+
+    polygon_series = pl.Series([polygon_coords], dtype=pl.List(pl.Array(pl.Float32, 2)))
+
+    df = pl.DataFrame(
+        {
+            "polygons": [polygon_series],
+        }
+    )
+
+    # Create converter instance
+    converter_instance = PolygonToBBoxConverter()
+
+    # Set up field specs with normalized coordinates
+    input_polygon_field = PolygonField(
+        dtype=pl.Float32, format="xy", normalize=True, semantic=Semantic.Default
+    )
+    output_bbox_field = BBoxField(
+        dtype=pl.Float32, format="x1y1x2y2", normalize=True, semantic=Semantic.Default
+    )
+
+    setattr(
+        converter_instance,
+        "input_polygon",
+        AttributeSpec(name="polygons", field=input_polygon_field),
+    )
+    setattr(
+        converter_instance,
+        "output_bbox",
+        AttributeSpec(name="bboxes", field=output_bbox_field),
+    )
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    # Get the bbox data
+    bboxes = result_df["bboxes"][0]
+
+    # Check rectangle bbox with normalized coordinates
+    rectangle_bbox = bboxes[0]
+    assert abs(rectangle_bbox[0] - 0.3) < 1e-6  # x1 (normalized)
+    assert abs(rectangle_bbox[1] - 0.3) < 1e-6  # y1 (normalized)
+    assert abs(rectangle_bbox[2] - 0.4) < 1e-6  # x2 (normalized)
+    assert abs(rectangle_bbox[3] - 0.4) < 1e-6  # y2 (normalized)


### PR DESCRIPTION
This PR adds a new mask type for instance segmentation. The difference with semantic segmentation is that the semantic segmentation mask is a 2D mask containing the class ID associated with each pixel while the instance segmentation mask is a stack of boolean masks, one for each object.

The PR adds the following:
* Converter from polygons to masks
* Converter from polygons to bounding boxes because many instance segmentation algorithm needs both the masks and the bounding box of each object

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
