### PR TITLE
fix: restrict Python version upgrade by Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -90,6 +90,14 @@
       matchDepNames: ["python"],
       matchDepTypes: ["uses-with"],
     },
+
+    // Python version in TOML is updated manually
+    {
+      enabled: false,
+      matchDatasources: ["python-version"],
+      matchDepTypes: ["requires-python"],
+      matchDepNames: ["python"],
+    },
   ],
 
   // Enable security upgrades


### PR DESCRIPTION
This PR updates Renovate config to prevent Python version update in TOML ([PR example](https://github.com/open-edge-platform/datumaro/pull/1974))

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
