### PR TITLE
Add support for keeping empty samples when filtering labels

### DIFF
--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -615,6 +615,7 @@ class Dataset(Generic[DType]):
         labels: str | int | Sequence[str | int],
         label_field_name: str | None = None,
         update_categories: bool = False,
+        keep_empty_samples: bool = False,
     ) -> Dataset[DType]:
         """
         Return a new dataset containing only items that have at least one of the given labels.
@@ -639,10 +640,17 @@ class Dataset(Generic[DType]):
                 contain only the filtered labels (with indices remapped to 0, 1, 2, ...).
                 If ``False`` (default), the original LabelCategories are preserved and
                 label indices remain unchanged.
+            keep_empty_samples: If ``True``, all samples are kept in the dataset even if
+                they have no matching labels. Non-matching labels and their corresponding
+                annotations are removed, but the sample's media data (e.g., images) is
+                preserved. If ``False`` (default), samples without any matching labels
+                are removed from the dataset entirely.
 
         Returns:
-            A new Dataset containing only the items whose label field contains
-            at least one of the specified labels.
+            A new Dataset containing items filtered by the specified labels.
+            If ``keep_empty_samples=False``, only items with at least one matching label
+            are included. If ``keep_empty_samples=True``, all items are included but with
+            non-matching labels and annotations stripped away.
 
         Raises:
             KeyError: If ``label_field_name`` is not found in the schema.
@@ -667,6 +675,9 @@ class Dataset(Generic[DType]):
 
             # Update categories to only contain filtered labels (indices remapped)
             filtered = dataset.filter_by_labels(["cat", "dog"], update_categories=True)
+
+            # Keep all samples but strip non-matching labels and annotations
+            filtered = dataset.filter_by_labels(["cat"], keep_empty_samples=True)
             ```
         """
 
@@ -684,7 +695,14 @@ class Dataset(Generic[DType]):
             raise ValueError("No labels provided to filter by. Please provide at least one label name or index.")
 
         label_indices = resolve_label_indices(labels, categories, label_field_name)
-        filtered_df = filter_df_by_label_indices(self.df, label_field_name, label_field_instance, label_indices)
+        filtered_df = filter_df_by_label_indices(
+            self.df,
+            label_field_name,
+            label_field_instance,
+            label_indices,
+            schema=self.schema,
+            keep_empty_samples=keep_empty_samples,
+        )
 
         if update_categories:
             # For hierarchical categories, automatically include all ancestor labels

