### PR TITLE
Enable Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,6 +53,22 @@
       matchPackagePatterns: ["*"],
       schedule: ["* * 1 * *"], // every month
     },
+
+    // uv version used in GitHub Actions is updated manually
+    {
+      enabled: false,
+      matchDatasources: ["github-releases"],
+      matchDepNames: ["astral-sh/uv"],
+      matchDepTypes: ["uses-with"],
+    },
+
+    // python version used in GitHub Actions is updated manually
+    {
+      enabled: false,
+      matchDatasources: ["github-releases"],
+      matchDepNames: ["python"],
+      matchDepTypes: ["uses-with"],
+    },
   ],
 
   // Enable security upgrades

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,10 +50,22 @@
       matchManagers: ["pip_requirements"],
     },
 
-    // Disable non-security upgrades for cargo
+    // Group Go version upgrades
+    {
+      enabled: true,
+      matchPackageNames: ["golang", "go"],
+      matchDatasource: ["crate"],
+      allowedVersions: "<1.24",
+      schedule: ["* * * * 0"], // weekly
+    },
+
+    // Disable derive_more major upgrades to prevent regressions
+    // Will be enabled in a next step
     {
       enabled: false,
-      matchManagers: ["cargo"],
+      matchDatasources: ["crate"],
+      matchPackageNames: ["derive_more"],
+      matchUpdateTypes: ["major"],
     },
 
     // Group GitHub Actions updates

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,13 +44,6 @@
       schedule: ["* * * * 0"], // weekly
     },
 
-    // numpy is updated manually
-    {
-      enabled: false,
-      matchDatasources: ["pypi"],
-      matchDepNames: ["numpy"],
-    },
-
     // Disable non-security upgrades for docs/requirements.txt
     {
       enabled: false,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,7 +31,7 @@
   // `matchBaseBranches` in specific rule
   baseBranches: ["develop"],
 
-  enabledManagers: ["github-actions", "pep621", "cargo", "pip_requirements"]
+  enabledManagers: ["github-actions", "pep621", "cargo", "pip_requirements"],
 
   // Set limit to 10
   ignorePresets: [":prHourlyLimit2"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,64 @@
+// Dependency Update Configuration
+//
+// See https://docs.renovatebot.com/configuration-options/
+// See https://json5.org/ for JSON5 syntax
+
+// [!] While updating the Renovate config, test changes on your own fork.
+//  1. Modify the Renovate configuration, which is located in .github/renovate.json5 and push your changes to the default branch of your fork.
+//  2. Enable the Renovate GitHub app in your GitHub account.
+//     Verify that Renovate is activated in the repository settings within the Renovate Dashboard.
+//     To enable the dashboard set `dependencyDashboard` to true
+//  3. Trigger the Renovate app from the dashboard, or push a new commit to your fork’s default branch to re-trigger Renovate.
+//  4. Use the dashboard to initiate Renovate and create a PR on your fork, then check that the proposed PRs are modifying the correct parts.
+//  5. Once you’ve validated that the Renovate configuration works on your fork, submit a PR,
+//     and include links in the description to share details about the testing you've conducted.
+
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  // regenerate lock weekly https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ["* * * * 0"], // weekly
+  },
+
+  extends: ["config:base", ":gitSignOff", "helpers:pinGitHubActionDigests"],
+  // https://docs.renovatebot.com/presets-default/#gitsignoff
+  // https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests
+
+  // if necessary, add supported releases branches here
+  // it is possible to enable/disable specific upgrades per branch with
+  // `matchBaseBranches` in specific rule
+  baseBranches: ["develop"],
+
+  //  enabledManagers: ["github-actions", "pep621"], TODO
+
+  // Set limit to 10
+  ignorePresets: [":prHourlyLimit2"],
+  prHourlyLimit: 10,
+
+  packageRules: [
+    {
+      enabled: true,
+      matchManagers: ["pep621"],
+      schedule: ["* * * * 0"], // weekly
+    },
+
+    // Group GitHub Actions updates
+    {
+      enabled: true,
+      separateMajorMinor: false,
+      groupName: "GitHub Actions",
+      matchManagers: ["github-actions"],
+      matchPackagePatterns: ["*"],
+      schedule: ["* * 1 * *"], // every month
+    },
+  ],
+
+  // Enable security upgrades
+  vulnerabilityAlerts: {
+    enabled: true,
+  },
+  osvVulnerabilityAlerts: true,
+  dependencyDashboard: true,
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,20 +50,11 @@
       matchManagers: ["pip_requirements"],
     },
 
