### PR TITLE
Rotated BBox support for CVAT

### DIFF
--- a/src/datumaro/plugins/data_formats/cvat/base.py
+++ b/src/datumaro/plugins/data_formats/cvat/base.py
@@ -19,6 +19,7 @@ from datumaro.components.annotation import (
     Points,
     Polygon,
     PolyLine,
+    RotatedBbox,
 )
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import DatasetImportError
@@ -149,6 +150,7 @@ class CvatBase(SubsetBase):
                     shape["z_order"] = int(el.attrib.get("z_order", 0))
 
                     if el.tag == "box":
+                        # Get box coordinates
                         shape["points"] = list(
                             map(
                                 float,
@@ -160,6 +162,10 @@ class CvatBase(SubsetBase):
                                 ],
                             )
                         )
+
+                        # Check if rotation is present
+                        if "rotation" in el.attrib:
+                            shape["rotation"] = float(el.attrib.get("rotation", "0"))
                     elif el.tag == "mask":
                         shape["rle"] = el.attrib["rle"]
                         shape["left"] = el.attrib["left"]
@@ -303,11 +309,34 @@ class CvatBase(SubsetBase):
             )
 
         elif ann_type == "box":
-            x, y = points[0], points[1]
-            w, h = points[2] - x, points[3] - y
+            x1, y1 = points[0], points[1]  # xtl, ytl
+            x2, y2 = points[2], points[3]  # xbr, ybr
+            w = x2 - x1
+            h = y2 - y1
+
+            # If rotation is present, convert to RotatedBbox
+            if "rotation" in ann:
+                # Convert from CVAT format (xtl,ytl,xbr,ybr + rotation)
+                # to Datumaro format (cx,cy,w,h,r)
+                cx = (x1 + x2) / 2
+                cy = (y1 + y2) / 2
+                return RotatedBbox(
+                    cx,
+                    cy,
+                    w,
+                    h,
+                    float(ann["rotation"]),
+                    label=label_id,
+                    z_order=z_order,
+                    id=ann_id,
+                    attributes=attributes,
+                    group=group,
+                )
+
+            # Otherwise use regular Bbox
             return Bbox(
-                x,
-                y,
+                x1,
+                y1,
                 w,
                 h,
                 label=label_id,

--- a/src/datumaro/plugins/data_formats/cvat/exporter.py
+++ b/src/datumaro/plugins/data_formats/cvat/exporter.py
@@ -387,6 +387,30 @@ class _SubsetWriter:
                     ]
                 )
             )
+        elif shape.type == AnnotationType.rotated_bbox:
+            # Convert from Datumaro format (cx,cy,w,h,r)
+            # to CVAT format (xtl,ytl,xbr,ybr + rotation)
+            cx, cy = shape.points[0], shape.points[1]
+            w, h = shape.points[2], shape.points[3]
+            rotation = shape.points[4]
+
+            # Calculate corners from center coordinates
+            xtl = cx - w / 2
+            ytl = cy - h / 2
+            xbr = cx + w / 2
+            ybr = cy + h / 2
+
+            shape_data.update(
+                OrderedDict(
+                    [
+                        ("xtl", "{:.2f}".format(xtl)),
+                        ("ytl", "{:.2f}".format(ytl)),
+                        ("xbr", "{:.2f}".format(xbr)),
+                        ("ybr", "{:.2f}".format(ybr)),
+                        ("rotation", "{:.2f}".format(rotation)),
+                    ]
+                )
+            )
         elif shape.type == AnnotationType.mask:
             # From the manual test for the dataset exported from the CVAT 2.5,
             # the RLE encoding in the dataset has (W, H) binary 2D np.ndarray, not (H, W)
@@ -424,7 +448,7 @@ class _SubsetWriter:
         if shape.group:
             shape_data["group_id"] = str(shape.group)
 
-        if shape.type == AnnotationType.bbox:
+        if shape.type in [AnnotationType.bbox, AnnotationType.rotated_bbox]:
             self._writer.open_box(shape_data)
         elif shape.type == AnnotationType.polygon:
             self._writer.open_polygon(shape_data)
@@ -464,7 +488,7 @@ class _SubsetWriter:
                         label_name,
                     )
 
-        if shape.type == AnnotationType.bbox:
+        if shape.type in [AnnotationType.bbox, AnnotationType.rotated_bbox]:
             self._writer.close_box()
         elif shape.type == AnnotationType.polygon:
             self._writer.close_polygon()

--- a/src/datumaro/plugins/data_formats/cvat/format.py
+++ b/src/datumaro/plugins/data_formats/cvat/format.py
@@ -22,6 +22,7 @@ class CvatPath:
     }
     SUPPORTED_EXPORT_SHAPES = {
         AnnotationType.bbox,
+        AnnotationType.rotated_bbox,
         AnnotationType.polygon,
         AnnotationType.polyline,
         AnnotationType.points,

--- a/tests/unit/test_cvat_format.py
+++ b/tests/unit/test_cvat_format.py
@@ -14,6 +14,7 @@ from datumaro.components.annotation import (
     Points,
     Polygon,
     PolyLine,
+    RotatedBbox,
 )
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
@@ -355,6 +356,14 @@ class CvatExporterTest(TestCase):
                     media=Image.from_numpy(data=np.zeros((5, 10, 3))),
                     annotations=[Mask(image=mask, z_order=1, label=3, group=4)],
                 ),
+                DatasetItem(
+                    id=4,
+                    subset="s4",
+                    media=Image.from_numpy(data=np.ones((5, 10, 3))),
+                    annotations=[
+                        RotatedBbox(1, 10, 5, 5, 45, label=0, attributes={"occluded": False}),
+                    ],
+                ),
             ],
             categories={AnnotationType.label: src_label_cat},
         )
@@ -427,6 +436,15 @@ class CvatExporterTest(TestCase):
                             group=4,
                             attributes={"occluded": False},
                         )
+                    ],
+                    attributes={"frame": 0},
+                ),
+                DatasetItem(
+                    id=4,
+                    subset="s4",
+                    media=Image.from_numpy(data=np.ones((5, 10, 3))),
+                    annotations=[
+                        RotatedBbox(1, 10, 5, 5, 45, label=0, attributes={"occluded": False}),
                     ],
                     attributes={"frame": 0},
                 ),


### PR DESCRIPTION
This PR adds support for rotated bounding boxes in the CVAT importer and exporter.

Fixes #1887

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
