### PR TITLE
Improve dtype conversions

### DIFF
--- a/src/datumaro/experimental/converters/__init__.py
+++ b/src/datumaro/experimental/converters/__init__.py
@@ -7,7 +7,9 @@ from datumaro.experimental.converters.annotation_converters import (
     BBoxDtypeConverter,
     LabelDtypeConverter,
     LabelIndexConverter,
+    PolygonDtypeConverter,
     PolygonToBBoxConverter,
+    RotatedBBoxDtypeConverter,
     RotatedBBoxToPolygonConverter,
 )
 from datumaro.experimental.converters.base import AttributeRemapperConverter, ConversionError, Converter, list_eval_ref
@@ -62,12 +64,14 @@ __all__ = [
     # Annotation converters
     "LabelIndexConverter",
     "MaskCallableToMaskConverter",
+    "PolygonDtypeConverter",
     "PolygonToBBoxConverter",
     "PolygonToInstanceMaskConverter",
     # Mask converters
     "PolygonToMaskConverter",
     # Image converters
     "RedBlueColorConverter",
+    "RotatedBBoxDtypeConverter",
     "RotatedBBoxToPolygonConverter",
     "UInt8ToFloat32Converter",
     "_can_lazy_converter_handle_conversion",

--- a/src/datumaro/experimental/converters/annotation_converters.py
+++ b/src/datumaro/experimental/converters/annotation_converters.py
@@ -206,11 +206,44 @@ class BBoxCoordinateConverter(Converter):
         return result_df.drop([temp_width_col, temp_height_col])
 
 
+def _create_fixed_array_cast_expr(target_dtype: pl.DataType, array_size: int) -> pl.Expr:
+    """
+    Create a Polars expression to cast a fixed-size array to a target dtype.
+
+    Args:
+        target_dtype: The target Polars data type
+        array_size: The size of the fixed array (e.g., 4 for BBox, 5 for RotatedBBox)
+
+    Returns:
+        Polars expression that casts each element and reconstructs the array
+    """
+    return pl.concat_arr(*[pl.element().arr.get(i).cast(target_dtype) for i in range(array_size)])
+
+
+def _convert_fixed_array_dtype(
+    df: pl.DataFrame, input_col: str, output_col: str, target_dtype: pl.DataType, array_size: int
+) -> pl.DataFrame:
+    """
+    Convert a column containing List[Array[dtype, N]] to a new dtype.
+
+    Args:
+        df: Input DataFrame
+        input_col: Name of the input column
+        output_col: Name of the output column
+        target_dtype: Target Polars dtype
+        array_size: Size of the fixed arrays
+
+    Returns:
+        DataFrame with converted column
+    """
+    return df.with_columns(
+        pl.col(input_col).list.eval(_create_fixed_array_cast_expr(target_dtype, array_size)).alias(output_col)
+    )
+
+
 @converter
 class BBoxDtypeConverter(Converter):
-    """
-    Convert BBox field between different data types.
-    """
+    """Convert BBox field between different data types."""
 
     input_bbox: AttributeSpec[BBoxField]
     output_bbox: AttributeSpec[BBoxField]
@@ -221,33 +254,54 @@ class BBoxDtypeConverter(Converter):
             name=self.output_bbox.name,
             field=BBoxField(
                 semantic=self.input_bbox.field.semantic,
-                dtype=self.output_bbox.field.dtype,  # Use target dtype
+                dtype=self.output_bbox.field.dtype,
                 format=self.input_bbox.field.format,
                 normalize=self.input_bbox.field.normalize,
             ),
         )
-
-        # Apply converter only if dtypes are different
         return self.input_bbox.field.dtype != self.output_bbox.field.dtype
 
     def convert(self, df: pl.DataFrame) -> pl.DataFrame:
         """Convert bbox data to target dtype."""
-        input_col = self.input_bbox.name
-        output_col = self.output_bbox.name
+        return _convert_fixed_array_dtype(
+            df, self.input_bbox.name, self.output_bbox.name, self.output_bbox.field.dtype, array_size=4
+        )
 
