### PR TITLE
Fix image paths of exports with images exported

### DIFF
--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -82,10 +82,9 @@ def _export_image_path_field(
             return None
 
         extension = source_path.suffix if source_path.suffix else ".png"
-        rel_path = f"{field_name}/{idx:06d}{extension}"
+        rel_path = f"{field_name}_{idx:06d}{extension}"
         abs_path = output_dir / rel_path
 
-        abs_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source_path, abs_path)
         return str(rel_path)
     except Exception as e:
@@ -251,7 +250,7 @@ def export_dataset(
                 if not path_map:
                     continue
 
-                # Create a mapping DataFrame from the exported paths (O(ExportedCount) vs O(DatasetCount))
+                # Create a mapping DataFrame from the exported paths
                 mapping_df = pl.DataFrame(
                     {"__idx": list(path_map.keys()), "__new_path": list(path_map.values())},
                     schema={"__idx": pl.UInt32, "__new_path": pl.String},
@@ -390,7 +389,7 @@ def _reconstruct_field_values(
 
     values: list[object | None] = []
     for idx in range(num_rows):
-        pattern = f"{field_name}/{idx:06d}.*" if is_path_field else f"{field_name}_{idx:06d}.*"
+        pattern = f"{field_name}_{idx:06d}.*"
         matches = sorted(images_base_dir.glob(pattern))
         file_path = matches[0] if matches else None
 

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -76,7 +76,7 @@ def _export_image_path_field(
 ) -> str | None:
     """Export an ImagePathField by copying the file from the filesystem."""
     try:
-        source_path = Path(value)
+        source_path = Path(str(value))
         if not source_path.exists():
             print(f"Warning: Image file not found: {value}")
             return None
@@ -239,19 +239,24 @@ def export_dataset(
         work_dir = output_path
 
     try:
-        # Export DataFrame to Parquet
-        # Filter out Object columns (like callables) as they can't be serialized to Parquet
-        columns_to_export = [col for col, dtype in dataset.df.schema.items() if dtype != pl.Object]
-        parquet_path = work_dir / DATAFRAME_FILE
-        dataset.df.select(columns_to_export).write_parquet(parquet_path)
-
+        df_to_export = dataset.df
         # Export images if requested
         if export_images:
             images_dir = work_dir / IMAGES_DIR
-            _export_images_from_dataset(dataset, images_dir)
+            images_paths = _export_images_from_dataset(dataset, images_dir)
+
+            for field_name, path_map in images_paths.items():
+                paths_column = [path_map.get(i) for i in range(len(df_to_export))]
+                df_to_export = df_to_export.with_columns(pl.Series(field_name, paths_column, dtype=pl.String))
+
+        # Export DataFrame to Parquet
+        # Filter out Object columns (like callables) as they can't be serialized to Parquet
+        columns_to_export = [col for col, dtype in df_to_export.schema.items() if dtype != pl.Object]
+        parquet_path = work_dir / DATAFRAME_FILE
+        df_to_export.select(columns_to_export).write_parquet(parquet_path)
 
         # Track which columns are Object types (excluded from parquet)
-        object_columns = [col for col, dtype in dataset.df.schema.items() if dtype == pl.Object]
+        object_columns = [col for col, dtype in df_to_export.schema.items() if dtype == pl.Object]
 
         # Create metadata
         metadata = {

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -83,8 +83,9 @@ def _export_image_path_field(
 
         extension = source_path.suffix if source_path.suffix else ".png"
         rel_path = f"{field_name}/{idx:06d}{extension}"
-        abs_path = output_dir / rel_path.replace("/", "_")
+        abs_path = output_dir / rel_path
 
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source_path, abs_path)
         return str(rel_path)
     except Exception as e:
@@ -245,9 +246,24 @@ def export_dataset(
             images_dir = work_dir / IMAGES_DIR
             images_paths = _export_images_from_dataset(dataset, images_dir)
 
+            df_to_export = df_to_export.with_row_index("__idx")
             for field_name, path_map in images_paths.items():
-                paths_column = [path_map.get(i) for i in range(len(df_to_export))]
-                df_to_export = df_to_export.with_columns(pl.Series(field_name, paths_column, dtype=pl.String))
+                if not path_map:
+                    continue
+
+                # Create a mapping DataFrame from the exported paths (O(ExportedCount) vs O(DatasetCount))
+                mapping_df = pl.DataFrame(
+                    {"__idx": list(path_map.keys()), "__new_path": list(path_map.values())},
+                    schema={"__idx": pl.UInt32, "__new_path": pl.String},
+                )
+
+                # Left join to apply updates; rows not in path_map will have null paths
+                df_to_export = (
+                    df_to_export.join(mapping_df, on="__idx", how="left")
+                    .with_columns(pl.col("__new_path").alias(field_name))
+                    .drop("__new_path")
+                )
+            df_to_export = df_to_export.drop("__idx")
 
         # Export DataFrame to Parquet
         # Filter out Object columns (like callables) as they can't be serialized to Parquet
@@ -374,7 +390,7 @@ def _reconstruct_field_values(
 
     values: list[object | None] = []
     for idx in range(num_rows):
-        pattern = f"{field_name}_{idx:06d}.*"
+        pattern = f"{field_name}/{idx:06d}.*" if is_path_field else f"{field_name}_{idx:06d}.*"
         matches = sorted(images_base_dir.glob(pattern))
         file_path = matches[0] if matches else None
 

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -155,7 +155,7 @@ def test_export_image_path_field(tmp_path):
         rel_path = result["image_path"][idx]
 
         # Verify the file exists and format is preserved
-        img_file = output_dir / rel_path.replace("/", "_")
+        img_file = output_dir / rel_path
         assert img_file.exists()
 
         # Check that the file extension is preserved
@@ -888,7 +888,7 @@ def test_export_import_different_field_types(tmp_path):
     # Verify images were exported
     images_dir = export_dir / IMAGES_DIR
     assert (images_dir / "image_callable_000000.png").exists()
-    assert (images_dir / "image_path_000000.png").exists()
+    assert (images_dir / "image_path/000000.png").exists()
     assert (images_dir / "mask_callable_000000.png").exists()
     assert (images_dir / "instance_mask_callable_000000.png").exists()
 
@@ -990,7 +990,7 @@ def test_export_dataset_export_images_true_and_false(tmp_path):
     assert "000000.jpg" in exported_path
 
     # Check if the file exists on disk (handling the replacement of / with _ in filename)
-    exported_file_on_disk = export_dir_true / IMAGES_DIR / exported_path.replace("/", "_")
+    exported_file_on_disk = export_dir_true / IMAGES_DIR / exported_path
     assert exported_file_on_disk.exists()
 
     # 3. Case: export_images=False

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -888,7 +888,7 @@ def test_export_import_different_field_types(tmp_path):
     # Verify images were exported
     images_dir = export_dir / IMAGES_DIR
     assert (images_dir / "image_callable_000000.png").exists()
-    assert (images_dir / "image_path/000000.png").exists()
+    assert (images_dir / "image_path_000000.png").exists()
     assert (images_dir / "mask_callable_000000.png").exists()
     assert (images_dir / "instance_mask_callable_000000.png").exists()
 

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -951,3 +951,58 @@ def test_export_import_different_field_types(tmp_path):
     assert imported_sample.tile.y == sample.tile.y
     assert imported_sample.tile.width == sample.tile.width
     assert imported_sample.tile.height == sample.tile.height
+
+
+def test_export_dataset_export_images_true_and_false(tmp_path):
+    """
+    Test that export_dataset stores relative paths in Parquet when export_images=True
+    and original absolute paths when export_images=False.
+    """
+    # 1. Setup: Create a temporary source image
+    source_dir = tmp_path / "source_media"
+    source_dir.mkdir()
+    source_img_path = source_dir / "cat1.jpg"
+    PILImage.fromarray(np.zeros((10, 10, 3), dtype=np.uint8)).save(source_img_path)
+
+    class SampleWithPath(Sample):
+        img: str = image_path_field()
+
+    dataset = Dataset(SampleWithPath)
+    dataset.append(SampleWithPath(img=str(source_img_path)))
+
+    # 2. Case: export_images=True
+    # The path in Parquet should be relative to the export directory
+    export_dir_true = tmp_path / "exported_with_images"
+    export_dataset(
+        dataset=dataset,
+        output_path=export_dir_true,
+        as_zip=False,
+        export_images=True,
+    )
+
+    df_true = pl.read_parquet(export_dir_true / DATAFRAME_FILE)
+    exported_path = df_true["img"][0]
+
+    assert exported_path is not None
+    assert exported_path != str(source_img_path)
+    # Verify the exported file exists at the path relative to images/
+    # Note: rel_path in _export_image_path_field is 'img/000000.jpg'
+    assert "000000.jpg" in exported_path
+
+    # Check if the file exists on disk (handling the replacement of / with _ in filename)
+    exported_file_on_disk = export_dir_true / IMAGES_DIR / exported_path.replace("/", "_")
+    assert exported_file_on_disk.exists()
+
+    # 3. Case: export_images=False
+    # The path in Parquet should remain the original absolute path
+    export_dir_false = tmp_path / "exported_without_images"
+    export_dataset(
+        dataset=dataset,
+        output_path=export_dir_false,
+        as_zip=False,
+        export_images=False,
+    )
+
+    df_false = pl.read_parquet(export_dir_false / DATAFRAME_FILE)
+    assert df_false["img"][0] == str(source_img_path)
+    assert not (export_dir_false / IMAGES_DIR).exists()


### PR DESCRIPTION
This pull request refines the image export logic in the experimental export/import module, ensures consistent handling of image paths, and introduces a new integration test to verify correct behavior when exporting datasets with or without images. The changes improve both code correctness and test coverage.

**Image Export Logic Improvements:**

* Changed the image export path construction in `_export_image_path_field` to use string conversion for `Path` and updated the naming convention to use underscores instead of slashes, ensuring paths are consistent and safe for file systems.
* Updated the export logic in `export_dataset` to correctly update DataFrame image path fields with their new relative paths when `export_images=True`, using a left join with a mapping DataFrame, and to retain original absolute paths when `export_images=False`.

**Test Adjustments and Additions:**

* Modified integration tests to match the new image path convention, checking for the correct file existence and path format in exported datasets.
* Added a new integration test `test_export_dataset_export_images_true_and_false` to verify that image paths are stored as relative paths in Parquet when images are exported, and as absolute paths otherwise. This test also checks that the exported files exist in the correct location.

Resolves #2019 

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
