### PR TITLE
Multi label support

### DIFF
--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -397,7 +397,10 @@ class LabelField(Field):
             return {name: pl.Series(name, [None], dtype=pl_type)}
 
         if self.multi_label:
-            return {name: pl.Series(name, [to_numpy(value)], dtype=pl.List(self.dtype))}
+            # Handle single label as a list for multi-label fields
+            if not isinstance(value, list):
+                value = [value]
+            return {name: pl.Series(name, [value], dtype=pl_type)}
 
         return {name: pl.Series(name, [value], dtype=pl_type)}
 

--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -426,9 +426,6 @@ class LabelField(Field):
             return {name: pl.Series(name, [None], dtype=pl_type)}
 
         if self.multi_label:
-            # Handle single label as a list for multi-label fields
-            if not isinstance(value, list):
-                value = [value]
             return {name: pl.Series(name, [value], dtype=pl_type)}
 
         return {name: pl.Series(name, [value], dtype=pl_type)}

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -557,8 +557,10 @@ class ForwardLabelAnnotationConverter(ForwardAnnotationConverter):
         labels = [ann for ann in annotations if isinstance(ann, Label)]
         result = {}
         if len(labels) > 0:
-            # For single label classification, take the first label
-            result["label"] = labels[0].label
+            if "multi_label_ids" in labels[0].attributes:
+                result["label"] = labels[0].attributes["multi_label_ids"]
+            else:
+                result["label"] = labels[0].label
         else:
             result["label"] = None
         return result
@@ -720,12 +722,14 @@ def _convert_legacy_item(item: DatasetItem, analysis_result: AnalysisResult) -> 
     return attributes
 
 
-def convert_from_legacy(legacy_dataset: LegacyDataset) -> Dataset[Sample]:
+def convert_from_legacy(
+    legacy_dataset: LegacyDataset, multi_label: bool = False
+) -> Dataset[Sample]:
     """Convert legacy dataset to experimental format with automatic schema inference.
 
     Args:
         legacy_dataset: The legacy Datumaro dataset to convert
-
+        multi_label: If true, configure label_field with multi_label=True
     Returns:
         A new experimental Dataset with inferred schema and converted data
 
@@ -739,7 +743,8 @@ def convert_from_legacy(legacy_dataset: LegacyDataset) -> Dataset[Sample]:
 
     # Step 1: Analyze dataset to infer schema
     analysis_result = analyze_legacy_dataset(legacy_dataset)
-
+    if multi_label:
+        analysis_result.schema.attributes["label"].annotation = label_field(multi_label=True)
     # Step 2: Create experimental dataset with inferred schema
     experimental_dataset = Dataset(analysis_result.schema)
 

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -642,6 +642,8 @@ class ForwardLabelAnnotationConverter(ForwardAnnotationConverter):
         if len(labels) > 0:
             if "multi_label_ids" in labels[0].attributes:
                 result[self.name_prefix + "label"] = labels[0].attributes["multi_label_ids"]
+            elif self.label_attribute.annotation.multi_label:
+                result[self.name_prefix + "label"] = [labels[0].label]
             else:
                 result[self.name_prefix + "label"] = labels[0].label
         else:

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -774,10 +774,16 @@ def analyze_legacy_dataset(
     ann_types = legacy_dataset.ann_types()
 
     attributes: dict[str, AttributeInfo] = {}
-    media_converter: ForwardMediaConverter | None = None
     ann_converters: dict[AnnotationType, ForwardAnnotationConverter] = {}
 
-    # Get media attributes from converter
+    label_groups = legacy_dataset.categories()[AnnotationType.label].label_groups
+    label_group_names = (
+        [group for group in label_groups if group.name.startswith("Classification labels__")]
+        if label_groups
+        else []
+    )
+    multi_label = len(label_group_names) > 1
+
     media_converter = get_forward_media_converter(legacy_dataset, semantic)
     if media_converter is not None:
         attributes.update(media_converter.get_schema_attributes())
@@ -797,9 +803,9 @@ def analyze_legacy_dataset(
         if converter is not None:
             ann_converters[ann_type] = converter
             ann_attributes = converter.get_schema_attributes()
-
+            if multi_label:
+                ann_attributes[AnnotationType.label.name].annotation = label_field(multi_label=True)
             attributes.update(ann_attributes)
-
     schema = Schema(attributes=attributes)
     return AnalysisResult(
         schema=schema,
@@ -825,14 +831,11 @@ def _convert_legacy_item(item: DatasetItem, analysis_result: AnalysisResult) -> 
     return attributes
 
 
-def convert_from_legacy(
-    legacy_dataset: LegacyDataset, multi_label: bool = False
-) -> Dataset[Sample]:
+def convert_from_legacy(legacy_dataset: LegacyDataset) -> Dataset[Sample]:
     """Convert legacy dataset to experimental format with automatic schema inference.
 
     Args:
         legacy_dataset: The legacy Datumaro dataset to convert
-        multi_label: If true, configure label_field with multi_label=True
     Returns:
         A new experimental Dataset with inferred schema and converted data
 
@@ -846,8 +849,7 @@ def convert_from_legacy(
 
     # Step 1: Analyze dataset to infer schema
     analysis_result = analyze_legacy_dataset(legacy_dataset)
-    if multi_label:
-        analysis_result.schema.attributes["label"].annotation = label_field(multi_label=True)
+
     # Step 2: Create experimental dataset with inferred schema
     experimental_dataset = Dataset(analysis_result.schema)
 

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -861,7 +861,7 @@ class DetectionSample(Sample):
         np.ndarray[Any, np.dtype[np.float32]], bbox_field(dtype=pl.Float32, format="x1y1x2y2")
     ]
     bbox_labels: Annotated[
-        np.ndarray[Any, np.dtype[np.int32]], label_field(dtype=pl.Int32, multi_label=True)
+        np.ndarray[Any, np.dtype[np.int32]], label_field(dtype=pl.Int32, is_list=True)
     ]
 
 
@@ -871,7 +871,7 @@ class RotatedDetectionSample(Sample):
         np.ndarray[Any, np.dtype[np.float32]], rotated_bbox_field(dtype=pl.Float32)
     ]
     rotated_bbox_labels: Annotated[
-        np.ndarray[Any, np.dtype[np.int32]], label_field(dtype=pl.Int32, multi_label=True)
+        np.ndarray[Any, np.dtype[np.int32]], label_field(dtype=pl.Int32, is_list=True)
     ]
 
 


### PR DESCRIPTION
This pull request introduces improvements to multi-label classification support in the experimental Datumaro codebase, specifically enhancing how multi-label fields are handled during conversion from legacy datasets and in the Polars serialization logic. The changes ensure that single labels are correctly treated as lists for multi-label fields and that multi-label configuration is properly propagated during legacy dataset conversion.

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