-        # Cast bbox values to target dtype by converting each element
-        return df.with_columns(
-            pl.col(input_col)
-            .list.eval(pl.element().arr.to_list().list.eval(pl.element().cast(self.output_bbox.field.dtype)))
-            .alias(output_col)
+
+@converter
+class RotatedBBoxDtypeConverter(Converter):
+    """Convert RotatedBBox field between different data types."""
+
+    input_rotated_bbox: AttributeSpec[RotatedBBoxField]
+    output_rotated_bbox: AttributeSpec[RotatedBBoxField]
+
+    def filter_output_spec(self) -> bool:
+        """Configure output rotated bbox specification with target dtype."""
+        self.output_rotated_bbox = AttributeSpec(
+            name=self.output_rotated_bbox.name,
+            field=RotatedBBoxField(
+                semantic=self.input_rotated_bbox.field.semantic,
+                dtype=self.output_rotated_bbox.field.dtype,
+                format=self.input_rotated_bbox.field.format,
+                normalize=self.input_rotated_bbox.field.normalize,
+            ),
+        )
+        return self.input_rotated_bbox.field.dtype != self.output_rotated_bbox.field.dtype
+
+    def convert(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Convert rotated bbox data to target dtype."""
+        return _convert_fixed_array_dtype(
+            df,
+            self.input_rotated_bbox.name,
+            self.output_rotated_bbox.name,
+            self.output_rotated_bbox.field.dtype,
+            array_size=5,
         )
 
 
 @converter
 class LabelDtypeConverter(Converter):
-    """
-    Convert Label field between different data types.
-    """
+    """Convert Label field between different data types."""
 
     input_label: AttributeSpec[LabelField]
     output_label: AttributeSpec[LabelField]
@@ -258,27 +312,56 @@ class LabelDtypeConverter(Converter):
             name=self.output_label.name,
             field=LabelField(
                 semantic=self.input_label.field.semantic,
-                dtype=self.output_label.field.dtype,  # Use target dtype
+                dtype=self.output_label.field.dtype,
                 multi_label=self.input_label.field.multi_label,
                 is_list=self.input_label.field.is_list,
             ),
         )
-
-        # Apply converter only if dtypes are different
         return self.input_label.field.dtype != self.output_label.field.dtype
 
     def convert(self, df: pl.DataFrame) -> pl.DataFrame:
         """Convert label data to target dtype."""
         input_col = self.input_label.name
         output_col = self.output_label.name
+        target_dtype = self.output_label.field.dtype
 
         if self.input_label.field.is_list:
-            # Handle list of labels
-            return df.with_columns(
-                pl.col(input_col).list.eval(pl.element().cast(self.output_label.field.dtype)).alias(output_col)
-            )
-        # Handle single label
-        return df.with_columns(pl.col(input_col).cast(self.output_label.field.dtype).alias(output_col))
+            return df.with_columns(pl.col(input_col).list.eval(pl.element().cast(target_dtype)).alias(output_col))
+        return df.with_columns(pl.col(input_col).cast(target_dtype).alias(output_col))
+
+
+@converter
+class PolygonDtypeConverter(Converter):
+    """Convert Polygon field between different data types."""
+
+    input_polygon: AttributeSpec[PolygonField]
+    output_polygon: AttributeSpec[PolygonField]
+
+    def filter_output_spec(self) -> bool:
+        """Configure output polygon specification with target dtype."""
+        self.output_polygon = AttributeSpec(
+            name=self.output_polygon.name,
+            field=PolygonField(
+                semantic=self.input_polygon.field.semantic,
+                dtype=self.output_polygon.field.dtype,
+                format=self.input_polygon.field.format,
+                normalize=self.input_polygon.field.normalize,
+            ),
+        )
+        return self.input_polygon.field.dtype != self.output_polygon.field.dtype
+
+    def convert(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Convert polygon data to target dtype."""
+        input_col = self.input_polygon.name
+        output_col = self.output_polygon.name
+        target_dtype = self.output_polygon.field.dtype
+
+        # Polygon structure: List[List[Array[dtype, 2]]]
+        return df.with_columns(
+            pl.col(input_col)
+            .list.eval(pl.element().list.eval(_create_fixed_array_cast_expr(target_dtype, 2)))
+            .alias(output_col)
+        )
 
 
 @converter

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -65,7 +65,7 @@ class Sample:
             field = attr_info.field
 
             if not self._validate_attribute_type(expected_type, value):
-                raise TypeError(f"Attribute `{name}` must be of type `{expected_type}` but is type {type(value)}.")
+                raise TypeError(f"Attribute `{name}` must be of type `{expected_type}` but is type `{type(value)}`.")
 
             # Custom field validation (if any)
             if hasattr(field, "validate"):

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -65,7 +65,7 @@ class Sample:
             field = attr_info.field
 
             if not self._validate_attribute_type(expected_type, value):
-                raise TypeError(f"Attribute `{name}` must be of type `{expected_type}`.")
+                raise TypeError(f"Attribute `{name}` must be of type `{expected_type}` but is type {type(value)}.")
 
             # Custom field validation (if any)
             if hasattr(field, "validate"):

--- a/tests/unit/experimental/test_converters.py
+++ b/tests/unit/experimental/test_converters.py
@@ -5,8 +5,10 @@ Unit tests for converter registry and converter implementations.
 import os
 import tempfile
 from dataclasses import field
+from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 import polars as pl
 import pytest
 
@@ -32,6 +34,7 @@ from datumaro.experimental.converters import (
     converter,
     find_conversion_path,
 )
+from datumaro.experimental.dataset import Dataset, Sample
 from datumaro.experimental.fields import (
     BBoxField,
     Field,
@@ -1209,7 +1212,7 @@ def test_find_conversion_path_inferred_categories():
     )
 
     # Create source schema with label categories
-    label_categories = LabelCategories(labels=["cat", "dog", "bird"])
+    label_categories = LabelCategories(labels=("cat", "dog", "bird"))
     source_schema = Schema(
         attributes={
             "polygons": AttributeInfo(
@@ -2144,3 +2147,381 @@ def test_rotated_bbox_to_polygon_converter():
     # Check second polygon (45-degree rotation)
     polygon2 = polygons[1]
     assert len(polygon2) == 4  # Four corners
+
+
+def test_bbox_dtype_converter_int_to_float():
+    """Test BBoxDtypeConverter converting Int32 to Float32."""
+    from datumaro.experimental.converters import BBoxDtypeConverter
+
+    converter_instance = BBoxDtypeConverter()
+
+    # Create test data with Int32 bboxes
+    df = pl.DataFrame(
+        {"bbox": [[[5, 5, 20, 20], [25, 30, 50, 60]]]},
+        schema=pl.Schema({"bbox": pl.List(pl.Array(pl.Int32, 4))}),
+    )
+
+    # Set up converter attributes
+    input_bbox_field = BBoxField(dtype=pl.Int32(), format="x1y1x2y2", normalize=False)
+    output_bbox_field = BBoxField(dtype=pl.Float32(), format="x1y1x2y2", normalize=False)
+
+    setattr(converter_instance, "input_bbox", AttributeSpec(name="bbox", field=input_bbox_field))
+    setattr(converter_instance, "output_bbox", AttributeSpec(name="bbox", field=output_bbox_field))
+
+    # Test filter - should return True for dtype change
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    assert "bbox" in result_df.columns
+    # Check dtype conversion
+    result_bbox = result_df["bbox"][0]
+    assert result_bbox[0].to_numpy().dtype == np.float32
+    assert result_bbox[1].to_numpy().dtype == np.float32
+
+    # Check values preserved
+    np.testing.assert_array_almost_equal(result_bbox[0].to_numpy(), [5.0, 5.0, 20.0, 20.0])
+    np.testing.assert_array_almost_equal(result_bbox[1].to_numpy(), [25.0, 30.0, 50.0, 60.0])
+
+
+def test_bbox_dtype_converter_float_to_int():
+    """Test BBoxDtypeConverter converting Float64 to Int32."""
+    from datumaro.experimental.converters import BBoxDtypeConverter
+
+    converter_instance = BBoxDtypeConverter()
+
+    # Create test data with Float64 bboxes
+    df = pl.DataFrame(
+        {"bbox": [[[10.5, 20.7, 30.2, 40.9]]]},
+        schema=pl.Schema({"bbox": pl.List(pl.Array(pl.Float64, 4))}),
+    )
+
+    # Set up converter attributes
+    input_bbox_field = BBoxField(dtype=pl.Float64(), format="x1y1x2y2", normalize=False)
+    output_bbox_field = BBoxField(dtype=pl.Int32(), format="x1y1x2y2", normalize=False)
+
+    setattr(converter_instance, "input_bbox", AttributeSpec(name="bbox", field=input_bbox_field))
+    setattr(converter_instance, "output_bbox", AttributeSpec(name="bbox", field=output_bbox_field))
+
+    # Test filter - should return True for dtype change
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    assert "bbox" in result_df.columns
+    # Check dtype conversion
+    result_bbox = result_df["bbox"][0]
+    assert result_bbox[0].to_numpy().dtype == np.int32
+    # Values should be truncated
+    np.testing.assert_array_equal(result_bbox[0].to_numpy(), [10, 20, 30, 40])
+
+
+def test_bbox_dtype_converter_same_dtype():
+    """Test BBoxDtypeConverter returns False when dtypes are the same."""
+    from datumaro.experimental.converters import BBoxDtypeConverter
+
+    converter_instance = BBoxDtypeConverter()
+
+    # Set up converter attributes with same dtype
+    input_bbox_field = BBoxField(dtype=pl.Float32(), format="x1y1x2y2", normalize=False)
+    output_bbox_field = BBoxField(dtype=pl.Float32(), format="x1y1x2y2", normalize=False)
+
+    setattr(converter_instance, "input_bbox", AttributeSpec(name="bbox", field=input_bbox_field))
+    setattr(converter_instance, "output_bbox", AttributeSpec(name="bbox", field=output_bbox_field))
+
+    # Test filter - should return False when dtypes are the same
+    assert converter_instance.filter_output_spec() is False
+
+
+def test_rotated_bbox_dtype_converter_int_to_float():
+    """Test RotatedBBoxDtypeConverter converting Int32 to Float32."""
+    from datumaro.experimental.converters import RotatedBBoxDtypeConverter
+
+    converter_instance = RotatedBBoxDtypeConverter()
+
+    # Create test data with Int32 rotated bboxes (cx, cy, w, h, r)
+    df = pl.DataFrame(
+        {"rotated_bbox": [[[50, 60, 30, 20, 0], [100, 120, 40, 25, 1]]]},
+        schema=pl.Schema({"rotated_bbox": pl.List(pl.Array(pl.Int32, 5))}),
+    )
+
+    # Set up converter attributes
+    input_field = RotatedBBoxField(dtype=pl.Int32(), format="cxcywhr", normalize=False)
+    output_field = RotatedBBoxField(dtype=pl.Float32(), format="cxcywhr", normalize=False)
+
+    setattr(converter_instance, "input_rotated_bbox", AttributeSpec(name="rotated_bbox", field=input_field))
+    setattr(converter_instance, "output_rotated_bbox", AttributeSpec(name="rotated_bbox", field=output_field))
+
+    # Test filter - should return True for dtype change
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    assert "rotated_bbox" in result_df.columns
+    # Check dtype conversion
+    result_rotated_bbox = result_df["rotated_bbox"][0]
+    assert result_rotated_bbox[0].to_numpy().dtype == np.float32
+
+    # Check values preserved
+    np.testing.assert_array_almost_equal(result_rotated_bbox[0].to_numpy(), [50.0, 60.0, 30.0, 20.0, 0.0])
+    np.testing.assert_array_almost_equal(result_rotated_bbox[1].to_numpy(), [100.0, 120.0, 40.0, 25.0, 1.0])
+
+
+def test_rotated_bbox_dtype_converter_same_dtype():
+    """Test RotatedBBoxDtypeConverter returns False when dtypes are the same."""
+    from datumaro.experimental.converters import RotatedBBoxDtypeConverter
+
+    converter_instance = RotatedBBoxDtypeConverter()
+
+    # Set up converter attributes with same dtype
+    input_field = RotatedBBoxField(dtype=pl.Float32(), format="cxcywhr", normalize=False)
+    output_field = RotatedBBoxField(dtype=pl.Float32(), format="cxcywhr", normalize=False)
+
+    setattr(converter_instance, "input_rotated_bbox", AttributeSpec(name="rotated_bbox", field=input_field))
+    setattr(converter_instance, "output_rotated_bbox", AttributeSpec(name="rotated_bbox", field=output_field))
+
+    # Test filter - should return False when dtypes are the same
+    assert converter_instance.filter_output_spec() is False
+
+
+def test_label_dtype_converter_int32_to_uint8():
+    """Test LabelDtypeConverter converting Int32 to UInt8."""
+    from datumaro.experimental.converters import LabelDtypeConverter
+
+    converter_instance = LabelDtypeConverter()
+
+    # Create test data with Int32 label
+    df = pl.DataFrame(
+        {"label": [5]},
+        schema=pl.Schema({"label": pl.Int32()}),
+    )
+
+    # Set up converter attributes
+    input_field = LabelField(dtype=pl.Int32(), multi_label=False, is_list=False)
+    output_field = LabelField(dtype=pl.UInt8(), multi_label=False, is_list=False)
+
+    setattr(converter_instance, "input_label", AttributeSpec(name="label", field=input_field))
+    setattr(converter_instance, "output_label", AttributeSpec(name="label", field=output_field))
+
+    # Test filter - should return True for dtype change
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    assert "label" in result_df.columns
+    assert result_df["label"].dtype == pl.UInt8
+    assert result_df["label"][0] == 5
+
+
+def test_label_dtype_converter_list_labels():
+    """Test LabelDtypeConverter with is_list=True."""
+    from datumaro.experimental.converters import LabelDtypeConverter
+
+    converter_instance = LabelDtypeConverter()
+
+    # Create test data with list of Int32 labels
+    df = pl.DataFrame(
+        {"labels": [[1, 2, 3, 255]]},
+        schema=pl.Schema({"labels": pl.List(pl.Int32())}),
+    )
+
+    # Set up converter attributes
+    input_field = LabelField(dtype=pl.Int32(), multi_label=False, is_list=True)
+    output_field = LabelField(dtype=pl.UInt8(), multi_label=False, is_list=True)
+
+    setattr(converter_instance, "input_label", AttributeSpec(name="labels", field=input_field))
+    setattr(converter_instance, "output_label", AttributeSpec(name="labels", field=output_field))
+
+    # Test filter - should return True for dtype change
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    assert "labels" in result_df.columns
+    assert result_df["labels"].dtype == pl.List(pl.UInt8)
+    assert result_df["labels"][0].to_list() == [1, 2, 3, 255]
+
+
+def test_label_dtype_converter_same_dtype():
+    """Test LabelDtypeConverter returns False when dtypes are the same."""
+    from datumaro.experimental.converters import LabelDtypeConverter
+
+    converter_instance = LabelDtypeConverter()
+
+    # Set up converter attributes with same dtype
+    input_field = LabelField(dtype=pl.Int32(), multi_label=False, is_list=False)
+    output_field = LabelField(dtype=pl.Int32(), multi_label=False, is_list=False)
+
+    setattr(converter_instance, "input_label", AttributeSpec(name="label", field=input_field))
+    setattr(converter_instance, "output_label", AttributeSpec(name="label", field=output_field))
+
+    # Test filter - should return False when dtypes are the same
+    assert converter_instance.filter_output_spec() is False
+
+
+def test_polygon_dtype_converter_int_to_float():
+    """Test PolygonDtypeConverter converting Int32 to Float32."""
+    from datumaro.experimental.converters import PolygonDtypeConverter
+
+    converter_instance = PolygonDtypeConverter()
+
+    # Create test data with Int32 polygons: List[List[Array[2]]]
+    # Each polygon is a list of (x, y) points
+    polygon1 = [[10, 10], [30, 10], [20, 30]]  # Triangle
+    polygon2 = [[40, 40], [60, 40], [60, 60], [40, 60]]  # Rectangle
+
+    df = pl.DataFrame(
+        {"polygon": [[polygon1, polygon2]]},
+        schema=pl.Schema({"polygon": pl.List(pl.List(pl.Array(pl.Int32, 2)))}),
+    )
+
+    # Set up converter attributes
+    input_field = PolygonField(dtype=pl.Int32(), format="xy", normalize=False)
+    output_field = PolygonField(dtype=pl.Float32(), format="xy", normalize=False)
+
+    setattr(converter_instance, "input_polygon", AttributeSpec(name="polygon", field=input_field))
+    setattr(converter_instance, "output_polygon", AttributeSpec(name="polygon", field=output_field))
+
+    # Test filter - should return True for dtype change
+    assert converter_instance.filter_output_spec() is True
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    assert "polygon" in result_df.columns
+    # Check dtype conversion - get the inner arrays and check their dtype
+    result_polygons = result_df["polygon"][0]
+    assert len(result_polygons) == 2
+
+    # Check first polygon (triangle)
+    result_polygon1 = result_polygons[0]
+    assert len(result_polygon1) == 3
+    np.testing.assert_array_almost_equal(result_polygon1[0].to_numpy(), [10.0, 10.0])
+    np.testing.assert_array_almost_equal(result_polygon1[1].to_numpy(), [30.0, 10.0])
+    np.testing.assert_array_almost_equal(result_polygon1[2].to_numpy(), [20.0, 30.0])
+
+    # Check second polygon (rectangle)
+    result_polygon2 = result_polygons[1]
+    assert len(result_polygon2) == 4
+
+
+def test_polygon_dtype_converter_same_dtype():
+    """Test PolygonDtypeConverter returns False when dtypes are the same."""
+    from datumaro.experimental.converters import PolygonDtypeConverter
+
+    converter_instance = PolygonDtypeConverter()
+
+    # Set up converter attributes with same dtype
+    input_field = PolygonField(dtype=pl.Float32(), format="xy", normalize=False)
+    output_field = PolygonField(dtype=pl.Float32(), format="xy", normalize=False)
+
+    setattr(converter_instance, "input_polygon", AttributeSpec(name="polygon", field=input_field))
+    setattr(converter_instance, "output_polygon", AttributeSpec(name="polygon", field=output_field))
+
+    # Test filter - should return False when dtypes are the same
+    assert converter_instance.filter_output_spec() is False
+
+
+def test_bbox_dtype_converter_preserves_array_structure():
+    """Test that BBoxDtypeConverter preserves the fixed-size array structure."""
+    from datumaro.experimental.converters import BBoxDtypeConverter
+
+    converter_instance = BBoxDtypeConverter()
+
+    # Create test data with multiple bboxes
+    df = pl.DataFrame(
+        {"bbox": [[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]]},
+        schema=pl.Schema({"bbox": pl.List(pl.Array(pl.Int32, 4))}),
+    )
+
+    # Set up converter attributes
+    input_bbox_field = BBoxField(dtype=pl.Int32(), format="x1y1x2y2", normalize=False)
+    output_bbox_field = BBoxField(dtype=pl.Float32(), format="x1y1x2y2", normalize=False)
+
+    setattr(converter_instance, "input_bbox", AttributeSpec(name="bbox", field=input_bbox_field))
+    setattr(converter_instance, "output_bbox", AttributeSpec(name="bbox", field=output_bbox_field))
+
+    converter_instance.filter_output_spec()
+
+    # Test conversion
+    result_df = converter_instance.convert(df)
+
+    # Check that the result maintains the List[Array[4]] structure
+    assert result_df.schema["bbox"] == pl.List(pl.Array(pl.Float32, 4))
+
+    # Check that all bboxes are correctly converted
+    result_bboxes = result_df["bbox"][0]
+    assert len(result_bboxes) == 3
+    np.testing.assert_array_almost_equal(result_bboxes[0].to_numpy(), [1.0, 2.0, 3.0, 4.0])
+    np.testing.assert_array_almost_equal(result_bboxes[1].to_numpy(), [5.0, 6.0, 7.0, 8.0])
+    np.testing.assert_array_almost_equal(result_bboxes[2].to_numpy(), [9.0, 10.0, 11.0, 12.0])
+
+
+def test_create_fixed_array_cast_expr():
+    """Test the _create_fixed_array_cast_expr helper function."""
+    from datumaro.experimental.converters.annotation_converters import _create_fixed_array_cast_expr
+
+    # Test with 4-element array (bbox)
+    arr_data = np.array([1, 2, 3, 4], dtype=np.int32)
+    df = pl.DataFrame(
+        {"arr": [[arr_data]]},
+        schema=pl.Schema({"arr": pl.List(pl.Array(pl.Int32(), 4))}),
+    )
+
+    # Apply the expression
+    result = df.select(pl.col("arr").list.eval(_create_fixed_array_cast_expr(pl.Float64(), 4)))
+
+    # Check result
+    assert result["arr"].dtype == pl.List(pl.Array(pl.Float64(), 4))
+    np.testing.assert_array_almost_equal(result["arr"][0][0].to_numpy(), [1.0, 2.0, 3.0, 4.0])
+
+
+def test_convert_fixed_array_dtype():
+    """Test the _convert_fixed_array_dtype helper function."""
+    from datumaro.experimental.converters.annotation_converters import _convert_fixed_array_dtype
+
+    # Test with 5-element array (rotated bbox)
+    df = pl.DataFrame(
+        {"input": [[[10, 20, 30, 40, 50]]]},
+        schema=pl.Schema({"input": pl.List(pl.Array(pl.Int32(), 5))}),
+    )
+
+    # Apply the conversion
+    result_df = _convert_fixed_array_dtype(df, "input", "output", pl.Float32(), array_size=5)
+
+    # Check result
+    assert "output" in result_df.columns
+    assert result_df["output"].dtype == pl.List(pl.Array(pl.Float32(), 5))
+    np.testing.assert_array_almost_equal(result_df["output"][0][0].to_numpy(), [10.0, 20.0, 30.0, 40.0, 50.0])
+
+
+def test_bbox_dtype_conversion_numpy_dtype():
+    class DetectionSampleFloat(Sample):
+        bboxes: npt.NDArray[np.floating[Any]] = bbox_field(dtype=pl.Float32())
+
+    class DetectionSampleInt(Sample):
+        bboxes: npt.NDArray[np.integer[Any]] = bbox_field(dtype=pl.Int32())
+
+    # Create source dataset with int32 bboxes
+    dataset_int = Dataset(DetectionSampleInt)
+    di_int = DetectionSampleInt(bboxes=np.array([[5, 5, 20, 20], [25, 30, 50, 60]], dtype=np.int32))
+    dataset_int.append(di_int)
+
+    # Convert to float32 schema
+    dataset_float = dataset_int.convert_to_schema(DetectionSampleFloat)
+
+    # Verify original dataset is unchanged
+    assert dataset_int[0].bboxes.dtype == np.int32
+    np.testing.assert_array_equal(dataset_int[0].bboxes, [[5, 5, 20, 20], [25, 30, 50, 60]])
+
+    # The dtype should be float32, not object
+    assert dataset_float[0].bboxes.dtype == np.float32
+
+    # Verify the values are correct
+    expected_values = np.array([[5.0, 5.0, 20.0, 20.0], [25.0, 30.0, 50.0, 60.0]], dtype=np.float32)
+    np.testing.assert_array_almost_equal(dataset_float[0].bboxes, expected_values)


### PR DESCRIPTION
This pull request introduces new converters for handling data type conversions for polygons and rotated bounding boxes, and refactors the existing bounding box and label converters to use a shared utility for fixed-size array casting. 

Also fixes the issue described in https://github.com/open-edge-platform/datumaro/issues/1977

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
