### PR TITLE
Move linter, docs workflows to dedicated runner group

### DIFF
--- a/.github/workflows/docs_latest.yml
+++ b/.github/workflows/docs_latest.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   Build-Docs:
-    runs-on: ubuntu-24.04
+    runs-on: overflow
     permissions:
       contents: write
     steps:

--- a/.github/workflows/docs_stable.yml
+++ b/.github/workflows/docs_stable.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   Build-Docs:
-    runs-on: ubuntu-24.04
+    runs-on: overflow
     permissions:
       contents: write
     steps:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,7 @@ on:
 permissions: {}
 jobs:
   pre-commit:
-    runs-on: ubuntu-24.04
+    runs-on: overflow
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -30,9 +30,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-24.04", "windows-2022", "macos-15"]
+        os: ["overflow", "windows-2022", "macos-15"]
         python-version: ["3.10", "3.14"]
-    name: pr test (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    # Use more descriptive job name for better visibility in CI results
+    # Overflow labeled runner is equivalent to ubuntu-latest in terms of resources
+    name: pr test (${{ matrix.os == 'overflow' && 'ubuntu-' || matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     steps:
       - name: Harden the runner (audit all outbound calls)

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -34,7 +34,7 @@ jobs:
         python-version: ["3.10", "3.14"]
     # Use more descriptive job name for better visibility in CI results
     # Overflow labeled runner is equivalent to ubuntu-latest in terms of resources
-    name: pr test (${{ matrix.os == 'overflow' && 'ubuntu-' || matrix.os }}, Python ${{ matrix.python-version }})
+    name: pr test (${{ matrix.os == 'overflow' && 'ubuntu-24.04' || matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     steps:
       - name: Harden the runner (audit all outbound calls)


### PR DESCRIPTION
This PR moves some of workflows to be run on GH runners labeled as "overflow". In terms of resources these runners are equivalent to ubuntu-latest standard runner configuration.

### Checklist
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
