### PR TITLE
Add format parameter to datum patch

### DIFF
--- a/docs/source/docs/command-reference/patch.md
+++ b/docs/source/docs/command-reference/patch.md
@@ -5,7 +5,8 @@
 Updates items of the first dataset with items from the second one.
 
 By default, datasets are updated in-place. The `-o/--output-dir`
-option can be used to specify another output directory. When
+option can be used to specify another output directory. The
+`-f/--format` option can be used to specify the output format. When
 updating in-place, use the `--overwrite` parameter along with the
 `--save-media` export option (in-place updates fail by default
 to prevent data loss).
@@ -26,7 +27,7 @@ This command can be applied to arbitrary datasets.
 
 ## Usage
 ```console
-datum patch [-h] [-o DST_DIR] [--overwrite]
+datum patch [-h] [-o DST_DIR] [-f FORMAT] [--overwrite]
                target patch
                [-- EXPORT_ARGS]
 ```
@@ -37,6 +38,7 @@ Parameters:
 - `target` (string) - Target dataset path (path to dataset directory, optionally with format specification)
 - `patch` (string) - Patch dataset path (path to dataset directory, optionally with format specification)
 - `-o, --output-dir` (string) - Output directory (default: save in-place)
+- `-f, --format` (string) - Output format (default: target dataset format)
 - `--overwrite` - Overwrite existing files in the save directory, if it is not empty
 - `-h, --help` - Print the help message and exit
 - `extra_args` - Additional arguments for exporting (pass '-- -h' for help). Must be specified after the main command arguments and after the '--' separator
@@ -50,4 +52,9 @@ Parameters:
 - Generate a patched dataset
   ```console
   datum patch -o patched_dataset/ dataset1/ dataset2/
+  ```
+
+- Generate a patched dataset in a different format
+  ```console
+  datum patch -o patched_dataset/ -f yolo_ultralytics dataset1/ dataset2/
   ```

--- a/src/datumaro/cli/commands/patch.py
+++ b/src/datumaro/cli/commands/patch.py
@@ -66,6 +66,7 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         default=None,
         help="Output directory (default: save in-place)",
     )
+    parser.add_argument("-f", "--format", help="Output format (default: target dataset format)")
     parser.add_argument(
         "--overwrite",
         action="store_true",
@@ -98,11 +99,12 @@ def patch_command(args):
         raise CliException("Directory '%s' already exists (pass --overwrite to overwrite)" % dst_dir)
     dst_dir = osp.abspath(dst_dir)
 
-    # Get the exporter for the target format
+    # Get the exporter for the output format
+    format = args.format or target_dataset.format
     try:
-        exporter = env.exporters[target_dataset.format]
+        exporter = env.exporters[format]
     except KeyError:
-        raise CliException("Exporter for format '%s' is not found" % target_dataset.format)
+        raise CliException("Exporter for format '%s' is not found" % format)
 
     extra_args = exporter.parse_cmdline(args.extra_args)
 
@@ -110,7 +112,7 @@ def patch_command(args):
     target_dataset.update(patch_dataset)
 
     # Save the updated dataset
-    target_dataset.save(save_dir=dst_dir, **extra_args)
+    target_dataset.export(save_dir=dst_dir, format=format, **extra_args)
 
     log.info("Patched dataset has been saved to '%s'" % dst_dir)
 

--- a/src/datumaro/cli/commands/patch.py
+++ b/src/datumaro/cli/commands/patch.py
@@ -21,7 +21,8 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         Updates items of the first dataset with items from the second one.|n
         |n
         By default, datasets are updated in-place. The '-o/--output-dir'
-        option can be used to specify another output directory. When
+        option can be used to specify another output directory. The
+        '-f/--format' option can be used to specify the output format. When
         updating in-place, use the '--overwrite' parameter along with the
         '--save-media' export option (in-place updates fail by default
         to prevent data loss).|n
@@ -53,6 +54,9 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         |n
         - Generate a patched dataset:|n
         |s|s%(prog)s -o patched_dataset/ dataset1/ dataset2/|n
+        |n
+        - Generate a patched dataset in a different format:|n
+        |s|s%(prog)s -o patched_dataset/ -f yolo_ultralytics dataset1/ dataset2/|n
         """,
         formatter_class=MultilineFormatter,
     )


### PR DESCRIPTION

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

**Issue:**

The CLI command `datum patch` currently defaults to the format of the target dataset. For YOLO, this command outputs a strict format, which you can find detailed [here](https://github.com/open-edge-platform/datumaro/blob/develop/docs/source/docs/data-formats/formats/yolo.md?plain=1#L32). However, this strict format is not as commonly used as the more flexible YOLO format or the modern [YOLO Ultralytics format](https://github.com/open-edge-platform/datumaro/blob/develop/docs/source/docs/data-formats/formats/yolo_ultralytics.md). Therefore, we should allow users to specify their desired output format.

**Solution:**

Add a format parameter to `datum patch` to allow users to specify the output format. 

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [x] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
