### PR TITLE
Fix wrong axes being swapped with channels_first option

### DIFF
--- a/src/datumaro/experimental/fields/images.py
+++ b/src/datumaro/experimental/fields/images.py
@@ -38,7 +38,7 @@ class TensorField(Field):
         numpy_value = to_numpy(value, self.dtype)
 
         if self.channels_first and numpy_value is not None:
-            numpy_value = numpy_value.swapaxes(0, -1)
+            numpy_value = np.transpose(numpy_value, (2, 0, 1))
 
         schema = self.to_polars_schema("tensor")
 
@@ -59,7 +59,7 @@ class TensorField(Field):
         numpy_data = np.array(flat_data).reshape(shape) if flat_data is not None else None
 
         if self.channels_first and numpy_data is not None:
-            numpy_data = numpy_data.swapaxes(0, -1)
+            numpy_data = np.transpose(numpy_data, (2, 0, 1))
 
         return from_polars_data(numpy_data, target_type)  # type: ignore
 


### PR DESCRIPTION
Wrong logic was being applied to the axes swapping when using channels_first. 

swapaxes(0, -1) — Exchanges exactly two axes. For a 3D array with shape (h, w, c), this swaps axis 0 and axis 2 (last), resulting in shape (c, w, h).

np.transpose(arr, (2, 0, 1)) — Reorders all axes according to the specified permutation. For shape (h, w, c), this produces shape (c, h, w).


Fixes #1979 

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
