### PR TITLE
Small changes required for OTX tiling support

### DIFF
--- a/src/datumaro/experimental/converters.py
+++ b/src/datumaro/experimental/converters.py
@@ -25,7 +25,6 @@ from .fields import (
     ImageBytesField,
     ImageCallableField,
     ImageField,
-    ImageInfo,
     ImageInfoField,
     ImagePathField,
     InstanceMaskCallableField,
@@ -161,6 +160,7 @@ class RGBToBGRConverter(Converter):
             field=ImageField(
                 semantic=self.input_image.field.semantic,
                 dtype=self.input_image.field.dtype,
+                channels_first=self.output_image.field.channels_first,
                 format="BGR",  # Set output format to BGR
             ),
         )
@@ -227,6 +227,7 @@ class UInt8ToFloat32Converter(Converter):
                 semantic=self.input_image.field.semantic,
                 dtype=pl.Float32,
                 format=self.input_image.field.format,
+                channels_first=self.output_image.field.channels_first,
             ),
         )
         return self.input_image.field.dtype == pl.UInt8
@@ -271,7 +272,6 @@ class ImagePathToImageConverter(Converter):
 
     input_path: AttributeSpec[ImagePathField]
     output_image: AttributeSpec[ImageField]
-    output_info: AttributeSpec[ImageInfoField]
 
     def filter_output_spec(self) -> bool:
         """Configure output image specification based on input."""
@@ -282,13 +282,7 @@ class ImagePathToImageConverter(Converter):
                 semantic=self.input_path.field.semantic,
                 dtype=pl.UInt8,  # Default to UInt8 for loaded images
                 format="RGB",  # Default to RGB format
-            ),
-        )
-        # Configure output info specification
-        self.output_info = AttributeSpec(
-            name=self.output_info.name,
-            field=ImageInfoField(
-                semantic=self.input_path.field.semantic,
+                channels_first=self.output_image.field.channels_first,
             ),
         )
         return True
@@ -305,12 +299,10 @@ class ImagePathToImageConverter(Converter):
         """
         input_col = self.input_path.name
         output_col = self.output_image.name
-        output_info_col = self.output_info.name
 
         # Load images from paths
         image_data: list[Any] = []
         image_shapes: list[list[int]] = []
-        image_infos: list[ImageInfo] = []
 
         for path in df[input_col]:
             # Load image using PIL
@@ -324,12 +316,8 @@ class ImagePathToImageConverter(Converter):
                 image_data.append(img_array.flatten())
                 image_shapes.append(list(img_array.shape))
 
-                # Create image info with just width and height
-                image_infos.append(ImageInfo(width=img_array.shape[1], height=img_array.shape[0]))
-
         # Create output DataFrame
         image_schema = self.output_image.field.to_polars_schema("image")
-        image_info_schema = self.output_info.field.to_polars_schema("image_info")
 
         result_df = df.clone()
 
@@ -337,8 +325,55 @@ class ImagePathToImageConverter(Converter):
             [
                 pl.Series(output_col, image_data, dtype=image_schema["image"]),
                 pl.Series(output_col + "_shape", image_shapes, dtype=image_schema["image_shape"]),
-                pl.Series(output_info_col, image_infos, dtype=image_info_schema["image_info"]),
             ]
+        )
+
+        return result_df
+
+
+@converter
+class ImageToImageInfo(Converter):
+    """
+    Lazy converter that loads images from file paths using Pillow.
+
+    This converter reads image files from disk and converts them to tensor format.
+    It's marked as lazy to defer the expensive I/O operation until the data
+    is actually accessed.
+    """
+
+    input_image: AttributeSpec[ImageField]
+    output_info: AttributeSpec[ImageInfoField]
+
+    def filter_output_spec(self) -> bool:
+        """Configure output image specification based on input."""
+        # Configure output info specification
+        self.output_info = AttributeSpec(
+            name=self.output_info.name,
+            field=ImageInfoField(
+                semantic=self.input_image.field.semantic,
+            ),
+        )
+        return True
+
+    def convert(self, df: pl.DataFrame) -> pl.DataFrame:
+        """
+        Convert image paths to loaded image tensors and image info.
+
+        Args:
+            df: DataFrame containing image path column
+
+        Returns:
+            DataFrame with loaded image data, shape information, and image info
+        """
+        input_col = self.input_image.name + "_shape"
+        output_col = self.output_info.name
+
+        # Set image info
+        result_df = df.with_columns(
+            pl.struct(
+                pl.col(input_col).list.get(0).alias("height"),
+                pl.col(input_col).list.get(1).alias("width"),
+            ).alias(output_col)
         )
 
         return result_df
@@ -356,7 +391,6 @@ class ImageBytesToImageConverter(Converter):
 
     input_bytes: AttributeSpec[ImageBytesField]
     output_image: AttributeSpec[ImageField]
-    output_info: AttributeSpec[ImageInfoField]
 
     def filter_output_spec(self) -> bool:
         """Configure output image specification based on input."""
@@ -367,13 +401,7 @@ class ImageBytesToImageConverter(Converter):
                 semantic=self.input_bytes.field.semantic,
                 dtype=pl.UInt8,  # Default to UInt8 for decoded images
                 format="RGB",  # Default to RGB format
-            ),
-        )
-        # Configure output info specification
-        self.output_info = AttributeSpec(
-            name=self.output_info.name,
-            field=ImageInfoField(
-                semantic=self.input_bytes.field.semantic,
+                channels_first=self.output_image.field.channels_first,
             ),
         )
         return True
@@ -390,12 +418,10 @@ class ImageBytesToImageConverter(Converter):
         """
         input_col = self.input_bytes.name
         output_col = self.output_image.name