--- a/src/datumaro/experimental/filtering/label_filter.py
+++ b/src/datumaro/experimental/filtering/label_filter.py
@@ -118,16 +118,200 @@ def resolve_label_indices(
     return label_indices
 
 
+def find_associated_annotation_fields(
+    schema: Schema,
+    label_field_name: str,
+    label_field_instance: LabelField,
+) -> list[str]:
+    """Find annotation fields that are associated with a label field by semantic.
+
+    Associated annotation fields are those that:
+    1. Have the same semantic value as the label field
+    2. Are not the label field itself
+    3. Are list-type fields (storing multiple annotations per sample)
+
+    Args:
+        schema: The dataset schema.
+        label_field_name: Name of the label field.
+        label_field_instance: The LabelField instance.
+
+    Returns:
+        List of field names that are associated with the label field.
+    """
+    associated_fields: list[str] = []
+    label_semantic = label_field_instance.semantic
+
+    for attr_name, attr_info in schema.attributes.items():
+        if attr_name == label_field_name:
+            continue
+
+        field = attr_info.field
+        # Check if the field has the same semantic
+        if hasattr(field, "semantic") and field.semantic == label_semantic:
+            # For is_list label fields, we need to filter associated list-type annotation fields
+            # These are typically BBoxField, PolygonField, KeypointsField, etc.
+            # which store lists of annotations as pl.List(...)
+            polars_schema = field.to_polars_schema(attr_name)
+            for col_dtype in polars_schema.values():
+                # Check if it's a list type (annotations are stored as lists)
+                if isinstance(col_dtype, pl.List):
+                    associated_fields.append(attr_name)
+                    break
+
+    return associated_fields
+
+
+def _filter_associated_fields(
+    df: pl.DataFrame,
+    keep_mask_expr: pl.Expr,
+    associated_fields: list[str],
+) -> list[pl.Expr]:
+    """Build column expressions to filter associated annotation fields using a mask.
+
+    Args:
+        df: The DataFrame being filtered.
+        keep_mask_expr: Boolean mask expression indicating which elements to keep.
+        associated_fields: List of field names to filter.
+
+    Returns:
+        List of Polars expressions to update the associated fields.
+    """
+    columns_to_update: list[pl.Expr] = []
+    for field_name in associated_fields:
+        if field_name in df.columns:
+
+            def filter_by_mask(s: dict[str, Any], fname: str = field_name) -> list[Any] | None:
+                if s[fname] is None:
+                    return None
+                return [v for v, m in zip(s[fname], s["__mask__"]) if m]
+
+            columns_to_update.append(
+                pl.struct([pl.col(field_name), keep_mask_expr.alias("__mask__")])
+                .map_elements(
+                    filter_by_mask,
+                    return_dtype=df.schema[field_name],
+                )
+                .alias(field_name)
+            )
+    return columns_to_update
+
+
+def _filter_list_and_multi_label(
+    df: pl.DataFrame,
+    label_field_name: str,
+    label_indices: list[int],
+    schema: Schema | None,
+    label_field_instance: LabelField,
+    keep_empty_samples: bool,
+) -> pl.DataFrame:
+    """Filter DataFrame with List(List(UInt)) label structure."""
+    label_col = pl.col(label_field_name)
+
+    # Compute a boolean mask for which outer elements to keep
+    keep_mask_expr = label_col.list.eval(pl.element().list.eval(pl.element().is_in(label_indices)).list.any())
+
+    # Filter the label column: keep matching elements in inner lists, drop empty inner lists
+    filtered_label_expr = (
+        label_col.list.eval(
+            pl.element().list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element())).list.drop_nulls()
+        )
+        .list.eval(pl.when(pl.element().list.len() > 0).then(pl.element()))
+        .list.drop_nulls()
+    )
+
+    columns_to_update: list[pl.Expr] = [filtered_label_expr.alias(label_field_name)]
+
+    if schema is not None:
+        associated_fields = find_associated_annotation_fields(schema, label_field_name, label_field_instance)
+        columns_to_update.extend(_filter_associated_fields(df, keep_mask_expr, associated_fields))
+
+    result = df.with_columns(columns_to_update)
+    if not keep_empty_samples:
+        result = result.filter(label_col.is_not_null() & (label_col.list.len() > 0))
+    return result
+
+
+def _filter_list_label(
+    df: pl.DataFrame,
+    label_field_name: str,
+    label_indices: list[int],
+    schema: Schema | None,
+    label_field_instance: LabelField,
+    keep_empty_samples: bool,
+) -> pl.DataFrame:
+    """Filter DataFrame with List(UInt) label structure (one label per annotation)."""
+    label_col = pl.col(label_field_name)
+
+    # Compute a boolean mask for which elements to keep
+    keep_mask_expr = label_col.list.eval(pl.element().is_in(label_indices))
+
+    # Filter the label column
+    filtered_label_expr = label_col.list.eval(
+        pl.when(pl.element().is_in(label_indices)).then(pl.element())
+    ).list.drop_nulls()
+
+    columns_to_update: list[pl.Expr] = [filtered_label_expr.alias(label_field_name)]
+
+    if schema is not None:
+        associated_fields = find_associated_annotation_fields(schema, label_field_name, label_field_instance)
+        columns_to_update.extend(_filter_associated_fields(df, keep_mask_expr, associated_fields))
+
+    result = df.with_columns(columns_to_update)
+    if not keep_empty_samples:
+        result = result.filter(label_col.is_not_null() & (label_col.list.len() > 0))
+    return result
+
+
+def _filter_multi_label(
+    df: pl.DataFrame,
+    label_field_name: str,
+    label_indices: list[int],
+    keep_empty_samples: bool,
+) -> pl.DataFrame:
+    """Filter DataFrame with multi-label structure (multiple labels per sample, not per annotation)."""
+    label_col = pl.col(label_field_name)
+
+    result = df.with_columns(
+        label_col.list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element())).list.drop_nulls()
+    )
+    if not keep_empty_samples:
+        result = result.filter(label_col.is_not_null() & (label_col.list.len() > 0))
+    return result
+
+
+def _filter_scalar_label(
+    df: pl.DataFrame,
+    label_field_name: str,
+    label_indices: list[int],
+    keep_empty_samples: bool,
+) -> pl.DataFrame:
+    """Filter DataFrame with scalar label structure."""
+    label_col = pl.col(label_field_name)
+
+    if keep_empty_samples:
+        # Set non-matching labels to null instead of filtering
+        return df.with_columns(
+            pl.when(label_col.is_in(label_indices)).then(label_col).otherwise(pl.lit(None)).alias(label_field_name)
+        )
+    return df.filter(label_col.is_in(label_indices))
+
+
 def filter_df_by_label_indices(
     df: pl.DataFrame,
     label_field_name: str,
     label_field_instance: LabelField,
     label_indices: list[int],
+    schema: Schema | None = None,
+    keep_empty_samples: bool = False,
 ) -> pl.DataFrame:
     """Return a filtered DataFrame keeping rows that match any of *label_indices*.
 
     This function both filters rows (keeping only those with at least one matching label)
     AND removes non-matching labels from within each sample's label field.
+
+    When the label field is a list type (is_list=True), this function also filters
+    associated annotation fields (e.g., bboxes, polygons) that share the same semantic,
+    keeping only the annotations at the same indices as the kept labels.
 
     The filtering strategy is chosen based on the ``is_list`` and
     ``multi_label`` flags of *label_field_instance*.
@@ -137,31 +321,26 @@ def filter_df_by_label_indices(
         label_field_name: Name of the label column.
         label_field_instance: The LabelField instance.
         label_indices: List of label indices to keep.
+        schema: Optional schema to find associated annotation fields to filter.
+        keep_empty_samples: If True, keep all rows even if they have no matching labels
+            (labels and annotations will be empty). If False (default), rows without
+            matching labels are removed.
 
     Returns:
         Filtered DataFrame.
     """
