### PR TITLE
Enforce semantics for generic fields and add bool polars converter

### DIFF
--- a/src/datumaro/experimental/data_formats/coco/sample.py
+++ b/src/datumaro/experimental/data_formats/coco/sample.py
@@ -9,6 +9,7 @@ import polars as pl
 from datumaro.experimental import LazyImage, Sample
 from datumaro.experimental.categories import LabelCategories
 from datumaro.experimental.data_formats.coco.constants import COCO_LABEL_TO_SUPER
+from datumaro.experimental.data_formats.semantics import AREAS, CAPTION_GROUP_IDS, IMAGE_ID, ISCROWD
 from datumaro.experimental.fields import (
     ImageInfo,
     Subset,
@@ -34,19 +35,19 @@ class CocoSample(Sample):
     bboxes: np.ndarray | None = bbox_field(dtype=pl.Float32(), format="xywh")
     polygons: np.ndarray | None = polygon_field(dtype=pl.Float32())
     labels: np.ndarray | None = label_field(dtype=pl.UInt32(), is_list=True)
-    areas: np.ndarray | None = numeric_field(dtype=pl.Float32(), is_list=True)
-    iscrowd: np.ndarray | None = bool_field(is_list=True)
+    areas: np.ndarray | None = numeric_field(dtype=pl.Float32(), is_list=True, semantic=AREAS)
+    iscrowd: np.ndarray | None = bool_field(is_list=True, semantic=ISCROWD)
 
     # Keypoint annotations (from person_keypoints_train/val)
     keypoints: np.ndarray | None = keypoints_field(dtype=pl.Float32())
 
     # Caption annotations (from captions_train/val)
-    captions: np.ndarray | None = caption_field(is_list=True, semantic="caption")
-    caption_group_ids: np.ndarray | None = numeric_field(dtype=pl.UInt32(), is_list=True, semantic="caption")
+    captions: np.ndarray | None = caption_field(is_list=True)
+    caption_group_ids: np.ndarray | None = numeric_field(dtype=pl.UInt32(), is_list=True, semantic=CAPTION_GROUP_IDS)
 
     # Dataset organization
     subset: Subset = subset_field()
-    image_id: int | None = numeric_field(dtype=pl.Int32(), semantic="image_id")
+    image_id: int | None = numeric_field(dtype=pl.Int32(), semantic=IMAGE_ID)
 
 
 class CocoCategories(LabelCategories):

--- a/src/datumaro/experimental/data_formats/semantics.py
+++ b/src/datumaro/experimental/data_formats/semantics.py
@@ -3,7 +3,7 @@
 
 """
 This module defines semantic tags for fields used in Datumaro's supported data formats. The semantics can be used to
-ensure generic fields such as NumericField, BoolField, and StringField are kept when converting to specific dataformat
+ensure generic fields such as NumericField, BoolField, and StringField are kept when converting to specific data format
 Sample schemas.
 """
 

--- a/src/datumaro/experimental/data_formats/semantics.py
+++ b/src/datumaro/experimental/data_formats/semantics.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022-2026 Intel Corporation
-# LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+# SPDX-License-Identifier: MIT
 
 """
 This module defines semantic tags for fields used in Datumaro's supported data formats. The semantics can be used to

--- a/src/datumaro/experimental/data_formats/semantics.py
+++ b/src/datumaro/experimental/data_formats/semantics.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2022-2026 Intel Corporation
+# LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+"""
+This module defines semantic tags for fields used in Datumaro's supported data formats. The semantics can be used to
+ensure generic fields such as NumericField, BoolField, and StringField are kept when converting to specific dataformat
+Sample schemas.
+"""
+
+# Dataset organization semantics
+IMAGE_ID = "image_id"  # NumericField | stores the image id
+
+# COCO semantics
+AREAS = "areas"  # NumericField | stores the area of an annotation
+ISCROWD = "iscrowd"  # BoolField | stores whether an annotation is a crowd
+CAPTION_GROUP_IDS = "caption_group_ids"  # NumericField | stores group ids for captions to link multiple captions

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -570,7 +570,7 @@ class Dataset(Generic[DType]):
             categories=inferred_categories,
         )
 
-    def filter_by_subset(self, subset: Subset | list[Subset] | tuple[Subset, ...]) -> Dataset[DType]:
+    def filter_by_subset(self, subset: Subset | Sequence[Subset]) -> Dataset[DType]:
         """
         Return new dataset with items from given subset(s).
 

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -570,15 +570,15 @@ class Dataset(Generic[DType]):
             categories=inferred_categories,
         )
 
