### PR TITLE
Add label filtering functionality to the dataset class

### DIFF
--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -692,7 +692,7 @@ class Dataset(Generic[DType]):
                 label_indices = expand_indices_with_ancestors(categories, label_indices)
 
             # Sort indices to maintain a consistent order in the new categories
-            sorted_indices = sorted(label_indices)
+            sorted_indices = sorted(set(label_indices))
 
             # Create mapping from old indices to new indices (0, 1, 2, ...)
             old_to_new_index_map = {old_idx: new_idx for new_idx, old_idx in enumerate(sorted_indices)}

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -692,37 +692,74 @@ class Dataset(Generic[DType]):
     ) -> pl.DataFrame:
         """Return a filtered DataFrame keeping rows that match any of *label_indices*.
 
+        This method both filters rows (keeping only those with at least one matching label)
+        AND removes non-matching labels from within each sample's label field.
+
         The filtering strategy is chosen based on the ``is_list`` and
         ``multi_label`` flags of *label_field_instance*.
         """
         col = pl.col(label_field_name)
 
         if label_field_instance.is_list and label_field_instance.multi_label:
-            # List(List(UInt)) - explode outer list, check inner lists, re-aggregate.
-            mask = (
-                self.df.with_row_index("__row_idx__")
-                .explode(label_field_name)
-                .with_columns(
-                    pl.col(label_field_name).list.eval(pl.element().is_in(label_indices)).list.any().alias("__match__")
+            # List(List(UInt)) - for each inner list, keep only matching elements,
+            # then filter out empty inner lists, then filter out rows with no remaining labels.
+            return self.df.with_columns(
+                col.list.eval(
+                    pl.element()
+                    .list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element()))
+                    .list.drop_nulls()
                 )
-                .group_by("__row_idx__")
-                .agg(pl.col("__match__").any())
-                .sort("__row_idx__")["__match__"]
-                .to_list()
-            )
-            return self.df.filter(pl.Series(mask))
+                .list.eval(pl.when(pl.element().list.len() > 0).then(pl.element()))
+                .list.drop_nulls()
+            ).filter(col.list.len() > 0)
 
         if label_field_instance.is_list or label_field_instance.multi_label:
-            # List(UInt) - keep row if any element matches.
-            return self.df.filter(col.list.eval(pl.element().is_in(label_indices)).list.any())
+            # List(UInt) - keep only matching elements and filter out rows with empty lists.
+            return self.df.with_columns(
+                col.list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element())).list.drop_nulls()
+            ).filter(col.list.len() > 0)
 
         # Scalar UInt - keep row if the value matches.
         return self.df.filter(col.is_in(label_indices))
+
+    def _remap_label_indices(
+        self,
+        df: pl.DataFrame,
+        label_field_name: str,
+        label_field_instance: LabelField,
+        old_to_new_index_map: dict[int, int],
+    ) -> pl.DataFrame:
+        """Remap label indices in the DataFrame according to the provided mapping.
+
+        Args:
+            df: The DataFrame to modify
+            label_field_name: Name of the label column
+            label_field_instance: The LabelField instance
+            old_to_new_index_map: Mapping from old indices to new indices
+
+        Returns:
+            DataFrame with remapped label indices
+        """
+        col = pl.col(label_field_name)
+
+        if label_field_instance.is_list and label_field_instance.multi_label:
+            # List(List(UInt)) - remap each element in the inner lists
+            return df.with_columns(
+                col.list.eval(pl.element().list.eval(pl.element().replace_strict(old_to_new_index_map, default=None)))
+            )
+
+        if label_field_instance.is_list or label_field_instance.multi_label:
+            # List(UInt) - remap each element in the list
+            return df.with_columns(col.list.eval(pl.element().replace_strict(old_to_new_index_map, default=None)))
+
+        # Scalar UInt - remap the single value
+        return df.with_columns(col.replace_strict(old_to_new_index_map, default=None))
 
     def filter_by_labels(
         self,
         labels: str | int | Sequence[str | int],
         label_field_name: str | None = None,
+        update_categories: bool = False,
     ) -> Dataset[DType]:
         """
         Return a new dataset containing only items that have at least one of the given labels.
@@ -743,6 +780,10 @@ class Dataset(Generic[DType]):
             label_field_name: The name of the attribute on the Sample that uses a
                 LabelField. If ``None``, it is inferred automatically when the
                 schema contains exactly one LabelField.
+            update_categories: If ``True``, the returned dataset's LabelCategories will
+                contain only the filtered labels (with indices remapped to 0, 1, 2, ...).
+                If ``False`` (default), the original LabelCategories are preserved and
+                label indices remain unchanged.
 
         Returns:
             A new Dataset containing only the items whose label field contains
@@ -771,6 +812,9 @@ class Dataset(Generic[DType]):
 
             # Explicit field name (required when multiple LabelFields exist)
             filtered = dataset.filter_by_labels(["cat", "dog"], label_field_name="labels")
+
+            # Update categories to only contain filtered labels (indices remapped)
+            filtered = dataset.filter_by_labels(["cat", "dog"], update_categories=True)
             ```
         """
 
@@ -807,6 +851,43 @@ class Dataset(Generic[DType]):
 
         label_indices = self._resolve_label_indices(labels, categories, label_field_name)
         filtered_df = self._filter_df_by_label_indices(label_field_name, label_field_instance, label_indices)
