### PR TITLE
Export segment info attributes in coco panoptic

### DIFF
--- a/src/datumaro/plugins/data_formats/coco/base.py
+++ b/src/datumaro/plugins/data_formats/coco/base.py
@@ -392,7 +392,8 @@ class _CocoBase(SubsetBase):
         for segm_info in self._parse_field(ann, "segments_info", list):
             cat_id = self._get_label_id(segm_info)
             segm_id = self._parse_field(segm_info, "id", int)
-            attributes = {"is_crowd": bool(self._parse_field(segm_info, "iscrowd", int))}
+            attributes = segm_info.get("attributes", {})
+            attributes["is_crowd"] = bool(self._parse_field(segm_info, "iscrowd", int))
             parsed_annotations.append(
                 Mask(
                     image=mask.lazy_extract(segm_id),

--- a/src/datumaro/plugins/data_formats/coco/exporter.py
+++ b/src/datumaro/plugins/data_formats/coco/exporter.py
@@ -649,6 +649,10 @@ class _PanopticExporter(_TaskExporter):
             segment_info["area"] = float(ann.get_area())
             segment_info["bbox"] = [float(p) for p in ann.get_bbox()]
             segment_info["iscrowd"] = cast(ann.attributes.get("is_crowd"), int, 0)
+            if self._context._allow_attributes:
+                attrs = self._convert_attributes(ann)
+                if attrs:
+                    segment_info["attributes"] = attrs
             segments_info.append(segment_info)
             masks.append(ann)
 

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -1639,6 +1639,36 @@ class CocoExporterTest:
             stream=stream,
         )
 
+    def test_can_save_and_load_panoptic_with_attributes(self, test_dir, stream: bool):
+        dataset = Dataset.from_iterable(
+            [
+                DatasetItem(
+                    id=1,
+                    subset="train",
+                    media=Image.from_numpy(data=np.ones((4, 4, 3))),
+                    annotations=[
+                        Mask(
+                            image=np.array([[0, 1, 0, 0], [0, 1, 0, 0], [0, 1, 1, 1], [0, 0, 0, 0]]),
+                            attributes={"is_crowd": False, "x": 5, "y": "abc"},
+                            label=4,
+                            group=3,
+                            id=3,
+                        ),
+                    ],
+                    attributes={"id": 1},
+                ),
+            ],
+            categories=[str(i) for i in range(10)],
+        )
+
+        self._test_save_and_load(
+            dataset,
+            partial(CocoPanopticExporter.convert, save_media=True),
+            test_dir,
+            require_media=True,
+            stream=stream,
+        )
+
     def test_can_save_and_load_stuff(self, test_dir, stream: bool):
         source_dataset = Dataset.from_iterable(
             [


### PR DESCRIPTION
Segment info extra attributes are useful to identify instances in frame sequences. Adds I/O on annotation attributes for segment info.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [x] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