-    def filter_by_subset(self, subset: Subset) -> Dataset[DType]:
+    def filter_by_subset(self, subset: Subset | list[Subset] | tuple[Subset, ...]) -> Dataset[DType]:
         """
-        Return new dataset with items from given subset.
+        Return new dataset with items from given subset(s).
 
         Args:
-            subset: the subset to filter on
+            subset: a single subset or a list/tuple of subsets to filter on
 
         Returns:
-            A new Dataset with items of the given subset.
+            A new Dataset with items of the given subset(s).
         """
         for subset_column_name, attribute_info in self.schema.attributes.items():
             if isinstance(attribute_info.field, SubsetField):
@@ -586,7 +586,11 @@ class Dataset(Generic[DType]):
         else:
             raise RuntimeError(f"Dataset does not have an attribute for 'SubsetField': schema: {self.df.schema}")
 
-        filtered_df = self.df.filter(self.df[subset_column_name] == subset.name)
+        if isinstance(subset, (list, tuple)):
+            subset_names = [s.name for s in subset]
+            filtered_df = self.df.filter(self.df[subset_column_name].is_in(subset_names))
+        else:
+            filtered_df = self.df.filter(self.df[subset_column_name] == subset.name)
 
         return Dataset.from_dataframe(
             df=filtered_df,

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import collections.abc
 import types
 import typing
+from collections.abc import Sequence
 from functools import cache
 from typing import TYPE_CHECKING, Annotated, Any, Generic, TypeGuard, Union, cast, get_args, get_origin, get_type_hints
 
@@ -586,7 +587,7 @@ class Dataset(Generic[DType]):
         else:
             raise RuntimeError(f"Dataset does not have an attribute for 'SubsetField': schema: {self.df.schema}")
 
-        if isinstance(subset, (list, tuple)):
+        if isinstance(subset, Sequence):
             subset_names = [s.name for s in subset]
             filtered_df = self.df.filter(self.df[subset_column_name].is_in(subset_names))
         else:

--- a/src/datumaro/experimental/fields/__init__.py
+++ b/src/datumaro/experimental/fields/__init__.py
@@ -52,10 +52,18 @@ from datumaro.experimental.fields.masks import (
     mask_callable_field,
     mask_field,
 )
-from datumaro.experimental.fields.types import NumericField, StringField, bool_field, numeric_field, string_field
+from datumaro.experimental.fields.types import (
+    BoolField,
+    NumericField,
+    StringField,
+    bool_field,
+    numeric_field,
+    string_field,
+)
 
 __all__ = [
     "BBoxField",
+    "BoolField",
     "CaptionField",
     "EllipseField",
     "Field",

--- a/src/datumaro/experimental/fields/types.py
+++ b/src/datumaro/experimental/fields/types.py
@@ -24,7 +24,7 @@ class NumericField(Field):
         is_list: If True, the field can hold a list of numeric values instead of a single value.
     """
 
-    semantic: str = "default"
+    semantic: str
     dtype: pl.DataType = field(default_factory=pl.Float32)
     is_list: bool = False
 
@@ -47,17 +47,17 @@ class NumericField(Field):
 
 
 def numeric_field(
+    semantic: str,
     dtype: Any = pl.Float32(),
     is_list: bool = False,
-    semantic: str = "default",
 ) -> Any:
     """
     Create a NumericField instance.
 
     Args:
+        semantic: String tag describing the field purpose
         dtype: Polars data type for the numeric value (e.g., pl.Float32, pl.Int64)
         is_list: Whether this field should be treated as a list type
-        semantic: String tag describing the field purpose (optional)
 
     Returns:
         NumericField configured with the given parameters
@@ -77,7 +77,7 @@ class BoolField(Field):
         is_list: If True, the field can hold a list of boolean values instead of a single value.
     """
 
-    semantic: str = "default"
+    semantic: str
     is_list: bool = False
     dtype: pl.DataType = field(default_factory=pl.Boolean, init=False)
 
@@ -99,14 +99,14 @@ class BoolField(Field):
 
 
 def bool_field(
-    semantic: str = "default",
+    semantic: str,
     is_list: bool = False,
 ) -> Any:
     """
     Create a BoolField instance.
 
     Args:
-        semantic: String tag describing the field purpose (optional)
+        semantic: String tag describing the field purpose
         is_list: Whether this field should be treated as a list type
 
     Returns:
@@ -127,7 +127,7 @@ class StringField(Field):
         is_list: If True, the field can hold a list of string values instead of a single value.
     """
 
-    semantic: str = "default"
+    semantic: str
     is_list: bool = False
     dtype: pl.DataType = field(default_factory=pl.String, init=False)
 
@@ -149,14 +149,14 @@ class StringField(Field):
 
 
 def string_field(
-    semantic: str = "default",
+    semantic: str,
     is_list: bool = False,
 ) -> Any:
     """
     Create a StringField instance.
 
     Args:
-        semantic: String tag describing the field purpose (optional)
+        semantic: String tag describing the field purpose
         is_list: Whether this field should be treated as a list type
 
     Returns:

--- a/src/datumaro/experimental/type_registry.py
+++ b/src/datumaro/experimental/type_registry.py
@@ -110,6 +110,7 @@ _from_polars_converters: dict[type, Callable[[Any], Any]] = {
     float: lambda x: float(x),
     str: lambda x: str(x),
     bytes: lambda x: bytes(x),
+    bool: lambda x: bool(x),
 }
 
 

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -276,7 +276,7 @@ def test_export_basic_dataset_to_directory(tmp_path):
 
     class SimpleSample(Sample):
         label: int = label_field()
-        score: float = numeric_field(dtype=pl.Float32())
+        score: float = numeric_field(dtype=pl.Float32(), semantic="score")
 
     dataset = Dataset(SimpleSample, categories={"label": LABEL_CATEGORIES})
     dataset.append(SimpleSample(label=1, score=0.9))
@@ -431,7 +431,7 @@ def test_import_basic_dataset_from_directory(tmp_path):
 
     class SimpleSample(Sample):
         label: int = label_field()
-        score: float = numeric_field(dtype=pl.Float32())
+        score: float = numeric_field(dtype=pl.Float32(), semantic="score")
 
     # Export first
     original_dataset = Dataset(SimpleSample, categories={"label": LABEL_CATEGORIES})
@@ -697,7 +697,7 @@ def test_roundtrip_preserves_data_integrity(tmp_path):
 
     class ComplexSample(Sample):
         label: int = label_field()
-        score: float = numeric_field(dtype=pl.Float32())
+        score: float = numeric_field(dtype=pl.Float32(), semantic="score")
         image: Callable[[], np.ndarray] = image_callable_field()
 
     def make_image(value):
@@ -755,7 +755,7 @@ def test_export_large_dataset(tmp_path):
     """Test exporting larger dataset (performance check)."""
 
     class SimpleSample(Sample):
-        value: int = numeric_field(dtype=pl.UInt16())
+        value: int = numeric_field(dtype=pl.UInt16(), semantic="value")
 
     dataset = Dataset(SimpleSample)
     for i in range(1000):
@@ -823,7 +823,7 @@ def test_export_import_different_field_types(tmp_path):
 
     class ComprehensiveSample(Sample):
         label: int = label_field()
-        score: float = numeric_field()
+        score: float = numeric_field(semantic="score")
         subset: Subset = subset_field()
 
         tensor: np.ndarray = tensor_field(dtype=pl.Float32())

--- a/tests/unit/experimental/converters/test_base_converters.py
+++ b/tests/unit/experimental/converters/test_base_converters.py
@@ -902,9 +902,9 @@ def test_get_optional_field_types():
     # Schema with mix of optional and required fields
     schema = Schema(
         attributes={
-            "required_int": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32())),
+            "required_int": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32(), semantic="required_int")),
             "optional_int": AttributeInfo(type=int | None, field=numeric_field(dtype=pl.Int32(), semantic="opt_int")),
