### PR TITLE
Rename bbox_labels and polyon_labels to labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This release streamlines Datumaro by removing a number of lesser-used features, 
 
 ### New features
 - Experimental dataset class
-  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>, <https://github.com/open-edge-platform/datumaro/pull/1868>, <https://github.com/open-edge-platform/datumaro/pull/1876>, <https://github.com/open-edge-platform/datumaro/pull/1877>, <https://github.com/open-edge-platform/datumaro/pull/1879>)
+  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>, <https://github.com/open-edge-platform/datumaro/pull/1868>, <https://github.com/open-edge-platform/datumaro/pull/1876>, <https://github.com/open-edge-platform/datumaro/pull/1877>, <https://github.com/open-edge-platform/datumaro/pull/1879>, <https://github.com/open-edge-platform/datumaro/pull/1881>)
 
 ### Enhancements
 - Mark several dependencies as optional

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -309,7 +309,7 @@ class ForwardBboxAnnotationConverter(ForwardAnnotationConverter):
     def get_schema_attributes(self) -> dict[str, AttributeInfo]:
         attributes = {"bboxes": self.bbox_attribute}
         if self.bbox_labels_attribute is not None:
-            attributes["bbox_labels"] = self.bbox_labels_attribute
+            attributes["labels"] = self.bbox_labels_attribute
         return attributes
 
     def convert_annotations(
@@ -333,7 +333,7 @@ class ForwardBboxAnnotationConverter(ForwardAnnotationConverter):
 
         # Only add bbox_labels if we have label categories
         if self.bbox_labels_attribute is not None:
-            result["bbox_labels"] = np.array(labels, dtype=np.int32)
+            result["labels"] = np.array(labels, dtype=np.int32)
 
         return result
 
@@ -386,7 +386,7 @@ class ForwardPolygonAnnotationConverter(ForwardAnnotationConverter):
     def get_schema_attributes(self) -> dict[str, AttributeInfo]:
         attributes = {"polygons": self.polygon_attribute}
         if self.polygon_labels_attribute is not None:
-            attributes["polygon_labels"] = self.polygon_labels_attribute
+            attributes["labels"] = self.polygon_labels_attribute
         return attributes
 
     def convert_annotations(
@@ -415,7 +415,7 @@ class ForwardPolygonAnnotationConverter(ForwardAnnotationConverter):
 
         # Only add polygon_labels if we have label categories
         if self.polygon_labels_attribute is not None:
-            result["polygon_labels"] = np.array(labels, dtype=np.int32)
+            result["labels"] = np.array(labels, dtype=np.int32)
 
         return result
 

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -531,7 +531,7 @@ def test_bbox_annotation_converter_convert_annotations_single_bbox():
     expected_labels = np.array([1], dtype=np.int32)
 
     np.testing.assert_array_equal(result["bboxes"], expected_bbox)
-    np.testing.assert_array_equal(result["bbox_labels"], expected_labels)
+    np.testing.assert_array_equal(result["labels"], expected_labels)
 
 
 def test_bbox_annotation_converter_convert_annotations_multiple_bboxes():
@@ -562,7 +562,7 @@ def test_bbox_annotation_converter_convert_annotations_multiple_bboxes():
     expected_labels = np.array([1, 2], dtype=np.int32)
 
     np.testing.assert_array_equal(result["bboxes"], expected_bboxes)
-    np.testing.assert_array_equal(result["bbox_labels"], expected_labels)
+    np.testing.assert_array_equal(result["labels"], expected_labels)
 
 
 def test_bbox_annotation_converter_convert_annotations_empty_list():
@@ -652,7 +652,7 @@ def test_analyze_image_and_bbox_dataset():
         # Should have image and bbox attributes
         assert "image_path" in analysis_result.schema.attributes
         assert "bboxes" in analysis_result.schema.attributes
-        assert "bbox_labels" in analysis_result.schema.attributes
+        assert "labels" in analysis_result.schema.attributes
 
 
 def test_analyze_image_only_dataset():
@@ -740,7 +740,7 @@ def test_convert_simple_bbox_dataset():
         assert hasattr(sample, "image_path")
         assert Path(getattr(sample, "image_path")) == Path(image_path)
         assert hasattr(sample, "bboxes")
-        assert hasattr(sample, "bbox_labels")
+        assert hasattr(sample, "labels")
 
         expected_bboxes = np.array(
             [
@@ -752,7 +752,7 @@ def test_convert_simple_bbox_dataset():
         expected_labels = np.array([1, 2], dtype=np.int32)
 
         np.testing.assert_array_equal(getattr(sample, "bboxes"), expected_bboxes)
-        np.testing.assert_array_equal(getattr(sample, "bbox_labels"), expected_labels)
+        np.testing.assert_array_equal(getattr(sample, "labels"), expected_labels)
 
 
 def test_convert_empty_dataset():
@@ -1201,7 +1201,7 @@ def test_forward_polygon_annotation_converter_convert_annotations():
     result = converter.convert_annotations(annotations, item)
 
     assert "polygons" in result
-    assert "polygon_labels" in result
+    assert "labels" in result
 
     # Check polygon data
     polygons = result["polygons"]
@@ -1214,7 +1214,7 @@ def test_forward_polygon_annotation_converter_convert_annotations():
     assert np.all(polygons[1] == [[20, 20], [30, 20], [30, 30], [20, 30]])
 
     # Check labels
-    labels = result["polygon_labels"]
+    labels = result["labels"]
     assert len(labels) == 2
     assert labels[0] == 1
     assert labels[1] == 2
@@ -1323,9 +1323,9 @@ def test_polygon_conversion_with_labels():
         assert len(experimental_dataset) == 1
         exp_sample = experimental_dataset[0]
 
-        # Check that polygons and polygon_labels are present
+        # Check that polygons and labels are present
         assert hasattr(exp_sample, "polygons")
-        assert hasattr(exp_sample, "polygon_labels")
+        assert hasattr(exp_sample, "labels")
 
         # Check polygon data
         assert len(exp_sample.polygons) == 2
@@ -1335,7 +1335,7 @@ def test_polygon_conversion_with_labels():
         )  # Rectangle
 
         # Check labels
-        np.testing.assert_array_equal(exp_sample.polygon_labels, [1, 2])
+        np.testing.assert_array_equal(exp_sample.labels, [1, 2])
 
         # Convert back to legacy format
         restored_legacy_dataset = convert_to_legacy(experimental_dataset)

--- a/tests/unit/experimental/test_legacy_integration.py
+++ b/tests/unit/experimental/test_legacy_integration.py
@@ -84,7 +84,7 @@ def test_object_detection(
         assert "bboxes" in schema.attributes
         assert "image_path" in schema.attributes
         assert "bboxes" in schema.attributes
-        assert "bbox_labels" in schema.attributes
+        assert "labels" in schema.attributes
 
         # Verify data conversion for first few samples
         for legacy_item, experimental_sample in zip(legacy_dataset, experimental_dataset):
@@ -95,7 +95,7 @@ def test_object_detection(
 
             # Check bbox data
             assert hasattr(experimental_sample, "bboxes")
-            assert hasattr(experimental_sample, "bbox_labels")
+            assert hasattr(experimental_sample, "labels")
 
             # Get bbox annotations from legacy item
             bbox_anns = [ann for ann in legacy_item.annotations if isinstance(ann, Bbox)]
@@ -103,7 +103,7 @@ def test_object_detection(
 
             # Verify bbox array shape and values
             bboxes = getattr(experimental_sample, "bboxes")
-            labels = getattr(experimental_sample, "bbox_labels")
+            labels = getattr(experimental_sample, "labels")
 
             assert bboxes.shape[0] == len(bbox_anns)
             assert bboxes.shape[1] == 4  # x1, y1, x2, y2


### PR DESCRIPTION
Some datasets like COCO have multiple shapes like bounding box and polygon for the same annotation. Those annotation shapes share the same labels but since the legacy Datumaro dataset does not support sharing the labels, they are duplicated.

When converting to the new dataset format, we do not want to create separate fields for the bounding box and polygon labels because they are the same and trying to create multiple fields of the same type result in a conflict. Therefore, we use the same name both the bounding box and polygon labels. This means that the bounding and polygon converters will overwrite each others labels but this is not a problem since the values are the same. In the future, it would be better to add validation for that.

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
