### PR TITLE
Automatic sample type detection on data import

### DIFF
--- a/src/datumaro/experimental/__init__.py
+++ b/src/datumaro/experimental/__init__.py
@@ -4,7 +4,7 @@
 
 from .converters import Converter, ConverterRegistry, converter
 from .dataset import Dataset, Sample
-from .export_import import export_dataset, import_dataset
+from .export_import import export_dataset, import_dataset, register_sample
 from .media import ImageCache, LazyImage
 from .schema import AttributeInfo, Schema
 from .tiling import tilers

--- a/src/datumaro/experimental/data_formats/coco/sample.py
+++ b/src/datumaro/experimental/data_formats/coco/sample.py
@@ -6,7 +6,7 @@
 import numpy as np
 import polars as pl
 
-from datumaro.experimental import LazyImage, Sample
+from datumaro.experimental import LazyImage, Sample, register_sample
 from datumaro.experimental.categories import LabelCategories
 from datumaro.experimental.data_formats.coco.constants import COCO_LABEL_TO_SUPER
 from datumaro.experimental.data_formats.semantics import AREAS, CAPTION_GROUP_IDS, IMAGE_ID, ISCROWD
@@ -26,6 +26,7 @@ from datumaro.experimental.fields import (
 )
 
 
+@register_sample
 class CocoSample(Sample):
     # Basic image information
     image: LazyImage = image_path_field()

--- a/src/datumaro/experimental/data_formats/yolo/sample.py
+++ b/src/datumaro/experimental/data_formats/yolo/sample.py
@@ -6,7 +6,7 @@
 import numpy as np
 import polars as pl
 