-            "required_str": AttributeInfo(type=str, field=string_field()),
+            "required_str": AttributeInfo(type=str, field=string_field(semantic="required_str")),
             "optional_str": AttributeInfo(type=str | None, field=string_field(semantic="opt_str")),
         }
     )
@@ -927,7 +927,7 @@ def test_get_optional_field_types_empty_schema():
 
     schema = Schema(
         attributes={
-            "required_int": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32())),
+            "required_int": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32(), semantic="required_int")),
         }
     )
 
@@ -947,7 +947,7 @@ def test_filter_unreachable_optional_fields():
     # Create a target state with two fields
     target_state = _SchemaState(
         {
-            NumericField: AttributeSpec(name="num", field=numeric_field(dtype=pl.Int32())),
+            NumericField: AttributeSpec(name="num", field=numeric_field(dtype=pl.Int32(), semantic="opt_num")),
             StringField: AttributeSpec(name="str", field=string_field(semantic="str")),
         }
     )
@@ -975,7 +975,7 @@ def test_filter_unreachable_optional_fields_keeps_required():
     # Create a target state with two fields
     target_state = _SchemaState(
         {
-            NumericField: AttributeSpec(name="num", field=numeric_field(dtype=pl.Int32())),
+            NumericField: AttributeSpec(name="num", field=numeric_field(dtype=pl.Int32(), semantic="opt_num")),
             StringField: AttributeSpec(name="str", field=string_field(semantic="str")),
         }
     )
