### PR TITLE
Include empty annotation files for Yolo format

### DIFF
--- a/src/datumaro/plugins/data_formats/yolo/importer.py
+++ b/src/datumaro/plugins/data_formats/yolo/importer.py
@@ -87,7 +87,7 @@ class _YoloLooseImporter(Importer):
             # Check the first line only
             return True
 
-        raise DatasetImportError("Empty file is not allowed.")
+        return True
 
     @classmethod
     def _find_loose(cls, path: str, dirname: str) -> List[Dict[str, Any]]:
@@ -171,12 +171,7 @@ class _YoloUltralyticsImporter(_YoloLooseImporter):
 
     @classmethod
     def _check_ann_file_impl(cls, fp: TextIOWrapper) -> bool:
-        try:
-            return _YoloLooseImporter._check_ann_file_impl(fp)
-        except DatasetImportError as e:
-            if e.args[0] == "Empty file is not allowed.":
-                return True
-            raise
+        return _YoloLooseImporter._check_ann_file_impl(fp)
 
 
 class YoloImporter(Importer):


### PR DESCRIPTION
Fix https://github.com/open-edge-platform/datumaro/issues/1959. This issue also prevents detecting the Yolo dataset with empty annotations.

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
