### PR TITLE
Rotated bounding box support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This release streamlines Datumaro by removing a number of lesser-used features, 
 ### Removed features
 - CLI commmands:
   - explain, explore, generate, prune
-    (<https://github.com/open-edge-platform/datumaro/pull/1812>, <https://github.com/open-edge-platform/datumaro/pull/1813>, <https://github.com/open-edge-platform/datumaro/pull/1814>, <https://github.com/open-edge-platform/datumaro/pull/1815>)
+    (<https://github.com/open-edge-platform/datumaro/pull/1812>, <https://github.com/open-edge-platform/datumaro/pull/1813>, <https://github.com/open-edge-platform/datumaro/pull/1814>, <https://github.com/open-edge-platform/datumaro/pull/1815>, <https://github.com/open-edge-platform/datumaro/pull/1880>)
   - model: add, remove, run, info
     (<https://github.com/open-edge-platform/datumaro/pull/1816>)
   - project: add, create, export, import, remove, checkout, commit, log, info, status

--- a/src/datumaro/experimental/__init__.py
+++ b/src/datumaro/experimental/__init__.py
@@ -11,6 +11,7 @@ from .fields import (
     ImageInfoField,
     ImagePathField,
     LabelField,
+    RotatedBBoxField,
     TensorField,
     bbox_field,
     image_callable_field,
@@ -18,6 +19,7 @@ from .fields import (
     image_info_field,
     image_path_field,
     label_field,
+    rotated_bbox_field,
     tensor_field,
 )
 from .schema import AttributeInfo, Field, Schema, Semantic

--- a/src/datumaro/experimental/converters.py
+++ b/src/datumaro/experimental/converters.py
@@ -32,6 +32,7 @@ from .fields import (
     LabelField,
     MaskField,
     PolygonField,
+    RotatedBBoxField,
 )
 from .type_registry import polars_to_numpy_dtype
 
@@ -753,7 +754,7 @@ class PolygonToInstanceMaskConverter(Converter):
         )
 
 
-@converter(lazy=True)
+@converter
 class PolygonToBBoxConverter(Converter):
     """
     Converts polygon annotations to bounding boxes.
@@ -931,3 +932,73 @@ class ImageCallableToImageConverter(Converter):
         )
 
         return result_df
+
+
+@converter
+class RotatedBBoxToPolygonConverter(Converter):
+    """
+    Converts rotated bounding boxes to polygon coordinates.
+
+    Transforms rotated bounding box parameters (cx, cy, w, h, r) into
+    polygon corner points by rotating the rectangle corners around the center.
+    """
+
+    input_rotated_bbox: AttributeSpec[RotatedBBoxField]
+    output_polygon: AttributeSpec[PolygonField]
+
+    def filter_output_spec(self) -> bool:
+        """Configure output specification for polygon format."""
+        # Configure output for polygon format
+        self.output_polygon = AttributeSpec(
+            name=self.output_polygon.name,
+            field=PolygonField(
+                semantic=self.input_rotated_bbox.field.semantic,
+                dtype=self.input_rotated_bbox.field.dtype,
+                format=self.output_polygon.field.format,
+                normalize=self.input_rotated_bbox.field.normalize,  # Inherit normalization
+            ),
+        )
+        return True
+
+    def convert(self, df: pl.DataFrame) -> pl.DataFrame:
+        """
+        Convert rotated bounding boxes to polygon corner points.
+
+        Args:
+            df: DataFrame with rotated bounding box coordinates
+
+        Returns:
+            DataFrame with polygon data in output column
+        """
+        input_column_name = self.input_rotated_bbox.name
+        output_column_name = self.output_polygon.name
+
+        cx = pl.element().arr.get(0)
+        cy = pl.element().arr.get(1)
+        w = pl.element().arr.get(2)
+        h = pl.element().arr.get(3)
+        r = pl.element().arr.get(4)
+
+        def rotate_corner(expr: pl.Expr):
+            px = expr.arr.get(0)
+            py = expr.arr.get(1)
+            cos_theta = r.cos()
+            sin_theta = r.sin()
+            return pl.concat_arr(
+                cos_theta * px - sin_theta * py + cx, sin_theta * px + cos_theta * py + cy
+            )
+
+        df = df.with_columns(
+            pl.col(input_column_name)
+            .list.eval(
+                pl.concat_list(
+                    rotate_corner(pl.concat_arr(-w / 2, -h / 2)),
+                    rotate_corner(pl.concat_arr(w / 2, -h / 2)),
+                    rotate_corner(pl.concat_arr(w / 2, h / 2)),
+                    rotate_corner(pl.concat_arr(-w / 2, h / 2)),
+                )
+            )
+            .alias(output_column_name)
+        )
+
+        return df

--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -212,6 +212,70 @@ def bbox_field(
     return BBoxField(semantic=semantic, dtype=dtype, format=format, normalize=normalize)
 
 
+@dataclass(frozen=True)
+class RotatedBBoxField(Field):
+    """
+    Represents a rotated bounding box field with format and normalization options.
+
+    Handles rotated bounding box data with support for different coordinate formats
+    and optional normalization to [0,1] range. Stores all attributes (cx, cy, w, h, r)
+    in one tensor similar to BBoxField.
+
+    Attributes:
+        semantic: Semantic tags describing the rotated bounding box purpose
+        dtype: Polars data type for coordinate values
+        format: Coordinate format (e.g., "cxcywhr", "cxcywha" for angle in degrees)
+        normalize: Whether coordinates are normalized to [0,1] range
+    """
+
+    semantic: Semantic
+    dtype: PolarsDataType = pl.Float32()
+    format: str = "cxcywhr"
+    normalize: bool = False
+
+    def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
+        """Generate schema for rotated bounding box as list of 5-element arrays."""
+        return {name: pl.List(pl.Array(self.dtype, 5))}
+
+    def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
+        """Convert rotated bounding box tensor to Polars list format."""
+        numpy_value = to_numpy(value, self.dtype)
+
+        return {
+            name: pl.Series(
+                name,
+                numpy_value.reshape(1, -1, 5),
+                dtype=pl.List(pl.Array(self.dtype, 5)),
+            )
+        }
+
+    def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type[T]) -> T:
+        """Reconstruct rotated bounding box tensor from Polars data."""
+        polars_data = df[name][row_index]
+        return from_polars_data(polars_data, target_type)  # type: ignore
+
+
+def rotated_bbox_field(
+    dtype: Any,
+    format: str = "cxcywhr",
+    normalize: bool = False,
+    semantic: Semantic = Semantic.Default,
+) -> Any:
+    """
+    Create a RotatedBBoxField instance with the specified parameters.
+
+    Args:
+        dtype: Polars data type for coordinate values
+        format: Coordinate format (defaults to "cxcywhr" for cx,cy,w,h,rotation_radians)
+        normalize: Whether coordinates are normalized (defaults to False)
+        semantic: Semantic tags describing the rotated bounding box purpose (optional)
+
+    Returns:
+        RotatedBBoxField instance configured with the given parameters
+    """
+    return RotatedBBoxField(semantic=semantic, dtype=dtype, format=format, normalize=normalize)
+
+
 @dataclass
 class ImageInfo:
     """Container for image metadata (width and height)."""

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -11,6 +11,7 @@ experimental dataset format with automatic schema inference and type conversion.
 from __future__ import annotations
 
 import io
+import math
 from abc import ABC, abstractmethod
 from typing import Any, Optional, Type, cast
 
@@ -20,7 +21,7 @@ from PIL import Image as PILImage
 
 from datumaro.components.annotation import Annotation, AnnotationType, Bbox
 from datumaro.components.annotation import LabelCategories as LegacyLabelCategories
-from datumaro.components.annotation import Polygon
+from datumaro.components.annotation import Polygon, RotatedBbox
 from datumaro.components.dataset import Dataset as LegacyDataset
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
 from datumaro.components.media import FromDataMixin, FromFileMixin, Image, MediaElement
@@ -33,6 +34,7 @@ from .fields import (
     ImagePathField,
     LabelField,
     PolygonField,
+    RotatedBBoxField,
     bbox_field,
     image_bytes_field,
     image_callable_field,
@@ -40,6 +42,7 @@ from .fields import (
     image_path_field,
     label_field,
     polygon_field,
+    rotated_bbox_field,
 )
 from .schema import AttributeInfo, Schema
 
@@ -338,6 +341,88 @@ class ForwardBboxAnnotationConverter(ForwardAnnotationConverter):
         return result
 
 
+class ForwardRotatedBboxAnnotationConverter(ForwardAnnotationConverter):
+    """Forward converter for RotatedBbox annotations."""
+
+    def __init__(
+        self,
+        rotated_bbox_attribute: AttributeInfo,
+        rotated_bbox_labels_attribute: AttributeInfo | None = None,
+    ):
+        """Initialize converter with rotated bbox attributes."""
+        self.rotated_bbox_attribute = rotated_bbox_attribute
+        self.rotated_bbox_labels_attribute = rotated_bbox_labels_attribute
+
+    @classmethod
+    def create_from_categories(
+        cls, categories: CategoriesInfo
+    ) -> "ForwardRotatedBboxAnnotationConverter":
+        """Create converter instance from dataset categories."""
+        # Create attribute for rotated bboxes (cx, cy, w, h, r)
+        rotated_bbox_attribute = AttributeInfo(
+            type=np.ndarray,
+            annotation=rotated_bbox_field(dtype=pl.Float32),
+        )
+
+        # Create attribute for labels if we have label categories
+        rotated_bbox_labels_attribute = None
+        # Extract label categories if available
+        legacy_label_categories = categories.get(AnnotationType.label, None)
+
+        if legacy_label_categories is not None and len(legacy_label_categories.items) > 0:
+            # Convert legacy label categories to new format
+            new_label_categories = LabelCategories()
+            for label_item in legacy_label_categories.items:
+                new_label_categories.add(label_item.name)
+
+            rotated_bbox_labels_attribute = AttributeInfo(
+                type=np.ndarray,
+                annotation=label_field(is_list=True),
+                categories=new_label_categories,
+            )
+
+        return cls(
+            rotated_bbox_attribute=rotated_bbox_attribute,
+            rotated_bbox_labels_attribute=rotated_bbox_labels_attribute,
+        )
+
+    @classmethod
+    def get_annotation_type(cls) -> AnnotationType:
+        return AnnotationType.rotated_bbox
+
+    def get_schema_attributes(self) -> dict[str, AttributeInfo]:
+        attributes = {"rotated_bboxes": self.rotated_bbox_attribute}
+        if self.rotated_bbox_labels_attribute is not None:
+            attributes["rotated_bbox_labels"] = self.rotated_bbox_labels_attribute
+        return attributes
+
+    def convert_annotations(
+        self, annotations: list[Annotation], item: DatasetItem
+    ) -> dict[str, Any]:
+        rotated_bboxes: list[list[float]] = []
+        labels: list[int | None] = []
+
+        for ann in annotations:
+            if isinstance(ann, RotatedBbox):
+                # Convert from degrees to radians for rotation angle
+                r_radians = math.radians(ann.r)
+                rotated_bboxes.append([ann.cx, ann.cy, ann.w, ann.h, r_radians])
+                labels.append(ann.label)
+
+        # Ensure proper shapes for empty arrays
+        rotated_bboxes_array = np.array(rotated_bboxes, dtype=np.float32)
+        if rotated_bboxes_array.shape == (0,):
+            rotated_bboxes_array = rotated_bboxes_array.reshape(0, 5)
+
+        result = {"rotated_bboxes": rotated_bboxes_array}
+
+        # Only add rotated_bbox_labels if we have label categories
+        if self.rotated_bbox_labels_attribute is not None:
+            result["rotated_bbox_labels"] = np.array(labels, dtype=np.int32)
+
+        return result
+
+
 class ForwardPolygonAnnotationConverter(ForwardAnnotationConverter):
     """Forward converter for Polygon annotations."""
 
@@ -429,6 +514,7 @@ def register_builtin_forward_converters():
     # Annotation converters
     register_forward_annotation_converter(ForwardBboxAnnotationConverter)
     register_forward_annotation_converter(ForwardPolygonAnnotationConverter)
+    register_forward_annotation_converter(ForwardRotatedBboxAnnotationConverter)
 
 
 from dataclasses import dataclass
@@ -702,6 +788,89 @@ class BackwardBboxAnnotationConverter(BackwardAnnotationConverter):
         return {AnnotationType.label: label_categories}
 
 
+class BackwardRotatedBboxAnnotationConverter(BackwardAnnotationConverter):
+    """Backward converter for RotatedBbox annotations."""
+
+    def __init__(self, rotated_bboxes_attr: str, rotated_bbox_labels_attr: str | None):
+        """Initialize with the names of the rotated bbox-related attributes."""
+        self.rotated_bboxes_attr = rotated_bboxes_attr
+        self.rotated_bbox_labels_attr = rotated_bbox_labels_attr
+
+    @classmethod
+    def create_from_schema(cls, schema: Schema) -> "BackwardRotatedBboxAnnotationConverter | None":
+        """Create converter if schema contains rotated bbox fields."""
+        rotated_bboxes_attr: str | None = None
+        rotated_bbox_labels_attr: str | None = None
+
+        for attr_name, attr_info in schema.attributes.items():
+            if isinstance(attr_info.annotation, RotatedBBoxField):
+                rotated_bboxes_attr = attr_name
+            elif isinstance(attr_info.annotation, LabelField):
+                rotated_bbox_labels_attr = attr_name
+
+        if rotated_bboxes_attr is None:
+            return None
+
+        return cls(rotated_bboxes_attr, rotated_bbox_labels_attr)
+
+    def get_annotation_type(self) -> AnnotationType:
+        return AnnotationType.rotated_bbox
+
+    def convert_to_legacy_annotations(
+        self, sample: Sample, categories: CategoriesInfo
+    ) -> list[Annotation]:
+        """Convert experimental rotated bbox data to legacy RotatedBbox annotations."""
+        rotated_bboxes = getattr(sample, self.rotated_bboxes_attr, None)
+        if rotated_bboxes is None or len(rotated_bboxes) == 0:
+            return []
+
+        rotated_bbox_labels = None
+        if self.rotated_bbox_labels_attr is not None:
+            rotated_bbox_labels = getattr(sample, self.rotated_bbox_labels_attr, None)
+
+        annotations: list[Annotation] = []
+        for i, bbox in enumerate(rotated_bboxes):
+            cx, cy, w, h, r_radians = bbox
+            # Convert from radians to degrees
+            r_degrees = math.degrees(r_radians)
+
+            label = None
+            if rotated_bbox_labels is not None and i < len(rotated_bbox_labels):
+                label = int(rotated_bbox_labels[i])
+
+            annotation = RotatedBbox(
+                cx=float(cx),
+                cy=float(cy),
+                w=float(w),
+                h=float(h),
+                r=float(r_degrees),
+                label=label,
+            )
+            annotations.append(annotation)
+
+        return annotations
+
+    def infer_categories(self, experimental_dataset: Dataset[Sample]) -> CategoriesInfo:
+        """Infer label categories from rotated_bbox_labels."""
+
+        # Collect all unique label IDs
+        label_ids: set[int] = set()
+        for sample in experimental_dataset:
+            if self.rotated_bbox_labels_attr is not None:
+                rotated_bbox_labels = getattr(sample, self.rotated_bbox_labels_attr, None)
+                if rotated_bbox_labels is not None:
+                    for label_id in rotated_bbox_labels:
+                        if label_id is not None:
+                            label_ids.add(int(label_id))
+
+        # Create label categories
+        label_categories = LegacyLabelCategories()
+        for label_id in sorted(label_ids):
+            label_categories.add(f"class_{label_id}")
+
+        return {AnnotationType.label: label_categories}
+
+
 class BackwardPolygonAnnotationConverter(BackwardAnnotationConverter):
     """Backward converter for Polygon annotations."""
 
@@ -905,6 +1074,7 @@ def register_builtin_backward_converters():
     # Register backward annotation converters
     register_backward_annotation_converter(BackwardBboxAnnotationConverter)
     register_backward_annotation_converter(BackwardPolygonAnnotationConverter)
+    register_backward_annotation_converter(BackwardRotatedBboxAnnotationConverter)
 
 
 # Auto-register built-in converters when module is imported

--- a/tests/unit/experimental/test_converters.py
+++ b/tests/unit/experimental/test_converters.py
@@ -28,6 +28,7 @@ from datumaro.experimental.converters import (
     PolygonToInstanceMaskConverter,
     PolygonToMaskConverter,
     RGBToBGRConverter,
+    RotatedBBoxToPolygonConverter,
     UInt8ToFloat32Converter,
 )
 from datumaro.experimental.fields import (
@@ -42,9 +43,11 @@ from datumaro.experimental.fields import (
     LabelField,
     MaskField,
     PolygonField,
+    RotatedBBoxField,
     bbox_field,
     image_field,
     image_info_field,
+    rotated_bbox_field,
 )
 from datumaro.experimental.schema import AttributeInfo, Schema, Semantic
 
@@ -1869,3 +1872,79 @@ def test_image_callable_converter_dtype_handling():
     image_info2 = result2["output_info"][0]
     assert image_info2["width"] == 1  # width
     assert image_info2["height"] == 1  # height
+
+
+def test_rotated_bbox_to_polygon_converter():
+    """Test conversion from rotated bounding box to polygon format."""
+    import math
+
+    # Create test data with rotated bboxes: [cx, cy, w, h, r]
+    rotated_bbox_coords1 = [50.0, 60.0, 30.0, 20.0, 0.0]  # No rotation
+    rotated_bbox_coords2 = [100.0, 120.0, 40.0, 25.0, math.pi / 4]  # 45 degrees
+
+    rotated_bbox_series = pl.Series(
+        [rotated_bbox_coords1, rotated_bbox_coords2], dtype=pl.Array(pl.Float32, 5)
+    )
+
+    df = pl.DataFrame(
+        {
+            "rotated_bboxes": [rotated_bbox_series],
+        }
+    )
+
+    # Create converter instance
+    converter_instance = RotatedBBoxToPolygonConverter()
+
+    # Set up field specs
+    input_rotated_bbox_field = RotatedBBoxField(
+        dtype=pl.Float32, format="cxcywhr", normalize=False, semantic=Semantic.Default
+    )
+    output_polygon_field = PolygonField(
+        dtype=pl.Float32, format="xy", normalize=False, semantic=Semantic.Default
+    )
+
+    setattr(
+        converter_instance,
+        "input_rotated_bbox",
+        AttributeSpec(name="rotated_bboxes", field=input_rotated_bbox_field),
+    )
+    setattr(
+        converter_instance,
+        "output_polygon",
+        AttributeSpec(name="polygons", field=output_polygon_field),
+    )
+
+    # Test filter - should return True when we have valid input
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    # Check that polygon column was created
+    assert "polygons" in result_df.columns
+
+    # Get the polygon data
+    polygons = result_df["polygons"][0]
+
+    # Check that we have 2 polygons
+    assert len(polygons) == 2
+
+    # Check first polygon (no rotation) - should be axis-aligned rectangle
+    polygon1 = polygons[0]
+    assert len(polygon1) == 4  # Four corners
+
+    # For no rotation, corners should be at predictable positions
+    expected_corners = [
+        [35.0, 50.0],  # bottom-left
+        [65.0, 50.0],  # bottom-right
+        [65.0, 70.0],  # top-right
+        [35.0, 70.0],  # top-left
+    ]
+
+    for expected, actual in zip(expected_corners, polygon1):
+        assert abs(actual[0] - expected[0]) < 1e-5
+        assert abs(actual[1] - expected[1]) < 1e-5
+
+    # Check second polygon (45-degree rotation)
+    polygon2 = polygons[1]
+    assert len(polygon2) == 4  # Four corners

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -1,5 +1,6 @@
 """Unit tests for legacy dataset conversion functionality."""
 
+import math
 import tempfile
 from pathlib import Path
 from typing import Any, cast
@@ -9,7 +10,13 @@ import polars as pl
 import pytest
 from typing_extensions import Annotated
 
-from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories, Polygon
+from datumaro.components.annotation import (
+    AnnotationType,
+    Bbox,
+    LabelCategories,
+    Polygon,
+    RotatedBbox,
+)
 from datumaro.components.dataset import Dataset as LegacyDataset
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem
 from datumaro.components.media import Image, ImageFromData, ImageFromFile, MediaElement, Video
@@ -22,15 +29,18 @@ from datumaro.experimental.fields import (
     image_path_field,
     label_field,
     polygon_field,
+    rotated_bbox_field,
     tensor_field,
 )
 from datumaro.experimental.legacy import (
     BackwardBboxAnnotationConverter,
     BackwardImageMediaConverter,
     BackwardPolygonAnnotationConverter,
+    BackwardRotatedBboxAnnotationConverter,
     ForwardBboxAnnotationConverter,
     ForwardImageMediaConverter,
     ForwardPolygonAnnotationConverter,
+    ForwardRotatedBboxAnnotationConverter,
     analyze_experimental_dataset,
     analyze_legacy_dataset,
     convert_from_legacy,
@@ -815,6 +825,16 @@ class DetectionSample(Sample):
     ]
 
 
+class RotatedDetectionSample(Sample):
+    image_path: Annotated[str, image_path_field()]
+    rotated_bboxes: Annotated[
+        np.ndarray[Any, np.dtype[np.float32]], rotated_bbox_field(dtype=pl.Float32)
+    ]
+    rotated_bbox_labels: Annotated[
+        np.ndarray[Any, np.dtype[np.int32]], label_field(dtype=pl.Int32, multi_label=True)
+    ]
+
+
 def test_convert_to_legacy_simple():
     """Test basic convert_to_legacy functionality."""
     # Create experimental dataset with sample data
@@ -1416,3 +1436,307 @@ def test_polygon_conversion_without_labels():
         restored_polygon = polygon_anns[0]
         assert restored_polygon.points == [10, 20, 30, 25, 20, 40]
         assert restored_polygon.label is None
+
+
+def test_forward_rotated_bbox_annotation_converter_get_schema_attributes():
+    """Test schema attribute generation for rotated bboxes."""
+    categories: CategoriesInfo = {}  # Empty categories
+    converter = ForwardRotatedBboxAnnotationConverter.create_from_categories(categories)
+    assert converter is not None
+    attributes = converter.get_schema_attributes()
+
+    assert "rotated_bboxes" in attributes
+    # rotated_bbox_labels should not be present when there are no label categories
+    assert "rotated_bbox_labels" not in attributes
+    assert attributes["rotated_bboxes"].type == np.ndarray
+
+
+def test_forward_rotated_bbox_annotation_converter_convert_annotations():
+    """Test rotated bbox annotation conversion."""
+    import math
+
+    # Create categories with labels
+    label_categories = LabelCategories()
+    label_categories.add("class_1")
+    label_categories.add("class_2")
+    categories: CategoriesInfo = {AnnotationType.label: label_categories}
+
+    converter = ForwardRotatedBboxAnnotationConverter.create_from_categories(categories)
+    assert converter is not None
+
+    # Create rotated bbox annotations: RotatedBbox(cx, cy, w, h, r_degrees, ...)
+    rotated_bbox1 = RotatedBbox(50, 60, 30, 20, 45.0, label=0)  # 45 degrees
+    rotated_bbox2 = RotatedBbox(100, 120, 40, 25, -30.0, label=1)  # -30 degrees
+
+    annotations = [rotated_bbox1, rotated_bbox2]
+    item = DatasetItem(id="test")
+
+    result = converter.convert_annotations(annotations, item)
+
+    assert "rotated_bboxes" in result
+    assert "rotated_bbox_labels" in result
+
+    # Check rotated bbox data (should be converted to radians)
+    rotated_bboxes = result["rotated_bboxes"]
+    assert len(rotated_bboxes) == 2
+
+    # First rotated bbox: (50, 60, 30, 20, 45°) -> (50, 60, 30, 20, π/4 radians)
+    assert abs(rotated_bboxes[0, 0] - 50.0) < 1e-6
+    assert abs(rotated_bboxes[0, 1] - 60.0) < 1e-6
+    assert abs(rotated_bboxes[0, 2] - 30.0) < 1e-6
+    assert abs(rotated_bboxes[0, 3] - 20.0) < 1e-6
+    assert abs(rotated_bboxes[0, 4] - math.radians(45.0)) < 1e-6
+
+    # Second rotated bbox: (100, 120, 40, 25, -30°) -> (100, 120, 40, 25, -π/6 radians)
+    assert abs(rotated_bboxes[1, 0] - 100.0) < 1e-6
+    assert abs(rotated_bboxes[1, 1] - 120.0) < 1e-6
+    assert abs(rotated_bboxes[1, 2] - 40.0) < 1e-6
+    assert abs(rotated_bboxes[1, 3] - 25.0) < 1e-6
+    assert abs(rotated_bboxes[1, 4] - math.radians(-30.0)) < 1e-6
+
+    # Check labels
+    labels = result["rotated_bbox_labels"]
+    assert len(labels) == 2
+    assert labels[0] == 0
+    assert labels[1] == 1
+
+
+def test_backward_rotated_bbox_annotation_converter_create_from_schema():
+    """Test backward rotated bbox converter creation from schema."""
+    from datumaro.experimental.fields import LabelField, RotatedBBoxField
+    from datumaro.experimental.schema import AttributeInfo, Schema
+
+    # Create schema with rotated bbox attributes
+    attributes = {
+        "rotated_bboxes": AttributeInfo(
+            type=np.ndarray,
+            annotation=rotated_bbox_field(dtype=pl.Float32),
+        ),
+        "rotated_bbox_labels": AttributeInfo(
+            type=np.ndarray,
+            annotation=label_field(is_list=True),
+        ),
+    }
+    schema = Schema(attributes=attributes)
+
+    converter = BackwardRotatedBboxAnnotationConverter.create_from_schema(schema)
+    assert converter is not None
+    assert converter.rotated_bboxes_attr == "rotated_bboxes"
+    assert converter.rotated_bbox_labels_attr == "rotated_bbox_labels"
+
+
+def test_backward_rotated_bbox_annotation_converter_convert_to_legacy():
+    """Test backward conversion from experimental to legacy rotated bbox format."""
+    import math
+
+    from datumaro.experimental.fields import LabelField, RotatedBBoxField
+    from datumaro.experimental.schema import AttributeInfo, Schema
+
+    # Create experimental dataset with rotated bbox data
+    rotated_bbox_data = np.array(
+        [
+            [50.0, 60.0, 30.0, 20.0, math.radians(45.0)],  # 45 degrees in radians
+            [100.0, 120.0, 40.0, 25.0, math.radians(-30.0)],  # -30 degrees in radians
+        ],
+        dtype=np.float32,
+    )
+
+    label_data = np.array([0, 1], dtype=np.int32)
+
+    # Create experimental dataset and add sample with rotated bbox data
+    experimental_dataset = Dataset(RotatedDetectionSample)
+
+    sample = RotatedDetectionSample(
+        image_path="/path/to/test.jpg",
+        rotated_bboxes=rotated_bbox_data,
+        rotated_bbox_labels=label_data,
+    )
+    experimental_dataset.append(sample)
+
+    # Create categories for testing
+    categories: CategoriesInfo = {
+        AnnotationType.label: LabelCategories(),
+    }
+
+    # Create converter
+    attributes = {
+        "rotated_bboxes": AttributeInfo(
+            type=np.ndarray,
+            annotation=rotated_bbox_field(dtype=pl.Float32),
+        ),
+        "rotated_bbox_labels": AttributeInfo(
+            type=np.ndarray,
+            annotation=label_field(is_list=True),
+        ),
+    }
+    schema = Schema(attributes=attributes)
+
+    converter = BackwardRotatedBboxAnnotationConverter.create_from_schema(schema)
+    assert converter is not None
+
+    # Convert to legacy annotations
+    annotations = converter.convert_to_legacy_annotations(sample, categories)
+
+    # Check results
+    assert len(annotations) == 2
+
+    # Check first rotated bbox (should be converted back to degrees)
+    rotated_bbox1 = annotations[0]
+    assert isinstance(rotated_bbox1, RotatedBbox)
+    assert abs(rotated_bbox1.cx - 50.0) < 1e-5
+    assert abs(rotated_bbox1.cy - 60.0) < 1e-5
+    assert abs(rotated_bbox1.w - 30.0) < 1e-5
+    assert abs(rotated_bbox1.h - 20.0) < 1e-5
+    assert abs(rotated_bbox1.r - 45.0) < 1e-5  # Back to degrees
+    assert rotated_bbox1.label == 0
+
+    # Check second rotated bbox
+    rotated_bbox2 = annotations[1]
+    assert isinstance(rotated_bbox2, RotatedBbox)
+    assert abs(rotated_bbox2.cx - 100.0) < 1e-5
+    assert abs(rotated_bbox2.cy - 120.0) < 1e-5
+    assert abs(rotated_bbox2.w - 40.0) < 1e-5
+    assert abs(rotated_bbox2.h - 25.0) < 1e-5
+    assert abs(rotated_bbox2.r - (-30.0)) < 1e-5  # Back to degrees
+    assert rotated_bbox2.label == 1
+
+
+def test_rotated_bbox_conversion_with_labels():
+    """Test end-to-end rotated bbox conversion with labels."""
+    import math
+
+    # Create legacy dataset with rotated bbox and label categories
+    label_categories = LabelCategories()
+    label_categories.add("person")
+    label_categories.add("car")
+
+    items = [
+        DatasetItem(
+            id="test_item",
+            media=Image.from_file("test.jpg", size=(200, 150)),
+            annotations=[
+                RotatedBbox(75, 50, 40, 30, 30.0, label=0),  # person
+                RotatedBbox(125, 100, 60, 40, -45.0, label=1),  # car
+            ],
+        )
+    ]
+
+    legacy_dataset = LegacyDataset.from_iterable(
+        items,
+        ann_types={AnnotationType.rotated_bbox},
+        categories={AnnotationType.label: label_categories},
+    )
+
+    # Convert to experimental format
+    experimental_dataset = convert_from_legacy(legacy_dataset)
+
+    # Check experimental dataset
+    assert len(experimental_dataset) == 1
+    exp_sample = experimental_dataset[0]
+
+    # Check rotated bbox data
+    assert hasattr(exp_sample, "rotated_bboxes")
+    assert hasattr(exp_sample, "rotated_bbox_labels")
+
+    rotated_bboxes = exp_sample.rotated_bboxes
+    labels = exp_sample.rotated_bbox_labels
+
+    assert len(rotated_bboxes) == 2
+    assert len(labels) == 2
+
+    # Verify first rotated bbox (converted to radians)
+    assert abs(rotated_bboxes[0, 0] - 75.0) < 1e-6  # cx
+    assert abs(rotated_bboxes[0, 1] - 50.0) < 1e-6  # cy
+    assert abs(rotated_bboxes[0, 2] - 40.0) < 1e-6  # w
+    assert abs(rotated_bboxes[0, 3] - 30.0) < 1e-6  # h
+    assert abs(rotated_bboxes[0, 4] - math.radians(30.0)) < 1e-6  # r in radians
+    assert labels[0] == 0
+
+    # Verify second rotated bbox
+    assert abs(rotated_bboxes[1, 0] - 125.0) < 1e-6  # cx
+    assert abs(rotated_bboxes[1, 1] - 100.0) < 1e-6  # cy
+    assert abs(rotated_bboxes[1, 2] - 60.0) < 1e-6  # w
+    assert abs(rotated_bboxes[1, 3] - 40.0) < 1e-6  # h
+    assert abs(rotated_bboxes[1, 4] - math.radians(-45.0)) < 1e-6  # r in radians
+    assert labels[1] == 1
+
+    # Convert back to legacy format
+    restored_legacy_dataset = convert_to_legacy(experimental_dataset)
+
+    # Verify restored dataset
+    restored_items = list(restored_legacy_dataset)
+    assert len(restored_items) == 1
+
+    restored_item = restored_items[0]
+    rotated_bbox_anns = [ann for ann in restored_item.annotations if isinstance(ann, RotatedBbox)]
+    assert len(rotated_bbox_anns) == 2
+
+    # Check restored first rotated bbox (should be back to degrees)
+    restored_bbox1 = rotated_bbox_anns[0]
+    assert abs(restored_bbox1.cx - 75.0) < 1e-5
+    assert abs(restored_bbox1.cy - 50.0) < 1e-5
+    assert abs(restored_bbox1.w - 40.0) < 1e-5
+    assert abs(restored_bbox1.h - 30.0) < 1e-5
+    assert abs(restored_bbox1.r - 30.0) < 1e-5  # Back to degrees
+    assert restored_bbox1.label == 0
+
+    # Check restored second rotated bbox
+    restored_bbox2 = rotated_bbox_anns[1]
+    assert abs(restored_bbox2.cx - 125.0) < 1e-5
+    assert abs(restored_bbox2.cy - 100.0) < 1e-5
+    assert abs(restored_bbox2.w - 60.0) < 1e-5
+    assert abs(restored_bbox2.h - 40.0) < 1e-5
+    assert abs(restored_bbox2.r - (-45.0)) < 1e-5  # Back to degrees
+    assert restored_bbox2.label == 1
+
+
+def test_rotated_bbox_conversion_without_labels():
+    """Test rotated bbox conversion without label categories."""
+
+    # Create legacy dataset with rotated bbox but no label categories
+    items = [
+        DatasetItem(
+            id="test_item",
+            media=Image.from_file("test.jpg", size=(100, 100)),
+            annotations=[
+                RotatedBbox(50, 50, 20, 30, 0.0),  # No label, no rotation
+                RotatedBbox(25, 75, 10, 15, 90.0),  # No label, 90 degrees
+            ],
+        )
+    ]
+
+    legacy_dataset = LegacyDataset.from_iterable(items, ann_types={AnnotationType.rotated_bbox})
+
+    # Convert to experimental format
+    experimental_dataset = convert_from_legacy(legacy_dataset)
+
+    # Check experimental dataset
+    assert len(experimental_dataset) == 1
+    exp_sample = experimental_dataset[0]
+
+    # Should have rotated_bboxes but not rotated_bbox_labels
+    assert hasattr(exp_sample, "rotated_bboxes")
+    assert not hasattr(exp_sample, "rotated_bbox_labels")
+
+    rotated_bboxes = exp_sample.rotated_bboxes
+    assert len(rotated_bboxes) == 2
+
+    # Verify rotated bbox data
+    assert abs(rotated_bboxes[0, 0] - 50.0) < 1e-6  # cx
+    assert abs(rotated_bboxes[0, 1] - 50.0) < 1e-6  # cy
+    assert abs(rotated_bboxes[1, 4] - math.radians(90.0)) < 1e-6  # 90 degrees in radians
+
+    # Convert back to legacy format
+    restored_legacy_dataset = convert_to_legacy(experimental_dataset)
+
+    # Verify restored dataset
+    restored_items = list(restored_legacy_dataset)
+    assert len(restored_items) == 1
+
+    restored_item = restored_items[0]
+    rotated_bbox_anns = [ann for ann in restored_item.annotations if isinstance(ann, RotatedBbox)]
+    assert len(rotated_bbox_anns) == 2
+
+    # Check that labels are None (since we didn't have label categories)
+    for bbox in rotated_bbox_anns:
+        assert bbox.label is None

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -1,5 +1,6 @@
 """Unit tests for legacy dataset conversion functionality."""
 
+import io
 import math
 import tempfile
 from pathlib import Path
@@ -8,6 +9,7 @@ from typing import Any, cast
 import numpy as np
 import polars as pl
 import pytest
+from PIL import Image as PILImage
 from typing_extensions import Annotated
 
 from datumaro.components.annotation import (
@@ -392,9 +394,6 @@ def test_convert_from_legacy_with_image_paths():
 
 def test_convert_from_legacy_with_callable_image_data():
     """Test conversion with ImageFromData containing callable _data."""
-    import io
-
-    from PIL import Image as PILImage
 
     # Create test image bytes
     test_image1 = np.random.randint(0, 256, (32, 32, 3), dtype=np.uint8)
@@ -460,9 +459,6 @@ def test_convert_from_legacy_with_callable_image_data():
 
 def test_image_converter_with_mixed_callable_and_bytes_data():
     """Test that mixed callable and non-callable data uses callable field."""
-    import io
-
-    from PIL import Image as PILImage
 
     # Create test image bytes
     test_image = np.random.randint(0, 256, (16, 16, 3), dtype=np.uint8)
@@ -1453,7 +1449,6 @@ def test_forward_rotated_bbox_annotation_converter_get_schema_attributes():
 
 def test_forward_rotated_bbox_annotation_converter_convert_annotations():
     """Test rotated bbox annotation conversion."""
-    import math
 
     # Create categories with labels
     label_categories = LabelCategories()
@@ -1503,8 +1498,6 @@ def test_forward_rotated_bbox_annotation_converter_convert_annotations():
 
 def test_backward_rotated_bbox_annotation_converter_create_from_schema():
     """Test backward rotated bbox converter creation from schema."""
-    from datumaro.experimental.fields import LabelField, RotatedBBoxField
-    from datumaro.experimental.schema import AttributeInfo, Schema
 
     # Create schema with rotated bbox attributes
     attributes = {
@@ -1527,10 +1520,6 @@ def test_backward_rotated_bbox_annotation_converter_create_from_schema():
 
 def test_backward_rotated_bbox_annotation_converter_convert_to_legacy():
     """Test backward conversion from experimental to legacy rotated bbox format."""
-    import math
-
-    from datumaro.experimental.fields import LabelField, RotatedBBoxField
-    from datumaro.experimental.schema import AttributeInfo, Schema
 
     # Create experimental dataset with rotated bbox data
     rotated_bbox_data = np.array(
@@ -1603,7 +1592,6 @@ def test_backward_rotated_bbox_annotation_converter_convert_to_legacy():
 
 def test_rotated_bbox_conversion_with_labels():
     """Test end-to-end rotated bbox conversion with labels."""
-    import math
 
     # Create legacy dataset with rotated bbox and label categories
     label_categories = LabelCategories()

--- a/tests/unit/experimental/test_schema.py
+++ b/tests/unit/experimental/test_schema.py
@@ -18,6 +18,7 @@ from datumaro.experimental.fields import (
     ImageInfoField,
     ImagePathField,
     PolygonField,
+    RotatedBBoxField,
     TensorField,
     bbox_field,
     image_bytes_field,
@@ -26,6 +27,7 @@ from datumaro.experimental.fields import (
     image_info_field,
     image_path_field,
     polygon_field,
+    rotated_bbox_field,
     tensor_field,
 )
 from datumaro.experimental.schema import AttributeInfo, Schema, Semantic
@@ -182,6 +184,60 @@ def test_bbox_field_polars_conversion():
 
     assert isinstance(reconstructed, np.ndarray)
     assert np.allclose(reconstructed, test_bbox)
+
+
+def test_rotated_bbox_field_creation():
+    """Test RotatedBBoxField creation and properties."""
+    field = rotated_bbox_field(
+        dtype=pl.Float32, format="cxcywhr", normalize=True, semantic=Semantic.Default
+    )
+
+    assert isinstance(field, RotatedBBoxField)
+    assert field.dtype == pl.Float32
+    assert field.format == "cxcywhr"
+    assert field.normalize is True
+    assert field.semantic == Semantic.Default
+
+
+def test_rotated_bbox_field_creation_defaults():
+    """Test RotatedBBoxField creation with default values."""
+    field = rotated_bbox_field(dtype=pl.Float32)
+
+    assert isinstance(field, RotatedBBoxField)
+    assert field.dtype == pl.Float32
+    assert field.format == "cxcywhr"  # Default format
+    assert field.normalize is False  # Default normalization
+    assert field.semantic == Semantic.Default  # Default semantic
+
+
+def test_rotated_bbox_field_polars_schema():
+    """Test RotatedBBoxField Polars schema generation."""
+    field = rotated_bbox_field(dtype=pl.Float32)
+    schema = field.to_polars_schema("rotated_bbox")
+
+    expected = {"rotated_bbox": pl.List(pl.Array(pl.Float32, 5))}
+    assert schema == expected
+
+
+def test_rotated_bbox_field_polars_conversion():
+    """Test RotatedBBoxField to/from Polars conversion."""
+    field = cast(RotatedBBoxField, rotated_bbox_field(dtype=pl.Float32, normalize=False))
+    # Test with rotated bboxes: [cx, cy, w, h, r]
+    test_rotated_bbox = np.array(
+        [[50.0, 60.0, 30.0, 20.0, 0.785], [100.0, 120.0, 40.0, 25.0, 1.57]], dtype=np.float32
+    )
+
+    # Test to_polars
+    polars_data = field.to_polars("rotated_bbox", test_rotated_bbox)
+    assert "rotated_bbox" in polars_data
+    assert isinstance(polars_data["rotated_bbox"], pl.Series)
+
+    # Create DataFrame and test from_polars
+    df = pl.DataFrame(polars_data)
+    reconstructed = cast(np.ndarray[Any, Any], field.from_polars("rotated_bbox", 0, df, np.ndarray))
+
+    assert isinstance(reconstructed, np.ndarray)
+    assert np.allclose(reconstructed, test_rotated_bbox)
 
 
 def test_image_info_creation():


### PR DESCRIPTION
This pull request adds comprehensive support for rotated bounding boxes to the Datumaro experimental API, including new field types, converters, legacy compatibility, and unit tests. The changes enable handling rotated bounding box data throughout the annotation pipeline, including conversion to polygons and interoperability with legacy formats.

**Rotated Bounding Box Support**

* Introduced the `RotatedBBoxField` dataclass and `rotated_bbox_field` factory function to represent rotated bounding box data, supporting different formats and normalization. (`src/datumaro/experimental/fields.py`, [src/datumaro/experimental/fields.pyR215-R278](diffhunk://#diff-15c4d88a12c4710b96d3ee5bc5ceed34002cd9e746d88e66e5e8005d0644bfb7R215-R278))
* Registered `RotatedBBoxField` and `rotated_bbox_field` in all relevant experimental modules for annotation schemas and converters. (`src/datumaro/experimental/__init__.py`, [[1]](diffhunk://#diff-6c66a059cb4075cd7afbc29b4f34236f8101a1a47cdcc429c7a2d25868cc74b5R14-R22); `src/datumaro/experimental/converters.py`, [[2]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3R35); `src/datumaro/experimental/legacy.py`, [[3]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5R37-R45)

**Converters and Annotation Processing**

* Added `RotatedBBoxToPolygonConverter` to transform rotated bounding boxes into polygon corner points, with corresponding unit tests for correctness. (`src/datumaro/experimental/converters.py`, [[1]](diffhunk://#diff-3f9f0dd688c31e641cd286586053d2fc7d0f4a479a20c943739dbe081119a1a3R935-R1004); `tests/unit/experimental/test_converters.py`, [[2]](diffhunk://#diff-f7d8d115b4530c510a92b0dbc1a1174ca351f0c2767fd8137a2da599fff8b484R31) [[3]](diffhunk://#diff-f7d8d115b4530c510a92b0dbc1a1174ca351f0c2767fd8137a2da599fff8b484R1875-R1950)
* Implemented forward and backward annotation converters for rotated bounding boxes, enabling conversion between experimental and legacy formats (including angle conversion between radians and degrees). (`src/datumaro/experimental/legacy.py`, [[1]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5R344-R425) [[2]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5R791-R873)
* Registered the new converters for automatic use in the annotation conversion system. (`src/datumaro/experimental/legacy.py`, [[1]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5R517) [[2]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5R1077)

**Legacy API and Testing**

* Extended legacy API support for rotated bounding boxes, including import/export and category inference. (`src/datumaro/experimental/legacy.py`, [[1]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5L23-R24) [[2]](diffhunk://#diff-aa35f06eaa7d35ff5ffa7077e181ed0b773549c22d42a92e78e076947f9b88f5R791-R873)
* Added test samples and cases for rotated bounding box fields and converters, ensuring correct interoperability and conversion. (`tests/unit/experimental/test_legacy.py`, [[1]](diffhunk://#diff-68bad0abf07432874f6f4833b34619b0c142c223adb4659fc7363725102c2c9cL12-R19) [[2]](diffhunk://#diff-68bad0abf07432874f6f4833b34619b0c142c223adb4659fc7363725102c2c9cR32-R43) [[3]](diffhunk://#diff-68bad0abf07432874f6f4833b34619b0c142c223adb4659fc7363725102c2c9cR828-R837)

These changes collectively enable robust rotated bounding box handling in both experimental and legacy Datumaro workflows.
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
