### PR TITLE
Make Polars optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This release streamlines Datumaro by removing a number of lesser-used features, 
 
 ### New features
 - Experimental dataset class
-  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>, <https://github.com/open-edge-platform/datumaro/pull/1868>, <https://github.com/open-edge-platform/datumaro/pull/1876>, <https://github.com/open-edge-platform/datumaro/pull/1877>, <https://github.com/open-edge-platform/datumaro/pull/1879>, <https://github.com/open-edge-platform/datumaro/pull/1881>)
+  (<https://github.com/open-edge-platform/datumaro/pull/1807>, <https://github.com/open-edge-platform/datumaro/pull/1810>, <https://github.com/open-edge-platform/datumaro/pull/1811>, <https://github.com/open-edge-platform/datumaro/pull/1834>, <https://github.com/open-edge-platform/datumaro/pull/1858>, <https://github.com/open-edge-platform/datumaro/pull/1845>, <https://github.com/open-edge-platform/datumaro/pull/1863>, <https://github.com/open-edge-platform/datumaro/pull/1868>, <https://github.com/open-edge-platform/datumaro/pull/1876>, <https://github.com/open-edge-platform/datumaro/pull/1877>, <https://github.com/open-edge-platform/datumaro/pull/1879>, <https://github.com/open-edge-platform/datumaro/pull/1881>, <https://github.com/open-edge-platform/datumaro/pull/1891>)
 
 ### Enhancements
 - Mark several dependencies as optional

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -13,7 +13,6 @@ tqdm>=4.67.1 # version with the latest security fixes
 pycocotools>=2.0.4
 
 PyYAML==6.0.2
-polars>=1.31.0,<2.0.0
 
 # Sampler
 pandas>=1.4.0

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setuptools.setup(
         "nibabel": ["nibabel>=3.2.1"],
         # AVA dataset
         "protobuf": ["protobuf"],
+        "experimental": ["polars>=1.31.0,<2.0.0"],
     },
     ext_modules=ext_modules,
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ extras =
     nibabel
     protobuf
     cli
+    experimental
 
 
 [testenv:pre-commit]
@@ -94,6 +95,7 @@ deps=
     atheris
 extras =
     cli
+    experimental
 allowlist_externals =
     bash
 commands_pre =
@@ -111,6 +113,7 @@ extras =
     tfds: tfds
     torch: torch
     cli
+    experimental
 allowlist_externals =
     bash
 commands_pre =


### PR DESCRIPTION
Polars is currently only used in the experimental code, so there is no reason to install it by default.



<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
