### PR TITLE
Add support for missing images in export dataset

### DIFF
--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -549,6 +549,9 @@ def _import_dataset_from_dir(
     Returns:
         The imported Dataset instance
     """
+    # Normalize to an absolute path so that subsequent path joins (e.g. for
+    # metadata, the Parquet file, and image directories) behave consistently
+    # regardless of whether the caller passed a relative or absolute path.
     if not input_dir.is_absolute():
         input_dir = input_dir.resolve()
 

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -187,8 +187,6 @@ def _export_single_field(
     for idx in range(len(dataset)):
         value = _get_field_value(dataset, idx, field_name)
         if value is None:
-            if not skip_missing_images:
-                print(f"Warning: No value set for field {field_name}, idx {idx}.")
             continue
 
         rel_path = None
@@ -250,9 +248,6 @@ def _export_images_from_dataset(
 
     df_to_export = dataset.df.with_row_index("__idx")
     for field_name, path_map in images_paths.items():
-        if not path_map:
-            continue
-
         # Create a mapping DataFrame from the exported paths
         mapping_df = pl.DataFrame(
             {"__idx": list(path_map.keys()), "__new_path": list(path_map.values())},

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -145,6 +145,7 @@ def _export_single_field(
     field_name: str,
     field: object,
     output_dir: Path,
+    skip_missing_images: bool = False,
 ) -> dict[int, str]:
     """Export images for a single field across all rows."""
     field_paths: dict[int, str] = {}
@@ -152,6 +153,8 @@ def _export_single_field(
     for idx in range(len(dataset)):
         value = _get_field_value(dataset, idx, field_name)
         if value is None:
+            if not skip_missing_images:
+                print(f"Warning: No value set for field {field_name}, idx {idx}.")
             continue
 
         rel_path = None
@@ -164,6 +167,11 @@ def _export_single_field(
 
         if rel_path is not None:
             field_paths[idx] = rel_path
+        elif not skip_missing_images:
+            raise ValueError(
+                f"Value was set for field {field_name}, index {idx}, value {value}, but no image could be obtained "
+                f"(ImagePathField) or no image could be generated and saved (Image/MaskCallableField)."
+            )
 
     return field_paths
 
@@ -171,7 +179,8 @@ def _export_single_field(
 def _export_images_from_dataset(
     dataset: Dataset[DType],
     output_dir: Path,
-) -> dict[str, dict[int, str]]:
+    skip_missing_images: bool = False,
+) -> pl.DataFrame:
     """
     Export images from callable or path fields in the dataset.
 
@@ -182,21 +191,57 @@ def _export_images_from_dataset(
     Args:
         dataset: The dataset to export images from
         output_dir: Directory to save images to
+        skip_missing_images: Boolean indicating if to raise errors or skip when images are missing
 
     Returns:
         Dictionary mapping field names to dictionaries of row_idx -> relative path
     """
     output_dir.mkdir(parents=True, exist_ok=True)
-    image_paths: dict[str, dict[int, str]] = {}
+    images_paths: dict[str, dict[int, str]] = {}
 
     image_fields = _get_image_fields(dataset)
     if not image_fields:
-        return image_paths
+        return dataset.df
 
     for field_name, field in image_fields:
-        image_paths[field_name] = _export_single_field(dataset, field_name, field, output_dir)
+        images_paths[field_name] = _export_single_field(
+            dataset=dataset,
+            field_name=field_name,
+            field=field,
+            output_dir=output_dir,
+            skip_missing_images=skip_missing_images,
+        )
 
-    return image_paths
+    df_to_export = dataset.df.with_row_index("__idx")
+    for field_name, path_map in images_paths.items():
+        if not path_map:
+            continue
+
+        # Create a mapping DataFrame from the exported paths
+        mapping_df = pl.DataFrame(
+            {"__idx": list(path_map.keys()), "__new_path": list(path_map.values())},
+            schema={"__idx": pl.UInt32, "__new_path": pl.String},
+        )
+
+        # Left join to apply updates; rows not in path_map will have null paths
+        df_to_export = (
+            df_to_export.join(mapping_df, on="__idx", how="left")
+            .with_columns(pl.col("__new_path").alias(field_name))
+            .drop("__new_path")
+        )
+
+    # Check for missing images
+    image_fields = list(images_paths.keys())
+    missing_images_mask = pl.all_horizontal(pl.col(image_fields).is_null())
+
+    if skip_missing_images:
+        df_to_export = df_to_export.filter(~missing_images_mask)
+    else:
+        bad_rows = df_to_export.filter(missing_images_mask).select("__idx")
+        if not bad_rows.is_empty():
+            raise ValueError(f"Missing images for indices {bad_rows.to_series().to_list()}")
+
+    return df_to_export.drop("__idx")
 
 
 def export_dataset(
@@ -204,6 +249,7 @@ def export_dataset(
     output_path: str | Path,
     export_images: bool = True,
     as_zip: bool = False,
+    skip_missing_images: bool = False,
 ) -> None:
     """
     Export a dataset to disk in a structured format.
@@ -223,6 +269,7 @@ def export_dataset(
         output_path: Path to export to (directory or .zip file)
         export_images: Whether to export images from callable/path fields
         as_zip: Whether to package everything as a ZIP file
+        skip_missing_images: Boolean indicating if to raise errors or skip when images are missing
     """
     output_path = Path(output_path)
 
@@ -239,30 +286,14 @@ def export_dataset(
         work_dir = output_path
 
     try:
-        df_to_export = dataset.df
         # Export images if requested
         if export_images:
             images_dir = work_dir / IMAGES_DIR
-            images_paths = _export_images_from_dataset(dataset, images_dir)
-
-            df_to_export = df_to_export.with_row_index("__idx")
-            for field_name, path_map in images_paths.items():
-                if not path_map:
-                    continue
-
-                # Create a mapping DataFrame from the exported paths
-                mapping_df = pl.DataFrame(
-                    {"__idx": list(path_map.keys()), "__new_path": list(path_map.values())},
-                    schema={"__idx": pl.UInt32, "__new_path": pl.String},
-                )
-
-                # Left join to apply updates; rows not in path_map will have null paths
-                df_to_export = (
-                    df_to_export.join(mapping_df, on="__idx", how="left")
-                    .with_columns(pl.col("__new_path").alias(field_name))
-                    .drop("__new_path")
-                )
-            df_to_export = df_to_export.drop("__idx")
+            df_to_export = _export_images_from_dataset(
+                dataset=dataset, output_dir=images_dir, skip_missing_images=skip_missing_images
+            )
+        else:
+            df_to_export = dataset.df
 
         # Export DataFrame to Parquet
         # Filter out Object columns (like callables) as they can't be serialized to Parquet

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -179,7 +179,7 @@ def _export_single_field(
     field_name: str,
     field: object,
     output_dir: Path,
-    skip_missing_images: bool = False,
+    ignore_missing_images: bool = False,
 ) -> dict[int, str]:
     """Export images for a single field across all rows."""
     field_paths: dict[int, str] = {}
@@ -199,7 +199,7 @@ def _export_single_field(
 
         if rel_path is not None:
             field_paths[idx] = rel_path
-        elif not skip_missing_images:
+        elif not ignore_missing_images:
             raise ValueError(
                 f"Value was set for field {field_name}, index {idx}, value {value}, but no image could be obtained "
                 f"(ImagePathField) or no image could be generated and saved (Image/MaskCallableField)."
@@ -211,7 +211,7 @@ def _export_single_field(
 def _export_images_from_dataset(
     dataset: Dataset[DType],
     output_dir: Path,
-    skip_missing_images: bool = False,
+    ignore_missing_images: bool = False,
 ) -> pl.DataFrame:
     """
     Export images from callable or path fields in the dataset.
@@ -223,7 +223,8 @@ def _export_images_from_dataset(
     Args:
         dataset: The dataset to export images from
         output_dir: Directory to save images to
-        skip_missing_images: Boolean indicating if to raise errors or skip when images are missing
+        ignore_missing_images: if True, silently skip images that cannot be found or generated, instead of raising an
+            error.
 
     Returns:
         A :class:`polars.DataFrame` with image-related fields updated to contain
@@ -243,7 +244,7 @@ def _export_images_from_dataset(
             field_name=field_name,
             field=field,
             output_dir=output_dir,
-            skip_missing_images=skip_missing_images,
+            ignore_missing_images=ignore_missing_images,
         )
 
     df_to_export = dataset.df.with_row_index("__idx")
@@ -265,7 +266,7 @@ def _export_images_from_dataset(
     image_fields = list(images_paths.keys())
     missing_images_mask = pl.all_horizontal(pl.col(image_fields).is_null())
 
-    if skip_missing_images:
+    if ignore_missing_images:
         df_to_export = df_to_export.filter(~missing_images_mask)
     else:
         bad_rows = df_to_export.filter(missing_images_mask).select("__idx")
@@ -280,7 +281,7 @@ def export_dataset(
     output_path: str | Path,
     export_images: bool = True,
     as_zip: bool = False,
-    skip_missing_images: bool = False,
+    ignore_missing_images: bool = False,
 ) -> None:
     """
     Export a dataset to disk in a structured format.
@@ -300,8 +301,8 @@ def export_dataset(
         output_path: Path to export to (directory or .zip file)
         export_images: Whether to export images from callable/path fields
         as_zip: Whether to package everything as a ZIP file
-        skip_missing_images: Boolean indicating whether to raise errors or skip when images are missing.
-            Only has an effect if ``export_images=True``; otherwise, it is ignored.
+        ignore_missing_images: if True, silently skip dataset items whose image cannot be found or generated, instead
+            of raising an error. Only has an effect if ``export_images=True``; otherwise, it is ignored.
     """
     output_path = Path(output_path)
 
@@ -322,7 +323,7 @@ def export_dataset(
         if export_images:
             images_dir = work_dir / IMAGES_DIR
             df_to_export = _export_images_from_dataset(
-                dataset=dataset, output_dir=images_dir, skip_missing_images=skip_missing_images
+                dataset=dataset, output_dir=images_dir, ignore_missing_images=ignore_missing_images
             )
         else:
             df_to_export = dataset.df

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -303,7 +303,7 @@ def export_dataset(
         output_path: Path to export to (directory or .zip file)
         export_images: Whether to export images from callable/path fields
         as_zip: Whether to package everything as a ZIP file
-        skip_missing_images: Boolean indicating if to raise errors or skip when images are missing
+        skip_missing_images: Boolean indicating whether to raise errors or skip when images are missing. Only has an effect if ``export_images=True``; otherwise, it is ignored.
     """
     output_path = Path(output_path)
 

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -228,7 +228,9 @@ def _export_images_from_dataset(
         skip_missing_images: Boolean indicating if to raise errors or skip when images are missing
 
     Returns:
-        Dictionary mapping field names to dictionaries of row_idx -> relative path
+        A :class:`polars.DataFrame` with image-related fields updated to contain
+        relative paths to the exported images. Rows with missing images are either
+        removed (when ``skip_missing_images`` is True) or cause a ValueError.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     images_paths: dict[str, dict[int, str]] = {}

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -300,7 +300,8 @@ def export_dataset(
         output_path: Path to export to (directory or .zip file)
         export_images: Whether to export images from callable/path fields
         as_zip: Whether to package everything as a ZIP file
-        skip_missing_images: Boolean indicating whether to raise errors or skip when images are missing. Only has an effect if ``export_images=True``; otherwise, it is ignored.
+        skip_missing_images: Boolean indicating whether to raise errors or skip when images are missing.
+            Only has an effect if ``export_images=True``; otherwise, it is ignored.
     """
     output_path = Path(output_path)
 

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -445,56 +445,6 @@ def _make_image_loader(path: Path):
     return load_image
 
 
-def _reconstruct_field_values(
-    field_name: str,
-    field: object,
-    images_base_dir: Path,
-    num_rows: int,
-) -> tuple[list[object | None], bool, bool]:
-    """
-    Reconstruct values for a single image-related field.
-
-    Returns:
-        Tuple of (values list, is_path_field, is_callable_field)
-    """
-    is_path_field = isinstance(field, ImagePathField)
-    is_callable_field = isinstance(field, ImageCallableField | InstanceMaskCallableField | MaskCallableField)
-
-    if not (is_path_field or is_callable_field):
-        return [], False, False
-
-    values: list[object | None] = []
-    for idx in range(num_rows):
-        pattern = f"{field_name}_{idx:06d}.*"
-        matches = sorted(images_base_dir.glob(pattern))
-        file_path = matches[0] if matches else None
-
-        if is_path_field:
-            values.append(str(file_path) if file_path is not None else None)
-        elif file_path is None:
-            values.append(None)
-        else:
-            values.append(_make_image_loader(file_path))
-
-    return values, is_path_field, is_callable_field
-
-
-def _update_dataframe_with_field(
-    df: pl.DataFrame,
-    field_name: str,
-    values: list[object | None],
-    is_path_field: bool,
-) -> pl.DataFrame:
-    """Update DataFrame with reconstructed field values."""
-    if is_path_field:
-        if field_name in df.columns:
-            df = df.drop(field_name)
-        return df.with_columns(pl.Series(field_name, values, dtype=pl.String()))
-    if field_name in df.columns:
-        return df.with_columns(pl.Series(field_name, values))
-    return df.with_columns(pl.Series(field_name, values, dtype=pl.Object()))
-
-
 def _reconstruct_image_fields(
     df: pl.DataFrame,
     schema: Schema,
@@ -504,18 +454,33 @@ def _reconstruct_image_fields(
     if not images_base_dir.exists():
         return df
 
+    updates: dict[str, pl.Series] = {}
     for field_name, attr_info in schema.attributes.items():
         field = getattr(attr_info, "field", None)
-        if field is None:
+        if field is None or field_name not in df.columns:
             continue
 
-        values, is_path_field, is_callable_field = _reconstruct_field_values(
-            field_name, field, images_base_dir, len(df)
-        )
+        is_path_field = isinstance(field, ImagePathField)
+        is_callable_field = isinstance(field, ImageCallableField | InstanceMaskCallableField | MaskCallableField)
 
-        if is_path_field or is_callable_field:
-            df = _update_dataframe_with_field(df, field_name, values, is_path_field)
+        if not (is_path_field or is_callable_field):
+            continue
 
+        file_names = df.get_column(field_name)
+        values: list[object | None] = []
+        if is_path_field:
+            values = [str(images_base_dir / file_name) if file_name is not None else None for file_name in file_names]
+        else:
+            values = [
+                _make_image_loader(images_base_dir / file_name) if file_name is not None else None
+                for file_name in file_names
+            ]
+
+        field_dtype = pl.String() if is_path_field else pl.Object()
+        updates[field_name] = pl.Series(field_name, values, dtype=field_dtype)
+
+    if updates:
+        df = df.with_columns(list(updates.values()))
     return df
 
 

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -547,6 +547,9 @@ def _import_dataset_from_dir(
     Returns:
         The imported Dataset instance
     """
+    if not input_dir.is_absolute():
+        input_dir = input_dir.resolve()
+
     metadata = _load_metadata(input_dir)
     df = _load_dataframe(input_dir)  # Check DataFrame exists before processing schema
     schema = Schema.from_dict(metadata["schema"])

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -666,10 +666,9 @@ def test_import_with_none_image_values(tmp_path):
     imported_dataset = import_dataset(export_dir, dtype=OptionalImageSample)
 
     # Verify dataset
-    assert len(imported_dataset) == 3
+    assert len(imported_dataset) == 2
     assert callable(imported_dataset[0].image)
-    assert imported_dataset[1].image is None
-    assert callable(imported_dataset[2].image)
+    assert callable(imported_dataset[1].image)
 
 
 def test_roundtrip_preserves_data_integrity(tmp_path):

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -69,7 +69,7 @@ def test_export_no_image_fields(tmp_path):
     output_dir = tmp_path / "output"
     result = _export_images_from_dataset(dataset, output_dir)
 
-    assert result == {}
+    assert result.equals(dataset.df)
 
 
 def test_export_image_callable_field(tmp_path):
@@ -100,9 +100,8 @@ def test_export_image_callable_field(tmp_path):
     assert "image" in result
     assert len(result["image"]) == 3
     for idx in range(3):
-        assert idx in result["image"]
-        rel_path = result["image"][idx]
-        assert rel_path == f"image_{idx:06d}.png"
+        rel_path = f"image_{idx:06d}.png"
+        assert rel_path in result["image"]
 
         # Verify file exists and is valid
         img_file = output_dir / rel_path
@@ -151,7 +150,6 @@ def test_export_image_path_field(tmp_path):
     assert len(result["image_path"]) == 3
 
     for idx in range(3):
-        assert idx in result["image_path"]
         rel_path = result["image_path"][idx]
 
         # Verify the file exists and format is preserved
@@ -190,7 +188,6 @@ def test_export_instance_mask_callable_field(tmp_path):
     assert len(result["mask"]) == 3
 
     for idx in range(3):
-        assert idx in result["mask"]
         rel_path = result["mask"][idx]
         assert rel_path == f"mask_{idx:06d}.png"
 
@@ -261,14 +258,14 @@ def test_export_with_none_values(tmp_path):
     dataset.append(OptionalImageSample(image=make_image))
 
     output_dir = tmp_path / "output"
-    result = _export_images_from_dataset(dataset, output_dir)
+    result = _export_images_from_dataset(dataset, output_dir, skip_missing_images=True)
 
     # Only indices 0 and 2 should be in result
     assert "image" in result
     assert len(result["image"]) == 2
-    assert 0 in result["image"]
-    assert 1 not in result["image"]
-    assert 2 in result["image"]
+    assert "image_000000.png" in result["image"]
+    assert "image_000001.png" not in result["image"]
+    assert "image_000002.png" in result["image"]
 
 
 def test_export_basic_dataset_to_directory(tmp_path):
@@ -680,7 +677,7 @@ def test_import_with_none_image_values(tmp_path):
     original_dataset.append(OptionalImageSample(image=make_image, label=3))
 
     export_dir = tmp_path / "export"
-    export_dataset(original_dataset, export_dir, export_images=True, as_zip=False)
+    export_dataset(original_dataset, export_dir, export_images=True, as_zip=False, skip_missing_images=True)
 
     # Import back
     imported_dataset = import_dataset(export_dir, dtype=OptionalImageSample)

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -59,7 +59,7 @@ MASK_CATEGORIES = MaskCategories.generate(size=256)
 
 
 def test_export_no_image_fields(tmp_path):
-    """Test that datasets without image fields return empty dict."""
+    """Test that datasets without image fields return the original dataframe."""
 
     class SimpleSample(Sample):
         label: int = label_field()

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -318,6 +318,8 @@ def test_export_images_error_failing_image_callable(tmp_path):
     output_dir = tmp_path / "output_bad_callable"
     with pytest.raises(ValueError, match="image"):
         _export_images_from_dataset(dataset, output_dir)
+
+
 def test_export_basic_dataset_to_directory(tmp_path):
     """Test basic export to directory."""
 

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -262,7 +262,7 @@ def test_export_with_none_values(tmp_path):
     dataset.append(OptionalImageSample(image=make_image))
 
     output_dir = tmp_path / "output"
-    result = _export_images_from_dataset(dataset, output_dir, skip_missing_images=True)
+    result = _export_images_from_dataset(dataset, output_dir, ignore_missing_images=True)
 
     # Only indices 0 and 2 should be in result
     assert "image" in result
@@ -708,7 +708,7 @@ def test_import_with_none_image_values(tmp_path):
     original_dataset.append(OptionalImageSample(image=make_image, label=3))
 
     export_dir = tmp_path / "export"
-    export_dataset(original_dataset, export_dir, export_images=True, as_zip=False, skip_missing_images=True)
+    export_dataset(original_dataset, export_dir, export_images=True, as_zip=False, ignore_missing_images=True)
 
     # Import back
     imported_dataset = import_dataset(export_dir, dtype=OptionalImageSample)

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -272,6 +272,52 @@ def test_export_with_none_values(tmp_path):
     assert "image_000002.png" in result["image"]
 
 
+def test_export_images_error_all_image_fields_null(tmp_path):
+    """Error when a row has null values for all image fields and skip_missing_images=False."""
+
+    class AllOptionalImagesSample(Sample):
+        image: Callable[[], np.ndarray] | None = image_callable_field()
+        image_path: str | None = image_path_field()
+
+    dataset = Dataset(AllOptionalImagesSample)
+    # Single row where all image-related fields are None
+    dataset.append(AllOptionalImagesSample(image=None, image_path=None))
+
+    output_dir = tmp_path / "output_all_null"
+    with pytest.raises(ValueError, match="image"):
+        _export_images_from_dataset(dataset, output_dir)
+
+
+def test_export_images_error_missing_image_path_file(tmp_path):
+    """Error when an ImagePathField points to a non-existent file and skip_missing_images=False."""
+
+    class PathImageSample(Sample):
+        image_path: str = image_path_field()
+
+    dataset = Dataset(PathImageSample)
+    missing_path = tmp_path / "does_not_exist.png"
+    dataset.append(PathImageSample(image_path=str(missing_path)))
+
+    output_dir = tmp_path / "output_missing_path"
+    with pytest.raises(ValueError, match="image"):
+        _export_images_from_dataset(dataset, output_dir)
+
+
+def test_export_images_error_failing_image_callable(tmp_path):
+    """Error when an ImageCallableField cannot generate an image and skip_missing_images=False."""
+
+    class CallableImageSample(Sample):
+        image: Callable[[], np.ndarray] = image_callable_field()
+
+    def bad_image():
+        raise RuntimeError("failed to generate image")
+
+    dataset = Dataset(CallableImageSample)
+    dataset.append(CallableImageSample(image=bad_image))
+
+    output_dir = tmp_path / "output_bad_callable"
+    with pytest.raises(ValueError, match="image"):
+        _export_images_from_dataset(dataset, output_dir)
 def test_export_basic_dataset_to_directory(tmp_path):
     """Test basic export to directory."""
 


### PR DESCRIPTION
Added handling of missing images, when we export images together with the dataset. That is, added a Boolean `skip_missing_images` (by default False), that:
- When `export_images=False`, `skip_missing_images` is ignored, because we can have image paths or image generators, so checking if an image exists is very resource intensive.
- When `export_images=True` and `skip_missing_images=False`, we raise a value error as soon as one of the images cannot be found on disk (`ImagePathField`) or cannot be generated (`ImageCallableField`), or when one of the rows of the original dataframe is null for all image fields.
- When `export_images=True` and `skip_missing_images=True`, any row that has null values for all image fields will be removed from the final dataframe/parquet file.

Resolves #2043 

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
