### PR TITLE
Ignore major version updates for optional-dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,6 +44,14 @@
       schedule: ["* * * * 0"], // weekly
     },
 
+    // disable major upgrades for optional-dependencies
+    {
+      enabled: false,
+      matchManagers: ["pep621"],
+      matchUpdateTypes: ["major"],
+      matchDepTypes: ["project.optional-dependencies"],
+    },
+
     {
       enabled: true,
       matchManagers: ["cargo"],


### PR DESCRIPTION
Configure renovate bot to ignore major version updates for optional-dependencies

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
