### PR TITLE
Add automatic dataset format detection and import functionality

### DIFF
--- a/src/datumaro/experimental/data_formats/base.py
+++ b/src/datumaro/experimental/data_formats/base.py
@@ -2,22 +2,26 @@
 #
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import os
 import shutil
 import tempfile
 from enum import Enum
+from typing import TYPE_CHECKING
 
-from datumaro.experimental import Dataset
-from datumaro.experimental.data_formats.coco.sample import CocoSample
-from datumaro.experimental.data_formats.yolo.sample import YoloSample
+if TYPE_CHECKING:
+    from datumaro.experimental import Dataset
 
 
 class DataFormat(Enum):
     """Supported data formats for load/save."""
 
+    DATUMARO = "DATUMARO"
     COCO = "COCO"
     YOLO = "YOLO"
     YOLO_ULTRALYTICS = "YOLO_ULTRALYTICS"
+    UNKNOWN = "UNKNOWN"
 
 
 def load_dataset(
@@ -134,6 +138,7 @@ def _save_dataset_to_dir(
     """Internal helper to save dataset to a directory."""
     if data_format == DataFormat.COCO:
         from datumaro.experimental.data_formats.coco.io import save_coco_dataset
+        from datumaro.experimental.data_formats.coco.sample import CocoSample
 
         dataset = dataset.convert_to_schema(CocoSample.infer_schema())
         save_coco_dataset(
@@ -143,6 +148,7 @@ def _save_dataset_to_dir(
         )
     elif data_format in (DataFormat.YOLO, DataFormat.YOLO_ULTRALYTICS):
         from datumaro.experimental.data_formats.yolo.io import save_yolo_dataset
+        from datumaro.experimental.data_formats.yolo.sample import YoloSample
 
         dataset = dataset.convert_to_schema(YoloSample.infer_schema())
         save_yolo_dataset(dataset, root_dir=output_dir, format=data_format)

--- a/src/datumaro/experimental/data_formats/base.py
+++ b/src/datumaro/experimental/data_formats/base.py
@@ -18,6 +18,7 @@ class DataFormat(Enum):
     """Supported data formats for load/save."""
 
     DATUMARO = "DATUMARO"
+    DATUMARO_LEGACY = "DATUMARO_LEGACY"
     COCO = "COCO"
     YOLO = "YOLO"
     YOLO_ULTRALYTICS = "YOLO_ULTRALYTICS"

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -29,13 +29,13 @@ import numpy as np
 import polars as pl
 from PIL import Image
 
+from datumaro.experimental.data_formats.base import DataFormat
 from datumaro.experimental.dataset import Dataset, Sample
 from datumaro.experimental.fields.images import ImageCallableField, ImagePathField
 from datumaro.experimental.fields.masks import InstanceMaskCallableField, MaskCallableField
 from datumaro.experimental.format_detection import (
     DATAFRAME_FILE,
     METADATA_FILE,
-    DetectedFormat,
     detect_dataset_format,
     find_dataset_root,
     import_coco_dataset,
@@ -593,11 +593,11 @@ def _import_dataset_from_dir(
 
     # Detect the dataset format and dispatch to appropriate loader
     match detect_dataset_format(input_dir):
-        case DetectedFormat.COCO:
+        case DataFormat.COCO:
             return import_coco_dataset(input_dir)
-        case DetectedFormat.YOLO:
+        case DataFormat.YOLO:
             return import_yolo_dataset(input_dir)
-        case DetectedFormat.DATUMARO:
+        case DataFormat.DATUMARO:
             return _import_datumaro_dataset(input_dir, dtype)
         case _:
             raise ValueError(

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -32,6 +32,14 @@ from PIL import Image
 from datumaro.experimental.dataset import Dataset, Sample
 from datumaro.experimental.fields.images import ImageCallableField, ImagePathField
 from datumaro.experimental.fields.masks import InstanceMaskCallableField, MaskCallableField
+from datumaro.experimental.format_detection import (
+    DATAFRAME_FILE,
+    METADATA_FILE,
+    DetectedFormat,
+    detect_dataset_format,
+    import_coco_dataset,
+    import_yolo_dataset,
+)
 from datumaro.experimental.schema import Schema
 
 if TYPE_CHECKING:
@@ -71,8 +79,6 @@ def register_sample(cls: type[Sample]) -> type[Sample]:
 
 
 # Constants for export structure
-METADATA_FILE = "metadata.json"
-DATAFRAME_FILE = "data.parquet"
 IMAGES_DIR = "images"
 try:
     VERSION = _pkg_version("datumaro")
@@ -371,15 +377,26 @@ def import_dataset(
     """
     Import a dataset from an exported format.
 
-    When dtype is None the function tries to automatically determine the correct Sample subclass by matching the stored
-    schema against all registered subclasses (discovered via the :func:`register_sample` registry).  If no
-    match is found, it falls back to the base ``Sample`` class.
+    This function automatically detects the dataset format and calls the appropriate
+    loader. Supported formats include:
+
+    - **Datumaro**: Native format with metadata.json and data.parquet files
+    - **COCO**: Detected by annotations directory with COCO JSON files, or JSON files
+      with 'images' and 'annotations' keys
+    - **YOLO**: Detected by data.yaml (Ultralytics), obj.names/obj.data (traditional),
+      or images/ and labels/ directories
+
+    When dtype is None the function tries to automatically determine the correct Sample
+    subclass by matching the stored schema against all registered subclasses (discovered
+    via the :func:`register_sample` registry). If no match is found, it falls back to
+    the base ``Sample`` class.
 
     Args:
         input_path: Path to the exported dataset (directory or .zip file)
-        dtype: Optional Sample class to use for the dataset.  When provided,
-            the dataset is typed with this class directly.  When ``None``,
-            automatic dtype detection is attempted (see above).
+        dtype: Optional Sample class to use for the dataset. When provided,
+            the dataset is typed with this class directly. When ``None``,
+            automatic dtype detection is attempted (see above). This parameter
+            is only used for Datumaro format datasets.
         extract_dir: Optional directory to extract zip contents to. If not provided,
             the zip will be extracted to a directory next to the zip file with the
             same name (excluding the .zip extension). This parameter is ignored
@@ -390,7 +407,20 @@ def import_dataset(
 
     Raises:
         FileNotFoundError: If required files are missing
-        ValueError: If the dataset format is invalid
+        ValueError: If the dataset format is invalid or cannot be detected
+
+    Examples:
+        Import a Datumaro-exported dataset::
+
+            dataset = import_dataset("/path/to/exported_dataset")
+
+        Import a COCO dataset (auto-detected)::
+
+            dataset = import_dataset("/path/to/coco_dataset")
+
+        Import a YOLO dataset (auto-detected)::
+
+            dataset = import_dataset("/path/to/yolo_dataset")
     """
     input_path = Path(input_path)
 
@@ -539,12 +569,18 @@ def _import_dataset_from_dir(
     """
     Import dataset from a directory.
 
+    Automatically detects the dataset format and delegates to the appropriate
+    loader for COCO, YOLO, or native Datumaro formats.
+
     Args:
         input_dir: Directory containing the exported dataset
-        dtype: Optional Sample class to use
+        dtype: Optional Sample class to use (only applies to Datumaro format)
 
     Returns:
         The imported Dataset instance
+
+    Raises:
+        ValueError: If the dataset format cannot be detected
     """
     # Normalize to an absolute path so that subsequent path joins (e.g. for
     # metadata, the Parquet file, and image directories) behave consistently
@@ -552,6 +588,28 @@ def _import_dataset_from_dir(
     if not input_dir.is_absolute():
         input_dir = input_dir.resolve()
 
+    # Detect the dataset format and dispatch to appropriate loader
+    match detect_dataset_format(input_dir):
+        case DetectedFormat.COCO:
+            return import_coco_dataset(input_dir)
+        case DetectedFormat.YOLO:
+            return import_yolo_dataset(input_dir)
+        case DetectedFormat.DATUMARO:
+            return _import_datumaro_dataset(input_dir, dtype)
+        case _:
+            raise ValueError(
+                f"Could not detect dataset format in '{input_dir}'. "
+                "Expected one of: Datumaro (metadata.json + data.parquet), "
+                "COCO (annotations/*.json with 'images' and 'annotations' keys), "
+                "or YOLO (data.yaml, obj.names, or images/ + labels/ directories)."
+            )
+
+
+def _import_datumaro_dataset(
+    input_dir: Path,
+    dtype: type[DType] | None = None,
+) -> Dataset[DType]:
+    """Import a native Datumaro-format dataset from a directory."""
     metadata = _load_metadata(input_dir)
     df = _load_dataframe(input_dir)  # Check DataFrame exists before processing schema
     schema = Schema.from_dict(metadata["schema"])

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -37,6 +37,7 @@ from datumaro.experimental.format_detection import (
     METADATA_FILE,
     DetectedFormat,
     detect_dataset_format,
+    find_dataset_root,
     import_coco_dataset,
     import_yolo_dataset,
 )
@@ -434,7 +435,9 @@ def import_dataset(
         extract_dir.mkdir(parents=True, exist_ok=True)
         with ZipFile(input_path) as zipf:
             zipf.extractall(extract_dir)
-        return _import_dataset_from_dir(extract_dir, dtype)
+
+        dataset_root = find_dataset_root(extract_dir)
+        return _import_dataset_from_dir(dataset_root, dtype)
     return _import_dataset_from_dir(input_path, dtype)
 
 

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -599,6 +599,8 @@ def _import_dataset_from_dir(
             return import_yolo_dataset(input_dir)
         case DataFormat.DATUMARO:
             return _import_datumaro_dataset(input_dir, dtype)
+        case DataFormat.DATUMARO_LEGACY:
+            return _import_legacy_datumaro_dataset(input_dir)
         case _:
             raise ValueError(
                 f"Could not detect dataset format in '{input_dir}'. "
@@ -627,3 +629,25 @@ def _import_datumaro_dataset(
         dtype = _match_dtype_from_schema(schema)
 
     return Dataset.from_dataframe(df, dtype, schema=schema)
+
+
+def _import_legacy_datumaro_dataset(input_dir: Path) -> Dataset:
+    """
+    Import a legacy Datumaro-format dataset from a directory.
+
+    This function provides backward compatibility for datasets exported with
+    the legacy Datumaro format. The legacy dataset is imported using the old
+    API and then converted to the new experimental Dataset format.
+
+    Args:
+        input_dir: Path to the legacy Datumaro dataset directory
+
+    Returns:
+        Dataset converted from the legacy format
+    """
+    # Import lazily to avoid circular imports and unnecessary dependencies
+    from datumaro import Dataset as LegacyDataset
+    from datumaro.experimental.legacy import convert_from_legacy
+
+    legacy_dataset = LegacyDataset.import_from(str(input_dir))
+    return convert_from_legacy(legacy_dataset)

--- a/src/datumaro/experimental/format_detection.py
+++ b/src/datumaro/experimental/format_detection.py
@@ -9,25 +9,21 @@ This module provides automatic detection of dataset formats (Datumaro, COCO, YOL
 and dispatches to the appropriate loader.
 """
 
+from __future__ import annotations
+
 import json
-from pathlib import Path
 from typing import TYPE_CHECKING
 
+from datumaro.experimental.data_formats.base import DataFormat
+
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from datumaro.experimental.dataset import Dataset
 
 # File names for native Datumaro format
 METADATA_FILE = "metadata.json"
 DATAFRAME_FILE = "data.parquet"
-
-
-class DetectedFormat:
-    """Detected dataset format types."""
-
-    DATUMARO = "datumaro"
-    COCO = "coco"
-    YOLO = "yolo"
-    UNKNOWN = "unknown"
 
 
 def is_coco_format(input_dir: Path) -> bool:
@@ -127,7 +123,7 @@ def is_datumaro_format(input_dir: Path) -> bool:
     return (input_dir / METADATA_FILE).exists() and (input_dir / DATAFRAME_FILE).exists()
 
 
-def detect_dataset_format(input_dir: Path) -> str:
+def detect_dataset_format(input_dir: Path) -> DataFormat:
     """
     Detect the format of a dataset directory.
 
@@ -140,15 +136,15 @@ def detect_dataset_format(input_dir: Path) -> str:
         input_dir: Path to the directory to check
 
     Returns:
-        One of: 'datumaro', 'coco', 'yolo', 'unknown'
+        DataFormat enum value: DATUMARO, COCO, YOLO, or UNKNOWN
     """
     if is_datumaro_format(input_dir):
-        return DetectedFormat.DATUMARO
+        return DataFormat.DATUMARO
     if is_coco_format(input_dir):
-        return DetectedFormat.COCO
+        return DataFormat.COCO
     if is_yolo_format(input_dir):
-        return DetectedFormat.YOLO
-    return DetectedFormat.UNKNOWN
+        return DataFormat.YOLO
+    return DataFormat.UNKNOWN
 
 
 def find_dataset_root(input_dir: Path) -> Path:
@@ -168,7 +164,7 @@ def find_dataset_root(input_dir: Path) -> Path:
         if format is detectable there, or a single nested child directory)
     """
     # If format is detectable at current level, return it
-    if detect_dataset_format(input_dir) != DetectedFormat.UNKNOWN:
+    if detect_dataset_format(input_dir) != DataFormat.UNKNOWN:
         return input_dir
 
     # Check if there's exactly one child directory (and no files)
@@ -216,7 +212,7 @@ def _find_coco_images_dir(input_dir: Path) -> str:
     return str(input_dir)
 
 
-def import_coco_dataset(input_dir: Path) -> "Dataset":
+def import_coco_dataset(input_dir: Path) -> Dataset:
     """
     Import a COCO-format dataset from a directory.
 
@@ -244,7 +240,7 @@ def import_coco_dataset(input_dir: Path) -> "Dataset":
     return load_coco_dataset(images_dir_path=images_dir, annotations_path=annotations_path)
 
 
-def import_yolo_dataset(input_dir: Path) -> "Dataset":
+def import_yolo_dataset(input_dir: Path) -> Dataset:
     """
     Import a YOLO-format dataset from a directory.
 

--- a/src/datumaro/experimental/format_detection.py
+++ b/src/datumaro/experimental/format_detection.py
@@ -123,23 +123,56 @@ def is_datumaro_format(input_dir: Path) -> bool:
     return (input_dir / METADATA_FILE).exists() and (input_dir / DATAFRAME_FILE).exists()
 
 
+def is_legacy_datumaro_format(input_dir: Path) -> bool:
+    """
+    Detect if a directory contains a legacy Datumaro-format dataset.
+
+    Legacy Datumaro format is identified by annotations/default.json file with 'dm_format_version' key
+
+    Args:
+        input_dir: Path to the directory to check
+
+    Returns:
+        True if the directory contains a legacy Datumaro-format dataset
+    """
+
+    default_json = input_dir / "annotations" / "default.json"
+    return default_json.exists() and _is_legacy_datumaro_json(default_json)
+
+
+def _is_legacy_datumaro_json(json_path: Path) -> bool:
+    """Check if a JSON file has legacy Datumaro structure (dm_format_version key)."""
+    try:
+        with open(json_path) as f:
+            data = json.load(f)
+            if isinstance(data, dict):
+                # Legacy Datumaro format has 'dm_format_version' key
+                return "dm_format_version" in data
+    except (json.JSONDecodeError, OSError):
+        pass
+    return False
+
+
 def detect_dataset_format(input_dir: Path) -> DataFormat:
     """
     Detect the format of a dataset directory.
 
     Checks formats in order of specificity:
     1. Datumaro (most specific - requires both metadata.json and data.parquet)
-    2. COCO (JSON files with images/annotations structure)
-    3. YOLO (data.yaml, obj.names, or directory structure)
+    2. Legacy Datumaro
+    3. COCO (JSON files with images/annotations structure)
+    4. YOLO (data.yaml, obj.names, or directory structure)
 
     Args:
         input_dir: Path to the directory to check
 
     Returns:
-        DataFormat enum value: DATUMARO, COCO, YOLO, or UNKNOWN
+        DataFormat enum value: DATUMARO, DATUMARO_LEGACY, COCO, YOLO, or UNKNOWN
     """
     if is_datumaro_format(input_dir):
         return DataFormat.DATUMARO
+    if is_legacy_datumaro_format(input_dir):
+        return DataFormat.DATUMARO_LEGACY
     if is_coco_format(input_dir):
         return DataFormat.COCO
     if is_yolo_format(input_dir):

--- a/src/datumaro/experimental/format_detection.py
+++ b/src/datumaro/experimental/format_detection.py
@@ -151,6 +151,39 @@ def detect_dataset_format(input_dir: Path) -> str:
     return DetectedFormat.UNKNOWN
 
 
+def find_dataset_root(input_dir: Path) -> Path:
+    """
+    Find the actual dataset root, descending at most one level into a single child directory.
+
+    Many third-party dataset zips extract with a single top-level folder
+    (e.g., dataset.zip -> dataset/annotations/...). This function checks if
+    the format is detectable at the input level, and if not, descends into
+    a single child directory (if one exists) to check there.
+
+    Args:
+        input_dir: The directory to start searching from
+
+    Returns:
+        The detected dataset root directory (may be the input directory itself
+        if format is detectable there, or a single nested child directory)
+    """
+    # If format is detectable at current level, return it
+    if detect_dataset_format(input_dir) != DetectedFormat.UNKNOWN:
+        return input_dir
+
+    # Check if there's exactly one child directory (and no files)
+    children = list(input_dir.iterdir())
+    child_dirs = [c for c in children if c.is_dir()]
+    child_files = [c for c in children if c.is_file()]
+
+    # Only descend if there's exactly one directory and no files
+    if len(child_dirs) == 1 and not child_files:
+        return child_dirs[0]
+
+    # Otherwise return the original directory
+    return input_dir
+
+
 def _find_coco_annotations(input_dir: Path) -> list[str]:
     """Find all COCO annotation files in a directory."""
     annotation_files: list[str] = []
@@ -178,11 +211,6 @@ def _find_coco_images_dir(input_dir: Path) -> str:
         candidate_dir = input_dir / candidate
         if candidate_dir.is_dir():
             return str(candidate_dir)
-
-    # Check for images/ subdirectory as fallback
-    images_subdir = input_dir / "images"
-    if images_subdir.is_dir():
-        return str(images_subdir)
 
     # Default to root directory
     return str(input_dir)

--- a/src/datumaro/experimental/format_detection.py
+++ b/src/datumaro/experimental/format_detection.py
@@ -1,0 +1,234 @@
+# Copyright (C) 2022-2026 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Dataset format detection and auto-import functionality.
+
+This module provides automatic detection of dataset formats (Datumaro, COCO, YOLO)
+and dispatches to the appropriate loader.
+"""
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datumaro.experimental.dataset import Dataset
+
+# File names for native Datumaro format
+METADATA_FILE = "metadata.json"
+DATAFRAME_FILE = "data.parquet"
+
+
+class DetectedFormat:
+    """Detected dataset format types."""
+
+    DATUMARO = "datumaro"
+    COCO = "coco"
+    YOLO = "yolo"
+    UNKNOWN = "unknown"
+
+
+def is_coco_format(input_dir: Path) -> bool:
+    """
+    Detect if a directory contains a COCO-format dataset.
+
+    COCO format is identified by:
+    - An 'annotations' subdirectory containing JSON files with COCO structure
+    - OR JSON files in the root containing 'images' and 'annotations' keys
+
+    Args:
+        input_dir: Path to the directory to check
+
+    Returns:
+        True if the directory contains a COCO-format dataset
+    """
+    # Check for annotations directory with COCO JSON files
+    annotations_dir = input_dir / "annotations"
+    if annotations_dir.is_dir():
+        for json_file in annotations_dir.glob("*.json"):
+            if is_coco_json_file(json_file):
+                return True
+
+    # Check for COCO JSON files in the root directory
+    for json_file in input_dir.glob("*.json"):
+        # Skip metadata.json which is Datumaro's format
+        if json_file.name == METADATA_FILE:
+            continue
+        if is_coco_json_file(json_file):
+            return True
+
+    return False
+
+
+def is_coco_json_file(json_path: Path) -> bool:
+    """
+    Check if a JSON file has COCO structure.
+
+    Args:
+        json_path: Path to the JSON file to check
+
+    Returns:
+        True if the file contains COCO-style data (images and annotations/categories keys)
+    """
+    try:
+        with open(json_path) as f:
+            data = json.load(f)
+            if isinstance(data, dict):
+                # COCO format has 'images' array and typically 'annotations' or 'categories'
+                return "images" in data and ("annotations" in data or "categories" in data)
+    except (json.JSONDecodeError, OSError):
+        pass
+    return False
+
+
+def is_yolo_format(input_dir: Path) -> bool:
+    """
+    Detect if a directory contains a YOLO-format dataset.
+
+    YOLO format is identified by:
+    - data.yaml file (Ultralytics format)
+    - OR obj.names/obj.data files (traditional format)
+    - OR images/ and labels/ directories (Ultralytics structure)
+
+    Args:
+        input_dir: Path to the directory to check
+
+    Returns:
+        True if the directory contains a YOLO-format dataset
+    """
+    # Check for Ultralytics format (data.yaml)
+    if (input_dir / "data.yaml").exists():
+        return True
+
+    # Check for traditional YOLO format (obj.names or obj.data)
+    if (input_dir / "obj.names").exists() or (input_dir / "obj.data").exists():
+        return True
+
+    # Check for Ultralytics-style directory structure
+    return (input_dir / "images").is_dir() and (input_dir / "labels").is_dir()
+
+
+def is_datumaro_format(input_dir: Path) -> bool:
+    """
+    Detect if a directory contains a Datumaro-exported dataset.
+
+    Datumaro format is identified by:
+    - metadata.json file
+    - data.parquet file
+
+    Args:
+        input_dir: Path to the directory to check
+
+    Returns:
+        True if the directory contains a Datumaro-format dataset
+    """
+    return (input_dir / METADATA_FILE).exists() and (input_dir / DATAFRAME_FILE).exists()
+
+
+def detect_dataset_format(input_dir: Path) -> str:
+    """
+    Detect the format of a dataset directory.
+
+    Checks formats in order of specificity:
+    1. Datumaro (most specific - requires both metadata.json and data.parquet)
+    2. COCO (JSON files with images/annotations structure)
+    3. YOLO (data.yaml, obj.names, or directory structure)
+
+    Args:
+        input_dir: Path to the directory to check
+
+    Returns:
+        One of: 'datumaro', 'coco', 'yolo', 'unknown'
+    """
+    if is_datumaro_format(input_dir):
+        return DetectedFormat.DATUMARO
+    if is_coco_format(input_dir):
+        return DetectedFormat.COCO
+    if is_yolo_format(input_dir):
+        return DetectedFormat.YOLO
+    return DetectedFormat.UNKNOWN
+
+
+def _find_coco_annotations(input_dir: Path) -> list[str]:
+    """Find all COCO annotation files in a directory."""
+    annotation_files: list[str] = []
+
+    # Check annotations/ subdirectory first
+    annotations_dir = input_dir / "annotations"
+    if annotations_dir.is_dir():
+        for json_file in annotations_dir.glob("*.json"):
+            if is_coco_json_file(json_file):
+                annotation_files.append(str(json_file))
+    else:
+        # Fall back to root directory
+        for json_file in input_dir.glob("*.json"):
+            if json_file.name != METADATA_FILE and is_coco_json_file(json_file):
+                annotation_files.append(str(json_file))
+
+    return annotation_files
+
+
+def _find_coco_images_dir(input_dir: Path) -> str:
+    """Find the images directory for a COCO dataset."""
+    # Common COCO image directory patterns
+    candidates = ["train2017", "val2017", "images", "train", "val"]
+    for candidate in candidates:
+        candidate_dir = input_dir / candidate
+        if candidate_dir.is_dir():
+            return str(candidate_dir)
+
+    # Check for images/ subdirectory as fallback
+    images_subdir = input_dir / "images"
+    if images_subdir.is_dir():
+        return str(images_subdir)
+
+    # Default to root directory
+    return str(input_dir)
+
+
+def import_coco_dataset(input_dir: Path) -> "Dataset":
+    """
+    Import a COCO-format dataset from a directory.
+
+    Automatically discovers annotation files and image directories.
+
+    Args:
+        input_dir: Path to the COCO dataset directory
+
+    Returns:
+        Dataset containing CocoSample instances
+
+    Raises:
+        FileNotFoundError: If no COCO annotation files are found
+    """
+    annotation_files = _find_coco_annotations(input_dir)
+    if not annotation_files:
+        raise FileNotFoundError(f"No COCO annotation files found in {input_dir}")
+
+    images_dir = _find_coco_images_dir(input_dir)
+
+    # Import inline to avoid circular imports
+    from datumaro.experimental.data_formats.coco.io import load_coco_dataset
+
+    annotations_path = annotation_files if len(annotation_files) > 1 else annotation_files[0]
+    return load_coco_dataset(images_dir_path=images_dir, annotations_path=annotations_path)
+
+
+def import_yolo_dataset(input_dir: Path) -> "Dataset":
+    """
+    Import a YOLO-format dataset from a directory.
+
+    Supports both Ultralytics and traditional YOLO formats.
+
+    Args:
+        input_dir: Path to the YOLO dataset directory
+
+    Returns:
+        Dataset containing YoloSample instances
+    """
+    # Import inline to avoid circular imports
+    from datumaro.experimental.data_formats.yolo.io import load_yolo_dataset
+
+    return load_yolo_dataset(root_dir=str(input_dir))

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -1526,3 +1526,29 @@ def test_import_zip_with_nested_coco_structure(tmp_path):
 
     # Verify the dataset was loaded correctly
     assert len(dataset) == 1
+
+
+def test_import_dataset_auto_detects_legacy_datumaro_format(tmp_path):
+    """Test that import_dataset correctly detects and imports legacy Datumaro format."""
+    from datumaro import Dataset as LegacyDataset
+    from datumaro.components.annotation import Label
+    from datumaro.components.dataset import DatasetItem
+
+    # Create a simple legacy dataset
+    legacy_dataset = LegacyDataset.from_iterable(
+        [
+            DatasetItem(id="item1", annotations=[Label(0)]),
+            DatasetItem(id="item2", annotations=[Label(1)]),
+        ],
+        categories=["cat", "dog"],
+    )
+
+    # Export to temp directory in datumaro format
+    export_dir = tmp_path / "legacy_export"
+    legacy_dataset.export(str(export_dir), format="datumaro")
+
+    # Import using auto-detection
+    dataset = import_dataset(export_dir)
+
+    # Verify the dataset was loaded and converted
+    assert len(dataset) >= 1  # Should have at least one sample

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -1481,3 +1481,48 @@ def test_import_dataset_auto_detects_datumaro_format(tmp_path):
 
     # Verify the dataset was loaded correctly
     assert len(imported_dataset) == 2
+
+
+def test_import_zip_with_nested_coco_structure(tmp_path):
+    """Test that import_dataset handles zips with a single top-level folder.
+
+    Many third-party dataset zips contain a single folder at the root level
+    (e.g., dataset.zip -> dataset/annotations/...). The import should descend
+    into such directories to find the actual dataset.
+    """
+    # Create a nested COCO structure: nested_folder/annotations/instances.json
+    nested_folder = tmp_path / "coco_dataset"
+    annotations_dir = nested_folder / "annotations"
+    annotations_dir.mkdir(parents=True)
+    images_dir = nested_folder / "images"
+    images_dir.mkdir()
+
+    # Create a test image
+    img = PILImage.new("RGB", (100, 100), color="red")
+    img.save(images_dir / "test.jpg")
+
+    # Create COCO annotation file
+    coco_annotations = {
+        "images": [{"id": 1, "file_name": "test.jpg", "width": 100, "height": 100}],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [10, 20, 30, 40], "area": 1200, "iscrowd": 0}
+        ],
+        "categories": [{"id": 1, "name": "cat", "supercategory": "animal"}],
+    }
+    with open(annotations_dir / "instances.json", "w") as f:
+        json.dump(coco_annotations, f)
+
+    # Create a zip file with the nested structure
+    zip_path = tmp_path / "nested_coco.zip"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        for file_path in nested_folder.rglob("*"):
+            if file_path.is_file():
+                arcname = file_path.relative_to(tmp_path)
+                zipf.write(file_path, arcname)
+
+    # Import using auto-detection - should descend into coco_dataset/
+    extract_dir = tmp_path / "extracted"
+    dataset = import_dataset(zip_path, extract_dir=extract_dir)
+
+    # Verify the dataset was loaded correctly
+    assert len(dataset) == 1

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -645,27 +645,32 @@ def test_import_dataset_with_instance_masks(tmp_path):
 
 
 def test_import_missing_metadata_raises_error(tmp_path):
-    """Test that missing metadata file raises FileNotFoundError."""
+    """Test that an empty directory raises ValueError when format cannot be detected."""
 
     empty_dir = tmp_path / "empty"
     empty_dir.mkdir()
 
-    with pytest.raises(FileNotFoundError, match="Metadata file not found"):
+    with pytest.raises(ValueError, match="Could not detect dataset format"):
         import_dataset(empty_dir)
 
 
 def test_import_missing_dataframe_raises_error(tmp_path):
-    """Test that missing dataframe file raises FileNotFoundError."""
+    """Test that missing dataframe file raises appropriate error.
+
+    With automatic format detection, a directory with only metadata.json
+    but no data.parquet will not be detected as Datumaro format, so it
+    will raise a format detection error.
+    """
 
     export_dir = tmp_path / "export"
     export_dir.mkdir()
 
-    # Create metadata but no dataframe
+    # Create metadata but no dataframe - this won't be detected as Datumaro format
     metadata = {"version": VERSION, "schema": {}}
     with open(export_dir / METADATA_FILE, "w") as f:
         json.dump(metadata, f)
 
-    with pytest.raises(FileNotFoundError, match="DataFrame file not found"):
+    with pytest.raises(ValueError, match="Could not detect dataset format"):
         import_dataset(export_dir)
 
 
@@ -1364,3 +1369,115 @@ def test_import_zip_extract_dir_is_ignored_for_directory_input(tmp_path):
     # Verify the dataset works correctly
     assert len(imported_dataset) == 1
     assert imported_dataset[0].label == 3
+
+
+# ============================================================================
+# Automatic Format Detection Tests
+# ============================================================================
+
+
+def test_import_dataset_auto_detects_coco_format(tmp_path):
+    """Test that import_dataset automatically detects and loads COCO format datasets."""
+    # Create a minimal COCO dataset structure
+    annotations_dir = tmp_path / "annotations"
+    annotations_dir.mkdir()
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+
+    # Create a test image
+    img = PILImage.new("RGB", (100, 100), color="red")
+    img.save(images_dir / "test.jpg")
+
+    # Create COCO annotation file
+    coco_annotations = {
+        "images": [{"id": 1, "file_name": "test.jpg", "width": 100, "height": 100}],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [10, 20, 30, 40], "area": 1200, "iscrowd": 0}
+        ],
+        "categories": [{"id": 1, "name": "cat", "supercategory": "animal"}],
+    }
+
+    with open(annotations_dir / "instances.json", "w") as f:
+        json.dump(coco_annotations, f)
+
+    # Import using auto-detection
+    dataset = import_dataset(tmp_path)
+
+    # Verify the dataset was loaded correctly
+    assert len(dataset) == 1
+
+
+def test_import_dataset_auto_detects_yolo_ultralytics_format(tmp_path):
+    """Test that import_dataset automatically detects and loads YOLO Ultralytics format datasets."""
+    # Create Ultralytics YOLO structure
+    images_dir = tmp_path / "images" / "train"
+    images_dir.mkdir(parents=True)
+    labels_dir = tmp_path / "labels" / "train"
+    labels_dir.mkdir(parents=True)
+
+    # Create a test image
+    img = PILImage.new("RGB", (100, 100), color="blue")
+    img.save(images_dir / "test.jpg")
+
+    # Create label file (YOLO format: class x_center y_center width height)
+    with open(labels_dir / "test.txt", "w") as f:
+        f.write("0 0.5 0.5 0.3 0.4\n")
+
+    # Create data.yaml
+    import yaml
+
+    data_yaml = {"names": ["cat", "dog"], "nc": 2, "train": "images/train", "val": "images/train"}
+    with open(tmp_path / "data.yaml", "w") as f:
+        yaml.dump(data_yaml, f)
+
+    # Import using auto-detection
+    dataset = import_dataset(tmp_path)
+
+    # Verify the dataset was loaded correctly
+    assert len(dataset) == 1
+
+
+def test_import_dataset_auto_detects_yolo_traditional_format(tmp_path):
+    """Test that import_dataset automatically detects and loads traditional YOLO format datasets."""
+    # Create traditional YOLO structure
+    train_dir = tmp_path / "obj_train_data"
+    train_dir.mkdir()
+
+    # Create a test image
+    img = PILImage.new("RGB", (100, 100), color="green")
+    img.save(train_dir / "test.jpg")
+
+    # Create label file
+    with open(train_dir / "test.txt", "w") as f:
+        f.write("0 0.5 0.5 0.3 0.4\n")
+
+    # Create obj.names
+    with open(tmp_path / "obj.names", "w") as f:
+        f.write("cat\ndog\n")
+
+    # Import using auto-detection
+    dataset = import_dataset(tmp_path)
+
+    # Verify the dataset was loaded correctly
+    assert len(dataset) == 1
+
+
+def test_import_dataset_auto_detects_datumaro_format(tmp_path):
+    """Test that import_dataset correctly detects native Datumaro format."""
+
+    class SimpleSample(Sample):
+        label: int = label_field()
+
+    # Create and export a Datumaro dataset
+    original_dataset = Dataset(SimpleSample, categories={"label": LABEL_CATEGORIES})
+    original_dataset.append(SimpleSample(label=1))
+    original_dataset.append(SimpleSample(label=2))
+
+    export_dir = tmp_path / "datumaro_export"
+    export_dataset(original_dataset, export_dir, export_images=False)
+
+    # Import using auto-detection
+    imported_dataset = import_dataset(export_dir)
+
+    # Verify the dataset was loaded correctly
+    assert len(imported_dataset) == 2


### PR DESCRIPTION
This pull request introduces automatic dataset format detection and import functionality, allowing the `import_dataset` function to seamlessly handle Datumaro, COCO, and YOLO formats without requiring manual specification. The changes refactor the import logic to use a new format detection module, improve error handling, and add comprehensive tests for auto-detection of all supported formats.

Resolves #2061 


<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
