### PR TITLE
Fix annotation mismatch for multi-polygon annotations

### DIFF
--- a/src/datumaro/experimental/data_formats/coco/helpers.py
+++ b/src/datumaro/experimental/data_formats/coco/helpers.py
@@ -388,9 +388,9 @@ def _collect_instances_for_image(
     image_id: int,
     instances_by_image: dict[int, list[dict]],
     cat_id_to_idx: dict[int, int],
-) -> tuple[list[list[float] | None], list[np.ndarray], list[int | None], list[float], list[bool]]:
+) -> tuple[list[list[float] | None], list[list[np.ndarray]], list[int | None], list[float], list[bool]]:
     bboxes_list: list[list[float] | None] = []
-    polygons_list: list[np.ndarray] = []
+    polygons_list: list[list[np.ndarray]] = []
     labels_list: list[int | None] = []
     areas_list: list[float] = []
     iscrowd_list: list[bool] = []
@@ -399,8 +399,33 @@ def _collect_instances_for_image(
         category_idx = cat_id_to_idx.get(ann.get("category_id"))
         segmentation = ann.get("segmentation")
 
-        # Handle multi-part polygons by splitting them into separate annotations
+        # Get all polygon parts as a list (keeps multi-part polygons together)
         polygon_parts = _segmentation_to_poly_parts(segmentation)
+
+        # Use original bbox if available, otherwise compute from all polygon parts
+        bbox = ann.get("bbox") if isinstance(ann.get("bbox"), list) else None
+        if bbox is None or len(bbox) != 4:
+            # Compute combined bbox from all polygon parts
+            all_x: list[float] = []
+            all_y: list[float] = []
+            for poly_array in polygon_parts:
+                if poly_array.size > 0:
+                    all_x.extend(poly_array[:, 0].tolist())
+                    all_y.extend(poly_array[:, 1].tolist())
+            if all_x and all_y:
+                x1, y1 = min(all_x), min(all_y)
+                x2, y2 = max(all_x), max(all_y)
+                bbox = [x1, y1, x2 - x1, y2 - y1]  # x, y, w, h
+            else:
+                bbox = [0.0, 0.0, 0.0, 0.0]
+
+        # Use original area if available, otherwise compute from bbox
+        if "area" in ann and isinstance(ann["area"], int | float):
+            area = float(ann["area"])
+        elif bbox is not None and len(bbox) == 4:
+            area = float(bbox[2] * bbox[3])
+        else:
+            area = 0.0
 
         ic = ann.get("iscrowd", 0)
         try:
@@ -408,24 +433,11 @@ def _collect_instances_for_image(
         except Exception:  # pragma: no cover - tolerant casting
             iscrowd_val = False
 
-        for poly_array in polygon_parts:
-            # Compute bbox from polygon points (x, y, w, h format for COCO compatibility)
-            if poly_array.size > 0:
-                x_coords = poly_array[:, 0]
-                y_coords = poly_array[:, 1]
-                x1, y1 = float(x_coords.min()), float(y_coords.min())
-                x2, y2 = float(x_coords.max()), float(y_coords.max())
-                computed_bbox = [x1, y1, x2 - x1, y2 - y1]  # x, y, w, h
-                area = (x2 - x1) * (y2 - y1)
-            else:
-                computed_bbox = [0.0, 0.0, 0.0, 0.0]
-                area = 0.0
-
-            bboxes_list.append(computed_bbox)
-            polygons_list.append(poly_array)
-            labels_list.append(category_idx)
-            areas_list.append(area)
-            iscrowd_list.append(iscrowd_val)
+        bboxes_list.append(bbox)
+        polygons_list.append(polygon_parts)  # Store all parts together as a list
+        labels_list.append(category_idx)
+        areas_list.append(area)
+        iscrowd_list.append(iscrowd_val)
 
     return bboxes_list, polygons_list, labels_list, areas_list, iscrowd_list
 
@@ -662,6 +674,72 @@ def _validate_and_normalize_instance_arrays(
     return n_inst, InstanceArrays(bboxes=bboxes, polygons=polygons, labels=labels, areas=areas_arr, iscrowd=iscrowd_arr)
 
 
+def _extract_label_idx(labels: Any, i: int) -> int | None:
+    """Extract label index from labels array at position i."""
+    if isinstance(labels, np.ndarray) and i < labels.shape[0]:
+        return int(labels[i])
+    return None
+
+
+def _extract_bbox(bboxes: Any, i: int) -> list[float]:
+    """Extract bounding box from bboxes array at position i."""
+    if isinstance(bboxes, np.ndarray) and i < bboxes.shape[0]:
+        bb = bboxes[i].tolist()
+        if len(bb) == 4:
+            return [float(bb[0]), float(bb[1]), float(bb[2]), float(bb[3])]
+    return [0.0, 0.0, 0.0, 0.0]
+
+
+def _extract_segmentation(polygons: Any, i: int) -> list[list[float]]:
+    """Extract segmentation polygons from polygons array at position i."""
+    segmentation: list[list[float]] = []
+    if not isinstance(polygons, np.ndarray) or i >= polygons.shape[0]:
+        return segmentation
+
+    poly_data = polygons[i]
+    if isinstance(poly_data, list):
+        for part in poly_data:
+            flat = _trim_poly_row(part)
+            if len(flat) >= 6:
+                segmentation.append(flat)
+    elif isinstance(poly_data, np.ndarray):
+        flat = _trim_poly_row(poly_data)
+        if len(flat) >= 6:
+            segmentation.append(flat)
+    return segmentation
+
+
+def _compute_bbox_from_segmentation(segmentation: list[list[float]]) -> list[float]:
+    """Compute bounding box from segmentation polygons."""
+    all_x: list[float] = []
+    all_y: list[float] = []
+    for flat in segmentation:
+        all_x.extend(flat[0::2])
+        all_y.extend(flat[1::2])
+    if all_x and all_y:
+        x0, y0 = min(all_x), min(all_y)
+        x1, y1 = max(all_x), max(all_y)
+        return [float(x0), float(y0), float(max(0.0, x1 - x0)), float(max(0.0, y1 - y0))]
+    return [0.0, 0.0, 0.0, 0.0]
+
+
+def _extract_area(areas: Any, i: int, bbox: list[float]) -> float:
+    """Extract area from areas array at position i, or compute from bbox."""
+    if isinstance(areas, np.ndarray) and i < areas.shape[0]:
+        return float(areas[i])
+    return float(bbox[2] * bbox[3]) if len(bbox) == 4 else 0.0
+
+
+def _extract_iscrowd(iscrowd: Any, i: int) -> int:
+    """Extract iscrowd flag from iscrowd array at position i."""
+    if isinstance(iscrowd, np.ndarray) and i < iscrowd.shape[0]:
+        try:
+            return int(bool(iscrowd[i]))
+        except Exception:
+            return 0
+    return 0
+
+
 def _serialize_single_instance(
     i: int,
     arrays: InstanceArrays,
@@ -669,44 +747,18 @@ def _serialize_single_instance(
     image_id: int,
     next_ann_id: int,
 ) -> tuple[dict, int]:
-    label_idx = None
-    labels = arrays.labels
-    if isinstance(labels, np.ndarray) and i < labels.shape[0]:
-        label_idx = int(labels[i])
+    label_idx = _extract_label_idx(arrays.labels, i)
     category_id = to_category_id(label_idx)
 
-    bbox = [0.0, 0.0, 0.0, 0.0]
-    bboxes = arrays.bboxes
-    if isinstance(bboxes, np.ndarray) and i < bboxes.shape[0]:
-        bb = bboxes[i].tolist()
-        if len(bb) == 4:
-            bbox = [float(bb[0]), float(bb[1]), float(bb[2]), float(bb[3])]
+    bbox = _extract_bbox(arrays.bboxes, i)
+    segmentation = _extract_segmentation(arrays.polygons, i)
 
-    flat: list[float] = []
-    polygons = arrays.polygons
-    if isinstance(polygons, np.ndarray) and i < polygons.shape[0]:
-        flat = _trim_poly_row(polygons[i])
+    # Compute bbox from all polygon parts if not provided
+    if bbox[2] == 0.0 or bbox[3] == 0.0:
+        bbox = _compute_bbox_from_segmentation(segmentation)
 
-    if (bbox[2] == 0.0 or bbox[3] == 0.0) and len(flat) >= 6:
-        xs = flat[0::2]
-        ys = flat[1::2]
-        if xs and ys:
-            x0, y0 = min(xs), min(ys)
-            x1, y1 = max(xs), max(ys)
-            bbox = [float(x0), float(y0), float(max(0.0, x1 - x0)), float(max(0.0, y1 - y0))]
-
-    if isinstance(arrays.areas, np.ndarray) and i < arrays.areas.shape[0]:
-        area_val = float(arrays.areas[i])
-    else:
-        area_val = float(bbox[2] * bbox[3]) if len(bbox) == 4 else 0.0
-
-    if isinstance(arrays.iscrowd, np.ndarray) and i < arrays.iscrowd.shape[0]:
-        try:
-            iscrowd_val = int(bool(arrays.iscrowd[i]))
-        except Exception:
-            iscrowd_val = 0
-    else:
-        iscrowd_val = 0
+    area_val = _extract_area(arrays.areas, i, bbox)
+    iscrowd_val = _extract_iscrowd(arrays.iscrowd, i)
 
     inst = {
         "id": next_ann_id,
@@ -715,6 +767,6 @@ def _serialize_single_instance(
         "bbox": bbox,
         "area": area_val,
         "iscrowd": iscrowd_val,
-        "segmentation": [flat] if len(flat) >= 6 else [],
+        "segmentation": segmentation,
     }
     return inst, next_ann_id + 1

--- a/src/datumaro/experimental/data_formats/coco/helpers.py
+++ b/src/datumaro/experimental/data_formats/coco/helpers.py
@@ -388,9 +388,9 @@ def _collect_instances_for_image(
     image_id: int,
     instances_by_image: dict[int, list[dict]],
     cat_id_to_idx: dict[int, int],
-) -> tuple[list[list[float] | None], list[list[np.ndarray]], list[int | None], list[float], list[bool]]:
+) -> tuple[list[list[float] | None], list[np.ndarray], list[int | None], list[float], list[bool]]:
     bboxes_list: list[list[float] | None] = []
-    polygons_list: list[list[np.ndarray]] = []
+    polygons_list: list[np.ndarray] = []
     labels_list: list[int | None] = []
     areas_list: list[float] = []
     iscrowd_list: list[bool] = []
@@ -399,33 +399,8 @@ def _collect_instances_for_image(
         category_idx = cat_id_to_idx.get(ann.get("category_id"))
         segmentation = ann.get("segmentation")
 
-        # Get all polygon parts as a list (keeps multi-part polygons together)
+        # Handle multi-part polygons by splitting them into separate annotations
         polygon_parts = _segmentation_to_poly_parts(segmentation)
-
-        # Use original bbox if available, otherwise compute from all polygon parts
-        bbox = ann.get("bbox") if isinstance(ann.get("bbox"), list) else None
-        if bbox is None or len(bbox) != 4:
-            # Compute combined bbox from all polygon parts
-            all_x: list[float] = []
-            all_y: list[float] = []
-            for poly_array in polygon_parts:
-                if poly_array.size > 0:
-                    all_x.extend(poly_array[:, 0].tolist())
-                    all_y.extend(poly_array[:, 1].tolist())
-            if all_x and all_y:
-                x1, y1 = min(all_x), min(all_y)
-                x2, y2 = max(all_x), max(all_y)
-                bbox = [x1, y1, x2 - x1, y2 - y1]  # x, y, w, h
-            else:
-                bbox = [0.0, 0.0, 0.0, 0.0]
-
-        # Use original area if available, otherwise compute from bbox
-        if "area" in ann and isinstance(ann["area"], int | float):
-            area = float(ann["area"])
-        elif bbox is not None and len(bbox) == 4:
-            area = float(bbox[2] * bbox[3])
-        else:
-            area = 0.0
 
         ic = ann.get("iscrowd", 0)
         try:
@@ -433,11 +408,24 @@ def _collect_instances_for_image(
         except Exception:  # pragma: no cover - tolerant casting
             iscrowd_val = False
 
-        bboxes_list.append(bbox)
-        polygons_list.append(polygon_parts)  # Store all parts together as a list
-        labels_list.append(category_idx)
-        areas_list.append(area)
-        iscrowd_list.append(iscrowd_val)
+        for poly_array in polygon_parts:
+            # Compute bbox from polygon points (x, y, w, h format for COCO compatibility)
+            if poly_array.size > 0:
+                x_coords = poly_array[:, 0]
+                y_coords = poly_array[:, 1]
+                x1, y1 = float(x_coords.min()), float(y_coords.min())
+                x2, y2 = float(x_coords.max()), float(y_coords.max())
+                computed_bbox = [x1, y1, x2 - x1, y2 - y1]  # x, y, w, h
+                area = (x2 - x1) * (y2 - y1)
+            else:
+                computed_bbox = [0.0, 0.0, 0.0, 0.0]
+                area = 0.0
+
+            bboxes_list.append(computed_bbox)
+            polygons_list.append(poly_array)
+            labels_list.append(category_idx)
+            areas_list.append(area)
+            iscrowd_list.append(iscrowd_val)
 
     return bboxes_list, polygons_list, labels_list, areas_list, iscrowd_list
 
@@ -674,72 +662,6 @@ def _validate_and_normalize_instance_arrays(
     return n_inst, InstanceArrays(bboxes=bboxes, polygons=polygons, labels=labels, areas=areas_arr, iscrowd=iscrowd_arr)
 
 
-def _extract_label_idx(labels: Any, i: int) -> int | None:
-    """Extract label index from labels array at position i."""
-    if isinstance(labels, np.ndarray) and i < labels.shape[0]:
-        return int(labels[i])
-    return None
-
-
-def _extract_bbox(bboxes: Any, i: int) -> list[float]:
-    """Extract bounding box from bboxes array at position i."""
-    if isinstance(bboxes, np.ndarray) and i < bboxes.shape[0]:
-        bb = bboxes[i].tolist()
-        if len(bb) == 4:
-            return [float(bb[0]), float(bb[1]), float(bb[2]), float(bb[3])]
-    return [0.0, 0.0, 0.0, 0.0]
-
-
-def _extract_segmentation(polygons: Any, i: int) -> list[list[float]]:
-    """Extract segmentation polygons from polygons array at position i."""
-    segmentation: list[list[float]] = []
-    if not isinstance(polygons, np.ndarray) or i >= polygons.shape[0]:
-        return segmentation
-
-    poly_data = polygons[i]
-    if isinstance(poly_data, list):
-        for part in poly_data:
-            flat = _trim_poly_row(part)
-            if len(flat) >= 6:
-                segmentation.append(flat)
-    elif isinstance(poly_data, np.ndarray):
-        flat = _trim_poly_row(poly_data)
-        if len(flat) >= 6:
-            segmentation.append(flat)
-    return segmentation
-
-
-def _compute_bbox_from_segmentation(segmentation: list[list[float]]) -> list[float]:
-    """Compute bounding box from segmentation polygons."""
-    all_x: list[float] = []
-    all_y: list[float] = []
-    for flat in segmentation:
-        all_x.extend(flat[0::2])
-        all_y.extend(flat[1::2])
-    if all_x and all_y:
-        x0, y0 = min(all_x), min(all_y)
-        x1, y1 = max(all_x), max(all_y)
-        return [float(x0), float(y0), float(max(0.0, x1 - x0)), float(max(0.0, y1 - y0))]
-    return [0.0, 0.0, 0.0, 0.0]
-
-
-def _extract_area(areas: Any, i: int, bbox: list[float]) -> float:
-    """Extract area from areas array at position i, or compute from bbox."""
-    if isinstance(areas, np.ndarray) and i < areas.shape[0]:
-        return float(areas[i])
-    return float(bbox[2] * bbox[3]) if len(bbox) == 4 else 0.0
-
-
-def _extract_iscrowd(iscrowd: Any, i: int) -> int:
-    """Extract iscrowd flag from iscrowd array at position i."""
-    if isinstance(iscrowd, np.ndarray) and i < iscrowd.shape[0]:
-        try:
-            return int(bool(iscrowd[i]))
-        except Exception:
-            return 0
-    return 0
-
-
 def _serialize_single_instance(
     i: int,
     arrays: InstanceArrays,
@@ -747,18 +669,44 @@ def _serialize_single_instance(
     image_id: int,
     next_ann_id: int,
 ) -> tuple[dict, int]:
-    label_idx = _extract_label_idx(arrays.labels, i)
+    label_idx = None
+    labels = arrays.labels
+    if isinstance(labels, np.ndarray) and i < labels.shape[0]:
+        label_idx = int(labels[i])
     category_id = to_category_id(label_idx)
 
-    bbox = _extract_bbox(arrays.bboxes, i)
-    segmentation = _extract_segmentation(arrays.polygons, i)
+    bbox = [0.0, 0.0, 0.0, 0.0]
+    bboxes = arrays.bboxes
+    if isinstance(bboxes, np.ndarray) and i < bboxes.shape[0]:
+        bb = bboxes[i].tolist()
+        if len(bb) == 4:
+            bbox = [float(bb[0]), float(bb[1]), float(bb[2]), float(bb[3])]
 
-    # Compute bbox from all polygon parts if not provided
-    if bbox[2] == 0.0 or bbox[3] == 0.0:
-        bbox = _compute_bbox_from_segmentation(segmentation)
+    flat: list[float] = []
+    polygons = arrays.polygons
+    if isinstance(polygons, np.ndarray) and i < polygons.shape[0]:
+        flat = _trim_poly_row(polygons[i])
 
-    area_val = _extract_area(arrays.areas, i, bbox)
-    iscrowd_val = _extract_iscrowd(arrays.iscrowd, i)
+    if (bbox[2] == 0.0 or bbox[3] == 0.0) and len(flat) >= 6:
+        xs = flat[0::2]
+        ys = flat[1::2]
+        if xs and ys:
+            x0, y0 = min(xs), min(ys)
+            x1, y1 = max(xs), max(ys)
+            bbox = [float(x0), float(y0), float(max(0.0, x1 - x0)), float(max(0.0, y1 - y0))]
+
+    if isinstance(arrays.areas, np.ndarray) and i < arrays.areas.shape[0]:
+        area_val = float(arrays.areas[i])
+    else:
+        area_val = float(bbox[2] * bbox[3]) if len(bbox) == 4 else 0.0
+
+    if isinstance(arrays.iscrowd, np.ndarray) and i < arrays.iscrowd.shape[0]:
+        try:
+            iscrowd_val = int(bool(arrays.iscrowd[i]))
+        except Exception:
+            iscrowd_val = 0
+    else:
+        iscrowd_val = 0
 
     inst = {
         "id": next_ann_id,
@@ -767,6 +715,6 @@ def _serialize_single_instance(
         "bbox": bbox,
         "area": area_val,
         "iscrowd": iscrowd_val,
-        "segmentation": segmentation,
+        "segmentation": [flat] if len(flat) >= 6 else [],
     }
     return inst, next_ann_id + 1

--- a/src/datumaro/experimental/data_formats/coco/helpers.py
+++ b/src/datumaro/experimental/data_formats/coco/helpers.py
@@ -397,27 +397,70 @@ def _collect_instances_for_image(
 
     for ann in instances_by_image.get(image_id, []):
         category_idx = cat_id_to_idx.get(ann.get("category_id"))
-        bbox = ann.get("bbox") if isinstance(ann.get("bbox"), list) else None
-        poly_array = _segmentation_to_poly(ann.get("segmentation"))
+        segmentation = ann.get("segmentation")
 
-        bboxes_list.append(bbox if bbox is not None else [0.0, 0.0, 0.0, 0.0])
-        polygons_list.append(poly_array)
-        labels_list.append(category_idx)
-
-        if "area" in ann and isinstance(ann["area"], int | float):
-            areas_list.append(float(ann["area"]))
-        elif bbox is not None and len(bbox) == 4:
-            areas_list.append(float(bbox[2] * bbox[3]))
-        else:
-            areas_list.append(0.0)
+        # Handle multi-part polygons by splitting them into separate annotations
+        polygon_parts = _segmentation_to_poly_parts(segmentation)
 
         ic = ann.get("iscrowd", 0)
         try:
-            iscrowd_list.append(bool(int(ic)))
+            iscrowd_val = bool(int(ic))
         except Exception:  # pragma: no cover - tolerant casting
-            iscrowd_list.append(False)
+            iscrowd_val = False
+
+        for poly_array in polygon_parts:
+            # Compute bbox from polygon points (x, y, w, h format for COCO compatibility)
+            if poly_array.size > 0:
+                x_coords = poly_array[:, 0]
+                y_coords = poly_array[:, 1]
+                x1, y1 = float(x_coords.min()), float(y_coords.min())
+                x2, y2 = float(x_coords.max()), float(y_coords.max())
+                computed_bbox = [x1, y1, x2 - x1, y2 - y1]  # x, y, w, h
+                area = (x2 - x1) * (y2 - y1)
+            else:
+                computed_bbox = [0.0, 0.0, 0.0, 0.0]
+                area = 0.0
+
+            bboxes_list.append(computed_bbox)
+            polygons_list.append(poly_array)
+            labels_list.append(category_idx)
+            areas_list.append(area)
+            iscrowd_list.append(iscrowd_val)
 
     return bboxes_list, polygons_list, labels_list, areas_list, iscrowd_list
+
+
+def _segmentation_to_poly_parts(segm: Any) -> list[np.ndarray]:
+    """Convert COCO segmentation to a list of polygon arrays, one per part.
+
+    This handles multi-part polygons by returning each part as a separate array,
+    ensuring each polygon part gets its own annotation.
+    """
+    if isinstance(segm, dict) or segm is None or (isinstance(segm, list) and len(segm) == 0):
+        return [np.zeros((0, 2), dtype=np.float32)]
+
+    if isinstance(segm, list):
+        # Check if it's a list of polygon parts (list[list[float]]) or a single polygon (list[float])
+        if len(segm) > 0 and isinstance(segm[0], (list, tuple, np.ndarray)):
+            # Multi-part polygon: each element is a separate polygon part
+            result = []
+            for part in segm:
+                try:
+                    arr = np.array(part, dtype=np.float32)
+                    if arr.size >= 6 and arr.size % 2 == 0:  # At least 3 points
+                        result.append(arr.reshape(-1, 2))
+                except Exception:  # noqa: S110
+                    pass
+            return result if result else [np.zeros((0, 2), dtype=np.float32)]
+        # Single polygon (flat list of coordinates)
+        try:
+            arr = np.array(segm, dtype=np.float32)
+            if arr.size >= 6 and arr.size % 2 == 0:
+                return [arr.reshape(-1, 2)]
+        except Exception:  # noqa: S110
+            pass
+
+    return [np.zeros((0, 2), dtype=np.float32)]
 
 
 def _collect_keypoints_for_image(image_id: int, keypoints_by_image: dict[int, list[dict]]) -> list[np.ndarray]:

--- a/src/datumaro/experimental/legacy/annotation_converters.py
+++ b/src/datumaro/experimental/legacy/annotation_converters.py
@@ -317,17 +317,23 @@ class ForwardRotatedBboxAnnotationConverter(ForwardAnnotationConverter):
 
 
 class ForwardPolygonAnnotationConverter(ForwardAnnotationConverter):
-    """Forward converter for Polygon annotations."""
+    """Forward converter for Polygon annotations.
+
+    This converter also generates bboxes from polygon bounds to ensure
+    that instance segmentation tasks have aligned bboxes, polygons, and labels.
+    """
 
     def __init__(
         self,
         polygon_attribute: AttributeInfo,
         polygon_labels_attribute: AttributeInfo | None,
+        bbox_attribute: AttributeInfo | None,
         name_prefix: str,
     ):
-        """Initialize with polygon attributes and label attribute."""
+        """Initialize with polygon attributes, bbox attribute and label attribute."""
         self.polygon_attribute = polygon_attribute
         self.polygon_labels_attribute = polygon_labels_attribute
+        self.bbox_attribute = bbox_attribute
         self.name_prefix = name_prefix
 
     @classmethod
@@ -362,28 +368,43 @@ class ForwardPolygonAnnotationConverter(ForwardAnnotationConverter):
                 categories=new_label_categories,
             )
 
+        # Also create bbox attribute to generate bboxes from polygon bounds
+        bbox_attribute = AttributeInfo(type=np.ndarray, field=bbox_field(dtype=pl.Float32(), semantic=semantic))
+
         return cls(
             polygon_attribute=polygon_attribute,
             polygon_labels_attribute=polygon_labels_attribute,
+            bbox_attribute=bbox_attribute,
             name_prefix=name_prefix,
         )
 
     def get_schema_attributes(self) -> dict[str, AttributeInfo]:
         attributes = {self.name_prefix + "polygons": self.polygon_attribute}
+        if self.bbox_attribute is not None:
+            attributes[self.name_prefix + "bboxes"] = self.bbox_attribute
         if self.polygon_labels_attribute is not None:
             attributes[self.name_prefix + "labels"] = self.polygon_labels_attribute
         return attributes
 
     def convert_annotations(self, annotations: list[Annotation], item: DatasetItem) -> dict[str, Any]:  # noqa: ARG002
         polygons: list[list[float]] = []
+        bboxes: list[list[float]] = []
         labels: list[int | None] = []
 
         for ann in annotations:
             if isinstance(ann, Polygon):
                 # Points are stored as flat coordinates in Polygon
                 # ann.points in the format [x1,y1,x2,y2,...] format
-                polygons.append(np.array(ann.points).reshape(-1, 2))
+                poly_points = np.array(ann.points).reshape(-1, 2)
+                polygons.append(poly_points)
                 labels.append(ann.label)
+
+                # Compute bounding box from polygon points (x1, y1, x2, y2 format)
+                x_coords = poly_points[:, 0]
+                y_coords = poly_points[:, 1]
+                x1, y1 = float(x_coords.min()), float(y_coords.min())
+                x2, y2 = float(x_coords.max()), float(y_coords.max())
+                bboxes.append([x1, y1, x2, y2])
 
         # Convert to numpy array - polygons is a list of variable-length coordinate lists
         # We'll store it as a ragged array (object dtype to handle different lengths)
@@ -395,6 +416,13 @@ class ForwardPolygonAnnotationConverter(ForwardAnnotationConverter):
         polygons_array = np.empty((len(polygons),), dtype=object)
         polygons_array[:] = polygons
         result = {self.name_prefix + "polygons": polygons_array}
+
+        # Add bboxes computed from polygon bounds
+        if self.bbox_attribute is not None:
+            bboxes_array = np.array(bboxes, dtype=np.float32)
+            if bboxes_array.shape == (0,):
+                bboxes_array = bboxes_array.reshape(0, 4)
+            result[self.name_prefix + "bboxes"] = bboxes_array
 
         # Only add polygon_labels if we have label categories
         if self.polygon_labels_attribute is not None:

--- a/src/datumaro/experimental/legacy/dataset_converters.py
+++ b/src/datumaro/experimental/legacy/dataset_converters.py
@@ -100,7 +100,15 @@ def analyze_legacy_dataset(
     # To avoid conflicts between the label attribute and the other ones, use semantic to distinguish them.
     is_anomaly = (AnnotationType.label in ann_types and len(ann_types) > 1) or anomaly
 
+    # Skip bbox converter when polygon converter exists, since polygon converter
+    # now generates bboxes from polygon bounds for proper instance segmentation alignment
+    skip_bbox_converter = AnnotationType.polygon in ann_types and AnnotationType.bbox in ann_types
+
     for ann_type in ann_types:
+        # Skip bbox converter if polygon converter will handle bboxes
+        if skip_bbox_converter and ann_type == AnnotationType.bbox:
+            continue
+
         ann_semantic = "anomaly" if is_anomaly and ann_type != AnnotationType.label else semantic
         name_prefix = "anomaly_" if is_anomaly and ann_type != AnnotationType.label else ""
         converter = get_forward_annotation_converter(ann_type, legacy_dataset, ann_semantic, name_prefix)

--- a/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
+++ b/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
@@ -50,7 +50,9 @@ def test_validate_and_normalize_instance_arrays_reshapes_and_checks_lengths():
     bbox = np.array([1, 2, 3, 4], dtype=np.float32)
     poly = np.array([[0, 0], [1, 1]], dtype=np.float32)
     polygons = np.empty((1,), dtype=object)
-    polygons[0] = poly
+    # polygons[i] should be a list of polygon arrays (multi-part polygon support)
+    polygons[0] = [poly]
+    polygons[0] = [poly]
 
     labels = np.array([0], dtype=np.int32)
     areas = np.array([[16.0]], dtype=np.float32)
@@ -73,7 +75,9 @@ def test_serialize_single_instance_uses_polygon_to_fill_bbox_and_area():
     bbox = np.array([0, 0, 0, 0], dtype=np.float32)
     poly = np.array([[1, 1], [4, 1], [4, 3], [1, 3]], dtype=np.float32)
     polygons = np.empty((1,), dtype=object)
-    polygons[0] = poly
+    # polygons[i] should be a list of polygon arrays (multi-part polygon support)
+    polygons[0] = [poly]
+    polygons[0] = [poly]
     labels = np.array([2], dtype=np.int32)
     areas = np.empty((0,), dtype=np.float32)
     iscrowd = np.array([[1]], dtype=np.int32)
@@ -204,7 +208,10 @@ def test_collect_helpers_extract_expected_fields():
     }
     bboxes, polys, labels, areas, iscrowd = _collect_instances_for_image(1, instances_by_image, {2: 0})
     assert bboxes[0] == [1, 1, 2, 2]
-    assert polys[0].shape == (4, 2)
+    # polys[0] is now a list of polygon arrays (multi-part polygon support)
+    assert isinstance(polys[0], list)
+    assert len(polys[0]) == 1
+    assert polys[0][0].shape == (4, 2)
     assert labels == [0]
     assert areas[0] == pytest.approx(4.0)
     assert iscrowd == [False]
@@ -225,7 +232,8 @@ def test_serialize_instances_requires_labels():
 def test_serialize_instances_and_keypoints(tmp_path: Path):
     poly = np.array([[0, 0], [1, 0], [1, 1]], dtype=np.float32)
     polygons = np.empty((1,), dtype=object)
-    polygons[0] = poly
+    # polygons[i] should be a list of polygon arrays (multi-part polygon support)
+    polygons[0] = [poly]
     sample = _make_sample(polygons=polygons)
     inst, next_id = _serialize_instances_for_sample(sample, 5, lambda idx: (idx or 0) + 1, 10)
     assert inst[0]["bbox"] == pytest.approx([1, 2, 3, 4])
@@ -271,3 +279,64 @@ def test_prepare_categories_and_save_subset(tmp_path: Path):
     assert "instances_train" in written
     content = json.loads(written["instances_train"].read_text())
     assert content["annotations"][0]["bbox"] == pytest.approx([1.0, 2.0, 3.0, 4.0])
+
+
+def test_collect_instances_multipart_polygon():
+    """Test that multi-part polygons are kept together as a single annotation with combined bbox."""
+    instances_by_image = {
+        1: [
+            {
+                "image_id": 1,
+                "category_id": 2,
+                "bbox": [0, 0, 10, 10],
+                # Multi-part polygon: two separate polygon parts
+                "segmentation": [
+                    [0, 0, 2, 0, 2, 2, 0, 2],  # Part 1: square at origin
+                    [5, 5, 7, 5, 7, 7, 5, 7],  # Part 2: square at (5,5)
+                ],
+                "area": 100.0,
+            },
+        ]
+    }
+    bboxes, polys, labels, areas, _ = _collect_instances_for_image(1, instances_by_image, {2: 0})
+
+    # Should be a single annotation, not two
+    assert len(bboxes) == 1
+    assert len(polys) == 1
+    assert len(labels) == 1
+
+    # polys[0] should be a list with two polygon arrays
+    assert isinstance(polys[0], list)
+    assert len(polys[0]) == 2
+    assert polys[0][0].shape == (4, 2)  # First part: 4 points
+    assert polys[0][1].shape == (4, 2)  # Second part: 4 points
+
+    # Bbox should be the original one from the annotation
+    assert bboxes[0] == [0, 0, 10, 10]
+    # Area should be the original one from the annotation
+    assert areas[0] == pytest.approx(100.0)
+
+
+def test_serialize_multipart_polygon():
+    """Test that multi-part polygons are serialized correctly to COCO format."""
+    # Create a multi-part polygon
+    poly1 = np.array([[0, 0], [2, 0], [2, 2], [0, 2]], dtype=np.float32)
+    poly2 = np.array([[5, 5], [7, 5], [7, 7], [5, 7]], dtype=np.float32)
+    polygons = np.empty((1,), dtype=object)
+    polygons[0] = [poly1, poly2]  # List of polygon arrays
+
+    sample = _make_sample(polygons=polygons, bboxes=np.array([[0, 0, 0, 0]], dtype=np.float32))
+
+    inst, _ = _serialize_instances_for_sample(sample, 5, lambda idx: (idx or 0) + 1, 10)
+
+    # Should produce a single annotation
+    assert len(inst) == 1
+
+    # The segmentation should have two parts
+    assert len(inst[0]["segmentation"]) == 2
+    assert inst[0]["segmentation"][0] == pytest.approx([0, 0, 2, 0, 2, 2, 0, 2])
+    assert inst[0]["segmentation"][1] == pytest.approx([5, 5, 7, 5, 7, 7, 5, 7])
+
+    # Bbox should be computed from all polygon parts (combined)
+    # Combined bbox: x in [0,7], y in [0,7] -> [0, 0, 7, 7]
+    assert inst[0]["bbox"] == pytest.approx([0, 0, 7, 7])

--- a/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
+++ b/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
@@ -50,9 +50,7 @@ def test_validate_and_normalize_instance_arrays_reshapes_and_checks_lengths():
     bbox = np.array([1, 2, 3, 4], dtype=np.float32)
     poly = np.array([[0, 0], [1, 1]], dtype=np.float32)
     polygons = np.empty((1,), dtype=object)
-    # polygons[i] should be a list of polygon arrays (multi-part polygon support)
-    polygons[0] = [poly]
-    polygons[0] = [poly]
+    polygons[0] = poly
 
     labels = np.array([0], dtype=np.int32)
     areas = np.array([[16.0]], dtype=np.float32)
@@ -75,9 +73,7 @@ def test_serialize_single_instance_uses_polygon_to_fill_bbox_and_area():
     bbox = np.array([0, 0, 0, 0], dtype=np.float32)
     poly = np.array([[1, 1], [4, 1], [4, 3], [1, 3]], dtype=np.float32)
     polygons = np.empty((1,), dtype=object)
-    # polygons[i] should be a list of polygon arrays (multi-part polygon support)
-    polygons[0] = [poly]
-    polygons[0] = [poly]
+    polygons[0] = poly
     labels = np.array([2], dtype=np.int32)
     areas = np.empty((0,), dtype=np.float32)
     iscrowd = np.array([[1]], dtype=np.int32)
@@ -208,10 +204,7 @@ def test_collect_helpers_extract_expected_fields():
     }
     bboxes, polys, labels, areas, iscrowd = _collect_instances_for_image(1, instances_by_image, {2: 0})
     assert bboxes[0] == [1, 1, 2, 2]
-    # polys[0] is now a list of polygon arrays (multi-part polygon support)
-    assert isinstance(polys[0], list)
-    assert len(polys[0]) == 1
-    assert polys[0][0].shape == (4, 2)
+    assert polys[0].shape == (4, 2)
     assert labels == [0]
     assert areas[0] == pytest.approx(4.0)
     assert iscrowd == [False]
@@ -232,8 +225,7 @@ def test_serialize_instances_requires_labels():
 def test_serialize_instances_and_keypoints(tmp_path: Path):
     poly = np.array([[0, 0], [1, 0], [1, 1]], dtype=np.float32)
     polygons = np.empty((1,), dtype=object)
-    # polygons[i] should be a list of polygon arrays (multi-part polygon support)
-    polygons[0] = [poly]
+    polygons[0] = poly
     sample = _make_sample(polygons=polygons)
     inst, next_id = _serialize_instances_for_sample(sample, 5, lambda idx: (idx or 0) + 1, 10)
     assert inst[0]["bbox"] == pytest.approx([1, 2, 3, 4])
@@ -279,64 +271,3 @@ def test_prepare_categories_and_save_subset(tmp_path: Path):
     assert "instances_train" in written
     content = json.loads(written["instances_train"].read_text())
     assert content["annotations"][0]["bbox"] == pytest.approx([1.0, 2.0, 3.0, 4.0])
-
-
-def test_collect_instances_multipart_polygon():
-    """Test that multi-part polygons are kept together as a single annotation with combined bbox."""
-    instances_by_image = {
-        1: [
-            {
-                "image_id": 1,
-                "category_id": 2,
-                "bbox": [0, 0, 10, 10],
-                # Multi-part polygon: two separate polygon parts
-                "segmentation": [
-                    [0, 0, 2, 0, 2, 2, 0, 2],  # Part 1: square at origin
-                    [5, 5, 7, 5, 7, 7, 5, 7],  # Part 2: square at (5,5)
-                ],
-                "area": 100.0,
-            },
-        ]
-    }
-    bboxes, polys, labels, areas, _ = _collect_instances_for_image(1, instances_by_image, {2: 0})
-
-    # Should be a single annotation, not two
-    assert len(bboxes) == 1
-    assert len(polys) == 1
-    assert len(labels) == 1
-
-    # polys[0] should be a list with two polygon arrays
-    assert isinstance(polys[0], list)
-    assert len(polys[0]) == 2
-    assert polys[0][0].shape == (4, 2)  # First part: 4 points
-    assert polys[0][1].shape == (4, 2)  # Second part: 4 points
-
-    # Bbox should be the original one from the annotation
-    assert bboxes[0] == [0, 0, 10, 10]
-    # Area should be the original one from the annotation
-    assert areas[0] == pytest.approx(100.0)
-
-
-def test_serialize_multipart_polygon():
-    """Test that multi-part polygons are serialized correctly to COCO format."""
-    # Create a multi-part polygon
-    poly1 = np.array([[0, 0], [2, 0], [2, 2], [0, 2]], dtype=np.float32)
-    poly2 = np.array([[5, 5], [7, 5], [7, 7], [5, 7]], dtype=np.float32)
-    polygons = np.empty((1,), dtype=object)
-    polygons[0] = [poly1, poly2]  # List of polygon arrays
-
-    sample = _make_sample(polygons=polygons, bboxes=np.array([[0, 0, 0, 0]], dtype=np.float32))
-
-    inst, _ = _serialize_instances_for_sample(sample, 5, lambda idx: (idx or 0) + 1, 10)
-
-    # Should produce a single annotation
-    assert len(inst) == 1
-
-    # The segmentation should have two parts
-    assert len(inst[0]["segmentation"]) == 2
-    assert inst[0]["segmentation"][0] == pytest.approx([0, 0, 2, 0, 2, 2, 0, 2])
-    assert inst[0]["segmentation"][1] == pytest.approx([5, 5, 7, 5, 7, 7, 5, 7])
-
-    # Bbox should be computed from all polygon parts (combined)
-    # Combined bbox: x in [0,7], y in [0,7] -> [0, 0, 7, 7]
-    assert inst[0]["bbox"] == pytest.approx([0, 0, 7, 7])

--- a/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
+++ b/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
@@ -203,7 +203,7 @@ def test_collect_helpers_extract_expected_fields():
         ]
     }
     bboxes, polys, labels, areas, iscrowd = _collect_instances_for_image(1, instances_by_image, {2: 0})
-    assert bboxes[0] == [1, 1, 2, 2]
+    assert bboxes[0] == [0.0, 0.0, 2.0, 2.0]  # Computed from polygon, not from annotation bbox
     assert polys[0].shape == (4, 2)
     assert labels == [0]
     assert areas[0] == pytest.approx(4.0)

--- a/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
+++ b/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
@@ -20,6 +20,7 @@ from datumaro.experimental.data_formats.coco.helpers import (
     _prepare_categories,
     _save_subset,
     _segmentation_to_poly,
+    _segmentation_to_poly_parts,
     _serialize_annotations_for_subset,
     _serialize_captions_for_sample,
     _serialize_instances_for_sample,
@@ -38,6 +39,48 @@ def test_segmentation_to_poly_from_nested_list():
     poly = _segmentation_to_poly(segm)
     assert poly.shape == (4, 2)
     assert np.allclose(poly, np.array([[0, 0], [2, 0], [2, 2], [0, 2]], dtype=np.float32))
+
+
+class SegmentationToPolyPartsTest:
+    """Unit tests for _segmentation_to_poly_parts multi-part polygon splitting."""
+
+    def test_none_returns_empty_array(self):
+        result = _segmentation_to_poly_parts(None)
+        assert len(result) == 1
+        assert result[0].shape == (0, 2)
+
+    def test_single_flat_polygon(self):
+        segm = [10.0, 20.0, 30.0, 20.0, 30.0, 40.0]
+        result = _segmentation_to_poly_parts(segm)
+        assert len(result) == 1
+        expected = np.array([[10, 20], [30, 20], [30, 40]], dtype=np.float32)
+        assert np.allclose(result[0], expected)
+
+    def test_single_nested_polygon(self):
+        segm = [[10.0, 20.0, 30.0, 20.0, 30.0, 40.0]]
+        result = _segmentation_to_poly_parts(segm)
+        assert len(result) == 1
+        expected = np.array([[10, 20], [30, 20], [30, 40]], dtype=np.float32)
+        assert np.allclose(result[0], expected)
+
+    def test_multi_part_polygon_splits_into_separate_arrays(self):
+        part1 = [0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0]
+        part2 = [20.0, 20.0, 30.0, 20.0, 30.0, 30.0, 20.0, 30.0]
+        segm = [part1, part2]
+        result = _segmentation_to_poly_parts(segm)
+        assert len(result) == 2
+        assert result[0].shape == (4, 2)
+        assert result[1].shape == (4, 2)
+        assert np.allclose(result[0], np.array([[0, 0], [10, 0], [10, 10], [0, 10]], dtype=np.float32))
+        assert np.allclose(result[1], np.array([[20, 20], [30, 20], [30, 30], [20, 30]], dtype=np.float32))
+
+    def test_multi_part_skips_too_short_parts(self):
+        valid = [0.0, 0.0, 10.0, 0.0, 10.0, 10.0]
+        too_short = [1.0, 2.0]  # Only 1 point, needs at least 3
+        segm = [valid, too_short]
+        result = _segmentation_to_poly_parts(segm)
+        assert len(result) == 1
+        assert result[0].shape == (3, 2)
 
 
 def test_trim_poly_row_discard_trailing_zero_rows():

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -1,6 +1,7 @@
 """Unit tests for legacy dataset conversion functionality."""
 
 import io
+import json
 import math
 import pickle
 import tempfile
@@ -1571,6 +1572,59 @@ class PolygonConversionTest:
         restored_polygon = polygon_anns[0]
         assert restored_polygon.points == [10, 20, 30, 25, 20, 40]
         assert restored_polygon.label is None
+
+    def test_two_polygons_inside_single_bounding_box(self):
+        """Test legacy COCO dataset with two polygons in the same annotation (multi-part segmentation)."""
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Build a COCO instances dataset on disk
+            (temp_path / "annotations").mkdir()
+            (temp_path / "images").mkdir()
+            coco_json = {
+                "images": [{"id": 1, "width": 640, "height": 480, "file_name": "img.jpg"}],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 1,
+                        "category_id": 1,
+                        "segmentation": [
+                            [10, 10, 20, 10, 15, 30],
+                            [25, 10, 35, 10, 30, 30],
+                        ],
+                        "area": 200.0,
+                        "bbox": [10, 10, 25, 20],
+                        "iscrowd": 0,
+                    },
+                ],
+                "categories": [{"id": 1, "name": "object"}],
+            }
+            (temp_path / "annotations" / "instances_train.json").write_text(json.dumps(coco_json))
+
+            # Import as a legacy COCO dataset
+            legacy_dataset = LegacyDataset.import_from(str(temp_path), "coco_instances")
+
+            # Verify the legacy dataset loaded both polygons
+            legacy_items = list(legacy_dataset)
+            assert len(legacy_items) == 1
+            polygon_anns = [a for a in legacy_items[0].annotations if isinstance(a, Polygon)]
+            assert len(polygon_anns) == 2
+
+            # Convert to v2 format
+            experimental_dataset = convert_from_legacy(legacy_dataset)
+
+            assert len(experimental_dataset) == 1
+            exp_sample = experimental_dataset[0]
+
+            # Both polygons should be preserved as separate entries
+            assert hasattr(exp_sample, "polygons")
+            assert len(exp_sample.polygons) == 2
+
+            # Verify polygon coordinates are preserved
+            poly_points = [exp_sample.polygons[i].tolist() for i in range(2)]
+            assert [[10, 10], [20, 10], [15, 30]] in poly_points
+            assert [[25, 10], [35, 10], [30, 30]] in poly_points
 
 
 class ForwardRotatedBboxAnnotationConverterTest:

--- a/tests/unit/experimental/test_legacy.py
+++ b/tests/unit/experimental/test_legacy.py
@@ -1505,7 +1505,8 @@ class PolygonConversionTest:
             assert len(restored_items) == 1
 
             restored_item = restored_items[0]
-            assert len(restored_item.annotations) == 2
+            # Expect 4 annotations: 2 polygons + 2 bboxes (derived from polygon bounds)
+            assert len(restored_item.annotations) == 4
 
             # Check restored polygons
             polygon_anns = [ann for ann in restored_item.annotations if isinstance(ann, Polygon)]


### PR DESCRIPTION
This [issue](https://github.com/open-edge-platform/training_extensions/issues/5344) from the OTX repo was facing problems with mismatching annotation counts in legacy datumaro format compared against the new datumaro format. After debugging, the COCO dataset referenced in the issue has images with multi-polygon annotations in a single bounding box. The new datumaro version was only keeping one polygon per bounding box, causing annotation data to be dropped. Below is a sample of the issue where the polygons in the image all belong to one bounding box. The annotations don't really make sense but datumaro was dropping everything but the tiny annotation. 
<img width="500" height="502" alt="image" src="https://github.com/user-attachments/assets/ef31e47d-dbd1-4a0b-a1b5-c343aa8af0cf" />


This PR addresses the issue in 2 ways; 

1.  For legacy datumaro datasets, the converter from old to new will now always generate a bounding box for every polygon and save every polygon as a separate annotation. This is not ideal since it drops some information for  instance segmentation but will be safe for further conversion to fit OTX's sample schemas. 
2. ~~For imported COCO datasets into the new format, the multi-polygon annotations will now be stored as is and no longer drop the additional polygons.~~ _second fix is not yet possible and [reverted](https://github.com/open-edge-platform/datumaro/pull/2021/commits/b2e83f648efc328138551049e9c3fb75589477f4), need to be able to store multiple polygons in a single PolygonField_

These multi-polygon COCO annotations need to be revisited at some point. Old datumaro is currently always assuming that each polygon is part of the object while generally the convention for multi-polygon COCO datasets is to have the first polygon be the outline of the object and any polygons thereafter should be interpreted as a hole. 

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
