### PR TITLE
Unfreeze TileInfo dataclass

### DIFF
--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -34,7 +34,7 @@ T = TypeVar("T")
 PolarsDataType: TypeAlias = Union[type[pl.DataType], pl.DataType]
 
 
-@dataclass(frozen=True)
+@dataclass()
 class TileInfo:
     """Information about a single tile within a larger image or data."""
 


### PR DESCRIPTION
The TileInfo dataclass needs to be unfrozen so that the source sample idx can be changed later on. 

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