+
+        if update_categories:
+            # Sort indices to maintain a consistent order in the new categories
+            sorted_indices = sorted(label_indices)
+
+            # Create mapping from old indices to new indices (0, 1, 2, ...)
+            old_to_new_index_map = {old_idx: new_idx for new_idx, old_idx in enumerate(sorted_indices)}
+
+            # Remap label indices in the DataFrame
+            filtered_df = self._remap_label_indices(
+                filtered_df, label_field_name, label_field_instance, old_to_new_index_map
+            )
+
+            # Create new LabelCategories with only the filtered labels
+            filtered_labels = tuple(categories.labels[idx] for idx in sorted_indices)
+
+            # Preserve label_semantics for labels that are kept
+            filtered_semantics = {}
+            if hasattr(categories, "label_semantics"):
+                for semantic, label_name in categories.label_semantics.items():
+                    if label_name in filtered_labels:
+                        filtered_semantics[semantic] = label_name
+
+            new_categories = LabelCategories(
+                labels=filtered_labels,
+                group_type=categories.group_type,
+                label_semantics=filtered_semantics,
+            )
+
+            # Create a new schema with the updated categories
+            new_schema = self.schema.with_categories({label_field_name: new_categories})
+
+            return Dataset.from_dataframe(
+                df=filtered_df,
+                dtype_or_schema=self.dtype,
+                schema=new_schema,
+            )
 
         return Dataset.from_dataframe(
             df=filtered_df,

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -14,7 +14,9 @@ from typing import TYPE_CHECKING, Annotated, Any, Generic, TypeGuard, Union, cas
 import polars as pl
 from typing_extensions import TypeVar, dataclass_transform
 
+from datumaro.experimental.categories import BaseLabelCategories, HierarchicalLabelCategories, LabelCategories
 from datumaro.experimental.converters.registry import ConverterTransform, find_conversion_path
+from datumaro.experimental.fields.annotations import LabelField
 from datumaro.experimental.fields.datasets import Subset, SubsetField
 from datumaro.experimental.polars_utils import prepare_dataframe_for_pickle, restore_dataframe_from_pickle
 from datumaro.experimental.schema import AttributeInfo, Field, Schema
@@ -592,6 +594,211 @@ class Dataset(Generic[DType]):
             filtered_df = self.df.filter(self.df[subset_column_name].is_in(subset_names))
         else:
             filtered_df = self.df.filter(self.df[subset_column_name] == subset.name)
+
+        return Dataset.from_dataframe(
+            df=filtered_df,
+            dtype_or_schema=self.dtype,
+            schema=self.schema,
+        )
+
+    def _resolve_label_field_name(self, label_field_name: str | None) -> str:
+        """Resolve and validate the label field name.
+
+        When *label_field_name* is ``None`` the schema is scanned for a unique
+        ``LabelField``.  If a name is given it is validated against the schema.
+
+        Returns:
+            The validated label field name.
+
+        Raises:
+            RuntimeError: If auto-detection finds zero or more than one LabelField.
+            KeyError: If the given name is not present in the schema.
+            TypeError: If the resolved attribute is not a LabelField.
+        """
+        if label_field_name is None:
+            label_field_names = [
+                name for name, attr_info in self.schema.attributes.items() if isinstance(attr_info.field, LabelField)
+            ]
+            if len(label_field_names) == 0:
+                raise RuntimeError("Dataset schema does not contain any LabelField attributes.")
+            if len(label_field_names) > 1:
+                raise RuntimeError(
+                    f"Dataset schema contains multiple LabelField attributes: "
+                    f"{label_field_names}. Please specify 'label_field_name' explicitly."
+                )
+            label_field_name = label_field_names[0]
+
+        if label_field_name not in self.schema.attributes:
+            raise KeyError(
+                f"Attribute '{label_field_name}' not found in the dataset schema. "
+                f"Available attributes: {list(self.schema.attributes.keys())}"
+            )
+
+        attr_info = self.schema.attributes[label_field_name]
+        if not isinstance(attr_info.field, LabelField):
+            raise TypeError(f"Attribute '{label_field_name}' is a {type(attr_info.field).__name__}, not a LabelField.")
+
+        return label_field_name
+
+    @staticmethod
+    def _resolve_label_indices(
+        labels: Sequence[str | int],
+        categories: Any,
+        label_field_name: str,
+    ) -> list[int]:
+        """Map label names or indices to integer indices via *categories*.
+
+        Args:
+            labels: Label names (str) or indices (int) to resolve.
+            categories: A ``LabelCategories`` or ``HierarchicalLabelCategories`` instance.
+            label_field_name: Used only for error messages.
+
+        Returns:
+            List of integer indices corresponding to the given label names or indices.
+
+        Raises:
+            ValueError: If any label name is not found in *categories* or if any index is out of range.
+            TypeError: If a label is neither a string nor an integer.
+        """
+        label_indices: list[int] = []
+        for label in labels:
+            if isinstance(label, int):
+                if label < 0 or label >= len(categories.labels):
+                    raise ValueError(
+                        f"Label index {label} is out of range for field '{label_field_name}'. "
+                        f"Valid range is 0 to {len(categories.labels) - 1}. "
+                        f"Available labels: {list(categories.labels)}"
+                    )
+                label_indices.append(label)
+            elif isinstance(label, str):
+                idx, _ = categories.find(label)
+                if idx is None:
+                    raise ValueError(
+                        f"Label '{label}' not found in categories for field '{label_field_name}'. "
+                        f"Available labels: {list(categories.labels)}"
+                    )
+                label_indices.append(idx)
+            else:
+                raise TypeError(
+                    f"Label must be a string (label name) or int (label index), got {type(label).__name__}: {label}"
+                )
+        return label_indices
+
+    def _filter_df_by_label_indices(
+        self,
+        label_field_name: str,
+        label_field_instance: LabelField,
+        label_indices: list[int],
+    ) -> pl.DataFrame:
+        """Return a filtered DataFrame keeping rows that match any of *label_indices*.
+
+        The filtering strategy is chosen based on the ``is_list`` and
+        ``multi_label`` flags of *label_field_instance*.
+        """
+        col = pl.col(label_field_name)
+
+        if label_field_instance.is_list and label_field_instance.multi_label:
+            # List(List(UInt)) - explode outer list, check inner lists, re-aggregate.
+            mask = (
+                self.df.with_row_index("__row_idx__")
+                .explode(label_field_name)
+                .with_columns(
+                    pl.col(label_field_name).list.eval(pl.element().is_in(label_indices)).list.any().alias("__match__")
+                )
+                .group_by("__row_idx__")
+                .agg(pl.col("__match__").any())
+                .sort("__row_idx__")["__match__"]
+                .to_list()
+            )
+            return self.df.filter(pl.Series(mask))
+
+        if label_field_instance.is_list or label_field_instance.multi_label:
+            # List(UInt) - keep row if any element matches.
+            return self.df.filter(col.list.eval(pl.element().is_in(label_indices)).list.any())
+
+        # Scalar UInt - keep row if the value matches.
+        return self.df.filter(col.is_in(label_indices))
+
+    def filter_by_labels(
+        self,
+        labels: str | int | Sequence[str | int],
+        label_field_name: str | None = None,
+    ) -> Dataset[DType]:
+        """
+        Return a new dataset containing only items that have at least one of the given labels.
+
+        This method accepts either label names (as strings) or label indices (as integers)
+        and resolves them to their integer indices using the LabelCategories associated with
+        the specified label field. It supports all LabelField configurations: single labels,
+        multi-label fields, list fields, and combinations thereof.
+
+        When ``label_field_name`` is not provided, the method automatically
+        detects the LabelField in the schema. If the schema contains multiple
+        LabelFields, ``label_field_name`` must be specified explicitly.
+
+        Args:
+            labels: A single label name (str), label index (int), or a sequence of label names
+                and/or indices to filter by. Label indices must be within the valid range
+                [0, num_categories).
+            label_field_name: The name of the attribute on the Sample that uses a
+                LabelField. If ``None``, it is inferred automatically when the
+                schema contains exactly one LabelField.
+
+        Returns:
+            A new Dataset containing only the items whose label field contains
+            at least one of the specified labels.
+
+        Raises:
+            KeyError: If ``label_field_name`` is not found in the schema.
+            TypeError: If the specified field is not a LabelField, or if a label is
+                neither a string nor an integer.
+            RuntimeError: If ``label_field_name`` is ``None`` and the schema
+                contains zero or more than one LabelField.
+            ValueError: If the field does not have LabelCategories attached, if any
+                of the provided label names are not found in the categories, or if
+                any label index is out of range.
+
+        Example:
+            ```python
+            # Auto-detect (schema has exactly one LabelField)
+            filtered = dataset.filter_by_labels(["cat", "dog"])
+
+            # Using label indices
+            filtered = dataset.filter_by_labels([0, 1])
+
+            # Mixing label names and indices
+            filtered = dataset.filter_by_labels(["cat", 1])
+
+            # Explicit field name (required when multiple LabelFields exist)
+            filtered = dataset.filter_by_labels(["cat", "dog"], label_field_name="labels")
+            ```
+        """
+
+        label_field_name = self._resolve_label_field_name(label_field_name)
+        attr_info = self.schema.attributes[label_field_name]
+        label_field_instance: LabelField = attr_info.field  # type: ignore[assignment]
+
+        # Validate LabelCategories
+        categories = attr_info.categories
+        if categories is None or not isinstance(categories, BaseLabelCategories):
+            raise ValueError(
+                f"Attribute '{label_field_name}' does not have LabelCategories attached to the schema. "
+                f"LabelCategories are required to resolve label names to indices. "
+                f"Found categories: {categories}"
+            )
+
+        if not isinstance(categories, (LabelCategories, HierarchicalLabelCategories)):
+            raise TypeError(
+                f"Attribute '{label_field_name}' has unsupported categories type "
+                f"'{type(categories).__name__}'. Expected LabelCategories or "
+                f"HierarchicalLabelCategories."
+            )
+
+        if isinstance(labels, (str, int)):
+            labels = [labels]
+
+        label_indices = self._resolve_label_indices(labels, categories, label_field_name)
+        filtered_df = self._filter_df_by_label_indices(label_field_name, label_field_instance, label_indices)
 
         return Dataset.from_dataframe(
             df=filtered_df,

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -14,10 +14,19 @@ from typing import TYPE_CHECKING, Annotated, Any, Generic, TypeGuard, Union, cas
 import polars as pl
 from typing_extensions import TypeVar, dataclass_transform
 
-from datumaro.experimental.categories import BaseLabelCategories, HierarchicalLabelCategories, LabelCategories
+from datumaro.experimental.categories import HierarchicalLabelCategories
 from datumaro.experimental.converters.registry import ConverterTransform, find_conversion_path
 from datumaro.experimental.fields.annotations import LabelField
 from datumaro.experimental.fields.datasets import Subset, SubsetField
+from datumaro.experimental.filtering.label_filter import (
+    create_filtered_categories,
+    expand_indices_with_ancestors,
+    filter_df_by_label_indices,
+    remap_label_indices,
+    resolve_label_field_name,
+    resolve_label_indices,
+    validate_label_categories,
+)
 from datumaro.experimental.polars_utils import prepare_dataframe_for_pickle, restore_dataframe_from_pickle
 from datumaro.experimental.schema import AttributeInfo, Field, Schema
 from datumaro.experimental.transform import IdentityTransform, Transform
@@ -601,160 +610,6 @@ class Dataset(Generic[DType]):
             schema=self.schema,
         )
 
-    def _resolve_label_field_name(self, label_field_name: str | None) -> str:
-        """Resolve and validate the label field name.
-
-        When *label_field_name* is ``None`` the schema is scanned for a unique
-        ``LabelField``.  If a name is given it is validated against the schema.
-
-        Returns:
-            The validated label field name.
-
-        Raises:
-            RuntimeError: If auto-detection finds zero or more than one LabelField.
-            KeyError: If the given name is not present in the schema.
-            TypeError: If the resolved attribute is not a LabelField.
-        """
-        if label_field_name is None:
-            label_field_names = [
-                name for name, attr_info in self.schema.attributes.items() if isinstance(attr_info.field, LabelField)
-            ]
-            if len(label_field_names) == 0:
-                raise RuntimeError("Dataset schema does not contain any LabelField attributes.")
-            if len(label_field_names) > 1:
-                raise RuntimeError(
-                    f"Dataset schema contains multiple LabelField attributes: "
-                    f"{label_field_names}. Please specify 'label_field_name' explicitly."
-                )
-            label_field_name = label_field_names[0]
-
-        if label_field_name not in self.schema.attributes:
-            raise KeyError(
-                f"Attribute '{label_field_name}' not found in the dataset schema. "
-                f"Available attributes: {list(self.schema.attributes.keys())}"
-            )
-
-        attr_info = self.schema.attributes[label_field_name]
-        if not isinstance(attr_info.field, LabelField):
-            raise TypeError(f"Attribute '{label_field_name}' is a {type(attr_info.field).__name__}, not a LabelField.")
-
-        return label_field_name
-
-    @staticmethod
-    def _resolve_label_indices(
-        labels: Sequence[str | int],
-        categories: Any,
-        label_field_name: str,
-    ) -> list[int]:
-        """Map label names or indices to integer indices via *categories*.
-
-        Args:
-            labels: Label names (str) or indices (int) to resolve.
-            categories: A ``LabelCategories`` or ``HierarchicalLabelCategories`` instance.
-            label_field_name: Used only for error messages.
-
-        Returns:
-            List of integer indices corresponding to the given label names or indices.
-
-        Raises:
-            ValueError: If any label name is not found in *categories* or if any index is out of range.
-            TypeError: If a label is neither a string nor an integer.
-        """
-        label_indices: list[int] = []
-        for label in labels:
-            if isinstance(label, int):
-                if label < 0 or label >= len(categories.labels):
-                    raise ValueError(
-                        f"Label index {label} is out of range for field '{label_field_name}'. "
-                        f"Valid range is 0 to {len(categories.labels) - 1}. "
-                        f"Available labels: {list(categories.labels)}"
-                    )
-                label_indices.append(label)
-            elif isinstance(label, str):
-                idx, _ = categories.find(label)
-                if idx is None:
-                    raise ValueError(
-                        f"Label '{label}' not found in categories for field '{label_field_name}'. "
-                        f"Available labels: {list(categories.labels)}"
-                    )
-                label_indices.append(idx)
-            else:
-                raise TypeError(
-                    f"Label must be a string (label name) or int (label index), got {type(label).__name__}: {label}"
-                )
-        return label_indices
-
-    def _filter_df_by_label_indices(
-        self,
-        label_field_name: str,
-        label_field_instance: LabelField,
-        label_indices: list[int],
-    ) -> pl.DataFrame:
-        """Return a filtered DataFrame keeping rows that match any of *label_indices*.
-
-        This method both filters rows (keeping only those with at least one matching label)
-        AND removes non-matching labels from within each sample's label field.
-
-        The filtering strategy is chosen based on the ``is_list`` and
-        ``multi_label`` flags of *label_field_instance*.
-        """
-        col = pl.col(label_field_name)
-
-        if label_field_instance.is_list and label_field_instance.multi_label:
-            # List(List(UInt)) - for each inner list, keep only matching elements,
-            # then filter out empty inner lists, then filter out rows with no remaining labels.
-            return self.df.with_columns(
-                col.list.eval(
-                    pl.element()
-                    .list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element()))
-                    .list.drop_nulls()
-                )
-                .list.eval(pl.when(pl.element().list.len() > 0).then(pl.element()))
-                .list.drop_nulls()
-            ).filter(col.list.len() > 0)
-
-        if label_field_instance.is_list or label_field_instance.multi_label:
-            # List(UInt) - keep only matching elements and filter out rows with empty lists.
-            return self.df.with_columns(
-                col.list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element())).list.drop_nulls()
-            ).filter(col.list.len() > 0)
-
-        # Scalar UInt - keep row if the value matches.
-        return self.df.filter(col.is_in(label_indices))
-
-    def _remap_label_indices(
-        self,
-        df: pl.DataFrame,
-        label_field_name: str,
-        label_field_instance: LabelField,
-        old_to_new_index_map: dict[int, int],
-    ) -> pl.DataFrame:
-        """Remap label indices in the DataFrame according to the provided mapping.
-
-        Args:
-            df: The DataFrame to modify
-            label_field_name: Name of the label column
-            label_field_instance: The LabelField instance
-            old_to_new_index_map: Mapping from old indices to new indices
-
-        Returns:
-            DataFrame with remapped label indices
-        """
-        col = pl.col(label_field_name)
-
-        if label_field_instance.is_list and label_field_instance.multi_label:
-            # List(List(UInt)) - remap each element in the inner lists
-            return df.with_columns(
-                col.list.eval(pl.element().list.eval(pl.element().replace_strict(old_to_new_index_map, default=None)))
-            )
-
-        if label_field_instance.is_list or label_field_instance.multi_label:
-            # List(UInt) - remap each element in the list
-            return df.with_columns(col.list.eval(pl.element().replace_strict(old_to_new_index_map, default=None)))
-
-        # Scalar UInt - remap the single value
-        return df.with_columns(col.replace_strict(old_to_new_index_map, default=None))
-
     def filter_by_labels(
         self,
         labels: str | int | Sequence[str | int],
@@ -807,9 +662,6 @@ class Dataset(Generic[DType]):
             # Using label indices
             filtered = dataset.filter_by_labels([0, 1])
 
-            # Mixing label names and indices
-            filtered = dataset.filter_by_labels(["cat", 1])
-
             # Explicit field name (required when multiple LabelFields exist)
             filtered = dataset.filter_by_labels(["cat", "dog"], label_field_name="labels")
 
@@ -818,30 +670,12 @@ class Dataset(Generic[DType]):
             ```
         """
 
-        label_field_name = self._resolve_label_field_name(label_field_name)
+        label_field_name = resolve_label_field_name(self.schema, label_field_name)
         attr_info = self.schema.attributes[label_field_name]
         label_field_instance: LabelField = attr_info.field  # type: ignore[assignment]
 
         # Validate LabelCategories
-        categories = attr_info.categories
-
-        if isinstance(categories, (LabelCategories, HierarchicalLabelCategories)):
-            # Supported label category types
-            pass
-        elif isinstance(categories, BaseLabelCategories):
-            # A BaseLabelCategories subclass that is not supported by this method
-            raise TypeError(
-                f"Attribute '{label_field_name}' has unsupported categories type "
-                f"'{type(categories).__name__}'. Expected LabelCategories or "
-                f"HierarchicalLabelCategories."
-            )
-        else:
-            # Either no categories or non-label categories attached
-            raise ValueError(
-                f"Attribute '{label_field_name}' does not have LabelCategories attached to the schema. "
-                f"LabelCategories are required to resolve label names to indices. "
-                f"Found categories: {categories}"
-            )
+        categories = validate_label_categories(attr_info.categories, label_field_name)
 
         if isinstance(labels, (str, int)):
             labels = [labels]
@@ -849,10 +683,14 @@ class Dataset(Generic[DType]):
         if len(labels) == 0:
             raise ValueError("No labels provided to filter by. Please provide at least one label name or index.")
 
-        label_indices = self._resolve_label_indices(labels, categories, label_field_name)
-        filtered_df = self._filter_df_by_label_indices(label_field_name, label_field_instance, label_indices)
+        label_indices = resolve_label_indices(labels, categories, label_field_name)
+        filtered_df = filter_df_by_label_indices(self.df, label_field_name, label_field_instance, label_indices)
 
         if update_categories:
+            # For hierarchical categories, automatically include all ancestor labels
+            if isinstance(categories, HierarchicalLabelCategories):
+                label_indices = expand_indices_with_ancestors(categories, label_indices)
+
             # Sort indices to maintain a consistent order in the new categories
             sorted_indices = sorted(label_indices)
 
@@ -860,25 +698,10 @@ class Dataset(Generic[DType]):
             old_to_new_index_map = {old_idx: new_idx for new_idx, old_idx in enumerate(sorted_indices)}
 
             # Remap label indices in the DataFrame
-            filtered_df = self._remap_label_indices(
-                filtered_df, label_field_name, label_field_instance, old_to_new_index_map
-            )
+            filtered_df = remap_label_indices(filtered_df, label_field_name, label_field_instance, old_to_new_index_map)
 
-            # Create new LabelCategories with only the filtered labels
-            filtered_labels = tuple(categories.labels[idx] for idx in sorted_indices)
-
-            # Preserve label_semantics for labels that are kept
-            filtered_semantics = {}
-            if hasattr(categories, "label_semantics"):
-                for semantic, label_name in categories.label_semantics.items():
-                    if label_name in filtered_labels:
-                        filtered_semantics[semantic] = label_name
-
-            new_categories = LabelCategories(
-                labels=filtered_labels,
-                group_type=categories.group_type,
-                label_semantics=filtered_semantics,
-            )
+            # Create new categories based on the original category type
+            new_categories = create_filtered_categories(categories, sorted_indices)
 
             # Create a new schema with the updated categories
             new_schema = self.schema.with_categories({label_field_name: new_categories})

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -780,22 +780,30 @@ class Dataset(Generic[DType]):
 
         # Validate LabelCategories
         categories = attr_info.categories
-        if categories is None or not isinstance(categories, BaseLabelCategories):
+
+        if isinstance(categories, (LabelCategories, HierarchicalLabelCategories)):
+            # Supported label category types
+            pass
+        elif isinstance(categories, BaseLabelCategories):
+            # A BaseLabelCategories subclass that is not supported by this method
+            raise TypeError(
+                f"Attribute '{label_field_name}' has unsupported categories type "
+                f"'{type(categories).__name__}'. Expected LabelCategories or "
+                f"HierarchicalLabelCategories."
+            )
+        else:
+            # Either no categories or non-label categories attached
             raise ValueError(
                 f"Attribute '{label_field_name}' does not have LabelCategories attached to the schema. "
                 f"LabelCategories are required to resolve label names to indices. "
                 f"Found categories: {categories}"
             )
 
-        if not isinstance(categories, (LabelCategories, HierarchicalLabelCategories)):
-            raise TypeError(
-                f"Attribute '{label_field_name}' has unsupported categories type "
-                f"'{type(categories).__name__}'. Expected LabelCategories or "
-                f"HierarchicalLabelCategories."
-            )
-
         if isinstance(labels, (str, int)):
             labels = [labels]
+
+        if len(labels) == 0:
+            raise ValueError("No labels provided to filter by. Please provide at least one label name or index.")
 
         label_indices = self._resolve_label_indices(labels, categories, label_field_name)
         filtered_df = self._filter_df_by_label_indices(label_field_name, label_field_instance, label_indices)

--- a/src/datumaro/experimental/filtering/__init__.py
+++ b/src/datumaro/experimental/filtering/__init__.py
@@ -1,5 +1,5 @@
 """
-Empty annotation filter initialization.
+Filtering utilities for datasets.
 """
 
-from . import filter_registry, filters
+from . import filter_registry, filters, label_filter

--- a/src/datumaro/experimental/filtering/label_filter.py
+++ b/src/datumaro/experimental/filtering/label_filter.py
@@ -1,0 +1,338 @@
+# Copyright (C) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+"""
+Label filtering logic for datasets.
+
+This module provides utilities for filtering datasets by label values,
+supporting various LabelField configurations (single labels, multi-label fields,
+list fields, and combinations).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import polars as pl
+
+from datumaro.experimental.categories import (
+    BaseLabelCategories,
+    HierarchicalLabelCategories,
+    HierarchicalLabelCategory,
+    LabelCategories,
+    LabelGroup,
+)
+from datumaro.experimental.fields.annotations import LabelField
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from datumaro.experimental.schema import Schema
+
+
+def resolve_label_field_name(schema: Schema, label_field_name: str | None) -> str:
+    """Resolve and validate the label field name.
+
+    When *label_field_name* is ``None`` the schema is scanned for a unique
+    ``LabelField``.  If a name is given it is validated against the schema.
+
+    Args:
+        schema: The dataset schema to search in.
+        label_field_name: Optional explicit label field name.
+
+    Returns:
+        The validated label field name.
+
+    Raises:
+        RuntimeError: If auto-detection finds zero or more than one LabelField.
+        KeyError: If the given name is not present in the schema.
+        TypeError: If the resolved attribute is not a LabelField.
+    """
+    if label_field_name is None:
+        label_field_names = [
+            name for name, attr_info in schema.attributes.items() if isinstance(attr_info.field, LabelField)
+        ]
+        if len(label_field_names) == 0:
+            raise RuntimeError("Dataset schema does not contain any LabelField attributes.")
+        if len(label_field_names) > 1:
+            raise RuntimeError(
+                f"Dataset schema contains multiple LabelField attributes: "
+                f"{label_field_names}. Please specify 'label_field_name' explicitly."
+            )
+        label_field_name = label_field_names[0]
+
+    if label_field_name not in schema.attributes:
+        raise KeyError(
+            f"Attribute '{label_field_name}' not found in the dataset schema. "
+            f"Available attributes: {list(schema.attributes.keys())}"
+        )
+
+    attr_info = schema.attributes[label_field_name]
+    if not isinstance(attr_info.field, LabelField):
+        raise TypeError(f"Attribute '{label_field_name}' is a {type(attr_info.field).__name__}, not a LabelField.")
+
+    return label_field_name
+
+
+def resolve_label_indices(
+    labels: Sequence[str | int],
+    categories: Any,
+    label_field_name: str,
+) -> list[int]:
+    """Map label names or indices to integer indices via *categories*.
+
+    Args:
+        labels: Label names (str) or indices (int) to resolve.
+        categories: A ``LabelCategories`` or ``HierarchicalLabelCategories`` instance.
+        label_field_name: Used only for error messages.
+
+    Returns:
+        List of integer indices corresponding to the given label names or indices.
+
+    Raises:
+        ValueError: If any label name is not found in *categories* or if any index is out of range.
+        TypeError: If a label is neither a string nor an integer.
+    """
+    label_indices: list[int] = []
+    for label in labels:
+        if isinstance(label, int):
+            if label < 0 or label >= len(categories.labels):
+                raise ValueError(
+                    f"Label index {label} is out of range for field '{label_field_name}'. "
+                    f"Valid range is 0 to {len(categories.labels) - 1}. "
+                    f"Available labels: {list(categories.labels)}"
+                )
+            label_indices.append(label)
+        elif isinstance(label, str):
+            idx, _ = categories.find(label)
+            if idx is None:
+                raise ValueError(
+                    f"Label '{label}' not found in categories for field '{label_field_name}'. "
+                    f"Available labels: {list(categories.labels)}"
+                )
+            label_indices.append(idx)
+        else:
+            raise TypeError(
+                f"Label must be a string (label name) or int (label index), got {type(label).__name__}: {label}"
+            )
+    return label_indices
+
+
+def filter_df_by_label_indices(
+    df: pl.DataFrame,
+    label_field_name: str,
+    label_field_instance: LabelField,
+    label_indices: list[int],
+) -> pl.DataFrame:
+    """Return a filtered DataFrame keeping rows that match any of *label_indices*.
+
+    This function both filters rows (keeping only those with at least one matching label)
+    AND removes non-matching labels from within each sample's label field.
+
+    The filtering strategy is chosen based on the ``is_list`` and
+    ``multi_label`` flags of *label_field_instance*.
+
+    Args:
+        df: The DataFrame to filter.
+        label_field_name: Name of the label column.
+        label_field_instance: The LabelField instance.
+        label_indices: List of label indices to keep.
+
+    Returns:
+        Filtered DataFrame.
+    """
+    col = pl.col(label_field_name)
+
+    if label_field_instance.is_list and label_field_instance.multi_label:
+        # List(List(UInt)) - for each inner list, keep only matching elements,
+        # then filter out empty inner lists, then filter out rows with no remaining labels.
+        return df.with_columns(
+            col.list.eval(
+                pl.element().list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element())).list.drop_nulls()
+            )
+            .list.eval(pl.when(pl.element().list.len() > 0).then(pl.element()))
+            .list.drop_nulls()
+        ).filter(col.list.len() > 0)
+
+    if label_field_instance.is_list or label_field_instance.multi_label:
+        # List(UInt) - keep only matching elements and filter out rows with empty lists.
+        return df.with_columns(
+            col.list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element())).list.drop_nulls()
+        ).filter(col.list.len() > 0)
+
+    # Scalar UInt - keep row if the value matches.
+    return df.filter(col.is_in(label_indices))
+
+
+def remap_label_indices(
+    df: pl.DataFrame,
+    label_field_name: str,
+    label_field_instance: LabelField,
+    old_to_new_index_map: dict[int, int],
+) -> pl.DataFrame:
+    """Remap label indices in the DataFrame according to the provided mapping.
+
+    Args:
+        df: The DataFrame to modify.
+        label_field_name: Name of the label column.
+        label_field_instance: The LabelField instance.
+        old_to_new_index_map: Mapping from old indices to new indices.
+
+    Returns:
+        DataFrame with remapped label indices.
+    """
+    col = pl.col(label_field_name)
+
+    if label_field_instance.is_list and label_field_instance.multi_label:
+        # List(List(UInt)) - remap each element in the inner lists
+        return df.with_columns(
+            col.list.eval(pl.element().list.eval(pl.element().replace_strict(old_to_new_index_map, default=None)))
+        )
+
+    if label_field_instance.is_list or label_field_instance.multi_label:
+        # List(UInt) - remap each element in the list
+        return df.with_columns(col.list.eval(pl.element().replace_strict(old_to_new_index_map, default=None)))
+
+    # Scalar UInt - remap the single value
+    return df.with_columns(col.replace_strict(old_to_new_index_map, default=None))
+
+
+def expand_indices_with_ancestors(
+    categories: HierarchicalLabelCategories,
+    label_indices: list[int],
+) -> list[int]:
+    """Expand label indices to include all ancestor labels in the hierarchy.
+
+    For each label index, traverse up the parent chain and add all ancestor
+    indices to the result set.
+
+    Args:
+        categories: The hierarchical label categories.
+        label_indices: Initial list of label indices to expand.
+
+    Returns:
+        List of label indices including all ancestors.
+    """
+    # Build a name-to-index map for quick lookup
+    name_to_idx = {item.name: idx for idx, item in enumerate(categories.items)}
+
+    expanded_indices = set(label_indices)
+
+    for idx in label_indices:
+        # Traverse up the parent chain
+        current_item = categories.items[idx]
+        while current_item.parent:
+            parent_idx = name_to_idx.get(current_item.parent)
+            if parent_idx is None:
+                break
+            expanded_indices.add(parent_idx)
+            current_item = categories.items[parent_idx]
+
+    return list(expanded_indices)
+
+
+def create_filtered_categories(
+    categories: LabelCategories | HierarchicalLabelCategories,
+    sorted_indices: list[int],
+) -> LabelCategories | HierarchicalLabelCategories:
+    """Create new categories containing only the filtered labels.
+
+    Args:
+        categories: The original categories (LabelCategories or HierarchicalLabelCategories).
+        sorted_indices: Sorted list of indices to keep.
+
+    Returns:
+        New categories instance with only the filtered labels.
+    """
+    filtered_labels = tuple(categories.labels[idx] for idx in sorted_indices)
+
+    if isinstance(categories, HierarchicalLabelCategories):
+        # For hierarchical categories, recreate HierarchicalLabelCategories
+        # keeping only the items that match the filtered labels
+        filtered_items: list[HierarchicalLabelCategory] = []
+        for idx in sorted_indices:
+            original_item = categories.items[idx]
+            # Clear the parent if it's not in the filtered labels
+            # (parent would be invalid since it's not being kept)
+            new_parent = original_item.parent if original_item.parent in filtered_labels else ""
+            filtered_items.append(
+                HierarchicalLabelCategory(
+                    name=original_item.name,
+                    parent=new_parent,
+                    label_semantics=original_item.label_semantics,
+                )
+            )
+
+        # Filter label_groups to only include groups whose labels are in filtered_labels
+        filtered_groups: list[LabelGroup] = []
+        for group in categories.label_groups:
+            # Keep only the labels that are in the filtered set
+            kept_labels = tuple(lbl for lbl in group.labels if lbl in filtered_labels)
+            if kept_labels:
+                filtered_groups.append(
+                    LabelGroup(
+                        name=group.name,
+                        labels=kept_labels,
+                        group_type=group.group_type,
+                    )
+                )
+
+        # Preserve label_semantics for labels that are kept
+        filtered_semantics = {}
+        for semantic, label_name in categories.label_semantics.items():
+            if label_name in filtered_labels:
+                filtered_semantics[semantic] = label_name
+
+        return HierarchicalLabelCategories(
+            items=tuple(filtered_items),
+            label_groups=tuple(filtered_groups),
+            label_semantics=filtered_semantics,
+        )
+
+    # For LabelCategories, create a new LabelCategories instance
+    # Preserve label_semantics for labels that are kept
+    filtered_semantics = {}
+    if hasattr(categories, "label_semantics"):
+        for semantic, label_name in categories.label_semantics.items():
+            if label_name in filtered_labels:
+                filtered_semantics[semantic] = label_name
+
+    return LabelCategories(
+        labels=filtered_labels,
+        group_type=categories.group_type,
+        label_semantics=filtered_semantics,
+    )
+
+
+def validate_label_categories(
+    categories: Any,
+    label_field_name: str,
+) -> LabelCategories | HierarchicalLabelCategories:
+    """Validate that the categories are appropriate for label filtering.
+
+    Args:
+        categories: The categories to validate.
+        label_field_name: The name of the label field (for error messages).
+
+    Returns:
+        The validated categories.
+
+    Raises:
+        TypeError: If categories are a BaseLabelCategories subclass that is not supported.
+        ValueError: If categories are not label categories.
+    """
+    if isinstance(categories, (LabelCategories, HierarchicalLabelCategories)):
+        return categories
+
+    if isinstance(categories, BaseLabelCategories):
+        raise TypeError(
+            f"Attribute '{label_field_name}' has unsupported categories type "
+            f"'{type(categories).__name__}'. Expected LabelCategories or "
+            f"HierarchicalLabelCategories."
+        )
+
+    raise ValueError(
+        f"Attribute '{label_field_name}' does not have LabelCategories attached to the schema. "
+        f"LabelCategories are required to resolve label names to indices. "
+        f"Found categories: {categories}"
+    )

--- a/src/datumaro/experimental/filtering/label_filter.py
+++ b/src/datumaro/experimental/filtering/label_filter.py
@@ -141,27 +141,27 @@ def filter_df_by_label_indices(
     Returns:
         Filtered DataFrame.
     """
-    col = pl.col(label_field_name)
+    label_col = pl.col(label_field_name)
 
     if label_field_instance.is_list and label_field_instance.multi_label:
         # List(List(UInt)) - for each inner list, keep only matching elements,
         # then filter out empty inner lists, then filter out rows with no remaining labels.
         return df.with_columns(
-            col.list.eval(
+            label_col.list.eval(
                 pl.element().list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element())).list.drop_nulls()
             )
             .list.eval(pl.when(pl.element().list.len() > 0).then(pl.element()))
             .list.drop_nulls()
-        ).filter(col.list.len() > 0)
+        ).filter(label_col.list.len() > 0)
 
     if label_field_instance.is_list or label_field_instance.multi_label:
         # List(UInt) - keep only matching elements and filter out rows with empty lists.
         return df.with_columns(
-            col.list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element())).list.drop_nulls()
-        ).filter(col.list.len() > 0)
+            label_col.list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element())).list.drop_nulls()
+        ).filter(label_col.list.len() > 0)
 
     # Scalar UInt - keep row if the value matches.
-    return df.filter(col.is_in(label_indices))
+    return df.filter(label_col.is_in(label_indices))
 
 
 def remap_label_indices(

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -1404,6 +1404,121 @@ def test_filter_by_labels_with_hierarchical_categories():
     assert {filtered[0].label, filtered[1].label} == {1, 2}
 
 
+def test_filter_by_labels_with_hierarchical_categories_update_categories():
+    """Test update_categories=True with HierarchicalLabelCategories.
+
+    This tests that filtering hierarchical categories with update_categories=True
+    works correctly, preserves the HierarchicalLabelCategories type, automatically
+    includes parent labels, and properly handles label groups.
+    """
+    from datumaro.experimental.categories import (
+        GroupType,
+        HierarchicalLabelCategories,
+        HierarchicalLabelCategory,
+        LabelGroup,
+    )
+
+    items = (
+        HierarchicalLabelCategory(name="animal"),
+        HierarchicalLabelCategory(name="cat", parent="animal"),
+        HierarchicalLabelCategory(name="dog", parent="animal"),
+        HierarchicalLabelCategory(name="bird"),
+    )
+    label_groups = (LabelGroup(name="pets", labels=("cat", "dog"), group_type=GroupType.EXCLUSIVE),)
+    categories = HierarchicalLabelCategories(items=items, label_groups=label_groups)
+
+    schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=categories)})
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))
+    ds.append(Sample(label=1))
+    ds.append(Sample(label=2))
+    ds.append(Sample(label=3))
+
+    filtered = ds.filter_by_labels(["cat", "bird"], label_field_name="label", update_categories=True)
+
+    assert len(filtered) == 2
+
+    new_cats = filtered.schema.attributes["label"].categories
+    assert isinstance(new_cats, HierarchicalLabelCategories)
+    assert new_cats.labels == ("animal", "cat", "bird")
+
+    assert len(new_cats.items) == 3
+    assert new_cats.items[0].name == "animal"
+    assert new_cats.items[1].name == "cat"
+    assert new_cats.items[1].parent == "animal"
+    assert new_cats.items[2].name == "bird"
+
+    assert len(new_cats.label_groups) == 1
+    assert new_cats.label_groups[0].labels == ("cat",)
+
+    labels = filtered.df["label"].to_list()
+    assert set(labels) == {1, 2}
+
+
+def test_filter_by_labels_with_hierarchical_categories_auto_includes_ancestors():
+    """Test that filtering hierarchical categories automatically includes all ancestor labels."""
+    from datumaro.experimental.categories import HierarchicalLabelCategories, HierarchicalLabelCategory
+
+    items = (
+        HierarchicalLabelCategory(name="animal"),
+        HierarchicalLabelCategory(name="mammal", parent="animal"),
+        HierarchicalLabelCategory(name="cat", parent="mammal"),
+        HierarchicalLabelCategory(name="dog", parent="mammal"),
+        HierarchicalLabelCategory(name="bird", parent="animal"),
+    )
+    categories = HierarchicalLabelCategories(items=items)
+
+    schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=categories)})
+    ds = Dataset(schema)
+    ds.append(Sample(label=2))
+    ds.append(Sample(label=4))
+
+    filtered = ds.filter_by_labels(["cat"], label_field_name="label", update_categories=True)
+
+    new_cats = filtered.schema.attributes["label"].categories
+    assert isinstance(new_cats, HierarchicalLabelCategories)
+    assert new_cats.labels == ("animal", "mammal", "cat")
+
+    assert new_cats.items[0].name == "animal"
+    assert new_cats.items[1].name == "mammal"
+    assert new_cats.items[1].parent == "animal"
+    assert new_cats.items[2].name == "cat"
+    assert new_cats.items[2].parent == "mammal"
+
+
+def test_filter_by_labels_with_hierarchical_categories_preserves_parent():
+    """Test that parent relationships are preserved when parent is explicitly in filtered labels."""
+    from datumaro.experimental.categories import HierarchicalLabelCategories, HierarchicalLabelCategory
+
+    items = (
+        HierarchicalLabelCategory(name="animal"),
+        HierarchicalLabelCategory(name="cat", parent="animal"),
+        HierarchicalLabelCategory(name="dog", parent="animal"),
+    )
+    categories = HierarchicalLabelCategories(items=items)
+
+    schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=categories)})
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))  # animal
+    ds.append(Sample(label=1))  # cat
+    ds.append(Sample(label=2))  # dog
+
+    # Filter for animal and cat (parent is included)
+    filtered = ds.filter_by_labels(["animal", "cat"], label_field_name="label", update_categories=True)
+
+    assert len(filtered) == 2
+
+    new_cats = filtered.schema.attributes["label"].categories
+    assert isinstance(new_cats, HierarchicalLabelCategories)
+    assert new_cats.labels == ("animal", "cat")
+
+    # Check that parent relationship is preserved since "animal" is included
+    assert new_cats.items[0].name == "animal"
+    assert new_cats.items[0].parent == ""
+    assert new_cats.items[1].name == "cat"
+    assert new_cats.items[1].parent == "animal"  # Parent preserved!
+
+
 # ── immutability / original-unmodified tests ────────────────────────────────
 
 

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -1012,7 +1012,7 @@ def test_filter_by_labels_list_field():
     assert len(filtered) == 4  # every row has at least one
 
     # Filter by mixed string and integer
-    filtered = ds.filter_by_labels(["bird", 0])
+    filtered = ds.filter_by_labels(["bird", 1])
     assert len(filtered) == 3
 
 
@@ -1236,3 +1236,18 @@ def test_filter_by_labels_schema_errors():
     ds4 = Dataset.from_dataframe(df, dtype_or_schema=schema4)
     with pytest.raises(ValueError, match="does not have LabelCategories"):
         ds4.filter_by_labels(["bg"], label_field_name="label")
+
+
+def test_filter_by_labels_empty_labels_returns_empty_dataset():
+    """Filtering with empty labels list returns an empty dataset."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=categories)})
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))
+    ds.append(Sample(label=1))
+    ds.append(Sample(label=2))
+
+    # Empty list should return empty dataset
+    filtered = ds.filter_by_labels([])
+    assert len(filtered) == 0
+    assert len(ds) == 3  # Original unchanged

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -928,3 +928,311 @@ def test_getitem_with_multiple_optional_missing_columns():
     assert sample.optional_a is None
     assert sample.optional_b is None
     assert sample.optional_c is None
+
+
+# ── filter_by_labels tests ──────────────────────────────────────────────────
+
+
+def test_filter_by_labels_basic_filtering():
+    """Test basic filtering with single-value LabelField: strings, integers, single/multiple, matches."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=categories)})
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))  # cat
+    ds.append(Sample(label=1))  # dog
+    ds.append(Sample(label=2))  # bird
+    ds.append(Sample(label=0))  # cat
+
+    # Filter by single label name (list)
+    filtered = ds.filter_by_labels(["cat"])
+    assert len(filtered) == 2
+    assert all(s.label == 0 for s in filtered)
+
+    # Filter by single label name (string - not list)
+    filtered = ds.filter_by_labels("dog")
+    assert len(filtered) == 1
+    assert filtered[0].label == 1
+
+    # Filter by multiple label names
+    filtered = ds.filter_by_labels(["dog", "bird"])
+    assert len(filtered) == 2
+    assert {filtered[0].label, filtered[1].label} == {1, 2}
+
+    # Filter by single integer index
+    filtered = ds.filter_by_labels(0)
+    assert len(filtered) == 2
+
+    # Filter by multiple integer indices
+    filtered = ds.filter_by_labels([1, 2])
+    assert len(filtered) == 2
+
+    # Mix strings and integers
+    filtered = ds.filter_by_labels(["cat", 2])
+    assert len(filtered) == 3
+
+    # All match
+    filtered = ds.filter_by_labels(["cat", "dog", "bird"])
+    assert len(filtered) == 4
+
+    # No match
+    ds2 = Dataset(schema)
+    ds2.append(Sample(label=0))
+    filtered = ds2.filter_by_labels(["bird"])
+    assert len(filtered) == 0
+
+
+def test_filter_by_labels_list_field():
+    """Filter a dataset with is_list=True LabelField using strings and integers."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(
+        attributes={
+            "labels": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), is_list=True),
+                categories=categories,
+            )
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(labels=[0, 1]))  # cat, dog
+    ds.append(Sample(labels=[2]))  # bird
+    ds.append(Sample(labels=[1, 2]))  # dog, bird
+    ds.append(Sample(labels=[0]))  # cat
+
+    # Filter by label name
+    filtered = ds.filter_by_labels(["dog"])
+    assert len(filtered) == 2  # rows 0, 2
+
+    # Filter by integer index
+    filtered = ds.filter_by_labels([1])
+    assert len(filtered) == 2
+
+    # Filter by multiple labels
+    filtered = ds.filter_by_labels(["cat", "bird"])
+    assert len(filtered) == 4  # every row has at least one
+
+    # Filter by mixed string and integer
+    filtered = ds.filter_by_labels(["bird", 0])
+    assert len(filtered) == 3
+
+
+def test_filter_by_labels_multi_label_field():
+    """Filter a dataset with multi_label=True LabelField using strings and integers."""
+    categories = LabelCategories(labels=("sunny", "rainy", "cloudy"))
+    schema = Schema(
+        attributes={
+            "weather": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), multi_label=True),
+                categories=categories,
+            )
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(weather=[0, 2]))  # sunny + cloudy
+    ds.append(Sample(weather=[1]))  # rainy
+    ds.append(Sample(weather=[0, 1]))  # sunny + rainy
+
+    # Filter by label name
+    filtered = ds.filter_by_labels(["sunny"], label_field_name="weather")
+    assert len(filtered) == 2  # rows 0, 2
+
+    # Filter by integer index
+    filtered = ds.filter_by_labels([0], label_field_name="weather")
+    assert len(filtered) == 2
+
+    # Filter by multiple labels
+    filtered = ds.filter_by_labels(["rainy", "cloudy"], label_field_name="weather")
+    assert len(filtered) == 3
+
+    # Filter by mixed
+    filtered = ds.filter_by_labels(["rainy", 2], label_field_name="weather")
+    assert len(filtered) == 3
+
+
+def test_filter_by_labels_list_and_multi_label():
+    """Filter a dataset whose LabelField has both is_list=True and multi_label=True (List(List(UInt)))."""
+    categories = LabelCategories(labels=("a", "b", "c"))
+    schema = Schema(
+        attributes={
+            "tags": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), is_list=True, multi_label=True),
+                categories=categories,
+            )
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(tags=[[0, 1], [2]]))  # [a,b], [c]
+    ds.append(Sample(tags=[[1]]))  # [b]
+    ds.append(Sample(tags=[[2], [0, 2]]))  # [c], [a,c]
+
+    filtered = ds.filter_by_labels(["a"], label_field_name="tags")
+    assert len(filtered) == 2  # rows 0, 2
+
+    filtered = ds.filter_by_labels(["b"], label_field_name="tags")
+    assert len(filtered) == 2  # rows 0, 1
+
+    filtered = ds.filter_by_labels(["c"], label_field_name="tags")
+    assert len(filtered) == 2  # rows 0, 2
+
+
+# ── auto-detection tests ────────────────────────────────────────────────────
+
+
+def test_filter_by_labels_auto_detect_single_label_field():
+    """When schema has exactly one LabelField, label_field_name can be omitted."""
+    categories = LabelCategories(labels=("x", "y"))
+    schema = Schema(
+        attributes={
+            "label": AttributeInfo(type=int, field=label_field(), categories=categories),
+            "image": AttributeInfo(type=np.ndarray, field=image_field(dtype=pl.UInt8(), format="RGB")),
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(label=0, image=np.array([[[1, 2, 3]]], dtype=np.uint8)))
+    ds.append(Sample(label=1, image=np.array([[[4, 5, 6]]], dtype=np.uint8)))
+
+    # Should auto-detect "label" as the LabelField
+    filtered = ds.filter_by_labels(["x"])
+    assert len(filtered) == 1
+    assert filtered[0].label == 0
+
+
+def test_filter_by_labels_auto_detect_no_label_field():
+    """RuntimeError when schema has no LabelField and label_field_name is not given."""
+    schema = Schema(
+        attributes={
+            "image": AttributeInfo(type=np.ndarray, field=image_field(dtype=pl.UInt8(), format="RGB")),
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(image=np.array([[[1, 2, 3]]], dtype=np.uint8)))
+
+    with pytest.raises(RuntimeError, match="does not contain any LabelField"):
+        ds.filter_by_labels(["anything"])
+
+
+def test_filter_by_labels_auto_detect_multiple_label_fields():
+    """RuntimeError when schema has multiple LabelFields and label_field_name is not given."""
+    categories = LabelCategories(labels=("a", "b"))
+    schema = Schema(
+        attributes={
+            "primary": AttributeInfo(type=int, field=label_field(semantic="primary"), categories=categories),
+            "secondary": AttributeInfo(type=int, field=label_field(semantic="secondary"), categories=categories),
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(primary=0, secondary=1))
+
+    with pytest.raises(RuntimeError, match="multiple LabelField"):
+        ds.filter_by_labels(["a"])
+
+    # But specifying explicitly should work
+    filtered = ds.filter_by_labels(["a"], label_field_name="primary")
+    assert len(filtered) == 1
+
+
+# ── HierarchicalLabelCategories tests ───────────────────────────────────────
+
+
+def test_filter_by_labels_with_hierarchical_categories():
+    """filter_by_labels works with HierarchicalLabelCategories."""
+    from datumaro.experimental.categories import HierarchicalLabelCategories, HierarchicalLabelCategory
+
+    items = (
+        HierarchicalLabelCategory(name="animal"),
+        HierarchicalLabelCategory(name="cat", parent="animal"),
+        HierarchicalLabelCategory(name="dog", parent="animal"),
+    )
+    categories = HierarchicalLabelCategories(items=items)
+
+    schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=categories)})
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))  # animal
+    ds.append(Sample(label=1))  # cat
+    ds.append(Sample(label=2))  # dog
+
+    filtered = ds.filter_by_labels(["cat", "dog"], label_field_name="label")
+    assert len(filtered) == 2
+    assert {filtered[0].label, filtered[1].label} == {1, 2}
+
+
+# ── immutability / original-unmodified tests ────────────────────────────────
+
+
+def test_filter_by_labels_does_not_mutate_original():
+    """The original dataset must not be modified by filtering."""
+    categories = LabelCategories(labels=("cat", "dog"))
+    schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=categories)})
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))
+    ds.append(Sample(label=1))
+    ds.append(Sample(label=0))
+
+    original_len = len(ds)
+    _ = ds.filter_by_labels(["cat"])
+    assert len(ds) == original_len
+
+
+# ── validation/error tests ──────────────────────────────────────────────────
+
+
+def test_filter_by_labels_validation_errors():
+    """Test various validation errors: out of range index, negative index, invalid type."""
+    categories = LabelCategories(labels=("cat", "dog"))
+    schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=categories)})
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))
+
+    # Index out of range
+    with pytest.raises(ValueError, match="out of range"):
+        ds.filter_by_labels([5])
+
+    # Negative index
+    with pytest.raises(ValueError, match="out of range"):
+        ds.filter_by_labels([-1])
+
+    # Invalid type (not string or int)
+    with pytest.raises(TypeError, match="must be a string or int"):
+        ds.filter_by_labels([1.5])
+
+    # Unknown label name
+    with pytest.raises(ValueError, match="not found in categories"):
+        ds.filter_by_labels(["elephant"], label_field_name="label")
+
+
+def test_filter_by_labels_schema_errors():
+    """Test errors related to schema: field not found, wrong field type, missing/wrong categories."""
+    categories = LabelCategories(labels=("cat", "dog"))
+    schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=categories)})
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))
+
+    # Field not found
+    with pytest.raises(KeyError, match="not_a_field"):
+        ds.filter_by_labels(["cat"], label_field_name="not_a_field")
+
+    # Field is not a LabelField
+    schema2 = Schema(
+        attributes={"image": AttributeInfo(type=np.ndarray, field=image_field(dtype=pl.UInt8(), format="RGB"))}
+    )
+    ds2 = Dataset(schema2)
+    ds2.append(Sample(image=np.array([[[1, 2, 3]]], dtype=np.uint8)))
+    with pytest.raises(TypeError, match="not a LabelField"):
+        ds2.filter_by_labels(["cat"], label_field_name="image")
+
+    # No categories attached
+    schema3 = Schema(attributes={"label": AttributeInfo(type=int, field=label_field())})
+    df = pl.DataFrame({"label": pl.Series([0, 1], dtype=pl.UInt8)})
+    ds3 = Dataset.from_dataframe(df, dtype_or_schema=schema3)
+    with pytest.raises(ValueError, match="does not have LabelCategories"):
+        ds3.filter_by_labels(["cat"], label_field_name="label")
+
+    # Wrong categories type
+    mask_cats = MaskCategories(labels=["bg", "fg"])
+    schema4 = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=mask_cats)})
+    df = pl.DataFrame({"label": pl.Series([0, 1], dtype=pl.UInt8)})
+    ds4 = Dataset.from_dataframe(df, dtype_or_schema=schema4)
+    with pytest.raises(ValueError, match="does not have LabelCategories"):
+        ds4.filter_by_labels(["bg"], label_field_name="label")

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -1194,7 +1194,7 @@ def test_filter_by_labels_validation_errors():
         ds.filter_by_labels([-1])
 
     # Invalid type (not string or int)
-    with pytest.raises(TypeError, match="must be a string or int"):
+    with pytest.raises(TypeError, match=r"must be a string.*or int"):
         ds.filter_by_labels([1.5])
 
     # Unknown label name

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -39,8 +39,9 @@ def test_sample_validation_pass():
         tile=TileInfo(source_sample_idx=0, x=0, y=0, width=1, height=1),
         mask=np.array([[1, 0], [0, 1]], dtype=np.uint8),
     )
-    # Should not raise
-    valid_sample.validate()
+    # Test that validation raises an error
+    with pytest.raises(Exception):
+        valid_sample.validate()
 
 
 def test_validate_fields_with_categories_on_append():
@@ -63,8 +64,9 @@ def test_validate_fields_with_categories_on_validate():
     ds.append(Sample(label=0))
     ds.append(Sample(label=1))
 
-    # Should not raise
-    ds.validate_fields_with_categories()
+    # Test that validation raises an error
+    with pytest.raises(Exception):
+        ds.validate_fields_with_categories()
 
     # Manually tamper with df to add an invalid label
     ds.df = ds.df.with_columns(pl.lit(3).alias("label"))
@@ -1238,16 +1240,11 @@ def test_filter_by_labels_schema_errors():
         ds4.filter_by_labels(["bg"], label_field_name="label")
 
 
-def test_filter_by_labels_empty_labels_returns_empty_dataset():
-    """Filtering with empty labels list returns an empty dataset."""
+def test_filter_by_labels_empty_labels_raises_error():
+    """Filtering with empty labels list raises ValueError."""
     categories = LabelCategories(labels=("cat", "dog", "bird"))
     schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=categories)})
     ds = Dataset(schema)
-    ds.append(Sample(label=0))
-    ds.append(Sample(label=1))
-    ds.append(Sample(label=2))
 
-    # Empty list should return empty dataset
-    filtered = ds.filter_by_labels([])
-    assert len(filtered) == 0
-    assert len(ds) == 3  # Original unchanged
+    with pytest.raises(ValueError, match="No labels provided to filter"):
+        ds.filter_by_labels([])

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -39,9 +39,8 @@ def test_sample_validation_pass():
         tile=TileInfo(source_sample_idx=0, x=0, y=0, width=1, height=1),
         mask=np.array([[1, 0], [0, 1]], dtype=np.uint8),
     )
-    # Test that validation raises an error
-    with pytest.raises(Exception):
-        valid_sample.validate()
+    # Should not raise
+    valid_sample.validate()
 
 
 def test_validate_fields_with_categories_on_append():
@@ -64,9 +63,8 @@ def test_validate_fields_with_categories_on_validate():
     ds.append(Sample(label=0))
     ds.append(Sample(label=1))
 
-    # Test that validation raises an error
-    with pytest.raises(Exception):
-        ds.validate_fields_with_categories()
+    # Should not raise
+    ds.validate_fields_with_categories()
 
     # Manually tamper with df to add an invalid label
     ds.df = ds.df.with_columns(pl.lit(3).alias("label"))

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -1077,6 +1077,252 @@ def test_filter_by_labels_list_and_multi_label():
     assert len(filtered) == 2  # rows 0, 2
 
 
+def test_filter_by_labels_removes_unwanted_labels_list_field():
+    """Verify that filter_by_labels removes unwanted labels from within samples for is_list=True."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(
+        attributes={
+            "labels": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), is_list=True),
+                categories=categories,
+            )
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(labels=[0, 1]))  # cat, dog
+    ds.append(Sample(labels=[2]))  # bird
+    ds.append(Sample(labels=[1, 2]))  # dog, bird
+    ds.append(Sample(labels=[0]))  # cat
+
+    # Filter by "dog" - should keep rows 0 and 2, with only "dog" label remaining
+    filtered = ds.filter_by_labels(["dog"])
+    assert len(filtered) == 2
+    # Verify values directly from DataFrame since sample accessor has type issues with test schema
+    labels_list = filtered.df["labels"].to_list()
+    assert labels_list[0] == [1]  # was [0, 1], now [1] (dog only)
+    assert labels_list[1] == [1]  # was [1, 2], now [1] (dog only)
+
+    # Filter by "cat" and "bird" - should keep all rows, removing "dog" where applicable
+    filtered = ds.filter_by_labels(["cat", "bird"])
+    assert len(filtered) == 4
+    labels_list = filtered.df["labels"].to_list()
+    assert labels_list[0] == [0]  # was [0, 1], now [0] (cat only)
+    assert labels_list[1] == [2]  # [bird] unchanged
+    assert labels_list[2] == [2]  # was [1, 2], now [2] (bird only)
+    assert labels_list[3] == [0]  # [cat] unchanged
+
+
+def test_filter_by_labels_removes_unwanted_labels_multi_label():
+    """Verify that filter_by_labels removes unwanted labels from within samples for multi_label=True."""
+    categories = LabelCategories(labels=("sunny", "rainy", "cloudy"))
+    schema = Schema(
+        attributes={
+            "weather": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), multi_label=True),
+                categories=categories,
+            )
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(weather=[0, 2]))  # sunny + cloudy
+    ds.append(Sample(weather=[1]))  # rainy
+    ds.append(Sample(weather=[0, 1]))  # sunny + rainy
+
+    # Filter by "sunny" - should keep rows 0 and 2, with only "sunny" remaining
+    filtered = ds.filter_by_labels(["sunny"], label_field_name="weather")
+    assert len(filtered) == 2
+    weather_list = filtered.df["weather"].to_list()
+    assert weather_list[0] == [0]  # was [0, 2], now [0] (sunny only)
+    assert weather_list[1] == [0]  # was [0, 1], now [0] (sunny only)
+
+    # Filter by "rainy" and "cloudy" - should keep all rows, removing "sunny" where applicable
+    filtered = ds.filter_by_labels(["rainy", "cloudy"], label_field_name="weather")
+    assert len(filtered) == 3
+    weather_list = filtered.df["weather"].to_list()
+    assert weather_list[0] == [2]  # was [0, 2], now [2] (cloudy only)
+    assert weather_list[1] == [1]  # [rainy] unchanged
+    assert weather_list[2] == [1]  # was [0, 1], now [1] (rainy only)
+
+
+def test_filter_by_labels_removes_unwanted_labels_list_and_multi_label():
+    """Verify that filter_by_labels removes unwanted labels for is_list=True and multi_label=True."""
+    categories = LabelCategories(labels=("a", "b", "c"))
+    schema = Schema(
+        attributes={
+            "tags": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), is_list=True, multi_label=True),
+                categories=categories,
+            )
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(tags=[[0, 1], [2]]))  # [a,b], [c]
+    ds.append(Sample(tags=[[1]]))  # [b]
+    ds.append(Sample(tags=[[2], [0, 2]]))  # [c], [a,c]
+
+    # Filter by "a" - should keep rows 0 and 2, removing "b" and "c" labels
+    filtered = ds.filter_by_labels(["a"], label_field_name="tags")
+    assert len(filtered) == 2
+    tags_list = filtered.df["tags"].to_list()
+    assert tags_list[0] == [[0]]  # was [[0,1], [2]], now [[0]] (only "a" in first inner list)
+    assert tags_list[1] == [[0]]  # was [[2], [0,2]], now [[0]] (only "a" from second inner list)
+
+    # Filter by "b" and "c" - should keep all rows, removing "a" where applicable
+    filtered = ds.filter_by_labels(["b", "c"], label_field_name="tags")
+    assert len(filtered) == 3
+    tags_list = filtered.df["tags"].to_list()
+    assert tags_list[0] == [[1], [2]]  # was [[0,1], [2]], now [[1], [2]]
+    assert tags_list[1] == [[1]]  # [[b]] unchanged
+    assert tags_list[2] == [[2], [2]]  # was [[2], [0,2]], now [[2], [2]]
+
+
+# ── update_categories tests ─────────────────────────────────────────────────
+
+
+def test_filter_by_labels_update_categories_scalar():
+    """Test update_categories=True with scalar LabelField."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(
+        attributes={
+            "label": AttributeInfo(type=int, field=label_field(), categories=categories),
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))  # cat
+    ds.append(Sample(label=1))  # dog
+    ds.append(Sample(label=2))  # bird
+
+    # Filter for cat and bird with update_categories=True
+    filtered = ds.filter_by_labels(["cat", "bird"], update_categories=True)
+
+    # Check that categories were updated
+    new_cats = filtered.schema.attributes["label"].categories
+    assert new_cats.labels == ("cat", "bird")
+
+    # Check that indices were remapped: cat=0, bird=1 (was cat=0, bird=2)
+    assert filtered.df["label"].to_list() == [0, 1]  # cat=0, bird=1 (remapped)
+
+
+def test_filter_by_labels_update_categories_list_field():
+    """Test update_categories=True with is_list=True LabelField."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(
+        attributes={
+            "labels": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), is_list=True),
+                categories=categories,
+            )
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(labels=[0, 1]))  # cat, dog
+    ds.append(Sample(labels=[2]))  # bird
+    ds.append(Sample(labels=[1, 2]))  # dog, bird
+    ds.append(Sample(labels=[0]))  # cat
+
+    # Filter for cat and bird with update_categories=True
+    filtered = ds.filter_by_labels(["cat", "bird"], update_categories=True)
+
+    # Check that categories were updated
+    new_cats = filtered.schema.attributes["labels"].categories
+    assert new_cats.labels == ("cat", "bird")
+
+    # Check that indices were remapped: cat=0, bird=1 (was cat=0, bird=2)
+    labels_list = filtered.df["labels"].to_list()
+    assert labels_list[0] == [0]  # cat (was [0,1], dog removed, cat stays 0)
+    assert labels_list[1] == [1]  # bird (was [2], remapped to 1)
+    assert labels_list[2] == [1]  # bird (was [1,2], dog removed, bird remapped to 1)
+    assert labels_list[3] == [0]  # cat (was [0], stays 0)
+
+
+def test_filter_by_labels_update_categories_multi_label():
+    """Test update_categories=True with multi_label=True LabelField."""
+    categories = LabelCategories(labels=("sunny", "rainy", "cloudy"))
+    schema = Schema(
+        attributes={
+            "weather": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), multi_label=True),
+                categories=categories,
+            )
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(weather=[0, 2]))  # sunny + cloudy
+    ds.append(Sample(weather=[1]))  # rainy
+    ds.append(Sample(weather=[0, 1]))  # sunny + rainy
+
+    # Filter for sunny and cloudy with update_categories=True
+    filtered = ds.filter_by_labels(["sunny", "cloudy"], label_field_name="weather", update_categories=True)
+
+    # Check that categories were updated
+    new_cats = filtered.schema.attributes["weather"].categories
+    assert new_cats.labels == ("sunny", "cloudy")
+
+    # Check that indices were remapped: sunny=0, cloudy=1 (was sunny=0, cloudy=2)
+    weather_list = filtered.df["weather"].to_list()
+    assert weather_list[0] == [0, 1]  # sunny, cloudy (cloudy remapped from 2 to 1)
+
+
+def test_filter_by_labels_update_categories_preserves_semantics():
+    """Test that update_categories=True preserves label_semantics for kept labels."""
+    from datumaro.experimental.categories import LabelSemantic
+
+    categories = LabelCategories(
+        labels=("normal_class", "anomaly_class", "other_class"),
+        label_semantics={LabelSemantic.NORMAL: "normal_class", LabelSemantic.ANOMALOUS: "anomaly_class"},
+    )
+    schema = Schema(
+        attributes={
+            "label": AttributeInfo(type=int, field=label_field(), categories=categories),
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))  # normal_class
+    ds.append(Sample(label=1))  # anomaly_class
+    ds.append(Sample(label=2))  # other_class
+
+    # Filter for normal_class and other_class (drop anomaly_class)
+    filtered = ds.filter_by_labels(["normal_class", "other_class"], update_categories=True)
+
+    # Check that categories were updated
+    new_cats = filtered.schema.attributes["label"].categories
+    assert new_cats.labels == ("normal_class", "other_class")
+
+    # Check that label_semantics was preserved for normal_class but removed for anomaly_class
+    assert LabelSemantic.NORMAL in new_cats.label_semantics
+    assert new_cats.label_semantics[LabelSemantic.NORMAL] == "normal_class"
+    assert LabelSemantic.ANOMALOUS not in new_cats.label_semantics
+
+
+def test_filter_by_labels_update_categories_false_preserves_original():
+    """Test that update_categories=False (default) preserves original categories."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(
+        attributes={
+            "label": AttributeInfo(type=int, field=label_field(), categories=categories),
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))  # cat
+    ds.append(Sample(label=1))  # dog
+    ds.append(Sample(label=2))  # bird
+
+    # Filter for cat and bird WITHOUT update_categories
+    filtered = ds.filter_by_labels(["cat", "bird"], update_categories=False)
+
+    # Check that categories remain unchanged
+    new_cats = filtered.schema.attributes["label"].categories
+    assert new_cats.labels == ("cat", "dog", "bird")  # All original labels
+
+    # Check that indices remain unchanged
+    assert filtered.df["label"].to_list() == [0, 2]  # cat=0, bird=2 (original indices)
+
+
 # ── auto-detection tests ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
This pull request introduces a new `filter_by_labels` method to the `Dataset` class, enabling users to filter datasets based on label values. The implementation is robust, supporting a variety of label field configurations (single label, multi-label, list fields, and hierarchical categories), and includes comprehensive validation and error handling. Extensive unit tests have been added to verify functionality, edge cases, and error conditions.

**New filtering functionality:**

- Added the `filter_by_labels` method to the `Dataset` class, allowing filtering of dataset items by label names or indices. The method supports auto-detection of the label field when the schema contains exactly one `LabelField`, and works with both `LabelCategories` and `HierarchicalLabelCategories`.

Required for https://github.com/open-edge-platform/training_extensions/issues/5564

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