@@ -1000,14 +1000,14 @@ def test_find_conversion_path_skips_unreachable_optional_fields():
     # Source schema has only an int field
     source_schema = Schema(
         attributes={
-            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32())),
+            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32(), semantic="opt_num")),
         }
     )
 
     # Target schema has int field + optional string field (unreachable from int)
     target_schema = Schema(
         attributes={
-            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32())),
+            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32(), semantic="opt_num")),
             "optional_name": AttributeInfo(type=str | None, field=string_field(semantic="name")),
         }
     )
@@ -1026,14 +1026,14 @@ def test_find_conversion_path_raises_for_unreachable_required_fields():
     # Source schema has only an int field
     source_schema = Schema(
         attributes={
-            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32())),
+            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32(), semantic="value")),
         }
     )
 
     # Target schema has int field + required string field (unreachable from int)
     target_schema = Schema(
         attributes={
-            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32())),
+            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32(), semantic="value")),
             "required_name": AttributeInfo(type=str, field=string_field(semantic="name")),  # Required, not optional
         }
     )
@@ -1050,14 +1050,14 @@ def test_find_conversion_path_with_multiple_optional_fields():
     # Source schema with one field
     source_schema = Schema(
         attributes={
-            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32())),
+            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32(), semantic="value")),
         }
     )
 
     # Target schema with same field + multiple optional fields that are unreachable
     target_schema = Schema(
         attributes={
-            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32())),
+            "value": AttributeInfo(type=int, field=numeric_field(dtype=pl.Int32(), semantic="value")),
             "opt_a": AttributeInfo(type=float | None, field=numeric_field(dtype=pl.Float32(), semantic="a")),
             "opt_b": AttributeInfo(type=float | None, field=numeric_field(dtype=pl.Float64(), semantic="b")),
         }

--- a/tests/unit/experimental/fields/test_string_field.py
+++ b/tests/unit/experimental/fields/test_string_field.py
@@ -19,7 +19,7 @@ from datumaro.experimental.fields import string_field
 )
 def test_string_field_roundtrip(text):
     class StringSample(Sample):
-        text: Annotated[str, string_field()]
+        text: Annotated[str, string_field(semantic="text")]
 
     ds = Dataset(StringSample)
 
@@ -34,7 +34,7 @@ def test_string_field_roundtrip(text):
 
 def test_string_field_list_roundtrip():
     class MultiStringSample(Sample):
-        texts: Annotated[list[str], string_field(is_list=True)]
+        texts: Annotated[list[str], string_field(is_list=True, semantic="texts")]
 
     ds = Dataset(MultiStringSample)
 

