### PR TITLE
Propagate categories when converting datasets

### DIFF
--- a/src/datumaro/experimental/converters/registry.py
+++ b/src/datumaro/experimental/converters/registry.py
@@ -117,6 +117,35 @@ class _SchemaState:
         """Get AttributeSpec for a specific field type."""
         return self.field_to_attr_spec.get(field_type)
 
+    def merge_categories_from(self, other: _SchemaState) -> _SchemaState:
+        """
+        Create a new state where None categories are filled from another state.
+
+        This is used to propagate categories from the source schema to the target
+        schema when the target doesn't have explicit categories defined.
+
+        Args:
+            other: The state to take categories from when this state has None
+
+        Returns:
+            A new _SchemaState with merged categories
+        """
+        merged_field_to_attr_spec = {}
+        for field_type, attr_spec in self.field_to_attr_spec.items():
+            if attr_spec.categories is None and field_type in other.field_to_attr_spec:
+                other_attr_spec = other.field_to_attr_spec[field_type]
+                if other_attr_spec.categories is not None:
+                    # Create a new AttributeSpec with the categories from the source
+                    merged_attr_spec = AttributeSpec(
+                        name=attr_spec.name,
+                        field=attr_spec.field,
+                        categories=other_attr_spec.categories,
+                    )
+                    merged_field_to_attr_spec[field_type] = merged_attr_spec
+                    continue
+            merged_field_to_attr_spec[field_type] = attr_spec
+        return _SchemaState(merged_field_to_attr_spec)
+
 
 @dataclass
 class _SearchNode:
@@ -445,7 +474,9 @@ def _find_conversion_path_for_semantic(
 
     # If we already have all required fields after initial renaming, we might be done
     if effective_start_state == target_state:
-        return initial_converters, target_state
+        # Merge categories from start state into target state where target has None
+        merged_state = target_state.merge_categories_from(effective_start_state)
+        return initial_converters, merged_state
 
     # Initialize A* search from the effective start state
     open_set: list[_SearchNode] = []
@@ -471,7 +502,9 @@ def _find_conversion_path_for_semantic(
         # Check if we've reached the goal - all target fields must match exactly
         if _heuristic_cost(current_node.state, target_state) == 0:
             # We've reached the goal, return the path
-            return current_node.path, current_node.state
+            # Merge categories from start state into the result state where it has None
+            merged_state = current_node.state.merge_categories_from(effective_start_state)
+            return current_node.path, merged_state
 
         # Explore neighbors
         for converter, new_state in _get_applicable_converters(

--- a/tests/unit/experimental/test_converters.py
+++ b/tests/unit/experimental/test_converters.py
@@ -65,6 +65,7 @@ from datumaro.experimental.fields import (
     bbox_field,
     image_field,
     image_info_field,
+    label_field,
 )
 from datumaro.experimental.schema import AttributeInfo, AttributeSpec, Schema
 
@@ -1255,6 +1256,35 @@ def test_find_conversion_path_inferred_categories():
     # Check that the mask categories include background + original labels
     expected_labels = ("background", "cat", "dog", "bird")
     assert mask_categories.labels == expected_labels
+
+
+def test_convert_to_schema_propagates_categories():
+    """Test that converting a dataset to a new schema propagates categories when target has None."""
+
+    class SourceSample(Sample):
+        label: npt.NDArray[np.int_] = label_field(dtype=pl.UInt8())
+
+    class TargetSample(Sample):
+        label: npt.NDArray[np.int_] = label_field(dtype=pl.UInt8())
+
+    # Create source dataset with categories
+    source_categories = LabelCategories(labels=("car", "truck", "motorbike"))
+    source_dataset = Dataset(
+        SourceSample,
+        categories={"label": source_categories},
+    )
+
+    # Convert to target schema (which has no explicit categories)
+    target_dataset = source_dataset.convert_to_schema(TargetSample)
+
+    # Categories should be propagated from source to target
+    source_label_categories = source_dataset.schema.attributes["label"].categories
+    target_label_categories = target_dataset.schema.attributes["label"].categories
+
+    assert source_label_categories is not None
+    assert target_label_categories is not None
+    assert source_label_categories == target_label_categories
+    assert target_label_categories.labels == ("car", "truck", "motorbike")
 
 
 def test_polygon_to_instance_mask_converter():


### PR DESCRIPTION
This pull request improves category propagation when converting datasets to new schemas in the registry module. The main change is that categories are now automatically merged from the source schema to the target schema when the target does not have explicit categories defined. This ensures that category information is preserved during schema conversion. 

Resolves #2009

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