-        output_info_col = self.output_info.name
 
         # Decode images from bytes
         image_data: list[np.ndarray] = []
         image_shapes: list[list[int]] = []
-        image_infos: list[ImageInfo] = []
 
         for image_bytes in df[input_col]:
             # Decode image using PIL
@@ -411,16 +437,12 @@ class ImageBytesToImageConverter(Converter):
                 image_data.append(img_array.reshape(-1))
                 image_shapes.append(list(img_array.shape))
 
-                # Create image info with just width and height
-                image_infos.append(ImageInfo(width=img_array.shape[1], height=img_array.shape[0]))
-
         # Create output DataFrame
         result_df = df.clone()
         result_df = result_df.with_columns(
             [
                 pl.Series(output_col, image_data),
                 pl.Series(output_col + "_shape", image_shapes),
-                pl.Series(output_info_col, image_infos),
             ]
         )
 
@@ -693,6 +715,8 @@ class PolygonToMaskConverter(Converter):
             field=MaskField(
                 semantic=self.input_polygon.field.semantic,
                 dtype=self.output_mask.field.dtype,
+                channels_first=self.output_mask.field.channels_first,
+                has_channels_dim=self.output_mask.field.has_channels_dim,
             ),
             categories=mask_categories,
         )
@@ -1024,7 +1048,6 @@ class ImageCallableToImageConverter(Converter):
 
     input_callable: AttributeSpec[ImageCallableField]
     output_image: AttributeSpec[ImageField]
-    output_info: AttributeSpec[ImageInfoField]
 
     def filter_output_spec(self) -> bool:
         """Configure output image and info specifications based on input."""
@@ -1035,13 +1058,7 @@ class ImageCallableToImageConverter(Converter):
                 semantic=self.input_callable.field.semantic,
                 dtype=pl.UInt8,  # Default to UInt8 for image data
                 format=self.input_callable.field.format,  # Use format from callable field
-            ),
-        )
-        # Configure output info specification
-        self.output_info = AttributeSpec(
-            name=self.output_info.name,
-            field=ImageInfoField(
-                semantic=self.input_callable.field.semantic,
+                channels_first=self.output_image.field.channels_first,
             ),
         )
         return True
