### PR TITLE
Fix sample validation for complex types

### DIFF
--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -78,15 +78,20 @@ class Sample:
         # Union and Callable types have to be handled separately,
         # because isinstance() does not work with Callable types.
         origin = get_origin(expected_type)
-        if origin is Union:
+        if origin in {Union, types.UnionType}:
             # Check each type in the Union
-            return any(self._validate_attribute_type(typ, value) for typ in get_args(expected_type))
-        if origin in {typing.Callable, collections.abc.Callable} or expected_type in {
+            result = any(self._validate_attribute_type(typ, value) for typ in get_args(expected_type))
+        elif origin in {typing.Callable, collections.abc.Callable} or expected_type in {
             typing.Callable,
             collections.abc.Callable,
         }:
-            return callable(value)
-        return isinstance(value, origin or expected_type)
+            result = callable(value)
+        else:
+            try:
+                result = isinstance(value, expected_type)
+            except TypeError:
+                result = isinstance(value, origin)
+        return result
 
     @classmethod
     @cache

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -86,7 +86,7 @@ class Sample:
             collections.abc.Callable,
         }:
             return callable(value)
-        return isinstance(value, expected_type)
+        return isinstance(value, origin or expected_type)
 
     @classmethod
     @cache

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -90,6 +90,8 @@ class Sample:
             try:
                 result = isinstance(value, expected_type)
             except TypeError:
+                # Some complex types cannot be validated, for example, sometimes when a numpy dtype is turned
+                # into a list using Polars List, the resulting complex dtype will contain a generic Any.
                 result = isinstance(value, origin)
         return result
 

--- a/tests/unit/experimental/test_sample.py
+++ b/tests/unit/experimental/test_sample.py
@@ -5,6 +5,7 @@ Unit tests for Sample class.
 from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 import polars as pl
 import pytest
 
@@ -17,6 +18,7 @@ from datumaro.experimental.fields import (
     bbox_field,
     image_field,
     image_info_field,
+    score_field,
 )
 from datumaro.experimental.fields.images import image_path_field
 from datumaro.experimental.schema import Schema
@@ -185,3 +187,11 @@ def test_sample_inheritance():
     assert len(extended_schema.attributes) == 3
     assert "image_info" in extended_schema.attributes
     assert "image_info" not in base_schema.attributes
+
+
+def test_sample_with_is_list():
+    class MySample(Sample):
+        confidence: npt.NDArray[np.float32] | None = score_field(dtype=pl.Float32(), is_list=True)
+
+    # Assert that sample can be created without validation errors
+    MySample(confidence=np.array([0.8]))

--- a/tests/unit/experimental/test_sample.py
+++ b/tests/unit/experimental/test_sample.py
@@ -18,7 +18,7 @@ from datumaro.experimental.fields import (
     bbox_field,
     image_field,
     image_info_field,
-    score_field,
+    numeric_field,
 )
 from datumaro.experimental.fields.images import image_path_field
 from datumaro.experimental.schema import Schema
@@ -191,7 +191,7 @@ def test_sample_inheritance():
 
 def test_sample_with_is_list():
     class MySample(Sample):
-        confidence: npt.NDArray[np.float32] | None = score_field(dtype=pl.Float32(), is_list=True)
+        confidence: npt.NDArray[np.float32] | None = numeric_field(dtype=pl.Float32(), is_list=True)
 
     # Assert that sample can be created without validation errors
     MySample(confidence=np.array([0.8]))


### PR DESCRIPTION
This pull request fixes a problem with type validation in the experimental dataset and sample modules. When we use the is_list boolean of score_field, a complex ndarray type is generated that includes an Any type, which is not accepted by isinstance. To circumvent problems with complex types, whenever isintance fails with a type error, we only validate against the origin type (ndarray instead of ndarray[float32], for example)

### Type validation improvements

* Updated the `_validate_attribute_type` method in `src/datumaro/experimental/dataset.py` to correctly handle type validation for generic types by using `origin` when available, improving support for complex type annotations.

### Test enhancements

* Added a new test, `test_sample_with_is_list`, in `tests/unit/experimental/test_sample.py` to verify that samples with list-type fields (using `is_list=True` in `score_field`) are created without validation errors.

Resolves #1971 
