### PR TITLE
Add StringField

### DIFF
--- a/src/datumaro/experimental/README.md
+++ b/src/datumaro/experimental/README.md
@@ -142,6 +142,7 @@ The module provides a rich set of field types for common ML data:
 | `SubsetField` | Dataset subset (train/val/test) | `subset_field()` |
 | `TileField` | Tile metadata for tiling operations | `tile_field()` |
 | `NumericField` | Numeric values | `numeric_field(dtype, is_list)` |
+| `StringField` | String values | `string_field()` |
 
 ### Semantic Tags
 

--- a/src/datumaro/experimental/fields/__init__.py
+++ b/src/datumaro/experimental/fields/__init__.py
@@ -52,7 +52,7 @@ from datumaro.experimental.fields.masks import (
     mask_callable_field,
     mask_field,
 )
-from datumaro.experimental.fields.types import NumericField, bool_field, numeric_field
+from datumaro.experimental.fields.types import NumericField, StringField, bool_field, numeric_field, string_field
 
 __all__ = [
     "BBoxField",
@@ -74,6 +74,7 @@ __all__ = [
     "NumericField",
     "PolygonField",
     "RotatedBBoxField",
+    "StringField",
     "Subset",
     "SubsetField",
     "TensorField",
@@ -98,6 +99,7 @@ __all__ = [
     "numeric_field",
     "polygon_field",
     "rotated_bbox_field",
+    "string_field",
     "subset_field",
     "tensor_field",
     "tile_field",

--- a/src/datumaro/experimental/fields/types.py
+++ b/src/datumaro/experimental/fields/types.py
@@ -16,9 +16,12 @@ class NumericField(Field):
     """
     Represents a numeric value with arbitrary semantics.
 
-    Use this for generic per-sample or per-instance numeric attributes such as
-    area, depth, distance, score, etc. Supports scalar values or lists of values when
-    ``is_list=True``.
+    This field can be used, for instance, to represent attributes like area, depth, distance, score, etc.
+
+    Attributes:
+        semantic: A string tag describing the purpose of the value (e.g., "area")
+        dtype: Polars data type for the numeric value (e.g., pl.Float32, pl.Int64)
+        is_list: If True, the field can hold a list of numeric values instead of a single value.
     """
 
     semantic: str = "default"
@@ -52,9 +55,9 @@ def numeric_field(
     Create a NumericField instance.
 
     Args:
-        dtype: Polars data type for numeric values (defaults to pl.Float32())
-        semantic: String tag describing the value purpose (optional)
+        dtype: Polars data type for the numeric value (e.g., pl.Float32, pl.Int64)
         is_list: Whether this field should be treated as a list type
+        semantic: String tag describing the field purpose (optional)
 
     Returns:
         NumericField configured with the given parameters
@@ -65,11 +68,13 @@ def numeric_field(
 @dataclass(frozen=True)
 class BoolField(Field):
     """
-    Represents a boolean value or a list of boolean values.
+    Represents a boolean value with arbitrary semantics.
 
-    Stored as Polars Boolean type and
-    converts back to Python ``bool``/``list[bool]`` or numpy arrays as needed
-    by the higher-level Dataset APIs.
+    This field can be used, for instance, to represent attributes like "is_occluded", "has_mask", "is_crowd", etc.
+
+    Attributes:
+        semantic: A string tag describing the purpose of the value (e.g., "is_occluded")
+        is_list: If True, the field can hold a list of boolean values instead of a single value.
     """
 
     semantic: str = "default"
@@ -113,11 +118,13 @@ def bool_field(
 @dataclass(frozen=True)
 class StringField(Field):
     """
-    Represents a string value or a list of string values.
+    Represents a string value with arbitrary semantics.
 
-    Stored as Polars String type and
-    converts back to Python ``str``/``list[str]`` as needed
-    by the higher-level Dataset APIs.
+    This field can be used, for instance, to represent attributes like "id", "source", "tags", etc...
+
+    Attributes:
+        semantic: A string tag describing the purpose of the value (e.g., "id")
+        is_list: If True, the field can hold a list of string values instead of a single value.
     """
 
     semantic: str = "default"

--- a/src/datumaro/experimental/fields/types.py
+++ b/src/datumaro/experimental/fields/types.py
@@ -27,10 +27,7 @@ class NumericField(Field):
 
     @property
     def _pl_type(self) -> pl.DataType:
-        pl_type = self.dtype
-        if self.is_list:
-            pl_type = pl.List(pl_type)
-        return pl_type
+        return pl.List(self.dtype) if self.is_list else self.dtype
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         return {name: self._pl_type}
@@ -81,7 +78,7 @@ class BoolField(Field):
 
     @property
     def _pl_type(self) -> pl.DataType:
-        return pl.List(pl.Boolean) if self.is_list else pl.Boolean
+        return pl.List(self.dtype) if self.is_list else self.dtype
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         return {name: self._pl_type}
@@ -129,7 +126,7 @@ class StringField(Field):
 
     @property
     def _pl_type(self) -> pl.DataType:
-        return pl.List(pl.String) if self.is_list else pl.String
+        return pl.List(self.dtype) if self.is_list else self.dtype
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         return {name: self._pl_type}

--- a/src/datumaro/experimental/fields/types.py
+++ b/src/datumaro/experimental/fields/types.py
@@ -14,7 +14,7 @@ from datumaro.experimental.type_registry import from_polars_data
 @dataclass(frozen=True)
 class NumericField(Field):
     """
-    Represents a neutral numeric value.
+    Represents a numeric value with arbitrary semantics.
 
     Use this for generic per-sample or per-instance numeric attributes such as
     area, depth, distance, score, etc. Supports scalar values or lists of values when
@@ -111,3 +111,51 @@ def bool_field(
         BoolField configured with the given parameters
     """
     return BoolField(semantic=semantic, is_list=is_list)
+
+
+@dataclass(frozen=True)
+class StringField(Field):
+    """
+    Represents a string value or a list of string values.
+
+    Stored as Polars String type and
+    converts back to Python ``str``/``list[str]`` as needed
+    by the higher-level Dataset APIs.
+    """
+
+    semantic: str = "default"
+    is_list: bool = False
+    dtype: pl.DataType = field(default_factory=pl.String, init=False)
+
+    @property
+    def _pl_type(self) -> pl.DataType:
+        return pl.List(pl.String) if self.is_list else pl.String
+
+    def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
+        return {name: self._pl_type}
+
+    def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
+        return {name: pl.Series(name, [value], dtype=self._pl_type)}
+
+    def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type[T]) -> T:
+        data = df[name][row_index]
+        if target_type is list:
+            return list(data) if data is not None else None  # type: ignore[return-value]
+        return from_polars_data(data, target_type)
+
+
+def string_field(
+    semantic: str = "default",
+    is_list: bool = False,
+) -> Any:
+    """
+    Create a StringField instance.
+
+    Args:
+        semantic: String tag describing the field purpose (optional)
+        is_list: Whether this field should be treated as a list type
+
+    Returns:
+        StringField configured with the given parameters
+    """
+    return StringField(semantic=semantic, is_list=is_list)

--- a/tests/unit/experimental/fields/test_string_field.py
+++ b/tests/unit/experimental/fields/test_string_field.py
@@ -1,0 +1,49 @@
+from typing import Annotated
+
+import pytest
+
+from datumaro.experimental.dataset import Dataset, Sample
+from datumaro.experimental.fields import string_field
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Hello world",
+        "",
+        "   Leading and trailing spaces   ",
+        "Special characters !@#$%^&*()_+-=[]{}|;':,.<>/?`~",
+        "Multiline\nText\nWith\nNewlines",
+        "Unicode characters: 你好，世界！👋🌍",
+    ],
+)
+def test_string_field_roundtrip(text):
+    class StringSample(Sample):
+        text: Annotated[str, string_field()]
+
+    ds = Dataset(StringSample)
+
+    s = StringSample(text=text)
+    ds.append(s)
+
+    assert len(ds) == 1
+    out = ds[0]
+    assert isinstance(out, StringSample)
+    assert out.text == text
+
+
+def test_string_field_list_roundtrip():
+    class MultiStringSample(Sample):
+        texts: Annotated[list[str], string_field(is_list=True)]
+
+    ds = Dataset(MultiStringSample)
+
+    texts = ["Hello world", "Good bye world"]
+    s = MultiStringSample(texts=texts)
+    ds.append(s)
+
+    assert len(ds) == 1
+    out = ds[0]
+    assert isinstance(out, MultiStringSample)
+    assert isinstance(out.texts, list)
+    assert out.texts == texts


### PR DESCRIPTION
This PR implements a new field type `StringField` which to store arbitrary strings. It can be used to attach metadata to a dataset sample, or even an id.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [x] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