@@ -1058,12 +1075,10 @@ class ImageCallableToImageConverter(Converter):
         """
         input_col = self.input_callable.name
         output_col = self.output_image.name
-        output_info_col = self.output_info.name
 
         # Execute callables to generate image data
         image_data: list[Any] = []
         image_shapes: list[list[int]] = []
-        image_infos: list[ImageInfo] = []
 
         for callable_obj in df[input_col]:
             try:
@@ -1073,7 +1088,6 @@ class ImageCallableToImageConverter(Converter):
                 if img_array is None:
                     image_data.append(None)
                     image_shapes.append(None)
-                    image_infos.append(None)
                     continue
 
                 # Validate that we got a numpy array
@@ -1099,10 +1113,6 @@ class ImageCallableToImageConverter(Converter):
                 image_data.append(img_array.flatten())
                 image_shapes.append(list(img_array.shape))
 
-                # Create image info with width and height from 3D array
-                height, width = img_array.shape[:2]
-                image_infos.append(ImageInfo(width=width, height=height))
-
             except Exception as e:
                 raise RuntimeError(f"Error executing callable for image generation: {e}") from e
 
@@ -1112,7 +1122,6 @@ class ImageCallableToImageConverter(Converter):
             [
                 pl.Series(output_col, image_data),
                 pl.Series(output_col + "_shape", image_shapes),
-                pl.Series(output_info_col, image_infos),
             ]
         )
 
@@ -1222,6 +1231,8 @@ class MaskCallableToMaskConverter(Converter):
             field=MaskField(
                 semantic=self.input_callable.field.semantic,
                 dtype=self.input_callable.field.dtype,  # Use dtype from callable field
+                channels_first=self.output_mask.field.channels_first,
+                has_channels_dim=self.output_mask.field.has_channels_dim,
             ),
             categories=self.input_callable.categories,
         )

--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -10,7 +10,8 @@ learning and computer vision applications.
 """
 
 from dataclasses import dataclass
-from typing import Any, TypeVar, Union
+from enum import Enum, auto
+from typing import Any, Optional, TypeVar, Union
 
 import numpy as np
 import polars as pl
@@ -18,6 +19,15 @@ from typing_extensions import TypeAlias
 
 from .schema import Field, Semantic
 from .type_registry import from_polars_data, to_numpy
+
+
+class Subset(Enum):
+    """Standard dataset subset values."""
+
+    Training = auto()
+    Validation = auto()
+    Testing = auto()
+
 
 T = TypeVar("T")
 
@@ -39,6 +49,7 @@ class TensorField(Field):
 
     semantic: Semantic
     dtype: PolarsDataType = pl.UInt8()
+    channels_first: bool = False
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         """Generate Polars schema with separate columns for data and shape."""
@@ -47,6 +58,10 @@ class TensorField(Field):
     def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
         """Convert tensor to flattened data and shape information."""
         numpy_value = to_numpy(value, self.dtype)
+
+        if self.channels_first and numpy_value is not None:
+            numpy_value = numpy_value.swapaxes(0, -1)
+
         schema = self.to_polars_schema("tensor")
 
         numpy_value_shape: Any | None = None
@@ -67,6 +82,10 @@ class TensorField(Field):
         flat_data = df[name][row_index]
         shape = df[name + "_shape"][row_index]
         numpy_data = np.array(flat_data).reshape(shape) if flat_data is not None else None
+
+        if self.channels_first and numpy_data is not None:
+            numpy_data = numpy_data.swapaxes(0, -1)
+
         return from_polars_data(numpy_data, target_type)  # type: ignore
 
 
@@ -99,7 +118,12 @@ class ImageField(TensorField):
     format: str = "RGB"
 
 
