### PR TITLE
Fix RotatedBbox.wrap() by assigning correct attributes

### DIFF
--- a/src/datumaro/components/annotation.py
+++ b/src/datumaro/components/annotation.py
@@ -1280,7 +1280,7 @@ class RotatedBbox(Shape):
         Returns:
             RotatedBbox: A new RotatedBbox instance with updated attributes.
         """
-        d = {"x": item.x, "y": item.y, "w": item.w, "h": item.h, "r": item.r}
+        d = {"cx": item.cx, "cy": item.cy, "w": item.w, "h": item.h, "r": item.r}
         d.update(kwargs)
         return attr.evolve(item, **d)
 

--- a/tests/unit/test_annotation.py
+++ b/tests/unit/test_annotation.py
@@ -46,15 +46,43 @@ class EllipseTest:
 
 class RotatedBboxTest:
     @pytest.fixture
-    def fxt_rot_bbox(self):
+    def fxt_rot_bbox(self) -> RotatedBbox:
         coords = np.random.randint(0, 180, size=(5,), dtype=np.uint8)
         return RotatedBbox(coords[0], coords[1], coords[2], coords[3], coords[4])
 
-    def test_create_polygon(self, fxt_rot_bbox):
+    def test_create_polygon(self, fxt_rot_bbox: RotatedBbox) -> None:
         polygon = fxt_rot_bbox.as_polygon()
 
         expected = RotatedBbox.from_rectangle(polygon)
         assert fxt_rot_bbox == expected
+
+    class RotatedBboxWrapTest:
+        @pytest.fixture
+        def fxt_rot_bbox(self) -> RotatedBbox:
+            return RotatedBbox(
+                cx=50.0, cy=60.0, w=40.0, h=20.0, r=30.0, label=1, id=5, group=3, attributes={"score": 0.95}
+            )
+
+        def test_wrap_creates_new_instance(self, fxt_rot_bbox: RotatedBbox) -> None:
+            wrapped = RotatedBbox.wrap(fxt_rot_bbox)
+            assert isinstance(wrapped, RotatedBbox)
+            assert wrapped is not fxt_rot_bbox
+
+        def test_wrap_updates_attributes(self, fxt_rot_bbox: RotatedBbox) -> None:
+            wrapped = RotatedBbox.wrap(fxt_rot_bbox, cx=100.0, label=10, group=20)
+            assert wrapped.cx == 100.0
+            assert (wrapped.cy, wrapped.w, wrapped.h, wrapped.r) == (
+                fxt_rot_bbox.cy,
+                fxt_rot_bbox.w,
+                fxt_rot_bbox.h,
+                fxt_rot_bbox.r,
+            )
+            assert (wrapped.label, wrapped.group) == (10, 20)
+
+        def test_wrap_preserves_other_attributes(self, fxt_rot_bbox: RotatedBbox) -> None:
+            wrapped = RotatedBbox.wrap(fxt_rot_bbox, cx=100.0)
+            assert (wrapped.label, wrapped.id, wrapped.group) == (1, 5, 3)
+            assert wrapped.attributes == {"score": 0.95}
 
 
 @pytest.fixture


### PR DESCRIPTION

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The `RotatedBbox.wrap()` function tries to access wrong attributes. This causes errors in dataset transforms that include rotated bounding boxes. See the example:

```python
"""Minimal reproducible example demonstrating the bug in RotatedBbox.wrap method.

The wrap method tries to access item.x and item.y, but RotatedBbox only has
cx and cy properties (center coordinates), not x and y.
"""

from datumaro.components.annotation import RotatedBbox

bbox = RotatedBbox(cx=100.0, cy=200.0, w=50.0, h=30.0, r=45.0, label=0)
wrapped_bbox = bbox.wrap(label=1)

```

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
