### PR TITLE
Add ImageCallable field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This release streamlines Datumaro by removing a number of lesser-used features, 
 
 ### New features
 - Experimental dataset class
-  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>, <https://github.com/open-edge-platform/datumaro/pull/1868>, <https://github.com/open-edge-platform/datumaro/pull/1876>, <https://github.com/open-edge-platform/datumaro/pull/1877>)
+  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>, <https://github.com/open-edge-platform/datumaro/pull/1868>, <https://github.com/open-edge-platform/datumaro/pull/1876>, <https://github.com/open-edge-platform/datumaro/pull/1877>, <https://github.com/open-edge-platform/datumaro/pull/1879>)
 
 ### Enhancements
 - Mark several dependencies as optional

--- a/src/datumaro/experimental/__init__.py
+++ b/src/datumaro/experimental/__init__.py
@@ -6,12 +6,14 @@ from .converter_registry import ConverterRegistry, converter, find_conversion_pa
 from .dataset import Dataset, Sample
 from .fields import (
     BBoxField,
+    ImageCallableField,
     ImageField,
     ImageInfoField,
     ImagePathField,
     LabelField,
     TensorField,
     bbox_field,
+    image_callable_field,
     image_field,
     image_info_field,
     image_path_field,

--- a/src/datumaro/experimental/converters.py
+++ b/src/datumaro/experimental/converters.py
@@ -23,6 +23,7 @@ from .converter_registry import AttributeSpec, Converter, converter
 from .fields import (
     BBoxField,
     ImageBytesField,
+    ImageCallableField,
     ImageField,
     ImageInfo,
     ImageInfoField,
@@ -829,3 +830,104 @@ class PolygonToBBoxConverter(Converter):
             )
 
         return df
+
+
+@converter(lazy=True)
+class ImageCallableToImageConverter(Converter):
+    """
+    Lazy converter that executes callables to generate image data.
+
+    This converter takes a callable stored in an ImageCallableField,
+    executes it to get image data as a numpy array, and produces both
+    ImageField and ImageInfoField outputs.
+    """
+
+    input_callable: AttributeSpec[ImageCallableField]
+    output_image: AttributeSpec[ImageField]
+    output_info: AttributeSpec[ImageInfoField]
+
+    def filter_output_spec(self) -> bool:
+        """Configure output image and info specifications based on input."""
+        # Configure output image specification
+        self.output_image = AttributeSpec(
+            name=self.output_image.name,
+            field=ImageField(
+                semantic=self.input_callable.field.semantic,
+                dtype=pl.UInt8,  # Default to UInt8 for image data
+                format=self.input_callable.field.format,  # Use format from callable field
+            ),
+        )
+        # Configure output info specification
+        self.output_info = AttributeSpec(
+            name=self.output_info.name,
+            field=ImageInfoField(
+                semantic=self.input_callable.field.semantic,
+            ),
+        )
+        return True
+
+    def convert(self, df: pl.DataFrame) -> pl.DataFrame:
+        """
+        Execute callables to generate image data and metadata.
+
+        Args:
+            df: DataFrame containing callable column
+
+        Returns:
+            DataFrame with image tensor data, shape information, and image info
+        """
+        input_col = self.input_callable.name
+        output_col = self.output_image.name
+        output_info_col = self.output_info.name
+
+        # Execute callables to generate image data
+        image_data: list[Any] = []
+        image_shapes: list[list[int]] = []
+        image_infos: list[ImageInfo] = []
+
+        for callable_obj in df[input_col]:
+            try:
+                # Execute the callable to get image array
+                img_array = callable_obj()
+
+                # Validate that we got a numpy array
+                if not isinstance(img_array, np.ndarray):
+                    raise TypeError(f"Callable must return numpy.ndarray, got {type(img_array)}")
+
+                # Ensure the array has 3 dimensions for an image (height, width, channels)
+                if len(img_array.shape) != 3:
+                    raise ValueError(
+                        f"Image array must be 3D (height, width, channels), got shape {img_array.shape}"
+                    )
+
+                # Check that the array has the expected dtype (no conversion)
+                expected_dtype = self.output_image.field.dtype
+                expected_numpy_dtype = polars_to_numpy_dtype(expected_dtype)
+                if img_array.dtype != expected_numpy_dtype:
+                    raise TypeError(
+                        f"Expected {expected_numpy_dtype} image array, got {img_array.dtype}"
+                    )
+                # If no specific dtype checking needed, accept as-is
+
+                # Store flattened image data and shape
+                image_data.append(img_array.flatten())
+                image_shapes.append(list(img_array.shape))
+
+                # Create image info with width and height from 3D array
+                height, width = img_array.shape[:2]
+                image_infos.append(ImageInfo(width=width, height=height))
+
+            except Exception as e:
+                raise RuntimeError(f"Error executing callable for image generation: {e}") from e
+
+        # Create output DataFrame
+        result_df = df.clone()
+        result_df = result_df.with_columns(
+            [
+                pl.Series(output_col, image_data),
+                pl.Series(output_col + "_shape", image_shapes),
+                pl.Series(output_info_col, image_infos),
+            ]
+        )
+
+        return result_df

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -207,7 +207,12 @@ class Dataset(Generic[DType]):
             series_data.update(attr_info.annotation.to_polars(key, getattr(sample, key)))
 
         new_row = pl.DataFrame(series_data).cast(dict(self.df.schema))  # type: ignore
-        self.df.extend(new_row)
+
+        # Use vstack instead of extend for object columns since extend doesn't support them
+        if any(dtype == pl.Object for dtype in self.df.schema.values()):
+            self.df = self.df.vstack(new_row)
+        else:
+            self.df.extend(new_row)
 
     def __getitem__(self, row_idx: int) -> DType:
         """

--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -564,3 +564,54 @@ def instance_mask_field(dtype: Any = pl.Boolean(), semantic: Semantic = Semantic
         InstanceMaskField instance configured with the given parameters
     """
     return InstanceMaskField(semantic=semantic, dtype=dtype)
+
+
+@dataclass(frozen=True)
+class ImageCallableField(Field):
+    """
+    Represents a field that stores a callable which returns an image as a numpy array.
+
+    This field is useful for lazy loading scenarios where images are generated
+    or loaded on-demand. The callable should return a numpy array representing
+    the image data when invoked.
+
+    Attributes:
+        semantic: Semantic tags describing the callable's purpose
+        format: Expected image color format (e.g., "RGB", "BGR", "RGBA")
+    """
+
+    semantic: Semantic
+    format: str = "RGB"
+
+    def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
+        """Return schema with Object type to store callable."""
+        return {name: pl.Object}
+
+    def to_polars(self, name: str, value: callable) -> dict[str, pl.Series]:
+        """Store callable as Object in Polars series."""
+        if not callable(value):
+            raise TypeError(f"Expected callable, got {type(value)}")
+        return {name: pl.Series(name, [value])}
+
+    def from_polars(
+        self, name: str, row_index: int, df: pl.DataFrame, target_type: type
+    ) -> callable:
+        """Extract callable from Polars dataframe."""
+        value = df[name][row_index]
+        if not callable(value):
+            raise TypeError(f"Expected callable in column {name}, got {type(value)}")
+        return value
+
+
+def image_callable_field(format: str = "RGB", semantic: Semantic = Semantic.Default) -> Any:
+    """
+    Create an ImageCallableField instance for storing image-generating callables.
+
+    Args:
+        format: Expected image color format (defaults to "RGB")
+        semantic: Semantic tags describing the callable's purpose (optional)
+
+    Returns:
+        ImageCallableField instance configured with the given parameters
+    """
+    return ImageCallableField(semantic=semantic, format=format)

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -10,11 +10,13 @@ experimental dataset format with automatic schema inference and type conversion.
 
 from __future__ import annotations
 
+import io
 from abc import ABC, abstractmethod
 from typing import Any, Optional, Type, cast
 
 import numpy as np
 import polars as pl
+from PIL import Image as PILImage
 
 from datumaro.components.annotation import Annotation, AnnotationType, Bbox
 from datumaro.components.annotation import LabelCategories as LegacyLabelCategories
@@ -33,6 +35,7 @@ from .fields import (
     PolygonField,
     bbox_field,
     image_bytes_field,
+    image_callable_field,
     image_info_field,
     image_path_field,
     label_field,
@@ -142,10 +145,11 @@ def get_forward_annotation_converter(
 class ForwardImageMediaConverter(ForwardMediaConverter):
     """Forward converter for Image media type supporting both file paths and byte data."""
 
-    def __init__(self, media_mixin: type, has_image_info: bool):
+    def __init__(self, media_mixin: type, has_image_info: bool, has_callable_data: bool = False):
         """Initialize converter with format preference and image info availability."""
         self.media_mixin = media_mixin
         self.has_image_info = has_image_info
+        self.has_callable_data = has_callable_data
 
     @classmethod
     def get_supported_media_types(cls) -> list[Type[MediaElement[Any]]]:
@@ -157,6 +161,7 @@ class ForwardImageMediaConverter(ForwardMediaConverter):
         """Create converter instance, detecting whether to use paths or bytes."""
         found_media_type: Optional[type] = None
         has_image_info = True  # Assume all images have size until proven otherwise
+        has_callable_data = False  # Track if any FromDataMixin has callable _data
 
         for item in dataset:
             if isinstance(item.media, Image):
@@ -173,6 +178,10 @@ class ForwardImageMediaConverter(ForwardMediaConverter):
                 if not item.media.has_size:
                     has_image_info = False
 
+                # Check if this is FromDataMixin with callable _data
+                if isinstance(item.media, FromDataMixin) and callable(item.media._data):
+                    has_callable_data = True
+
         if found_media_type is None:
             return None
 
@@ -183,13 +192,24 @@ class ForwardImageMediaConverter(ForwardMediaConverter):
         else:
             raise ValueError(f"Unknown media mixin for {found_media_type}.")
 
-        return cls(media_mixin=media_mixin, has_image_info=has_image_info)
+        return cls(
+            media_mixin=media_mixin,
+            has_image_info=has_image_info,
+            has_callable_data=has_callable_data,
+        )
 
     def get_schema_attributes(self) -> dict[str, AttributeInfo]:
         attributes: dict[str, AttributeInfo] = {}
 
         if self.media_mixin == FromDataMixin:
-            attributes["image_bytes"] = AttributeInfo(type=bytes, annotation=image_bytes_field())
+            if self.has_callable_data:
+                attributes["image_callable"] = AttributeInfo(
+                    type=callable, annotation=image_callable_field()
+                )
+            else:
+                attributes["image_bytes"] = AttributeInfo(
+                    type=bytes, annotation=image_bytes_field()
+                )
         elif self.media_mixin == FromFileMixin:
             attributes["image_path"] = AttributeInfo(type=str, annotation=image_path_field())
         else:
@@ -206,7 +226,34 @@ class ForwardImageMediaConverter(ForwardMediaConverter):
 
         if isinstance(item.media, Image):  # pyright: ignore[reportUnknownMemberType]
             if self.media_mixin == FromDataMixin:
-                result["image_bytes"] = item.media.data
+                if self.has_callable_data:
+                    # Create a wrapper callable that converts bytes to image array
+                    def create_image_callable(media_obj):
+                        """Create a callable that returns image array from bytes."""
+
+                        def get_image_array():
+                            # Get the bytes data (either directly or from callable)
+                            if callable(media_obj._data):
+                                bytes_data = media_obj._data()
+                            else:
+                                bytes_data = media_obj._data
+
+                            if not isinstance(bytes_data, bytes):
+                                raise TypeError(f"Expected bytes data, got {type(bytes_data)}")
+
+                            # Convert bytes to image array using PIL
+                            with PILImage.open(io.BytesIO(bytes_data)) as pil_image:
+                                # Convert to RGB if needed
+                                if pil_image.mode != "RGB":
+                                    pil_image = pil_image.convert("RGB")
+                                # Convert to numpy array
+                                return np.array(pil_image, dtype=np.uint8)
+
+                        return get_image_array
+
+                    result["image_callable"] = create_image_callable(item.media)
+                else:
+                    result["image_bytes"] = item.media._data
             elif self.media_mixin == FromFileMixin:
                 result["image_path"] = item.media.path
             else:

--- a/tests/unit/experimental/test_converters.py
+++ b/tests/unit/experimental/test_converters.py
@@ -22,6 +22,7 @@ from datumaro.experimental.converter_registry import (
 from datumaro.experimental.converters import (
     BBoxCoordinateConverter,
     ImageBytesToImageConverter,
+    ImageCallableToImageConverter,
     ImagePathToImageConverter,
     PolygonToBBoxConverter,
     PolygonToInstanceMaskConverter,
@@ -33,6 +34,7 @@ from datumaro.experimental.fields import (
     BBoxField,
     Field,
     ImageBytesField,
+    ImageCallableField,
     ImageField,
     ImageInfoField,
     ImagePathField,
@@ -1686,3 +1688,184 @@ def test_polygon_to_bbox_converter_normalized():
     assert abs(rectangle_bbox[1] - 0.3) < 1e-6  # y1 (normalized)
     assert abs(rectangle_bbox[2] - 0.4) < 1e-6  # x2 (normalized)
     assert abs(rectangle_bbox[3] - 0.4) < 1e-6  # y2 (normalized)
+
+
+def test_image_callable_to_image_converter():
+    """Test ImageCallableToImageConverter functionality."""
+    import numpy as np
+
+    # Create a callable that returns a test image
+    def create_test_image():
+        return np.array(
+            [
+                [[255, 0, 0], [0, 255, 0], [0, 0, 255]],
+                [[255, 255, 0], [255, 0, 255], [0, 255, 255]],
+                [[128, 128, 128], [64, 64, 64], [192, 192, 192]],
+            ],
+            dtype=np.uint8,
+        )
+
+    # Create input DataFrame with callable
+    df = pl.DataFrame({"my_callable": [create_test_image]}, schema={"my_callable": pl.Object})
+
+    # Create converter instance
+    converter_instance = ImageCallableToImageConverter()  # type: ignore[call-arg]
+
+    # Set up converter attributes
+    input_field = ImageCallableField(format="RGB", semantic=Semantic.Default)
+    output_field = ImageField(dtype=pl.UInt8, format="RGB", semantic=Semantic.Default)
+    output_info_field = ImageInfoField(semantic=Semantic.Default)
+
+    setattr(
+        converter_instance,
+        "input_callable",
+        AttributeSpec(name="my_callable", field=input_field),
+    )
+    setattr(
+        converter_instance,
+        "output_image",
+        AttributeSpec(name="output_image", field=output_field),
+    )
+    setattr(
+        converter_instance,
+        "output_info",
+        AttributeSpec(name="output_info", field=output_info_field),
+    )
+
+    # Test filter - should return True
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    # Check expected columns exist
+    assert "output_image" in result_df.columns
+    assert "output_image_shape" in result_df.columns
+    assert "output_info" in result_df.columns
+
+    # Check image shape
+    image_shape = result_df["output_image_shape"][0]
+    assert list(image_shape) == [3, 3, 3]  # height, width, channels
+
+    # Check image info
+    image_info = result_df["output_info"][0]
+    assert image_info["width"] == 3
+    assert image_info["height"] == 3
+
+    # Check image data can be reconstructed
+    image_data = result_df["output_image"][0]
+    reconstructed = np.array(image_data, dtype=np.uint8).reshape(list(image_shape))
+    assert reconstructed.shape == (3, 3, 3)
+    assert reconstructed.dtype == np.uint8
+
+
+def test_image_callable_converter_error_handling():
+    """Test error handling in ImageCallableToImageConverter."""
+    import numpy as np
+
+    # Test with callable that returns non-numpy array
+    def bad_callable_1():
+        return "not an array"
+
+    # Test with callable that returns wrong shape
+    def bad_callable_2():
+        return np.array([1, 2, 3, 4])  # 1D array
+
+    # Test with callable that raises exception
+    def bad_callable_3():
+        raise ValueError("Something went wrong")
+
+    # Create converter instance
+    converter_instance = ImageCallableToImageConverter()  # type: ignore[call-arg]
+
+    # Set up converter attributes
+    input_field = ImageCallableField(format="RGB", semantic=Semantic.Default)
+    output_field = ImageField(dtype=pl.UInt8, format="RGB", semantic=Semantic.Default)
+    output_info_field = ImageInfoField(semantic=Semantic.Default)
+
+    setattr(
+        converter_instance,
+        "input_callable",
+        AttributeSpec(name="my_callable", field=input_field),
+    )
+    setattr(
+        converter_instance,
+        "output_image",
+        AttributeSpec(name="output_image", field=output_field),
+    )
+    setattr(
+        converter_instance,
+        "output_info",
+        AttributeSpec(name="output_info", field=output_info_field),
+    )
+
+    # Test TypeError for non-numpy return
+    df1 = pl.DataFrame({"my_callable": [bad_callable_1]}, schema={"my_callable": pl.Object})
+    with pytest.raises(RuntimeError, match="must return numpy.ndarray"):
+        converter_instance.convert(df1)
+
+    # Test ValueError for wrong shape
+    df2 = pl.DataFrame({"my_callable": [bad_callable_2]}, schema={"my_callable": pl.Object})
+    with pytest.raises(RuntimeError, match="must be 3D"):
+        converter_instance.convert(df2)
+
+    # Test exception propagation
+    df3 = pl.DataFrame({"my_callable": [bad_callable_3]}, schema={"my_callable": pl.Object})
+    with pytest.raises(RuntimeError, match="Error executing callable"):
+        converter_instance.convert(df3)
+
+
+def test_image_callable_converter_dtype_handling():
+    """Test dtype handling in ImageCallableToImageConverter."""
+    import numpy as np
+
+    # Test with uint8 image (should work)
+    def uint8_callable():
+        return np.array([[[255, 0, 128]]], dtype=np.uint8)
+
+    # Test with float32 image
+    def float32_callable():
+        return np.array([[[1.0, 0.5, 0.25]]], dtype=np.float32)
+
+    # Create converter instance
+    converter_instance = ImageCallableToImageConverter()  # type: ignore[call-arg]
+
+    # Set up converter attributes for uint8
+    input_field = ImageCallableField(format="RGB", semantic=Semantic.Default)
+    output_field = ImageField(dtype=pl.UInt8, format="RGB", semantic=Semantic.Default)
+    output_info_field = ImageInfoField(semantic=Semantic.Default)
+
+    setattr(
+        converter_instance, "input_callable", AttributeSpec(name="my_callable", field=input_field)
+    )
+    setattr(
+        converter_instance, "output_image", AttributeSpec(name="output_image", field=output_field)
+    )
+    setattr(
+        converter_instance,
+        "output_info",
+        AttributeSpec(name="output_info", field=output_info_field),
+    )
+
+    # Test uint8 image
+    df1 = pl.DataFrame({"my_callable": [uint8_callable]}, schema={"my_callable": pl.Object})
+    result1 = converter_instance.convert(df1)
+    image_data1 = np.array(result1["output_image"][0], dtype=np.uint8).reshape([1, 1, 3])
+    assert image_data1.dtype == np.uint8
+    assert image_data1[0, 0, 0] == 255
+    assert image_data1[0, 0, 1] == 0
+    assert image_data1[0, 0, 2] == 128
+
+    # Test float32 image with different output field
+    output_field_f32 = ImageField(dtype=pl.Float32, format="RGB", semantic=Semantic.Default)
+    setattr(
+        converter_instance,
+        "output_image",
+        AttributeSpec(name="output_image", field=output_field_f32),
+    )
+
+    df2 = pl.DataFrame({"my_callable": [float32_callable]}, schema={"my_callable": pl.Object})
+    result2 = converter_instance.convert(df2)
+    image_info2 = result2["output_info"][0]
+    assert image_info2["width"] == 1  # width
+    assert image_info2["height"] == 1  # height

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -12,7 +12,7 @@ from typing_extensions import Annotated
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories, Polygon
 from datumaro.components.dataset import Dataset as LegacyDataset
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
-from datumaro.components.media import Image, ImageFromFile, MediaElement, Video
+from datumaro.components.media import Image, ImageFromData, ImageFromFile, MediaElement, Video
 from datumaro.experimental.dataset import Dataset, Sample
 from datumaro.experimental.fields import (
     ImageInfo,
@@ -378,8 +378,123 @@ def test_convert_from_legacy_with_image_paths():
     # Check that image_path are present
     assert hasattr(sample1, "image_path")
     assert hasattr(sample2, "image_path")
-    assert sample1.image_path == "test1.jpg"
-    assert sample2.image_path == "test2.png"
+
+
+def test_convert_from_legacy_with_callable_image_data():
+    """Test conversion with ImageFromData containing callable _data."""
+    import io
+
+    from PIL import Image as PILImage
+
+    # Create test image bytes
+    test_image1 = np.random.randint(0, 256, (32, 32, 3), dtype=np.uint8)
+    test_image2 = np.random.randint(0, 256, (64, 64, 3), dtype=np.uint8)
+
+    # Create bytes using PIL
+    def create_image_bytes(img_array):
+        pil_image = PILImage.fromarray(img_array)
+        img_bytes = io.BytesIO()
+        pil_image.save(img_bytes, format="PNG")
+        return img_bytes.getvalue()
+
+    image_bytes1 = create_image_bytes(test_image1)
+    image_bytes2 = create_image_bytes(test_image2)
+
+    # Create callables that return these bytes
+    def get_image_bytes1():
+        return image_bytes1
+
+    def get_image_bytes2():
+        return image_bytes2
+
+    # Create dataset items with ImageFromData containing callable _data
+    items = [
+        DatasetItem(id="item1", media=ImageFromData(data=get_image_bytes1), annotations=[]),
+        DatasetItem(id="item2", media=ImageFromData(data=get_image_bytes2), annotations=[]),
+    ]
+
+    # Create legacy dataset
+    legacy_dataset = LegacyDataset.from_iterable(items)
+
+    # Convert to experimental format
+    experimental_dataset = convert_from_legacy(legacy_dataset)
+
+    # Verify conversion uses callable field instead of bytes field
+    assert "image_callable" in experimental_dataset.schema.attributes
+    assert "image_bytes" not in experimental_dataset.schema.attributes
+    assert "image_path" not in experimental_dataset.schema.attributes
+
+    # Verify samples
+    assert len(experimental_dataset) == 2
+
+    sample1 = experimental_dataset[0]
+    sample2 = experimental_dataset[1]
+
+    # Check that image_callable are present and work
+    assert hasattr(sample1, "image_callable")
+    assert hasattr(sample2, "image_callable")
+    assert callable(sample1.image_callable)
+    assert callable(sample2.image_callable)
+
+    # Test that callables return proper image arrays
+    result1 = sample1.image_callable()
+    result2 = sample2.image_callable()
+
+    assert isinstance(result1, np.ndarray)
+    assert isinstance(result2, np.ndarray)
+    assert result1.dtype == np.uint8
+    assert result2.dtype == np.uint8
+    assert result1.shape == (32, 32, 3)
+    assert result2.shape == (64, 64, 3)
+
+
+def test_image_converter_with_mixed_callable_and_bytes_data():
+    """Test that mixed callable and non-callable data uses callable field."""
+    import io
+
+    from PIL import Image as PILImage
+
+    # Create test image bytes
+    test_image = np.random.randint(0, 256, (16, 16, 3), dtype=np.uint8)
+    pil_image = PILImage.fromarray(test_image)
+    img_bytes = io.BytesIO()
+    pil_image.save(img_bytes, format="PNG")
+    image_bytes = img_bytes.getvalue()
+
+    def get_image_bytes():
+        return image_bytes
+
+    # Create dataset with mixed callable and non-callable data
+    items = [
+        DatasetItem(
+            id="item1", media=ImageFromData(data=get_image_bytes), annotations=[]
+        ),  # callable
+        DatasetItem(
+            id="item2", media=ImageFromData(data=image_bytes), annotations=[]
+        ),  # non-callable
+    ]
+
+    legacy_dataset = LegacyDataset.from_iterable(items)
+    experimental_dataset = convert_from_legacy(legacy_dataset)
+
+    # Should use callable field (callable takes precedence)
+    assert "image_callable" in experimental_dataset.schema.attributes
+    assert "image_bytes" not in experimental_dataset.schema.attributes
+
+    # Both samples should have working callables
+    sample1 = experimental_dataset[0]
+    sample2 = experimental_dataset[1]
+
+    assert hasattr(sample1, "image_callable")
+    assert hasattr(sample2, "image_callable")
+
+    result1 = sample1.image_callable()
+    result2 = sample2.image_callable()
+
+    assert isinstance(result1, np.ndarray)
+    assert isinstance(result2, np.ndarray)
+    assert result1.shape == (16, 16, 3)
+    assert result2.shape == (16, 16, 3)
 
 
 def test_bbox_annotation_converter_get_schema_attributes():

--- a/tests/unit/experimental/test_schema.py
+++ b/tests/unit/experimental/test_schema.py
@@ -12,6 +12,7 @@ from datumaro.experimental.dataset import Sample
 from datumaro.experimental.fields import (
     BBoxField,
     ImageBytesField,
+    ImageCallableField,
     ImageField,
     ImageInfo,
     ImageInfoField,
@@ -20,6 +21,7 @@ from datumaro.experimental.fields import (
     TensorField,
     bbox_field,
     image_bytes_field,
+    image_callable_field,
     image_field,
     image_info_field,
     image_path_field,
@@ -261,6 +263,105 @@ def test_image_path_field_polars_conversion():
 
     assert isinstance(reconstructed, str)
     assert reconstructed == test_path
+
+
+def test_image_callable_field_creation():
+    """Test ImageCallableField creation and properties."""
+    field = image_callable_field(format="RGB", semantic=Semantic.Default)
+
+    assert isinstance(field, ImageCallableField)
+    assert field.format == "RGB"
+    assert field.semantic == Semantic.Default
+
+    # Test with different format
+    field_bgr = image_callable_field(format="BGR", semantic=Semantic.Left)
+    assert field_bgr.format == "BGR"
+    assert field_bgr.semantic == Semantic.Left
+
+
+def test_image_callable_field_polars_schema():
+    """Test ImageCallableField Polars schema generation."""
+    field = image_callable_field()
+    schema = field.to_polars_schema("image_callable")
+
+    expected = {"image_callable": pl.Object}
+    assert schema == expected
+
+
+def test_image_callable_field_polars_conversion():
+    """Test ImageCallableField to/from Polars conversion."""
+    import numpy as np
+
+    field = image_callable_field()  # Create a test callable
+
+    def test_image_generator():
+        return np.array([[[255, 0, 0], [0, 255, 0]], [[0, 0, 255], [255, 255, 0]]], dtype=np.uint8)
+
+    # Test to_polars
+    polars_data = field.to_polars("image_callable", test_image_generator)
+    assert "image_callable" in polars_data
+    assert isinstance(polars_data["image_callable"], pl.Series)
+
+    # Create DataFrame and test from_polars
+    df = pl.DataFrame(polars_data)
+    reconstructed = field.from_polars("image_callable", 0, df, callable)
+
+    assert callable(reconstructed)
+    assert reconstructed == test_image_generator
+
+    # Test that the callable produces the expected output
+    result = reconstructed()
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (2, 2, 3)
+    assert result.dtype == np.uint8
+
+
+def test_image_callable_field_error_handling():
+    """Test ImageCallableField error handling."""
+    field = image_callable_field()
+
+    # Test with non-callable object
+    with pytest.raises(TypeError, match="Expected callable"):
+        field.to_polars("image_callable", "not_a_callable")
+
+    # Test with non-callable in from_polars
+    df = pl.DataFrame({"image_callable": ["not_a_callable"]})
+    with pytest.raises(TypeError, match="Expected callable in column"):
+        field.from_polars("image_callable", 0, df, callable)
+
+
+def test_image_callable_field_complex_callable():
+    """Test ImageCallableField with more complex callables."""
+    import numpy as np
+
+    field = image_callable_field(format="RGBA")  # Test with lambda
+    lambda_callable = lambda: np.zeros((5, 5, 4), dtype=np.uint8)
+
+    polars_data = field.to_polars("image_callable", lambda_callable)
+    df = pl.DataFrame(polars_data)
+    reconstructed = field.from_polars("image_callable", 0, df, callable)
+
+    result = reconstructed()
+    assert result.shape == (5, 5, 4)
+    assert result.dtype == np.uint8
+    assert np.all(result == 0)
+
+    # Test with class method
+    class ImageGenerator:
+        def __init__(self, size):
+            self.size = size
+
+        def generate(self):
+            return np.ones((self.size, self.size, 3), dtype=np.uint8) * 128
+
+    generator = ImageGenerator(3)
+    polars_data2 = field.to_polars("image_callable", generator.generate)
+    df2 = pl.DataFrame(polars_data2)
+    reconstructed2 = field.from_polars("image_callable", 0, df2, callable)
+
+    result2 = reconstructed2()
+    assert result2.shape == (3, 3, 3)
+    assert np.all(result2 == 128)
 
 
 def test_attribute_info_creation():


### PR DESCRIPTION
This PR introduces support for image callables which can be used to lazy loading of images. The main use case at the moment is to handle the conversion of legacy datasets to the new one. When loading an arrow file, the legacy dataset does not store a path to the image file, or bytes in memory, but instead store a callable which can be used to read the image from the arrow file.

### Lazy image field and conversion support

* Added `ImageCallableField` and `image_callable_field` factory to `fields.py`, allowing storage of callables that return image arrays for lazy loading scenarios.
* Implemented `ImageCallableToImageConverter` in `converters.py`, which executes stored callables to generate image tensors and associated metadata, including error handling and dtype checks.

### Legacy compatibility and conversion logic

* Updated legacy conversion logic in `legacy.py` to detect and support callable-based image data, including schema and media conversion handling for datasets with callables. [[1]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L145-R152) [[2]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5R164) [[3]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5R181-R184) [[4]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L186-R212) [[5]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L209-R256)

### DataFrame handling improvements

* Modified `Dataset.append` in `dataset.py` to use `vstack` instead of `extend` for DataFrames containing object columns, ensuring compatibility with callable fields.

### Testing and validation

* Added comprehensive unit tests for `ImageCallableToImageConverter`, covering correct conversion, error handling, and dtype support.

### API and import updates

* Updated imports and field lists in `__init__.py`, `converters.py`, and `legacy.py` to include the new callable field and converter. [[1]](diffhunk://#diff-6c66a059cb4075cd7afbc29b4f34236f8101a1a47cdcc429c7a2d25868cc74b5R9-R16) [[2]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3R26) [[3]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5R38) [[4]](diffhunk://#diff-68bad0abf07432874f6f4833b34619b0c142c223adb4659fc7363725102c2c9cL15-R15)
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