-def image_field(dtype: Any, format: str = "RGB", semantic: Semantic = Semantic.Default) -> Any:
+def image_field(
+    dtype: Any,
+    format: str = "RGB",
+    channels_first: bool = False,
+    semantic: Semantic = Semantic.Default,
+) -> Any:
     """
     Create an ImageField instance with the specified parameters.
 
@@ -111,7 +135,7 @@ def image_field(dtype: Any, format: str = "RGB", semantic: Semantic = Semantic.D
     Returns:
         ImageField instance configured with the given parameters
     """
-    return ImageField(semantic=semantic, dtype=dtype, format=format)
+    return ImageField(semantic=semantic, dtype=dtype, format=format, channels_first=channels_first)
 
 
 @dataclass(frozen=True)
@@ -573,6 +597,8 @@ class MaskField(Field):
 
     semantic: Semantic
     dtype: PolarsDataType = pl.UInt8()
+    channels_first: bool = False
+    has_channels_dim: bool = False
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         """Generate Polars schema with separate columns for data and shape."""
@@ -585,6 +611,11 @@ class MaskField(Field):
 
         numpy_value_shape: Any | None = None
         if numpy_value is not None:
+            if self.has_channels_dim:
+                if self.channels_first:
+                    numpy_value = numpy_value.squeeze(axis=0)
+                else:
+                    numpy_value = numpy_value.squeeze(axis=-1)
             numpy_value_shape = numpy_value.shape
             numpy_value = numpy_value.reshape(-1)
 
@@ -603,10 +634,22 @@ class MaskField(Field):
             if flat_data is not None and shape is not None
             else None
         )
+
+        if numpy_data is not None and self.has_channels_dim:
+            if self.channels_first:
+                numpy_data = numpy_data[np.newaxis, ...]
+            else:
+                numpy_data = numpy_data[..., np.newaxis]
+
         return from_polars_data(numpy_data, target_type)  # type: ignore
 
 
-def mask_field(dtype: Any = pl.UInt8(), semantic: Semantic = Semantic.Default) -> Any:
+def mask_field(
+    dtype: Any = pl.UInt8(),
+    channels_first: bool = False,
+    has_channels_dim: bool = False,
+    semantic: Semantic = Semantic.Default,
+) -> Any:
     """
     Create a MaskField instance with the specified parameters.
 
@@ -617,7 +660,12 @@ def mask_field(dtype: Any = pl.UInt8(), semantic: Semantic = Semantic.Default) -
     Returns:
         MaskField instance configured with the given parameters
     """
-    return MaskField(semantic=semantic, dtype=dtype)
+    return MaskField(
+        semantic=semantic,
+        dtype=dtype,
+        channels_first=channels_first,
+        has_channels_dim=has_channels_dim,
+    )
 
 
 @dataclass(frozen=True)