-    label_col = pl.col(label_field_name)
-
     if label_field_instance.is_list and label_field_instance.multi_label:
-        # List(List(UInt)) - for each inner list, keep only matching elements,
-        # then filter out empty inner lists, then filter out rows with no remaining labels.
-        return df.with_columns(
-            label_col.list.eval(
-                pl.element().list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element())).list.drop_nulls()
-            )
-            .list.eval(pl.when(pl.element().list.len() > 0).then(pl.element()))
-            .list.drop_nulls()
-        ).filter(label_col.list.len() > 0)
+        return _filter_list_and_multi_label(
+            df, label_field_name, label_indices, schema, label_field_instance, keep_empty_samples
+        )
 
-    if label_field_instance.is_list or label_field_instance.multi_label:
-        # List(UInt) - keep only matching elements and filter out rows with empty lists.
-        return df.with_columns(
-            label_col.list.eval(pl.when(pl.element().is_in(label_indices)).then(pl.element())).list.drop_nulls()
-        ).filter(label_col.list.len() > 0)
+    if label_field_instance.is_list:
+        return _filter_list_label(df, label_field_name, label_indices, schema, label_field_instance, keep_empty_samples)
 
-    # Scalar UInt - keep row if the value matches.
-    return df.filter(label_col.is_in(label_indices))
+    if label_field_instance.multi_label:
+        return _filter_multi_label(df, label_field_name, label_indices, keep_empty_samples)
+
+    return _filter_scalar_label(df, label_field_name, label_indices, keep_empty_samples)
 
 
 def remap_label_indices(

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -1179,6 +1179,264 @@ def test_filter_by_labels_removes_unwanted_labels_list_and_multi_label():
     assert tags_list[2] == [[2], [2]]  # was [[2], [0,2]], now [[2], [2]]
 
 
+def test_filter_by_labels_filters_associated_annotation_fields():
+    """Verify that filter_by_labels also filters associated annotation fields (e.g., bboxes)."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(
+        attributes={
+            "labels": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), is_list=True, semantic="default"),
+                categories=categories,
+            ),
+            "bboxes": AttributeInfo(
+                type=list,
+                field=bbox_field(dtype=pl.Float32(), semantic="default"),
+            ),
+        }
+    )
+    ds = Dataset(schema)
+    # Sample 0: cat (bbox [0,0,1,1]), dog (bbox [1,1,2,2])
+    ds.append(Sample(labels=[0, 1], bboxes=np.array([[0, 0, 1, 1], [1, 1, 2, 2]], dtype=np.float32)))
+    # Sample 1: bird (bbox [2,2,3,3])
+    ds.append(Sample(labels=[2], bboxes=np.array([[2, 2, 3, 3]], dtype=np.float32)))
+    # Sample 2: dog (bbox [3,3,4,4]), bird (bbox [4,4,5,5])
+    ds.append(Sample(labels=[1, 2], bboxes=np.array([[3, 3, 4, 4], [4, 4, 5, 5]], dtype=np.float32)))
+    # Sample 3: cat (bbox [5,5,6,6])
+    ds.append(Sample(labels=[0], bboxes=np.array([[5, 5, 6, 6]], dtype=np.float32)))
+
+    # Filter by "dog" - should keep only samples with dog and remove cat/bird bboxes
+    filtered = ds.filter_by_labels(["dog"])
+    assert len(filtered) == 2  # rows 0, 2
+    labels_list = filtered.df["labels"].to_list()
+    bboxes_list = filtered.df["bboxes"].to_list()
+    # Row 0: was [cat, dog], now [dog] with only dog's bbox
+    assert labels_list[0] == [1]
+    assert len(bboxes_list[0]) == 1
+    np.testing.assert_array_almost_equal(bboxes_list[0][0], [1, 1, 2, 2])
+    # Row 2 (was row 2): was [dog, bird], now [dog] with only dog's bbox
+    assert labels_list[1] == [1]
+    assert len(bboxes_list[1]) == 1
+    np.testing.assert_array_almost_equal(bboxes_list[1][0], [3, 3, 4, 4])
+
+    # Filter by "cat" and "bird" - should keep all rows
+    filtered = ds.filter_by_labels(["cat", "bird"])
+    assert len(filtered) == 4
+    labels_list = filtered.df["labels"].to_list()
+    bboxes_list = filtered.df["bboxes"].to_list()
+    # Row 0: was [cat, dog], now [cat] with only cat's bbox
+    assert labels_list[0] == [0]
+    assert len(bboxes_list[0]) == 1
+    np.testing.assert_array_almost_equal(bboxes_list[0][0], [0, 0, 1, 1])
+    # Row 1: bird unchanged
+    assert labels_list[1] == [2]
+    assert len(bboxes_list[1]) == 1
+    np.testing.assert_array_almost_equal(bboxes_list[1][0], [2, 2, 3, 3])
+    # Row 2: was [dog, bird], now [bird] with only bird's bbox
+    assert labels_list[2] == [2]
+    assert len(bboxes_list[2]) == 1
+    np.testing.assert_array_almost_equal(bboxes_list[2][0], [4, 4, 5, 5])
+    # Row 3: cat unchanged
+    assert labels_list[3] == [0]
+    assert len(bboxes_list[3]) == 1
+    np.testing.assert_array_almost_equal(bboxes_list[3][0], [5, 5, 6, 6])
+
+
+def test_filter_by_labels_filters_associated_annotation_fields_list_and_multi_label():
+    """Verify that filter_by_labels also filters associated annotation fields with is_list=True and multi_label=True."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(
+        attributes={
+            "labels": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), is_list=True, multi_label=True, semantic="default"),
+                categories=categories,
+            ),
+            "bboxes": AttributeInfo(
+                type=list,
+                field=bbox_field(dtype=pl.Float32(), semantic="default"),
+            ),
+        }
+    )
+    ds = Dataset(schema)
+    # Sample 0: annotation 0 has [cat, dog], annotation 1 has [bird]
+    ds.append(Sample(labels=[[0, 1], [2]], bboxes=np.array([[0, 0, 1, 1], [1, 1, 2, 2]], dtype=np.float32)))
+    # Sample 1: annotation 0 has [bird]
+    ds.append(Sample(labels=[[2]], bboxes=np.array([[2, 2, 3, 3]], dtype=np.float32)))
+    # Sample 2: annotation 0 has [dog], annotation 1 has [cat, bird]
+    ds.append(Sample(labels=[[1], [0, 2]], bboxes=np.array([[3, 3, 4, 4], [4, 4, 5, 5]], dtype=np.float32)))
+
+    # Filter by "dog" - should keep annotations where inner list contains "dog"
+    filtered = ds.filter_by_labels(["dog"], label_field_name="labels")
+    assert len(filtered) == 2  # rows 0, 2
+    labels_list = filtered.df["labels"].to_list()
+    bboxes_list = filtered.df["bboxes"].to_list()
+    # Row 0: was [[cat,dog], [bird]], now [[dog]] with only first bbox
+    assert labels_list[0] == [[1]]  # dog only (cat removed from inner list)
+    assert len(bboxes_list[0]) == 1
+    np.testing.assert_array_almost_equal(bboxes_list[0][0], [0, 0, 1, 1])
+    # Row 2 (was row 2): was [[dog], [cat,bird]], now [[dog]] with only first bbox
+    assert labels_list[1] == [[1]]
+    assert len(bboxes_list[1]) == 1
+    np.testing.assert_array_almost_equal(bboxes_list[1][0], [3, 3, 4, 4])
+
+    # Filter by "cat" and "bird" - should keep annotations with cat or bird
+    filtered = ds.filter_by_labels(["cat", "bird"], label_field_name="labels")
+    assert len(filtered) == 3
+    labels_list = filtered.df["labels"].to_list()
+    bboxes_list = filtered.df["bboxes"].to_list()
+    # Row 0: was [[cat,dog], [bird]], now [[cat], [bird]] (both annotations kept)
+    assert labels_list[0] == [[0], [2]]  # cat and bird (dog removed from inner list)
+    assert len(bboxes_list[0]) == 2
+    # Row 1: bird unchanged
+    assert labels_list[1] == [[2]]
+    assert len(bboxes_list[1]) == 1
+    # Row 2: was [[dog], [cat,bird]], now [[cat,bird]] (only second annotation kept)
+    assert labels_list[2] == [[0, 2]]
+    assert len(bboxes_list[2]) == 1
+    np.testing.assert_array_almost_equal(bboxes_list[2][0], [4, 4, 5, 5])
+
+
+# ── keep_empty_samples tests ────────────────────────────────────────────────
+
+
+def test_filter_by_labels_keep_empty_samples_list_field():
+    """Test keep_empty_samples=True with is_list=True LabelField."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(
+        attributes={
+            "labels": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), is_list=True, semantic="default"),
+                categories=categories,
+            ),
+            "bboxes": AttributeInfo(
+                type=list,
+                field=bbox_field(dtype=pl.Float32(), semantic="default"),
+            ),
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(labels=[0, 1], bboxes=np.array([[0, 0, 1, 1], [1, 1, 2, 2]], dtype=np.float32)))  # cat, dog
+    ds.append(Sample(labels=[2], bboxes=np.array([[2, 2, 3, 3]], dtype=np.float32)))  # bird
+    ds.append(Sample(labels=[1, 2], bboxes=np.array([[3, 3, 4, 4], [4, 4, 5, 5]], dtype=np.float32)))  # dog, bird
+
+    # Filter by "cat" with keep_empty_samples=True - all 3 samples should be kept
+    filtered = ds.filter_by_labels(["cat"], keep_empty_samples=True)
+    assert len(filtered) == 3  # All samples kept
+
+    labels_list = filtered.df["labels"].to_list()
+    bboxes_list = filtered.df["bboxes"].to_list()
+
+    # Row 0: was [cat, dog], now [cat] with only cat's bbox
+    assert labels_list[0] == [0]
+    assert len(bboxes_list[0]) == 1
+    np.testing.assert_array_almost_equal(bboxes_list[0][0], [0, 0, 1, 1])
+
+    # Row 1: was [bird], now empty - but sample is kept
+    assert labels_list[1] == []
+    assert len(bboxes_list[1]) == 0
+
+    # Row 2: was [dog, bird], now empty - but sample is kept
+    assert labels_list[2] == []
+    assert len(bboxes_list[2]) == 0
+
+
+def test_filter_by_labels_keep_empty_samples_scalar():
+    """Test keep_empty_samples=True with scalar LabelField."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(
+        attributes={
+            "label": AttributeInfo(type=int, field=label_field(), categories=categories),
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(label=0))  # cat
+    ds.append(Sample(label=1))  # dog
+    ds.append(Sample(label=2))  # bird
+
+    # Filter by "cat" with keep_empty_samples=True - all 3 samples should be kept
+    filtered = ds.filter_by_labels(["cat"], keep_empty_samples=True)
+    assert len(filtered) == 3
+
+    labels_list = filtered.df["label"].to_list()
+    assert labels_list[0] == 0  # cat kept
+    assert labels_list[1] is None  # dog -> None
+    assert labels_list[2] is None  # bird -> None
+
+
+def test_filter_by_labels_keep_empty_samples_multi_label():
+    """Test keep_empty_samples=True with multi_label=True LabelField."""
+    categories = LabelCategories(labels=("sunny", "rainy", "cloudy"))
+    schema = Schema(
+        attributes={
+            "weather": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), multi_label=True),
+                categories=categories,
+            )
+        }
+    )
+    ds = Dataset(schema)
+    ds.append(Sample(weather=[0, 2]))  # sunny + cloudy
+    ds.append(Sample(weather=[1]))  # rainy
+    ds.append(Sample(weather=[0, 1]))  # sunny + rainy
+
+    # Filter by "sunny" with keep_empty_samples=True - all samples should be kept
+    filtered = ds.filter_by_labels(["sunny"], label_field_name="weather", keep_empty_samples=True)
+    assert len(filtered) == 3
+
+    weather_list = filtered.df["weather"].to_list()
+    assert weather_list[0] == [0]  # sunny only (cloudy removed)
+    assert weather_list[1] == []  # rainy -> empty
+    assert weather_list[2] == [0]  # sunny only (rainy removed)
+
+
+def test_filter_by_labels_keep_empty_samples_list_and_multi_label():
+    """Test keep_empty_samples=True with is_list=True and multi_label=True."""
+    categories = LabelCategories(labels=("a", "b", "c"))
+    schema = Schema(
+        attributes={
+            "tags": AttributeInfo(
+                type=list,
+                field=label_field(dtype=pl.UInt8(), is_list=True, multi_label=True, semantic="default"),
+                categories=categories,
+            ),
+            "bboxes": AttributeInfo(
+                type=list,
+                field=bbox_field(dtype=pl.Float32(), semantic="default"),
+            ),
+        }
+    )
+    ds = Dataset(schema)
+    # Sample 0: annotation 0 has [a,b], annotation 1 has [c]
+    ds.append(Sample(tags=[[0, 1], [2]], bboxes=np.array([[0, 0, 1, 1], [1, 1, 2, 2]], dtype=np.float32)))
+    # Sample 1: annotation 0 has [c]
+    ds.append(Sample(tags=[[2]], bboxes=np.array([[2, 2, 3, 3]], dtype=np.float32)))
+    # Sample 2: annotation 0 has [b], annotation 1 has [a, c]
+    ds.append(Sample(tags=[[1], [0, 2]], bboxes=np.array([[3, 3, 4, 4], [4, 4, 5, 5]], dtype=np.float32)))
+
+    # Filter by "a" with keep_empty_samples=True - all samples should be kept
+    filtered = ds.filter_by_labels(["a"], label_field_name="tags", keep_empty_samples=True)
+    assert len(filtered) == 3
+
+    tags_list = filtered.df["tags"].to_list()
+    bboxes_list = filtered.df["bboxes"].to_list()
+
+    # Row 0: was [[a,b], [c]], now [[a]] (only first annotation kept, with only "a")
+    assert tags_list[0] == [[0]]
+    assert len(bboxes_list[0]) == 1
+
+    # Row 1: was [[c]], now [] - no annotations with "a", but sample kept
+    assert tags_list[1] == []
+    assert len(bboxes_list[1]) == 0
+
+    # Row 2: was [[b], [a, c]], now [[a]] (only second annotation kept, with only "a")
+    assert tags_list[2] == [[0]]
+    assert len(bboxes_list[2]) == 1
+    np.testing.assert_array_almost_equal(bboxes_list[2][0], [4, 4, 5, 5])
+
+
 # ── update_categories tests ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Add support te keep empty samples when filtering labels. 

Also fixes a problem where annotations might not have been deleted in filtered samples which only had partial labels filtered.

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