-    // Group Go version upgrades
-    {
-      enabled: true,
-      matchPackageNames: ["golang", "go"],
-      matchDatasource: ["crate"],
-      allowedVersions: "<1.24",
-      schedule: ["* * * * 0"], // weekly
-    },
-
     // Disable derive_more major upgrades to prevent regressions
     // Will be enabled in a next step
     {
       enabled: false,
-      matchDatasource: ["crate"],
+      matchDatasources: ["crate"],
       matchPackageNames: ["derive_more"],
       matchUpdateTypes: ["major"],
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,9 +33,9 @@
 
   enabledManagers: ["github-actions", "pep621", "cargo", "pip_requirements"],
 
-  // Set limit to 10
+  // Set limit to 5
   ignorePresets: [":prHourlyLimit2"],
-  prHourlyLimit: 10,
+  prHourlyLimit: 5,
 
   packageRules: [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,7 +63,7 @@
     // Will be enabled in a next step
     {
       enabled: false,
-      matchDatasources: ["crate"],
+      matchDatasource: ["crate"],
       matchPackageNames: ["derive_more"],
       matchUpdateTypes: ["major"],
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,7 +31,7 @@
   // `matchBaseBranches` in specific rule
   baseBranches: ["develop"],
 
-  //  enabledManagers: ["github-actions", "pep621"], TODO
+  enabledManagers: ["github-actions", "pep621", "cargo", "pip_requirements"]
 
   // Set limit to 10
   ignorePresets: [":prHourlyLimit2"],
@@ -42,6 +42,12 @@
       enabled: true,
       matchManagers: ["pep621"],
       schedule: ["* * * * 0"], // weekly
+    },
+
+    // Disable non-security upgrades for docs/requirements.txt
+    {
+      enabled: false,
+      matchManagers: ["pip_requirements"],
     },
 
     // Group GitHub Actions updates

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,12 @@
       matchManagers: ["pip_requirements"],
     },
 
+    // Disable non-security upgrades for cargo
+    {
+      enabled: false,
+      matchManagers: ["cargo"],
+    },
+
     // Group GitHub Actions updates
     {
       enabled: true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,6 +44,13 @@
       schedule: ["* * * * 0"], // weekly
     },
 
+    // numpy is updated manually
+    {
+      enabled: false,
+      matchDatasources: ["pypi"],
+      matchDepNames: ["numpy"],
+    },
+
     // Disable non-security upgrades for docs/requirements.txt
     {
       enabled: false,

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -1,0 +1,42 @@
+# Renovate configuration validator
+#
+# This workflow validates changes proposed into Renovate configuration file
+# (.github/renovate.json5) and prevents non-valid configuration to be used by Renovate.
+#
+# Required Secrets:
+# - None
+#
+# Automatically triggered on:
+# - Pull requests to .github/renovate.json5.
+#
+
+name: Validate Renovate configuration
+
+on:
+  pull_request:
+    paths:
+      - ".github/renovate.json5"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout configuration
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Validate configuration
+        run: |
+          # renovate: datasource=docker
+          export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:40.11
+          docker run --rm --entrypoint "renovate-config-validator" \
+          -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5" \
+          ${RENOVATE_IMAGE} "/renovate.json5"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,84 @@
+# Dependencies Management Workflow
+#
+# This workflow automates the dependence management based on self-hosed Renovate
+# ensure the project's dependencies remains up-to-date and security fixes are delivered regularly.
+#
+# Key Features:
+# - Automated PR creation into pyproject.toml and uv.lock regeneration
+# - Dry-run for debug purposes
+# - Dependency dashboard (is available in GitHub issues) maintenance
+#
+# Process Stages:
+#
+# 1. Dependencies Management:
+#    - Runs on a daily schedule.
+#    - Identifies dependencies that may be updated based on .github/renovate.json5 configuration.
+#    - Opens corresponding PRs with respect to schedule defined in Renovate config file.
+#    - Updates Renovate Dependency dashboard that is available in GitHub issues.
+#
+# Required Secrets:
+# - RENOVATE_APP_ID: application ID
+# - RENOVATE_APP_PEM: application private key
+#
+# Example Usage:
+# 1. Scheduled Run:
+#    Automatically runs, daily
+#
+# 2. Manual Trigger:
+#    workflow_dispatch:
+#    inputs:
+#      dry-run:
+#        description: "Run Renovate in dry-run mode (no PR)"
+#        required: false
+#        default: false
+#        type: boolean
+#
+# Note: Renovate maintains and updates Dependency dashboard that is available in GitHub issues.
+
+name: Renovate
+on:
+  schedule:
+    # daily
+    - cron: "0 2 * * *"
+
+  # allow to manually trigger this workflow
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Run Renovate in dry-run mode (no PR)"
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  renovate:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Get token
+        id: get-github-app-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PEM }}
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@2d941ef4e268e53affdc1f11365c69a73e544f50 # v43.0.14
+        with:
+          configurationFile: .github/renovate.json5
+          token: "${{ steps.get-github-app-token.outputs.token }}"
+        env:
+          LOG_LEVEL: ${{ github.event_name == 'workflow_dispatch' && 'debug' || 'info' }}
+          # Dry run if the event is workflow_dispatch AND the dry-run input is true
+          RENOVATE_DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') && 'full' || null }}
+          RENOVATE_PLATFORM: github
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
This PR adds a workflows (`renovate.yml` and `renovate-config-validator.yml`) and configuration renovate.json5 to run Renovate as a GitHub Action.
Workflow `renovate.yml` will run daily and open PRs with suggested security upgrades and version upgrades (weekly and montly). 
Instead of using a Personal Access Token (PAT) that is tied to a particular user / faceless account this workflow uses private GitHub App with tuned permissions.

`renovate-config-validator.yml` workflow will validate changes in renovate.json5.

PR from Dependabot will be disabled.

Expected behavior:
PRs: https://github.com/AlexanderBarabanov/datumaro/pulls
Dashboard: https://github.com/AlexanderBarabanov/datumaro/issues/10

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
