### PR TITLE
Add support for saving datasets as zip archives

### DIFF
--- a/src/datumaro/experimental/data_formats/base.py
+++ b/src/datumaro/experimental/data_formats/base.py
@@ -82,6 +82,9 @@ def save_dataset(
     Raises:
         ValueError: If the data format is not supported.
     """
+    if data_format not in DataFormat:
+        raise ValueError(f"Unsupported data format: {data_format}")
+
     output_dir = os.path.dirname(output_path) if as_zip else output_path
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
@@ -107,11 +110,10 @@ def _save_dataset_as_zip(
 ) -> None:
     """Save dataset as a zip archive."""
     # Strip .zip extension if present since shutil.make_archive adds it automatically
-    if output_path.endswith(".zip"):
+    if output_path.lower().endswith(".zip"):
         output_path = output_path[:-4]
 
-    temp_dir = tempfile.mkdtemp()
-    try:
+    with tempfile.TemporaryDirectory() as temp_dir:
         _save_dataset_to_dir(
             dataset=dataset,
             data_format=data_format,
@@ -123,8 +125,6 @@ def _save_dataset_as_zip(
             format="zip",
             root_dir=temp_dir,
         )
-    finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 def _save_dataset_to_dir(

--- a/src/datumaro/experimental/data_formats/base.py
+++ b/src/datumaro/experimental/data_formats/base.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+import os
+import shutil
+import tempfile
 from enum import Enum
 
 from datumaro.experimental import Dataset
@@ -63,9 +66,8 @@ def load_dataset(
 def save_dataset(
     dataset: Dataset,
     data_format: DataFormat,
-    images_dir_path: str | dict[str, str] | None = None,
-    annotations_path: str | dict[str, str] | None = None,
-    root_dir: str | None = None,
+    output_path: str,
+    as_zip: bool = False,
 ) -> None:
     """
     Save a dataset in the specified format.
@@ -73,32 +75,77 @@ def save_dataset(
     Args:
         dataset: Dataset to save.
         data_format: The format to save the dataset in.
-        images_dir_path: Path to image directory (str) or dict mapping subset names to paths.
-        annotations_path: Path to annotations file (str) or dict mapping subset names to paths.
-        root_dir: Root directory for YOLO format datasets.
+        output_path: Output location. When as_zip=False, this is the output directory.
+            When as_zip=True, this is the zip file path (with or without .zip extension).
+        as_zip: If True, save as a zip archive.
 
     Raises:
-        ValueError: If the data format is not supported or required arguments are missing.
+        ValueError: If the data format is not supported.
     """
+    output_dir = os.path.dirname(output_path) if as_zip else output_path
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    if as_zip:
+        _save_dataset_as_zip(
+            dataset=dataset,
+            data_format=data_format,
+            output_path=output_path,
+        )
+    else:
+        _save_dataset_to_dir(
+            dataset=dataset,
+            data_format=data_format,
+            output_dir=output_path,
+        )
+
+
+def _save_dataset_as_zip(
+    dataset: Dataset,
+    data_format: DataFormat,
+    output_path: str,
+) -> None:
+    """Save dataset as a zip archive."""
+    # Strip .zip extension if present since shutil.make_archive adds it automatically
+    if output_path.endswith(".zip"):
+        output_path = output_path[:-4]
+
+    temp_dir = tempfile.mkdtemp()
+    try:
+        _save_dataset_to_dir(
+            dataset=dataset,
+            data_format=data_format,
+            output_dir=temp_dir,
+        )
+
+        shutil.make_archive(
+            base_name=output_path,
+            format="zip",
+            root_dir=temp_dir,
+        )
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _save_dataset_to_dir(
+    dataset: Dataset,
+    data_format: DataFormat,
+    output_dir: str,
+) -> None:
+    """Internal helper to save dataset to a directory."""
     if data_format == DataFormat.COCO:
         from datumaro.experimental.data_formats.coco.io import save_coco_dataset
-
-        if images_dir_path is None or annotations_path is None:
-            raise ValueError("images_dir_path and annotations_path are required for COCO format")
 
         dataset = dataset.convert_to_schema(CocoSample.infer_schema())
         save_coco_dataset(
             dataset,
-            images_dir_path=images_dir_path,
-            annotations_path=annotations_path,
+            images_dir_path=os.path.join(output_dir, "images"),
+            annotations_path=os.path.join(output_dir, "annotations.json"),
         )
     elif data_format in (DataFormat.YOLO, DataFormat.YOLO_ULTRALYTICS):
         from datumaro.experimental.data_formats.yolo.io import save_yolo_dataset
 
-        if root_dir is None:
-            raise ValueError("root_dir is required for YOLO format")
-
         dataset = dataset.convert_to_schema(YoloSample.infer_schema())
-        save_yolo_dataset(dataset, root_dir=root_dir, format=data_format)
+        save_yolo_dataset(dataset, root_dir=output_dir, format=data_format)
     else:
         raise ValueError(f"Unsupported data format: {data_format}")

--- a/src/datumaro/experimental/data_formats/base.py
+++ b/src/datumaro/experimental/data_formats/base.py
@@ -110,8 +110,7 @@ def _save_dataset_as_zip(
 ) -> None:
     """Save dataset as a zip archive."""
     # Strip .zip extension if present since shutil.make_archive adds it automatically
-    if output_path.lower().endswith(".zip"):
-        output_path = output_path[:-4]
+    output_path, _ = os.path.splitext(output_path)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         _save_dataset_to_dir(

--- a/tests/unit/experimental/data_formats/test_data_formats_base.py
+++ b/tests/unit/experimental/data_formats/test_data_formats_base.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+import zipfile
 from enum import Enum
 
 import pytest
@@ -65,22 +68,17 @@ def test_save_dataset_delegates_to_coco_with_converted_schema(monkeypatch):
 
     monkeypatch.setattr("datumaro.experimental.data_formats.coco.io.save_coco_dataset", fake_saver)
 
-    save_dataset(
-        dummy_dataset,
-        DataFormat.COCO,
-        images_dir_path="/tmp/images",
-        annotations_path="/tmp/annotations.json",
-    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        save_dataset(
+            dummy_dataset,
+            DataFormat.COCO,
+            tmp_dir,
+        )
 
-    assert captured["dataset"] is dummy_dataset
-    assert captured["images_dir_path"] == "/tmp/images"
-    assert captured["annotations_path"] == "/tmp/annotations.json"
-    assert dummy_dataset.converted_schema == CocoSample.infer_schema()
-
-
-def test_save_dataset_requires_paths_for_coco():
-    with pytest.raises(ValueError, match="images_dir_path and annotations_path are required"):
-        save_dataset(DummyDataset(), DataFormat.COCO)
+        assert captured["dataset"] is dummy_dataset
+        assert captured["images_dir_path"] == os.path.join(tmp_dir, "images")
+        assert captured["annotations_path"] == os.path.join(tmp_dir, "annotations.json")
+        assert dummy_dataset.converted_schema == CocoSample.infer_schema()
 
 
 def test_save_dataset_unsupported_format_raises():
@@ -88,6 +86,117 @@ def test_save_dataset_unsupported_format_raises():
         save_dataset(
             DummyDataset(),
             FakeFormat.OTHER,
-            images_dir_path="/tmp/images",
-            annotations_path="/tmp/annotations.json",
+            "/tmp/output",
         )
+
+
+# Tests for the as_zip functionality in save_dataset
+
+
+def test_save_as_zip_creates_archive_with_correct_files(monkeypatch):
+    """Test that as_zip=True creates a zip archive containing the expected files."""
+    dummy_dataset = DummyDataset()
+
+    def fake_saver(dataset, images_dir_path, annotations_path):
+        os.makedirs(images_dir_path, exist_ok=True)
+        with open(os.path.join(images_dir_path, "test_image.jpg"), "w") as f:
+            f.write("fake image data")
+        with open(annotations_path, "w") as f:
+            f.write('{"images": [], "annotations": []}')
+
+    monkeypatch.setattr("datumaro.experimental.data_formats.coco.io.save_coco_dataset", fake_saver)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        zip_path = os.path.join(tmp_dir, "my_dataset.zip")
+
+        save_dataset(
+            dummy_dataset,
+            DataFormat.COCO,
+            zip_path,
+            as_zip=True,
+        )
+
+        assert os.path.exists(zip_path)
+        assert zipfile.is_zipfile(zip_path)
+
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+            assert "annotations.json" in names
+            assert "images/test_image.jpg" in names
+
+
+def test_save_as_zip_adds_extension_if_missing(monkeypatch):
+    """Test that .zip extension is added if not present in output_path."""
+    dummy_dataset = DummyDataset()
+
+    def fake_saver(dataset, images_dir_path, annotations_path):
+        os.makedirs(images_dir_path, exist_ok=True)
+        with open(annotations_path, "w") as f:
+            f.write("{}")
+
+    monkeypatch.setattr("datumaro.experimental.data_formats.coco.io.save_coco_dataset", fake_saver)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # No .zip extension
+        output_path = os.path.join(tmp_dir, "my_dataset")
+
+        save_dataset(
+            dummy_dataset,
+            DataFormat.COCO,
+            output_path,
+            as_zip=True,
+        )
+
+        # Should have added .zip
+        zip_path = os.path.join(tmp_dir, "my_dataset.zip")
+        assert os.path.exists(zip_path)
+
+
+def test_save_as_zip_unsupported_format_raises():
+    """Test that unsupported format raises ValueError when as_zip=True."""
+    with pytest.raises(ValueError, match="Unsupported data format"):
+        save_dataset(
+            DummyDataset(),
+            FakeFormat.OTHER,
+            "/tmp/test.zip",
+            as_zip=True,
+        )
+
+
+def test_save_as_zip_cleans_up_on_error(monkeypatch):
+    """Test that temp directory is cleaned up even if an error occurs."""
+    dummy_dataset = DummyDataset()
+    created_temp_dir = None
+
+    original_mkdtemp = tempfile.mkdtemp
+
+    def tracking_mkdtemp(*args, **kwargs):
+        nonlocal created_temp_dir
+        result = original_mkdtemp(*args, **kwargs)
+        created_temp_dir = result
+        return result
+
+    # Import the base module and patch tempfile.mkdtemp on its imported tempfile
+    import datumaro.experimental.data_formats.base as base_module
+
+    monkeypatch.setattr(base_module.tempfile, "mkdtemp", tracking_mkdtemp)
+
+    def failing_saver(dataset, images_dir_path, annotations_path):
+        raise RuntimeError("Simulated save failure")
+
+    monkeypatch.setattr("datumaro.experimental.data_formats.coco.io.save_coco_dataset", failing_saver)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        zip_path = os.path.join(tmp_dir, "test.zip")
+
+        with pytest.raises(RuntimeError, match="Simulated save failure"):
+            save_dataset(
+                dummy_dataset,
+                DataFormat.COCO,
+                zip_path,
+                as_zip=True,
+            )
+
+        # Verify temp directory was still cleaned up
+        assert created_temp_dir is not None
+        assert not os.path.exists(created_temp_dir)


### PR DESCRIPTION
Adds support for zipping exported datasets. Also refactors the save dataset api by removing images/annotation/root_dir paths and assuming default paths for the data formats. 

resolves #2026 

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
