### PR TITLE
Re-introduce the Common Semantic Segmentation data format

### DIFF
--- a/docs/source/docs/data-formats/formats/common_semantic_segmentation.md
+++ b/docs/source/docs/data-formats/formats/common_semantic_segmentation.md
@@ -1,0 +1,54 @@
+# Common Semantic Segmentation
+
+## Format specification
+
+CSS format specification is available [here](https://github.com/openvinotoolkit/open_model_zoo/blob/master/tools/accuracy_checker/accuracy_checker/annotation_converters/README.md#supported-converters).
+
+Supported annotation types:
+- `Masks`
+
+CSS dataset directory should have the following structure:
+
+<!--lint disable fenced-code-flag-->
+```
+└─ Dataset/
+    ├── dataset_meta.json # a list of labels
+    ├── images/
+    │   ├── <img1>.png
+    │   ├── <img2>.png
+    │   └── ...
+    └── masks/
+        ├── <img1>.png
+        ├── <img2>.png
+        └── ...
+```
+
+To describe classes and colors, you should use [`dataset_meta.json`](/docs/data-formats/formats/index.rst#dataset-meta-info-file).
+
+## Convert to other formats
+
+Datumaro can convert a CSS dataset into any other format [Datumaro supports](/docs/data-formats/formats/index.rst).
+To get the expected result, convert the dataset to formats
+that support the segmentation task (e.g. PASCAL VOC, CamVid, Cityscapes, etc.)
+
+There are several ways to convert a CSS dataset to other dataset
+formats using CLI:
+
+``` bash
+datum convert -if common_semantic_segmentation -i <path/to/dataset> \
+    -f cityscapes -o <output/dir> -- --save-media
+```
+
+Or, using Python API:
+
+```python
+import datumaro as dm
+
+dataset = dm.Dataset.import_from('<path/to/dataset>', 'common_semantic_segmentation')
+dataset.export('save_dir', 'camvid', save_media=True)
+```
+
+## Examples
+
+Examples of using this format from the code can be found in
+[the format tests](https://github.com/open-edge-platform/datumaro/blob/develop/tests/unit/data_formats/test_common_semantic_segmentation_format.py)

--- a/src/datumaro/plugins/data_formats/common_semantic_segmentation.py
+++ b/src/datumaro/plugins/data_formats/common_semantic_segmentation.py
@@ -1,0 +1,200 @@
+# Copyright (C) 2022-2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import errno
+import os.path as osp
+from typing import List, Optional
+
+import numpy as np
+
+from datumaro.components.annotation import (
+    AnnotationType,
+    ExtractedMask,
+    LabelCategories,
+    MaskCategories,
+)
+from datumaro.components.dataset_base import DatasetItem, SubsetBase
+from datumaro.components.format_detection import FormatDetectionConfidence, FormatDetectionContext
+from datumaro.components.importer import ImportContext, Importer, with_subset_dirs
+from datumaro.components.media import Image
+from datumaro.util.image import find_images
+from datumaro.util.mask_tools import generate_colormap, lazy_mask
+from datumaro.util.meta_file_util import DATASET_META_FILE, is_meta_file, parse_meta_file
+
+
+class CommonSemanticSegmentationPath:
+    MASKS_DIR = "masks"
+    IMAGES_DIR = "images"
+
+
+def make_categories(label_map=None):
+    if label_map is None:
+        return {}
+
+    categories = {}
+    label_categories = LabelCategories()
+    for label in label_map:
+        label_categories.add(label)
+    categories[AnnotationType.label] = label_categories
+
+    has_colors = any(v is not None for v in label_map.values())
+    if not has_colors:  # generate new colors
+        colormap = generate_colormap(len(label_map))
+    else:  # only copy defined colors
+        label_id = lambda label: label_categories.find(label)[0]
+        colormap = {label_id(name): (desc[0], desc[1], desc[2]) for name, desc in label_map.items()}
+    mask_categories = MaskCategories(colormap)
+    mask_categories.inverse_colormap  # pylint: disable=pointless-statement
+    categories[AnnotationType.mask] = mask_categories
+    return categories
+
+
+class CommonSemanticSegmentationBase(SubsetBase):
+    def __init__(
+        self,
+        path: str,
+        *,
+        image_prefix: str = "",
+        mask_prefix: str = "",
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
+        if not osp.isdir(path):
+            raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
+
+        super().__init__(subset=subset, ctx=ctx)
+
+        self._image_prefix = image_prefix
+        self._mask_prefix = mask_prefix
+
+        meta_file = osp.join(path, DATASET_META_FILE)
+        if is_meta_file(meta_file):
+            self._root_dir = osp.dirname(meta_file)
+
+            label_map = parse_meta_file(meta_file)
+            self._categories = make_categories(label_map)
+        else:
+            raise FileNotFoundError(errno.ENOENT, "Dataset meta info file was not found", path)
+
+        self._items = list(self._load_items().values())
+
+    def _load_items(self):
+        items = {}
+
+        image_dir = osp.join(self._root_dir, CommonSemanticSegmentationPath.IMAGES_DIR)
+
+        if osp.isdir(image_dir):
+            images = {
+                osp.splitext(osp.relpath(p, image_dir))[0].replace("\\", "/")[
+                    len(self._image_prefix) :
+                ]: p
+                for p in find_images(image_dir, recursive=True)
+                if osp.basename(p).startswith(self._image_prefix)
+            }
+        else:
+            images = {}
+
+        mask_dir = osp.join(self._root_dir, CommonSemanticSegmentationPath.MASKS_DIR)
+        masks = [
+            mask_path
+            for mask_path in find_images(mask_dir, recursive=True)
+            if osp.basename(mask_path).startswith(self._mask_prefix)
+        ]
+
+        for mask_path in masks:
+            item_id = osp.splitext(osp.basename(mask_path))[0][len(self._mask_prefix) :]
+
+            image = images.get(item_id)
+            if image:
+                image = Image.from_file(path=image)
+
+            annotations = []
+            index_mask = lazy_mask(
+                mask_path, self._categories[AnnotationType.mask].inverse_colormap
+            )
+            np_mask = index_mask()  # loading mask through cache
+
+            classes = np.unique(np_mask)
+            for label_id in classes:
+                annotations.append(
+                    ExtractedMask(
+                        index_mask=index_mask,
+                        index=label_id,
+                        label=label_id,
+                    )
+                )
+                self._ann_types.add(AnnotationType.mask)
+
+            items[item_id] = DatasetItem(
+                id=item_id, subset=self._subset, media=image, annotations=annotations
+            )
+
+        return items
+
+    @staticmethod
+    def _lazy_extract_mask(mask, c):
+        return lambda: mask == c
+
+
+class CommonSemanticSegmentationImporter(Importer):
+    """CommonSemanticSegmentation is introduced in the accuracy checker tool of OpenVINO™
+    to cover a general format of datasets for semantic segmentation task.
+    This should have the following structure:
+        - Dataset/
+            - dataset_meta.json # a list of labels
+            - images/
+                - <img1>.png
+                - <img2>.png
+                - ...
+            - masks/
+                - <img1>.png
+                - <img2>.png
+                - ...
+    """
+
+    @classmethod
+    def build_cmdline_parser(cls, **kwargs):
+        parser = super().build_cmdline_parser(**kwargs)
+        parser.add_argument("--image-prefix", default="", help="Image prefix (default: '')")
+        parser.add_argument("--mask-prefix", default="", help="Mask prefix (default: '')")
+        return parser
+
+    @classmethod
+    def detect(cls, context: FormatDetectionContext) -> FormatDetectionConfidence:
+        context.require_file(DATASET_META_FILE)
+
+        context.require_file(osp.join(CommonSemanticSegmentationPath.IMAGES_DIR, "**", "*"))
+        context.require_file(osp.join(CommonSemanticSegmentationPath.MASKS_DIR, "**", "*"))
+
+        return FormatDetectionConfidence.MEDIUM
+
+    @classmethod
+    def find_sources(cls, path):
+        return [{"url": path, "format": "common_semantic_segmentation"}]
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [osp.splitext(DATASET_META_FILE)[1]]
+
+
+@with_subset_dirs
+class CommonSemanticSegmentationWithSubsetDirsImporter(CommonSemanticSegmentationImporter):
+    """It supports the following subset sub-directory structure for CommonSemanticSegmentation.
+
+    .. code-block::
+
+        Dataset/
+        └─ <split: train,val, ...>
+            ├── dataset_meta.json # a list of labels
+            ├── images/
+            │   ├── <img1>.png
+            │   ├── <img2>.png
+            │   └── ...
+            └── masks/
+                ├── <img1>.png
+                ├── <img2>.png
+                └── ...
+
+    Then, the imported dataset will have train, val, ... CommonSemanticSegmentation subsets.
+    """

--- a/src/datumaro/plugins/specs.json
+++ b/src/datumaro/plugins/specs.json
@@ -351,6 +351,31 @@
     }
   },
   {
+    "import_path": "datumaro.plugins.data_formats.common_semantic_segmentation.CommonSemanticSegmentationBase",
+    "plugin_name": "common_semantic_segmentation",
+    "plugin_type": "DatasetBase"
+  },
+  {
+    "import_path": "datumaro.plugins.data_formats.common_semantic_segmentation.CommonSemanticSegmentationImporter",
+    "plugin_name": "common_semantic_segmentation",
+    "plugin_type": "Importer",
+    "metadata": {
+      "file_extensions": [
+        ".json"
+      ]
+    }
+  },
+  {
+    "import_path": "datumaro.plugins.data_formats.common_semantic_segmentation.CommonSemanticSegmentationWithSubsetDirsImporter",
+    "plugin_name": "common_semantic_segmentation_with_subset_dirs",
+    "plugin_type": "Importer",
+    "metadata": {
+      "file_extensions": [
+        ".json"
+      ]
+    }
+  },
+  {
     "import_path": "datumaro.plugins.data_formats.cvat.base.CvatBase",
     "plugin_name": "cvat",
     "plugin_type": "DatasetBase"

--- a/tests/unit/data_formats/test_common_semantic_segmentation_format.py
+++ b/tests/unit/data_formats/test_common_semantic_segmentation_format.py
@@ -1,0 +1,225 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import os
+import shutil
+from collections import OrderedDict
+from typing import Any, Dict
+
+import numpy as np
+import pytest
+
+from datumaro.components.annotation import Mask
+from datumaro.components.dataset import Dataset
+from datumaro.components.dataset_base import DatasetItem
+from datumaro.components.errors import DatasetImportError
+from datumaro.components.media import Image
+from datumaro.plugins.data_formats.common_semantic_segmentation import (
+    CommonSemanticSegmentationImporter,
+    CommonSemanticSegmentationWithSubsetDirsImporter,
+    make_categories,
+)
+
+from .base import TestDataFormatBase
+
+from tests.utils.assets import get_test_asset_path
+
+DUMMY_DATASET_DIR = get_test_asset_path("common_semantic_segmentation_dataset", "dataset")
+
+DUMMY_NON_STANDARD_DATASET_DIR = get_test_asset_path(
+    "common_semantic_segmentation_dataset",
+    "non_standard_dataset",
+)
+
+
+@pytest.fixture
+def fxt_dataset():
+    return Dataset.from_iterable(
+        [
+            DatasetItem(
+                id="0001",
+                media=Image.from_numpy(data=np.ones((1, 5, 3))),
+                annotations=[
+                    Mask(image=np.array([[1, 1, 0, 1, 1]]), label=3),
+                    Mask(image=np.array([[0, 0, 1, 0, 0]]), label=5),
+                ],
+            ),
+            DatasetItem(
+                id="0002",
+                media=Image.from_numpy(data=np.ones((1, 5, 3))),
+                annotations=[
+                    Mask(image=np.array([[1, 1, 1, 0, 0]]), label=1),
+                    Mask(image=np.array([[0, 0, 0, 1, 1]]), label=4),
+                ],
+            ),
+        ],
+        categories=make_categories(
+            OrderedDict(
+                [
+                    ("Void", (0, 0, 0)),
+                    ("Animal", (64, 128, 64)),
+                    ("Archway", (192, 0, 128)),
+                    ("Bicyclist", (0, 128, 192)),
+                    ("Child", (192, 128, 64)),
+                    ("Road", (128, 64, 128)),
+                ]
+            )
+        ),
+    )
+
+
+@pytest.fixture
+def fxt_non_standard_dataset():
+    return Dataset.from_iterable(
+        [
+            DatasetItem(
+                id="0001",
+                media=Image.from_numpy(data=np.ones((1, 5, 3))),
+                annotations=[
+                    Mask(image=np.array([[1, 1, 0, 1, 1]]), label=3),
+                    Mask(image=np.array([[0, 0, 1, 0, 0]]), label=5),
+                ],
+            ),
+            DatasetItem(
+                id="0002",
+                media=Image.from_numpy(data=np.ones((1, 5, 3))),
+                annotations=[
+                    Mask(image=np.array([[1, 1, 0, 0, 0]]), label=1),
+                    Mask(image=np.array([[0, 0, 1, 0, 0]]), label=5),
+                    Mask(image=np.array([[0, 0, 0, 1, 1]]), label=7),
+                ],
+            ),
+        ],
+        categories=make_categories(
+            OrderedDict(
+                [
+                    ("Void", (0, 0, 0)),
+                    ("Animal", (64, 128, 64)),
+                    ("Archway", (192, 0, 128)),
+                    ("Bicyclist", (0, 128, 192)),
+                    ("Child", (192, 128, 64)),
+                    ("Road", (128, 64, 128)),
+                    ("Pedestrian", (64, 64, 0)),
+                    ("SignSymbol", (128, 128, 128)),
+                ]
+            )
+        ),
+    )
+
+
+IDS = ["DUMMY_DATASET_DIR", "DUMMY_NON_STANDARD_DATASET_DIR"]
+
+
+class CommonSemanticSegmentationImporterTest(TestDataFormatBase):
+    IMPORTER = CommonSemanticSegmentationImporter
+
+    @pytest.mark.parametrize(
+        "fxt_dataset_dir",
+        [DUMMY_DATASET_DIR, DUMMY_NON_STANDARD_DATASET_DIR],
+        ids=IDS,
+    )
+    def test_can_detect(self, fxt_dataset_dir: str):
+        return super().test_can_detect(fxt_dataset_dir)
+
+    @pytest.mark.parametrize(
+        ["fxt_dataset_dir", "fxt_expected_dataset", "fxt_import_kwargs"],
+        [
+            (DUMMY_DATASET_DIR, "fxt_dataset", {}),
+            (
+                DUMMY_NON_STANDARD_DATASET_DIR,
+                "fxt_non_standard_dataset",
+                {"image_prefix": "image_", "mask_prefix": "gt_"},
+            ),
+        ],
+        indirect=["fxt_expected_dataset"],
+        ids=IDS,
+    )
+    def test_can_import(
+        self,
+        fxt_dataset_dir: str,
+        fxt_expected_dataset: Dataset,
+        fxt_import_kwargs: Dict[str, Any],
+        request: pytest.FixtureRequest,
+    ):
+        return super().test_can_import(
+            fxt_dataset_dir, fxt_expected_dataset, fxt_import_kwargs, request
+        )
+
+    @pytest.mark.parametrize(
+        ["fxt_dataset_dir", "fxt_expected_dataset", "fxt_import_kwargs"],
+        [
+            (DUMMY_DATASET_DIR, "fxt_dataset", {}),
+            (
+                DUMMY_NON_STANDARD_DATASET_DIR,
+                "fxt_non_standard_dataset",
+                {"image_prefix": "image_", "mask_prefix": "gt_"},
+            ),
+        ],
+        indirect=["fxt_expected_dataset"],
+        ids=IDS,
+    )
+    def test_cannot_import_nested(
+        self,
+        fxt_dataset_dir: str,
+        fxt_expected_dataset: Dataset,
+        fxt_import_kwargs: Dict[str, Any],
+        request: pytest.FixtureRequest,
+        test_dir: str,
+    ):
+        shutil.copytree(fxt_dataset_dir, test_dir, dirs_exist_ok=True)
+        subdir_name = "subdir"
+        subdir = os.path.join(test_dir, subdir_name)
+        os.makedirs(subdir)
+        for _file in os.listdir(test_dir):
+            if _file != subdir_name:
+                file_path = os.path.join(test_dir, _file)
+                shutil.move(file_path, subdir)
+        with pytest.raises(DatasetImportError) as exc_info:
+            super().test_can_import(test_dir, fxt_expected_dataset, fxt_import_kwargs, request)
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, FileNotFoundError)
+
+
+class CommonSemanticSegmentationWithSubsetDirsImporterTest(TestDataFormatBase):
+    IMPORTER = CommonSemanticSegmentationWithSubsetDirsImporter
+
+    @pytest.mark.parametrize(
+        "fxt_dataset_dir_with_subset_dirs",
+        [DUMMY_DATASET_DIR, DUMMY_NON_STANDARD_DATASET_DIR],
+        indirect=["fxt_dataset_dir_with_subset_dirs"],
+        ids=IDS,
+    )
+    def test_can_detect(self, fxt_dataset_dir_with_subset_dirs: str):
+        return super().test_can_detect(fxt_dataset_dir_with_subset_dirs)
+
+    @pytest.mark.parametrize(
+        [
+            "fxt_dataset_dir_with_subset_dirs",
+            "fxt_expected_dataset_with_subsets",
+            "fxt_import_kwargs",
+        ],
+        [
+            (DUMMY_DATASET_DIR, "fxt_dataset", {}),
+            (
+                DUMMY_NON_STANDARD_DATASET_DIR,
+                "fxt_non_standard_dataset",
+                {"image_prefix": "image_", "mask_prefix": "gt_"},
+            ),
+        ],
+        indirect=["fxt_dataset_dir_with_subset_dirs", "fxt_expected_dataset_with_subsets"],
+        ids=IDS,
+    )
+    def test_can_import(
+        self,
+        fxt_dataset_dir_with_subset_dirs: str,
+        fxt_expected_dataset_with_subsets: Dataset,
+        fxt_import_kwargs: Dict[str, Any],
+        request: pytest.FixtureRequest,
+    ):
+        return super().test_can_import(
+            fxt_dataset_dir_with_subset_dirs,
+            fxt_expected_dataset_with_subsets,
+            fxt_import_kwargs,
+            request,
+        )


### PR DESCRIPTION
This format was initially removed by https://github.com/open-edge-platform/datumaro/pull/1745; however, it is still needed by OTX (see issue https://github.com/open-edge-platform/training_extensions/issues/4639).



<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/CONTRIBUTING.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/open-edge-platform/datumaro/blob/develop/CHANGELOG.md).
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