--- a/tests/unit/experimental/fields/test_types.py
+++ b/tests/unit/experimental/fields/test_types.py
@@ -1,0 +1,113 @@
+# Copyright (C) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+from typing import Annotated
+
+import polars as pl
+import pytest
+
+from datumaro.experimental.dataset import Dataset, Sample
+from datumaro.experimental.fields import bool_field, numeric_field
+from datumaro.experimental.fields.types import BoolField, NumericField, StringField
+
+# NumericField Tests
+
+
+@pytest.mark.parametrize("value", [0.0, 3.14, -3.14, 1e10, float("inf")])
+def test_numeric_field_roundtrip(value):
+    """Test NumericField roundtrip through Dataset."""
+
+    class NumericSample(Sample):
+        value: Annotated[float, numeric_field(dtype=pl.Float64())]
+
+    ds = Dataset(NumericSample)
+    s = NumericSample(value=value)
+    ds.append(s)
+
+    out = ds[0]
+    if value != float("inf"):
+        assert out.value == pytest.approx(value, rel=1e-5)
+    else:
+        assert out.value == value
+
+
+def test_numeric_field_list_roundtrip():
+    """Test NumericField with is_list=True roundtrip."""
+
+    class VectorSample(Sample):
+        values: Annotated[list[float], numeric_field(dtype=pl.Float32(), is_list=True)]
+
+    ds = Dataset(VectorSample)
+    values = [1.0, 2.0, 3.0]
+    s = VectorSample(values=values)
+    ds.append(s)
+
+    out = ds[0]
+    assert out.values == pytest.approx(values, rel=1e-5)
+
+
+def test_numeric_field_polars_conversion():
+    """Test NumericField to/from polars conversion."""
+    field = NumericField(dtype=pl.Float32())
+    result = field.to_polars("value", 3.14)
+    assert result["value"].dtype == pl.Float32()
+
+    df = pl.DataFrame({"value": [3.14]}).cast({"value": pl.Float32()})
+    assert field.from_polars("value", 0, df, float) == pytest.approx(3.14, rel=1e-5)
+
+
+# BoolField Tests
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_bool_field_roundtrip(value):
+    """Test BoolField roundtrip through Dataset."""
+
+    class BoolSample(Sample):
+        flag: Annotated[bool, bool_field()]
+
+    ds = Dataset(BoolSample)
+    s = BoolSample(flag=value)
+    ds.append(s)
+
+    assert ds[0].flag is value
+
+
+def test_bool_field_list_roundtrip():
+    """Test BoolField with is_list=True roundtrip."""
+
+    class MultiBoolSample(Sample):
+        flags: Annotated[list[bool], bool_field(is_list=True)]
+
+    ds = Dataset(MultiBoolSample)
+    flags = [True, False, True]
+    s = MultiBoolSample(flags=flags)
+    ds.append(s)
+
+    assert ds[0].flags == flags
+
+
+def test_bool_field_polars_conversion():
+    """Test BoolField to/from polars conversion."""
+    field = BoolField()
+    result = field.to_polars("flag", True)
+    assert result["flag"].dtype == pl.Boolean()
+    assert result["flag"][0] is True
+
+    df = pl.DataFrame({"flag": [False]})
+    assert field.from_polars("flag", 0, df, bool) is False
+
+
+# StringField Tests
+
+
+def test_string_field_polars_conversion():
+    """Test StringField to/from polars conversion."""
+    field = StringField()
+    result = field.to_polars("text", "hello")
+    assert result["text"].dtype == pl.String()
+    assert result["text"][0] == "hello"
+
+    df = pl.DataFrame({"text": ["world"]})
+    assert field.from_polars("text", 0, df, str) == "world"

--- a/tests/unit/experimental/fields/test_types.py
+++ b/tests/unit/experimental/fields/test_types.py
@@ -19,7 +19,7 @@ def test_numeric_field_roundtrip(value):
     """Test NumericField roundtrip through Dataset."""
 
     class NumericSample(Sample):
-        value: Annotated[float, numeric_field(dtype=pl.Float64())]
+        value: Annotated[float, numeric_field(dtype=pl.Float64(), semantic="value")]
 
     ds = Dataset(NumericSample)
     s = NumericSample(value=value)
@@ -36,7 +36,7 @@ def test_numeric_field_list_roundtrip():
     """Test NumericField with is_list=True roundtrip."""
 
     class VectorSample(Sample):
-        values: Annotated[list[float], numeric_field(dtype=pl.Float32(), is_list=True)]
+        values: Annotated[list[float], numeric_field(dtype=pl.Float32(), is_list=True, semantic="values")]
 
     ds = Dataset(VectorSample)
     values = [1.0, 2.0, 3.0]
@@ -49,7 +49,7 @@ def test_numeric_field_list_roundtrip():
 
 def test_numeric_field_polars_conversion():
     """Test NumericField to/from polars conversion."""
-    field = NumericField(dtype=pl.Float32())
+    field = NumericField(dtype=pl.Float32(), semantic="value")
     result = field.to_polars("value", 3.14)
     assert result["value"].dtype == pl.Float32()
 
@@ -65,7 +65,7 @@ def test_bool_field_roundtrip(value):
     """Test BoolField roundtrip through Dataset."""
 
     class BoolSample(Sample):
-        flag: Annotated[bool, bool_field()]
+        flag: Annotated[bool, bool_field(semantic="flag")]
 
     ds = Dataset(BoolSample)
     s = BoolSample(flag=value)
@@ -78,7 +78,7 @@ def test_bool_field_list_roundtrip():
     """Test BoolField with is_list=True roundtrip."""
 
     class MultiBoolSample(Sample):