-from datumaro.experimental import LazyImage, Sample
+from datumaro.experimental import LazyImage, Sample, register_sample
 from datumaro.experimental.fields import (
     ImageInfo,
     Subset,
@@ -18,6 +18,7 @@ from datumaro.experimental.fields import (
 )
 
 
+@register_sample
 class YoloSample(Sample):
     """
     Sample class for YOLO format datasets.

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -61,6 +61,11 @@ def register_sample(cls: type[Sample]) -> type[Sample]:
             image: Annotated[np.ndarray, ImageField()]
             label: Annotated[int, ScalarField()]
     """
+    # Validate that only proper Sample subclasses (excluding Sample itself)
+    # can be registered. This prevents invalid entries that could later cause
+    # failures during schema inference.
+    if not isinstance(cls, type) or not issubclass(cls, Sample) or cls is Sample:
+        raise TypeError(f"register_sample expects a subclass of Sample (excluding Sample itself), got {cls!r}")
     _sample_registry.add(cls)
     return cls
 

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -493,7 +493,6 @@ def _get_registered_samples() -> list[type[Sample]]:
     """Get all Sample subclasses that have been explicitly registered.
 
     Only returns classes that were registered via :func:`register_sample`.
-    Does not perform automatic discovery via ``__subclasses__()``.
 
     Returns:
         List of explicitly registered Sample subclasses

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -11,6 +11,7 @@ including support for:
 - JSON metadata for schema and categories
 - Image export for callable and path-based image fields
 - ZIP archive format for complete dataset packages
+- Automatic dtype detection when importing without an explicit ``dtype``
 """
 
 from __future__ import annotations
@@ -35,6 +36,34 @@ from datumaro.experimental.schema import Schema
 
 if TYPE_CHECKING:
     from .dataset import DType
+
+# Registry sample classes that can automatically be detected when importing datasets
+_sample_registry: set[type[Sample]] = set()
+
+
+def register_sample(cls: type[Sample]) -> type[Sample]:
+    """Register a Sample subclass for automatic dtype detection during import.
+
+    Use this to ensure that custom Sample subclasses defined outside of Datumaro
+    are discoverable by :func:`import_dataset` when ``dtype`` is not provided.
+    Can be used as a decorator or called directly.
+
+    Args:
+        cls: A Sample subclass to register
+
+    Returns:
+        The same class, unmodified (allows use as a decorator)
+
+    Example::
+
+        @register_sample
+        class MySample(Sample):
+            image: Annotated[np.ndarray, ImageField()]
+            label: Annotated[int, ScalarField()]
+    """
+    _sample_registry.add(cls)
+    return cls
+
 
 # Constants for export structure
 METADATA_FILE = "metadata.json"
@@ -306,10 +335,16 @@ def import_dataset(
     """
     Import a dataset from an exported format.
 
+    When dtype is None the function tries to automatically determine
+    the correct Sample subclass by matching the stored schema against all known subclasses (discovered via
+    ``__subclasses__()`` and the :func:`register_sample` registry).  If no
+    match is found, it falls back to the base ``Sample`` class.
+
     Args:
         input_path: Path to the exported dataset (directory or .zip file)
-        dtype: Optional Sample class to use for the dataset. If None, uses generic Sample. Only necessary for typing and
-        auto-completion; schema is loaded from metadata.
+        dtype: Optional Sample class to use for the dataset.  When provided,
+            the dataset is typed with this class directly.  When ``None``,
+            automatic dtype detection is attempted (see above).
 
     Returns:
         The imported Dataset instance
@@ -454,6 +489,41 @@ def _add_missing_object_columns(
     return df
 
 
+def _get_registered_samples() -> list[type[Sample]]:
+    """Get all Sample subclasses that have been explicitly registered.
+
+    Only returns classes that were registered via :func:`register_sample`.
+    Does not perform automatic discovery via ``__subclasses__()``.
+
+    Returns:
+        List of explicitly registered Sample subclasses
+    """
+    return list(_sample_registry)
+
+
+def _match_dtype_from_schema(schema: Schema) -> type[Sample]:
+    """Try to match a schema against registered Sample subclasses.
+
+    Compares attribute names and field types between the loaded schema and each
+    registered Sample subclass's inferred schema.
+
+    Args:
+        schema: The schema loaded from the dataset metadata
+
+    Returns:
+        The matching Sample subclass, or base Sample if no match is found
+    """
+    schema_signature = {(name, type(attr_info.field)) for name, attr_info in schema.attributes.items()}
+
+    for subclass in _get_registered_samples():
+        candidate_schema = subclass.infer_schema()
+        candidate_signature = {(name, type(attr_info.field)) for name, attr_info in candidate_schema.attributes.items()}
+        if schema_signature == candidate_signature:
+            return subclass
+
+    return Sample
+
+
 def _import_dataset_from_dir(
     input_dir: Path,
     dtype: type[DType] | None = None,
@@ -479,6 +549,6 @@ def _import_dataset_from_dir(
     df = _add_missing_object_columns(df, object_columns)
 
     if dtype is None:
-        dtype = Sample  # type: ignore
+        dtype = _match_dtype_from_schema(schema)
 
     return Dataset.from_dataframe(df, dtype, schema=schema)

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -335,9 +335,8 @@ def import_dataset(
     """
     Import a dataset from an exported format.
 
-    When dtype is None the function tries to automatically determine
-    the correct Sample subclass by matching the stored schema against all known subclasses (discovered via
-    ``__subclasses__()`` and the :func:`register_sample` registry).  If no
+    When dtype is None the function tries to automatically determine the correct Sample subclass by matching the stored
+    schema against all registered subclasses (discovered via the :func:`register_sample` registry).  If no
     match is found, it falls back to the base ``Sample`` class.
 
     Args:

--- a/src/datumaro/experimental/schema.py
+++ b/src/datumaro/experimental/schema.py
@@ -7,9 +7,11 @@ Schema definitions for the dataset system.
 
 import copy
 import importlib
+import types
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
-from typing import Any, Generic, Optional, TypeVar
+from functools import reduce
+from typing import Any, Generic, Optional, TypeVar, Union, get_args, get_origin
 
 from datumaro.experimental.categories import Categories
 from datumaro.experimental.fields.base import Field
@@ -62,7 +64,40 @@ BUILTIN_TYPES = {
     "list": list,
     "dict": dict,
     "tuple": tuple,
+    "NoneType": type(None),
 }
+
+
+def _resolve_type(type_name: str, type_module: str | None) -> type:
+    """Resolve a type from its name and module."""
+    if type_module and type_module != "builtins":
+        try:
+            module = importlib.import_module(type_module)
+            return getattr(module, type_name, object)
+        except (ImportError, AttributeError):
+            return object
+    if type_name in BUILTIN_TYPES:
+        return BUILTIN_TYPES.get(type_name, object)
+    return object
+
+
+def _resolve_type_from_qualified_name(qualified_name: str) -> type:
+    """Resolve a type from a qualified name like 'numpy.ndarray' or 'None'."""
+    qualified_name = qualified_name.strip()
+    if qualified_name == "None":
+        return type(None)
+    if qualified_name in BUILTIN_TYPES:
+        return BUILTIN_TYPES[qualified_name]
+    # Try to split into module and attribute (e.g., "numpy.ndarray")
+    parts = qualified_name.rsplit(".", 1)
+    if len(parts) == 2:
+        module_name, attr_name = parts
+        try:
+            module = importlib.import_module(module_name)
+            return getattr(module, attr_name, object)
+        except (ImportError, AttributeError):
+            return object
+    return object
 
 
 @dataclass
@@ -179,15 +214,32 @@ class Schema:
         categories = {}
 
         for name, attr_info in self.attributes.items():
-            # Store both module and name for better type reconstruction
-            type_info = attr_info.type.__name__ if hasattr(attr_info.type, "__name__") else str(attr_info.type)
-            type_module = attr_info.type.__module__ if hasattr(attr_info.type, "__module__") else None
+            attr_type = attr_info.type
 
-            attributes[name] = {
-                "type": type_info,
-                "type_module": type_module,
-                "field": attr_info.field.to_dict(),
-            }
+            # Check if this is a Union type (e.g., np.ndarray | None)
+            if isinstance(attr_type, types.UnionType) or get_origin(attr_type) is Union:
+                union_args = get_args(attr_type)
+                type_info = [
+                    {
+                        "name": arg.__name__ if hasattr(arg, "__name__") else str(arg),
+                        "module": arg.__module__ if hasattr(arg, "__module__") else None,
+                    }
+                    for arg in union_args
+                ]
+                attributes[name] = {
+                    "type": type_info,
+                    "type_module": "__union__",
+                    "field": attr_info.field.to_dict(),
+                }
+            else:
+                type_info = attr_type.__name__ if hasattr(attr_type, "__name__") else str(attr_type)
+                type_module = attr_type.__module__ if hasattr(attr_type, "__module__") else None
+
+                attributes[name] = {
+                    "type": type_info,
+                    "type_module": type_module,
+                    "field": attr_info.field.to_dict(),
+                }
             if attr_info.categories is not None:
                 categories[name] = attr_info.categories.to_dict()
 
@@ -222,19 +274,17 @@ class Schema:
             type_name = attr_dict.get("type", "object")
             type_module = attr_dict.get("type_module")
 
-            # Attempt to reconstruct the actual type
-            if type_module and type_module != "builtins":
-                try:
-                    module = importlib.import_module(type_module)
-                    attr_type = getattr(module, type_name, object)
-                except (ImportError, AttributeError):
-                    attr_type = object
-            elif type_name in BUILTIN_TYPES:
-                # Handle built-in types
-                attr_type = BUILTIN_TYPES.get(type_name, object)
+            if type_module == "__union__":
+                # Reconstruct Union type from list of component types (new format)
+                union_types = []
+                for component in type_name:
+                    comp_name = component["name"]
+                    comp_module = component.get("module")
+                    resolved = _resolve_type(comp_name, comp_module)
+                    union_types.append(resolved)
+                attr_type = reduce(lambda a, b: a | b, union_types)
             else:
-                # Default to object as placeholder
-                attr_type = object
+                attr_type = _resolve_type(type_name, type_module)
 
             attributes[name] = AttributeInfo(
                 type=attr_type,

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -28,8 +28,12 @@ from datumaro.experimental.export_import import (
     METADATA_FILE,
     VERSION,
     _export_images_from_dataset,
+    _get_registered_samples,
+    _match_dtype_from_schema,
+    _sample_registry,
     export_dataset,
     import_dataset,
+    register_sample,
 )
 from datumaro.experimental.fields import (
     ImageInfo,
@@ -620,27 +624,6 @@ def test_import_missing_dataframe_raises_error(tmp_path):
         import_dataset(export_dir)
 
 
-def test_import_without_dtype_uses_sample(tmp_path):
-    """Test that import without dtype uses generic Sample."""
-
-    class SimpleSample(Sample):
-        label: int = label_field()
-
-    # Export dataset
-    original_dataset = Dataset(SimpleSample, categories={"label": LABEL_CATEGORIES})
-    original_dataset.append(SimpleSample(label=1))
-
-    export_dir = tmp_path / "export"
-    export_dataset(original_dataset, export_dir, export_images=False, as_zip=False)
-
-    # Import without dtype
-    imported_dataset = import_dataset(export_dir, dtype=None)
-
-    # Verify dataset uses Sample
-    assert len(imported_dataset) == 1
-    assert imported_dataset.dtype == Sample
-
-
 def test_import_preserves_categories(tmp_path):
     """Test that import preserves category information."""
 
@@ -1006,3 +989,167 @@ def test_export_dataset_export_images_true_and_false(tmp_path):
     df_false = pl.read_parquet(export_dir_false / DATAFRAME_FILE)
     assert df_false["img"][0] == str(source_img_path)
     assert not (export_dir_false / IMAGES_DIR).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests for automatic dtype detection (_get_registered_samples,
+# _match_dtype_from_schema, register_sample)
+# ---------------------------------------------------------------------------
+
+
+def test_get_registered_samples_returns_empty_without_registration():
+    """_get_registered_samples should return empty list when no classes are registered."""
+    # Clear any existing registrations for this test
+    original_registry = _sample_registry.copy()
+    _sample_registry.clear()
+    try:
+        result = _get_registered_samples()
+        assert result == []
+    finally:
+        _sample_registry.update(original_registry)
+
+
+def test_get_registered_samples_returns_registered_classes():
+    """_get_registered_samples should return classes that were explicitly registered."""
+
+    class RegisteredChild(Sample):
+        label: int = label_field()
+
+    _sample_registry.discard(RegisteredChild)
+    try:
+        # Before registration, should not be in results
+        assert RegisteredChild not in _get_registered_samples()
+
+        # After registration, should be in results
+        register_sample(RegisteredChild)
+        assert RegisteredChild in _get_registered_samples()
+    finally:
+        _sample_registry.discard(RegisteredChild)
+
+
+def test_get_registered_samples_does_not_include_base_sample():
+    """The base Sample class itself should not appear in the result."""
+    result = _get_registered_samples()
+    assert Sample not in result
+
+
+def test_match_dtype_from_schema_returns_matching_subclass():
+    """_match_dtype_from_schema should return the subclass whose schema matches."""
+
+    @register_sample
+    class MatchMe(Sample):
+        label: int = label_field()
+        score: float = numeric_field(dtype=pl.Float32(), semantic="score")
+        subset: Subset = subset_field()
+
+    try:
+        schema = MatchMe.infer_schema()
+        result = _match_dtype_from_schema(schema)
+        assert result is MatchMe
+    finally:
+        _sample_registry.discard(MatchMe)
+
+
+def test_match_dtype_from_schema_falls_back_to_sample():
+    """When no subclass matches, _match_dtype_from_schema should return Sample."""
+    from datumaro.experimental.fields.types import NumericField
+    from datumaro.experimental.schema import AttributeInfo, Schema
+
+    # Build a schema that no existing subclass will match
+    schema = Schema(
+        attributes={
+            "unique_xyz_field": AttributeInfo(
+                type=int,
+                field=NumericField(dtype=pl.Int64(), semantic="unique_xyz"),
+            ),
+            "another_unique_abc": AttributeInfo(
+                type=float,
+                field=NumericField(dtype=pl.Float64(), semantic="unique_abc"),
+            ),
+        }
+    )
+    result = _match_dtype_from_schema(schema)
+    assert result is Sample
+
+
+def test_register_sample_makes_class_discoverable():
+    """register_sample should add a class to the registry so it is discoverable."""
+
+    class ExternalSample(Sample):
+        label: int = label_field()
+        score: float = numeric_field(dtype=pl.Float32(), semantic="score")
+
+    # Remove from registry in case a previous test registered it
+    _sample_registry.discard(ExternalSample)
+
+    register_sample(ExternalSample)
+    try:
+        assert ExternalSample in _sample_registry
+        assert ExternalSample in _get_registered_samples()
+    finally:
+        _sample_registry.discard(ExternalSample)
+
+
+def test_register_sample_works_as_decorator():
+    """register_sample should work as a class decorator and return the class."""
+
+    @register_sample
+    class DecoratedSample(Sample):
+        label: int = label_field()
+
+    try:
+        assert DecoratedSample in _sample_registry
+        # The decorator should return the class unchanged
+        assert issubclass(DecoratedSample, Sample)
+    finally:
+        _sample_registry.discard(DecoratedSample)
+
+
+def test_import_without_dtype_falls_back_to_sample_for_unknown_schema(tmp_path):
+    """When the exported schema doesn't match any subclass, dtype should fall back to Sample."""
+    from datumaro.experimental.fields.types import NumericField
+    from datumaro.experimental.schema import AttributeInfo, Schema
+
+    # Create a dataset with a unique schema that won't match any subclass
+    unique_schema = Schema(
+        attributes={
+            "weird_field_xyz": AttributeInfo(
+                type=int,
+                field=NumericField(dtype=pl.Int64(), semantic="weird_xyz"),
+            ),
+        }
+    )
+    dataset = Dataset(unique_schema)
+    dataset.append(Sample(weird_field_xyz=42))
+
+    export_dir = tmp_path / "export"
+    export_dataset(dataset, export_dir, export_images=False, as_zip=False)
+
+    imported_dataset = import_dataset(export_dir, dtype=None)
+    assert len(imported_dataset) == 1
+    assert imported_dataset.dtype == Sample
+
+
+def test_import_auto_detects_dtype_roundtrip(tmp_path):
+    """Full roundtrip: export with a known Sample subclass, import without dtype, verify auto-detection."""
+
+    @register_sample
+    class AutoDetectSample(Sample):
+        label: int = label_field()
+        score: float = numeric_field(dtype=pl.Float32(), semantic="score")
+        subset: Subset = subset_field()
+
+    try:
+        original_dataset = Dataset(AutoDetectSample, categories={"label": LABEL_CATEGORIES})
+        original_dataset.append(AutoDetectSample(label=2, score=0.75, subset=Subset.TRAINING))
+
+        export_dir = tmp_path / "export"
+        export_dataset(original_dataset, export_dir, export_images=False, as_zip=False)
+
+        imported_dataset = import_dataset(export_dir)  # no dtype
+        # Should auto-detect a matching subclass (not fall back to base Sample)
+        assert imported_dataset.dtype is not Sample
+        assert issubclass(imported_dataset.dtype, Sample)
+        assert len(imported_dataset) == 1
+    finally:
+        _sample_registry.discard(AutoDetectSample)

--- a/tests/unit/experimental/test_schema.py
+++ b/tests/unit/experimental/test_schema.py
@@ -1104,6 +1104,88 @@ def test_subset_field_roundtrip():
     assert reconstructed is None
 
 
+def test_schema_serialization_union_types():
+    """Test Schema to_dict/from_dict correctly handles Union types (e.g., np.ndarray | None)."""
+    schema = Schema(
+        attributes={
+            "bboxes": AttributeInfo(type=np.ndarray | None, field=bbox_field(dtype=pl.Float32())),
+            "image": AttributeInfo(type=np.ndarray, field=image_field(dtype=pl.UInt8())),
+        }
+    )
+
+    schema_dict = schema.to_dict()
+
+    # Union type should be serialized with __union__ marker and list of component types
+    bbox_attr = schema_dict["attributes"]["bboxes"]
+    assert bbox_attr["type_module"] == "__union__"
+    assert isinstance(bbox_attr["type"], list)
+    assert len(bbox_attr["type"]) == 2
+    type_names = {comp["name"] for comp in bbox_attr["type"]}
+    assert "ndarray" in type_names
+    assert "NoneType" in type_names
+
+    # Non-union type should be serialized normally
+    image_attr = schema_dict["attributes"]["image"]
+    assert image_attr["type"] == "ndarray"
+    assert image_attr["type_module"] == "numpy"
+
+    # Deserialize and verify round-trip
+    reconstructed = Schema.from_dict(schema_dict)
+    assert set(reconstructed.attributes.keys()) == {"bboxes", "image"}
+
+    # The reconstructed union type should work with isinstance-style checks
+    import types as _types
+
+    bbox_type = reconstructed.attributes["bboxes"].type
+    assert isinstance(bbox_type, _types.UnionType)
+    assert type(None) in bbox_type.__args__
+    assert np.ndarray in bbox_type.__args__
+
+    # Non-union type should be reconstructed correctly
+    assert reconstructed.attributes["image"].type is np.ndarray
+
+
+def test_schema_serialization_union_builtin_types():
+    """Test Schema serialization of Union types with builtin components (e.g., int | None)."""
+    schema = Schema(
+        attributes={
+            "score": AttributeInfo(type=int | None, field=tensor_field(dtype=pl.Int32())),
+        }
+    )
+
+    schema_dict = schema.to_dict()
+    reconstructed = Schema.from_dict(schema_dict)
+
+    import types as _types
+
+    score_type = reconstructed.attributes["score"].type
+    assert isinstance(score_type, _types.UnionType)
+    assert int in score_type.__args__
+    assert type(None) in score_type.__args__
+
+
+def test_resolve_type_helper():
+    """Test _resolve_type helper function."""
+    from datumaro.experimental.schema import _resolve_type
+
+    assert _resolve_type("int", "builtins") is int
+    assert _resolve_type("NoneType", None) is type(None)
+    assert _resolve_type("ndarray", "numpy") is np.ndarray
+    assert _resolve_type("nonexistent", "numpy") is object
+    assert _resolve_type("ndarray", "nonexistent_module") is object
+
+
+def test_resolve_type_from_qualified_name_helper():
+    """Test _resolve_type_from_qualified_name helper function."""
+    from datumaro.experimental.schema import _resolve_type_from_qualified_name
+
+    assert _resolve_type_from_qualified_name("numpy.ndarray") is np.ndarray
+    assert _resolve_type_from_qualified_name("None") is type(None)
+    assert _resolve_type_from_qualified_name("int") is int
+    assert _resolve_type_from_qualified_name("  numpy.ndarray  ") is np.ndarray
+    assert _resolve_type_from_qualified_name("nonexistent.module.Type") is object
+
+
 def test_subset_field_in_sample_with_union_type():
     """Test SubsetField usage in a Sample class with union type annotation."""
 


### PR DESCRIPTION
This pull request introduces automatic detection of the correct `Sample` subclass when importing datasets, improving extensibility and usability for custom dataset schemas. It adds a registration mechanism for `Sample` subclasses, updates the import logic to match schemas to registered types, and provides comprehensive tests for these features. The changes also fix schema serialization/deserialization to properly support union types with None values.

NOTE: Datasets exported before this PR is merged with union types that can be None can still throw an error. Only newly exported datasets will work correctly. I don't think its necessary to add backwards compatible logic at this time. 


<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
