### PR TITLE
Fix regression in the validate command.

### DIFF
--- a/src/datumaro/cli/commands/validate.py
+++ b/src/datumaro/cli/commands/validate.py
@@ -89,6 +89,17 @@ def validate_command(args):
     validator = validator_type(**extra_args)
     reports = validator.validate(dataset)
 
+    def _make_serializable(d):
+        for key, val in list(d.items()):
+            # tuple key to str
+            if isinstance(key, tuple) or isinstance(key, int):
+                d[str(key)] = val
+                d.pop(key)
+            if isinstance(val, dict):
+                _make_serializable(val)
+
+    _make_serializable(reports)
+
     # Save the validation report
     dst_file = generate_next_file_name("validation_report", ext=".json")
     log.info("Writing validation report to '%s'" % dst_file)


### PR DESCRIPTION
The command failed because some dictionary keys were not converted to a string before seralising to JSON. This PR restores the conversion code.



<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