-        flags: Annotated[list[bool], bool_field(is_list=True)]
+        flags: Annotated[list[bool], bool_field(is_list=True, semantic="flags")]
 
     ds = Dataset(MultiBoolSample)
     flags = [True, False, True]
@@ -90,7 +90,7 @@ def test_bool_field_list_roundtrip():
 
 def test_bool_field_polars_conversion():
     """Test BoolField to/from polars conversion."""
-    field = BoolField()
+    field = BoolField(semantic="flag")
     result = field.to_polars("flag", True)
     assert result["flag"].dtype == pl.Boolean()
     assert result["flag"][0] is True
@@ -104,7 +104,7 @@ def test_bool_field_polars_conversion():
 
 def test_string_field_polars_conversion():
     """Test StringField to/from polars conversion."""
-    field = StringField()
+    field = StringField(semantic="text")
     result = field.to_polars("text", "hello")
     assert result["text"].dtype == pl.String()
     assert result["text"][0] == "hello"

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -162,6 +162,30 @@ def test_filter_by_subset_filters_correctly():
         assert sample.subset == Subset.TRAINING
 
 
+def test_filter_by_multiple_subsets():
+    class SubsetSample(Sample):
+        image: np.ndarray = image_field(dtype=pl.UInt8(), format="RGB")
+        subset: Subset = subset_field()
+
+    dataset = Dataset(SubsetSample)
+    dataset.append(SubsetSample(image=np.array([1]), subset=Subset.TRAINING))
+    dataset.append(SubsetSample(image=np.array([2]), subset=Subset.VALIDATION))
+    dataset.append(SubsetSample(image=np.array([3]), subset=Subset.TESTING))
+    dataset.append(SubsetSample(image=np.array([4]), subset=Subset.TRAINING))
+
+    # Test with list of subsets
+    filtered = dataset.filter_by_subset([Subset.TRAINING, Subset.VALIDATION])
+    assert len(filtered) == 3
+    for sample in filtered:
+        assert sample.subset in (Subset.TRAINING, Subset.VALIDATION)
+
+    # Test with tuple of subsets
+    filtered = dataset.filter_by_subset((Subset.VALIDATION, Subset.TESTING))
+    assert len(filtered) == 2
+    for sample in filtered:
+        assert sample.subset in (Subset.VALIDATION, Subset.TESTING)
+
+
 def test_dataset_creation_from_sample_class():
     """Test Dataset creation from Sample class."""
 

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -821,10 +821,10 @@ def test_getitem_missing_column_for_optional_field():
     from datumaro.experimental.fields import numeric_field
 
     class SourceSample(Sample):
-        value: int = numeric_field(dtype=pl.Int32())
+        value: int = numeric_field(dtype=pl.Int32(), semantic="main")
 
     class TargetSample(Sample):
-        value: int = numeric_field(dtype=pl.Int32())
+        value: int = numeric_field(dtype=pl.Int32(), semantic="main")
         optional_value: int | None = numeric_field(dtype=pl.Int32(), semantic="optional")
 
     # Create source dataset
@@ -851,10 +851,10 @@ def test_getitem_missing_column_for_required_field_raises():
     from datumaro.experimental.fields import numeric_field
 
     class SourceSample(Sample):
-        value: int = numeric_field(dtype=pl.Int32())
+        value: int = numeric_field(dtype=pl.Int32(), semantic="value")
 
     class TargetSample(Sample):
-        value: int = numeric_field(dtype=pl.Int32())
+        value: int = numeric_field(dtype=pl.Int32(), semantic="value")
         required_value: int = numeric_field(dtype=pl.Int32(), semantic="required")  # Required, not optional
 
     # Create source dataset

--- a/tests/unit/experimental/test_sample.py
+++ b/tests/unit/experimental/test_sample.py
@@ -191,7 +191,9 @@ def test_sample_inheritance():
 
 def test_sample_with_is_list():
     class MySample(Sample):
-        confidence: npt.NDArray[np.float32] | None = numeric_field(dtype=pl.Float32(), is_list=True)
+        confidence: npt.NDArray[np.float32] | None = numeric_field(
+            dtype=pl.Float32(), is_list=True, semantic="confidence"
+        )
 
     # Assert that sample can be created without validation errors
     MySample(confidence=np.array([0.8]))


### PR DESCRIPTION
This PR makes the semantic required for BoolField, NumericField and Stringfield. The default value could cause problems when converting between different Schemas.

Also adds a bool from_polars converter and adds tests for the generic fields. 

Adds support to filter datasets by list/tuple of subsets 

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
