### PR TITLE
Fix missing bboxes in COCO import

### DIFF
--- a/src/datumaro/experimental/data_formats/coco/helpers.py
+++ b/src/datumaro/experimental/data_formats/coco/helpers.py
@@ -400,6 +400,8 @@ def _collect_instances_for_image(
     for ann in instances_by_image.get(image_id, []):
         category_idx = cat_id_to_idx.get(ann.get("category_id"))
         segmentation = ann.get("segmentation")
+        original_bbox = ann.get("bbox")
+        original_area = ann.get("area")
 
         # Handle multi-part polygons by splitting them into separate annotations
         polygon_parts = _segmentation_to_poly_parts(segmentation)
@@ -419,6 +421,10 @@ def _collect_instances_for_image(
                 x2, y2 = float(x_coords.max()), float(y_coords.max())
                 computed_bbox = [x1, y1, x2 - x1, y2 - y1]  # x, y, w, h
                 area = (x2 - x1) * (y2 - y1)
+            elif original_bbox is not None and len(original_bbox) == 4:
+                # Use original bbox from annotation if no polygon
+                computed_bbox = [float(v) for v in original_bbox]
+                area = float(original_area) if original_area is not None else computed_bbox[2] * computed_bbox[3]
             else:
                 computed_bbox = [0.0, 0.0, 0.0, 0.0]
                 area = 0.0

--- a/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
+++ b/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
@@ -259,6 +259,32 @@ def test_collect_helpers_extract_expected_fields():
     assert caps == (["hi"], [5])
 
 
+def test_collect_instances_uses_bbox_when_no_polygon():
+    """Test that bbox values are preserved when there's no polygon segmentation."""
+    instances_by_image = {
+        1: [
+            # Annotation with bbox but no polygon (empty segmentation)
+            {
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [100.0, 150.0, 200.0, 250.0],
+                "area": 50000.0,
+                "segmentation": [],
+            },
+        ]
+    }
+    bboxes, polys, labels, areas, iscrowd = _collect_instances_for_image(1, instances_by_image, {1: 0})
+
+    # Should use the original bbox from annotation, not [0, 0, 0, 0]
+    assert bboxes[0] == [100.0, 150.0, 200.0, 250.0]
+    # Polygon should be empty
+    assert polys[0].shape == (0, 2)
+    assert labels == [0]
+    # Should use the original area from annotation
+    assert areas[0] == pytest.approx(50000.0)
+    assert iscrowd == [False]
+
+
 def test_serialize_instances_requires_labels():
     sample = _make_sample(labels=None)
     with pytest.raises(ValueError):


### PR DESCRIPTION
The bboxes in an imported COCO dataset would only be calculated from polygons, not set directly if bboxes are directly available. This PR fixes that. 


<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
