### PR TITLE
Simplify original_size check in CVAT base.py

### DIFF
--- a/src/datumaro/plugins/data_formats/cvat/base.py
+++ b/src/datumaro/plugins/data_formats/cvat/base.py
@@ -215,9 +215,7 @@ class CvatBase(SubsetBase):
         frame_size = None
         original_size = [item for item in meta_root.iter("original_size")]
 
-        if len(original_size) > 1:
-            raise DatasetImportError("CVAT XML file should have only one <original_size> tag.")
-        if len(original_size) == 1:
+        if original_size:
             frame_size = (
                 int(original_size[0].find("height").text),
                 int(original_size[0].find("width").text),


### PR DESCRIPTION
CVAT project annotation file can include multiple tasks (https://github.com/open-edge-platform/datumaro/issues/1692). So it can have multiple <original_size> tags. This removes the check for only one <original_size> tag.



<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
