### PR TITLE
Add ScoreField

### DIFF
--- a/src/datumaro/experimental/__init__.py
+++ b/src/datumaro/experimental/__init__.py
@@ -13,6 +13,7 @@ from .fields import (
     ImagePathField,
     LabelField,
     RotatedBBoxField,
+    ScoreField,
     TensorField,
     bbox_field,
     image_callable_field,
@@ -21,6 +22,7 @@ from .fields import (
     image_path_field,
     label_field,
     rotated_bbox_field,
+    score_field,
     tensor_field,
 )
 from .schema import AttributeInfo, Field, Schema, Semantic

--- a/src/datumaro/experimental/fields.py
+++ b/src/datumaro/experimental/fields.py
@@ -561,6 +561,58 @@ def label_field(
     return LabelField(semantic=semantic, dtype=dtype, multi_label=multi_label, is_list=is_list)
 
 
+@dataclass(frozen=True)
+class ScoreField(Field):
+    """
+    Represents a prediction score.
+
+    By default stores a single float value in a Float32 column. If is_list=True,
+    stores a list of float values, matching multi-prediction scenarios.
+    """
+
+    semantic: Semantic
+    dtype: PolarsDataType = pl.Float32()
+    is_list: bool = False
+
+    @property
+    def _pl_type(self) -> pl.DataType:
+        pl_type = self.dtype
+        if self.is_list:
+            pl_type = pl.List(pl_type)
+        return pl_type
+
+    def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
+        return {name: self._pl_type}
+
+    def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
+        return {name: pl.Series(name, [value], dtype=self._pl_type)}
+
+    def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type[T]) -> T:
+        data = df[name][row_index]
+        if target_type is list:
+            return list(data) if data is not None else None  # type: ignore[return-value]
+        return from_polars_data(data, target_type)
+
+
+def score_field(
+    dtype: Any = pl.Float32(),
+    semantic: Semantic = Semantic.Default,
+    is_list: bool = False,
+) -> Any:
+    """
+    Create a ScoreField instance.
+
+    Args:
+        dtype: Polars data type for score values (defaults to pl.Float32())
+        semantic: Semantic tags describing the score purpose (optional)
+        is_list: Whether this field should be treated as a list type (defaults to False)
+
+    Returns:
+        ScoreField instance configured with the given parameters
+    """
+    return ScoreField(semantic=semantic, dtype=dtype, is_list=is_list)
+
+
 def convert_numpy_object_array_to_series(data: np.ndarray) -> pl.Series:
     """
     Convert ragged numpy object arrays to Polars Series recursively.

--- a/tests/unit/experimental/test_score_field.py
+++ b/tests/unit/experimental/test_score_field.py
@@ -1,0 +1,52 @@
+import polars as pl
+from typing_extensions import Annotated
+
+from datumaro.experimental import score_field
+from datumaro.experimental.dataset import Dataset, Sample
+
+
+def test_score_field_scalar_roundtrip():
+    class PredSample(Sample):
+        confidence: Annotated[float, score_field()]
+
+    ds = Dataset(PredSample)
+
+    s = PredSample(confidence=0.87)
+    ds.append(s)
+
+    assert len(ds) == 1
+    out = ds[0]
+    assert isinstance(out, PredSample)
+    assert abs(out.confidence - 0.87) < 1e-6
+
+
+def test_confidence_field_list_roundtrip():
+    class PredSample(Sample):
+        confidences: Annotated[list[float], score_field(is_list=True)]
+
+    ds = Dataset(PredSample)
+
+    vals = [0.1, 0.5, 0.9]
+    s = PredSample(confidences=vals)
+    ds.append(s)
+
+    assert len(ds) == 1
+    out = ds[0]
+    assert isinstance(out, PredSample)
+    assert len(out.confidences) == len(vals)
+    for a, b in zip(out.confidences, vals):
+        assert abs(a - b) < 1e-6
+
+
+def test_confidence_field_custom_dtype():
+    class PredSample(Sample):
+        confidence: Annotated[float, score_field(dtype=pl.Float64)]
+
+    ds = Dataset(PredSample)
+
+    s = PredSample(confidence=0.123456789)
+    ds.append(s)
+
+    out = ds[0]
+    assert isinstance(out.confidence, float)
+    assert abs(out.confidence - 0.123456789) < 1e-12


### PR DESCRIPTION
This pull request introduces a new `ScoreField` type to the experimental data schema, allowing the storage and handling of prediction scores in datasets. The implementation supports both scalar and list formats, as well as custom data types. Comprehensive tests are added to ensure correct round-trip serialization and deserialization of score values.

**New ScoreField type and API:**

* Added the `ScoreField` dataclass to `fields.py`, which represents a prediction score with support for scalar and list values, customizable data types, and Polars integration. Also added the `score_field` factory function for easy instantiation.
* Updated `__init__.py` to expose `ScoreField` and `score_field` in the experimental API. [[1]](diffhunk://#diff-6c66a059cb4075cd7afbc29b4f34236f8101a1a47cdcc429c7a2d25868cc74b5R16) [[2]](diffhunk://#diff-6c66a059cb4075cd7afbc29b4f34236f8101a1a47cdcc429c7a2d25868cc74b5R25)

**Testing:**

* Added a new unit test file `test_score_field.py` to verify scalar, list, and custom dtype support for the `ScoreField`, ensuring correct round-trip data handling with the dataset API.<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