@@ -938,3 +986,73 @@ def keypoints_field(
         KeypointsField instance configured with the given parameters
     """
     return KeypointsField(semantic=semantic, dtype=dtype, normalize=normalize)
+
+
+@dataclass(frozen=True)
+class SubsetField(Field):
+    """
+    A field for storing subset information in a dataset.
+
+    This field supports both Enum and string values for subsets, storing them
+    as Polars categorical type for efficient memory usage and type safety.
+    When using an Enum type, the field maintains type safety by ensuring values
+    match the Enum. When using strings, any string value is accepted.
+
+    Attributes:
+        semantic: Semantic tags for the field
+        subset_type: Optional type hint for the subset values (Enum or str)
+        categories: Optional list of valid category values, required for categorical type
+    """
+
+    semantic: Semantic
+    categories: Optional[list[str]] = None
+
+    def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
+        """Generate schema with categorical type for subset values."""
+        return {name: pl.Categorical()}
+
+    def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
+        """Convert subset value to Polars categorical type.
+
+        If value is an Enum, uses the enum name. Otherwise, uses string representation.
+        """
+        if value is None:
+            polars_value = None
+        elif isinstance(value, Enum):
+            polars_value = value.name
+        else:
+            polars_value = str(value)
+
+        # Create categorical series with predefined categories if available
+        return {name: pl.Series(name, [polars_value], dtype=pl.Categorical)}
+
+    def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type[T]) -> T:
+        """Reconstruct subset value from Polars data.
+
+        If target_type is an Enum, converts string back to enum value.
+        Otherwise, returns the string value directly.
+        """
+        value = df[name][row_index]
+
+        if value is None:
+            return None  # type: ignore
+
+        if issubclass(target_type, Enum):
+            # Convert string back to enum value
+            return target_type[value]  # type: ignore
+
+        # For string type or no type specified, return the string value
+        return value  # type: ignore
+
+
+def subset_field(subset_type: Optional[type] = None, semantic: Semantic = Semantic.Default) -> Any:
+    """
+    Create a SubsetField instance for storing dataset subset information.
+
+    Args:
+        semantic: Semantic tags for the field (defaults to Semantic.Default)
+
+    Returns:
+        SubsetField instance configured with the given parameters
+    """
+    return SubsetField(semantic=semantic)

--- a/src/datumaro/experimental/legacy.py
+++ b/src/datumaro/experimental/legacy.py
@@ -36,6 +36,7 @@ from .fields import (
     LabelField,
     PolygonField,
     RotatedBBoxField,
+    Subset,
     bbox_field,
     image_bytes_field,
     image_callable_field,
@@ -47,6 +48,7 @@ from .fields import (
     mask_callable_field,
     polygon_field,
     rotated_bbox_field,
+    subset_field,
 )
 from .schema import AttributeInfo, Schema, Semantic
 
@@ -752,6 +754,7 @@ class AnalysisResult:
     schema: Schema
     media_converter: ForwardMediaConverter | None
     ann_converters: dict[AnnotationType, ForwardAnnotationConverter]
+    subset_converter: SubsetConverter
     is_anomaly: bool
 
 
@@ -778,6 +781,10 @@ def analyze_legacy_dataset(
     if media_converter is not None:
         attributes.update(media_converter.get_schema_attributes())
 
+    # Add SubsetConverter since it's always needed and not tied to specific annotation types
+    subset_converter = SubsetConverter(semantic=semantic)
+    attributes.update(subset_converter.get_schema_attributes())
+
     # If we have a label converter plus other converters, assume that this is an anomaly task.
     # To avoid conflicts between the label attribute and the other ones, use semantic to distinguish them.
     is_anomaly = AnnotationType.label in ann_types and len(ann_types) > 1
@@ -801,6 +808,7 @@ def analyze_legacy_dataset(
         schema=schema,
         media_converter=media_converter,
         ann_converters=ann_converters,
+        subset_converter=subset_converter,
         is_anomaly=is_anomaly,
     )
 
@@ -813,6 +821,9 @@ def _convert_legacy_item(item: DatasetItem, analysis_result: AnalysisResult) -> 
     # Convert media using the analyzed converter
     if analysis_result.media_converter:
         attributes.update(analysis_result.media_converter.convert_item_media(item))
+
+    # Convert subset using the subset converter
+    attributes.update(analysis_result.subset_converter.convert_annotations(item.annotations, item))
 
     # Convert each annotation type using the analyzed converters
     for ann_converter in analysis_result.ann_converters.values():
@@ -998,26 +1009,32 @@ class ForwardMaskAnnotationConverter(ForwardAnnotationConverter):
 
         # Create categories based on legacy label categories
         new_label_categories = None
+        labels = []
         if legacy_label_categories is not None:
             labels = tuple(label_item.name for label_item in legacy_label_categories.items)
-            new_label_categories = LabelCategories(labels=labels)
+
+        mask_labels_attribute = None
 
         if is_semantic:
             # For semantic segmentation, use MaskCategories for mask_attribute
             colormap = {}
-            if new_label_categories is not None:
-                # Generate colors for all labels plus background
-                num_classes = len(new_label_categories) + 1  # +1 for background
-                colormap_dict = generate_colormap(num_classes, include_background=True)
 
-                # Convert colors to RgbColor
-                for index, color in colormap_dict.items():
-                    if isinstance(color, tuple):
-                        colormap[index] = RgbColor(*color)
-                    else:
-                        colormap[index] = color
+            # Have at least one label for the background
+            if len(labels) == 0:
+                labels = ("background",)
 
-            mask_categories = MaskCategories(colormap=colormap)
+            # Generate colors for all labels plus background
+            num_classes = len(labels)
+            colormap_dict = generate_colormap(num_classes, include_background=True)
+
+            # Convert colors to RgbColor
+            for index, color in colormap_dict.items():
+                if isinstance(color, tuple):
+                    colormap[index] = RgbColor(*color)
+                else:
+                    colormap[index] = color
+
+            mask_categories = MaskCategories(labels=labels, colormap=colormap)
             mask_attribute = AttributeInfo(
                 type=callable,
                 annotation=mask_callable_field(dtype=pl.UInt8, semantic=semantic),
@@ -1034,14 +1051,17 @@ class ForwardMaskAnnotationConverter(ForwardAnnotationConverter):
                 annotation=instance_mask_callable_field(dtype=pl.Boolean, semantic=semantic),
             )
 
-        mask_labels_attribute = None
-        # Only add mask_labels if we have label categories and using instance segmentation
-        if new_label_categories is not None and not is_semantic:
-            mask_labels_attribute = AttributeInfo(
-                type=np.ndarray,
-                annotation=label_field(is_list=True, semantic=semantic),  # Labels for each instance
-                categories=new_label_categories,
-            )
+            # Only add mask_labels if we have label categories
+            if len(labels) > 0:
+                new_label_categories = LabelCategories(labels=labels)
+
+                mask_labels_attribute = AttributeInfo(
+                    type=np.ndarray,
+                    annotation=label_field(
+                        is_list=True, semantic=semantic
+                    ),  # Labels for each instance
+                    categories=new_label_categories,
+                )
 
         return cls(
             mask_attribute=mask_attribute,
@@ -1504,6 +1524,90 @@ def convert_to_legacy(experimental_dataset: Dataset[Sample]) -> LegacyDataset:
     )
 
     return legacy_dataset
+
+
+class SubsetConverter(ForwardAnnotationConverter):
+    """Converts legacy subset strings to Subset enum values.
+
+    This converter handles mapping of legacy subset strings to their standardized
+    Subset enum values while preserving unrecognized values as strings.
+
+    The following mappings are supported:
+    - Train: "train", "TRAINING" -> Subset.Training
+    - Validation: "val", "VALIDATION" -> Subset.Validation
+    - Test: "test", "TEST" -> Subset.Testing
+    """
+
+    # Combined lookup table mapping strings to enum values
+    _SUBSET_MAP = (
+        {name: Subset.Training for name in {"train", "TRAINING"}}
+        | {name: Subset.Validation for name in {"val", "VALIDATION"}}
+        | {name: Subset.Testing for name in {"test", "TEST"}}
+    )
+
+    def __init__(self, semantic: Semantic = Semantic.Default, name_prefix: str = ""):
+        """Initialize the converter.
+
+        Args:
+            semantic: The semantic type for the converted fields
+            name_prefix: Prefix to prepend to all field names
+        """
+        self._semantic = semantic
+        self._name_prefix = name_prefix
+
+    @classmethod
+    def get_supported_annotation_types(cls) -> list[AnnotationType]:
+        """Return list of annotation types this converter can handle."""
+        return []  # Subset conversion does not handle any specific annotation type
+
+    @classmethod
+    def create(
+        cls, dataset: LegacyDataset, semantic: Semantic = Semantic.Default, name_prefix: str = ""
+    ) -> "ForwardAnnotationConverter | None":
+        """Create converter instance if dataset supports this annotation type.
+
+        Args:
+            dataset: Legacy dataset to create converter from
+            semantic: The semantic type for the converted fields
+            name_prefix: Prefix to prepend to all field names
+        """
+        return cls(semantic=semantic, name_prefix=name_prefix)
+
+    def get_schema_attributes(self) -> dict[str, AttributeInfo]:
+        """Return schema attributes for this annotation type.
+
+        Returns:
+            A dictionary with a single entry for the subset field, using SubsetField
+            with the configured semantic type.
+        """
+        field_name = f"{self._name_prefix}subset" if self._name_prefix else "subset"
+        return {
+            field_name: AttributeInfo(
+                type=str,
+                annotation=subset_field(semantic=self._semantic),
+            )
+        }
+
+    def convert_annotations(
+        self, annotations: list[Annotation], item: DatasetItem
+    ) -> dict[str, Any]:
+        """Convert dataset item subset to standardized format.
+
+        Args:
+            annotations: List of annotations (not used by this converter)
+            item: Legacy dataset item containing the subset information
+
+        Returns:
+            Dict containing the converted subset field
+        """
+        subset = item.subset
+        if subset is None:
+            return {}
+
+        # Convert legacy subset name to standardized format
+        converted_subset = self._SUBSET_MAP.get(subset, subset)
+        field_name = f"{self._name_prefix}subset" if self._name_prefix else "subset"
+        return {field_name: converted_subset}
 
 
 def register_builtin_backward_converters():

--- a/src/datumaro/experimental/type_registry.py
+++ b/src/datumaro/experimental/type_registry.py
@@ -250,6 +250,34 @@ try:
 except ImportError:
     pass
 
+# Register torchvision converters if available
+try:
+    from torchvision import tv_tensors  # pyright: ignore[reportMissingImports]
+
+    register_numpy_converter(
+        tv_tensors.Image, lambda x: x.detach().cpu().numpy()
+    )  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+
+    register_numpy_converter(
+        tv_tensors.BoundingBoxes, lambda x: x.detach().cpu().numpy()
+    )  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+
+    register_numpy_converter(
+        tv_tensors.Mask, lambda x: x.detach().cpu().numpy()
+    )  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+
+    # Conversion from Polars to tv_tensors BoundingBoxes and Keypoints are not supported
+    # because tv_tensors BoundingBoxes and Keypoints require the image size which is not available during conversion.
+    register_from_polars_converter(
+        tv_tensors.Image, lambda x: tv_tensors.Image(x)
+    )  # pyright: ignore[reportUnknownMemberType, reportUnknownLambdaType, reportUnknownArgumentType]
+
+    register_from_polars_converter(
+        tv_tensors.Mask, lambda x: tv_tensors.Mask(x)
+    )  # pyright: ignore[reportUnknownMemberType, reportUnknownLambdaType, reportUnknownArgumentType]
+except ImportError:
+    pass
+
 # Register PIL Image converters if available
 try:
     from PIL import Image

--- a/tests/unit/experimental/test_converters.py
+++ b/tests/unit/experimental/test_converters.py
@@ -265,18 +265,10 @@ def test_image_path_to_image_converter():
 
         assert "image" in result_df.columns
         assert "image_shape" in result_df.columns
-        assert "image_info" in result_df.columns
 
         # Check that image was loaded correctly
         result_shape = list(result_df["image_shape"][0])
         assert result_shape == [50, 75, 3]  # height, width, channels
-
-        # Check that image info was created correctly (only width and height)
-        image_info = result_df["image_info"][0]
-        assert "width" in image_info
-        assert "height" in image_info
-        assert image_info["width"] == 75  # width
-        assert image_info["height"] == 50  # height
 
 
 def test_image_bytes_to_image_converter():
@@ -325,18 +317,10 @@ def test_image_bytes_to_image_converter():
 
     assert "image" in result_df.columns
     assert "image_shape" in result_df.columns
-    assert "image_info" in result_df.columns
 
     # Check that image was loaded correctly
     result_shape = tuple(result_df["image_shape"][0])
     assert result_shape == (32, 48, 3)  # height, width, channels
-
-    # Check that image info was created correctly (only width and height)
-    image_info = result_df["image_info"][0]
-    assert "width" in image_info
-    assert "height" in image_info
-    assert image_info["width"] == 48  # width
-    assert image_info["height"] == 32  # height
 
     # Check that the actual image data is correct (approximately, since PNG compression may cause slight differences)
     result_image = result_df["image"][0].to_numpy().reshape(result_shape)
@@ -497,10 +481,20 @@ def test_multiple_converter_chaining():
 
     path, _ = find_conversion_path(source_schema, target_schema)
     # If successful, should have multiple steps
-    assert len(path.batch_converters) == 3
-    assert type(path.batch_converters[0]) is BBoxCoordinateConverter
-    assert type(path.batch_converters[1]) is RGBToBGRConverter
-    assert type(path.batch_converters[2]) is UInt8ToFloat32Converter
+    assert len(path.converters["image"]) == 2
+    assert type(path.converters["image"][0]) is UInt8ToFloat32Converter
+    assert type(path.converters["image"][1]) is RGBToBGRConverter
+
+    # FIXME(gdlg): the BBoxCoordinateConverter needs an image
+    # and it does not matter if the image is 8 bits or 32 bits,
+    # so converting the image then the bbox is correct, hence the dependency.
+    # The problem is that this is not desirable as it creates a spurious dependency
+    # on the 32 bits conversion even though it is not needed.
+    # To fix this, we need to adjust the weights to favour applying image conversions
+    # after the bbox ones.
+    assert len(path.converters["bbox"]) == 2
+    assert type(path.converters["bbox"][0]) is UInt8ToFloat32Converter
+    assert type(path.converters["bbox"][1]) is BBoxCoordinateConverter
 
 
 def test_astar_direct_conversion():
@@ -1873,16 +1867,10 @@ def test_image_callable_to_image_converter():
     # Check expected columns exist
     assert "output_image" in result_df.columns
     assert "output_image_shape" in result_df.columns
-    assert "output_info" in result_df.columns
 
     # Check image shape
     image_shape = result_df["output_image_shape"][0]
     assert list(image_shape) == [3, 3, 3]  # height, width, channels
-
-    # Check image info
-    image_info = result_df["output_info"][0]
-    assert image_info["width"] == 3
-    assert image_info["height"] == 3
 
     # Check image data can be reconstructed
     image_data = result_df["output_image"][0]
@@ -1998,9 +1986,11 @@ def test_image_callable_converter_dtype_handling():
 
     df2 = pl.DataFrame({"my_callable": [float32_callable]}, schema={"my_callable": pl.Object})
     result2 = converter_instance.convert(df2)
-    image_info2 = result2["output_info"][0]
-    assert image_info2["width"] == 1  # width
-    assert image_info2["height"] == 1  # height
+    image_data2 = np.array(result2["output_image"][0], dtype=np.float32).reshape([1, 1, 3])
+    assert image_data2.dtype == np.float32
+    assert image_data2[0, 0, 0] == 1.0
+    assert image_data2[0, 0, 1] == 0.5
+    assert image_data2[0, 0, 2] == 0.25
 
 
 def test_rotated_bbox_to_polygon_converter():

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -713,7 +713,9 @@ def test_analyze_unknown_annotation_type():
         # Should skip unknown annotation type
         assert "image_path" in analysis_result.schema.attributes
         assert "image_info" in analysis_result.schema.attributes
-        assert len(analysis_result.schema.attributes) == 2  # Only image_path and image_info field
+        assert (
+            len(analysis_result.schema.attributes) == 3
+        )  # Only image_path, image_info, and subset fields
 
 
 def test_convert_simple_bbox_dataset():


### PR DESCRIPTION
* channels_first and has_channels_dim support (fixes #1870)
* move creation of image_info to its own converter to avoid overriding existing image_info when reading an image
* subset attribute support
* add label names to MaskCategories in the legacy converter
* tv_tensors support (fixes #1873)

This PR requires https://github.com/open-edge-platform/datumaro/pull/1905 and must be merged afterwards.


<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
