### PR TITLE
Prevent file overwrite failure when exporting dataset to existing directory

### DIFF
--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -525,6 +525,11 @@ def _setup_work_directory(output_path: Path, as_zip: bool) -> tuple[Path, Path |
     """
     if as_zip:
         if output_path.suffix != ".zip":
+            if output_path.exists() and not output_path.is_dir():
+                raise FileExistsError(
+                    f"Output path already exists as a file: '{output_path}'. "
+                    "Please remove it or specify a different output path."
+                )
             zip_path = output_path / "dataset.zip"
         else:
             zip_path = output_path

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -519,13 +519,26 @@ def _setup_work_directory(output_path: Path, as_zip: bool) -> tuple[Path, Path |
 
     Returns:
         Tuple of (final_output_path, temp_dir, work_dir)
+
+    Raises:
+        FileExistsError: If the output path already exists (directory or zip file)
     """
     if as_zip:
         if output_path.suffix != ".zip":
-            output_path.mkdir(parents=True, exist_ok=True)
-            output_path = output_path / "dataset.zip"
+            zip_path = output_path / "dataset.zip"
+        else:
+            zip_path = output_path
+        if zip_path.exists():
+            raise FileExistsError(
+                f"Output file already exists: '{zip_path}'. Please remove it or specify a different output path."
+            )
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
         temp_dir = Path(tempfile.mkdtemp())
-        return output_path, temp_dir, temp_dir
+        return zip_path, temp_dir, temp_dir
+    if output_path.exists():
+        raise FileExistsError(
+            f"Output directory already exists: '{output_path}'. Please remove it or specify a different output path."
+        )
     output_path.mkdir(parents=True, exist_ok=True)
     return output_path, None, output_path
 

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -2235,3 +2235,38 @@ def test_import_dataset_auto_detects_legacy_datumaro_format(tmp_path):
 
     # Verify the dataset was loaded and converted
     assert len(dataset) >= 1  # Should have at least one sample
+
+
+def test_export_dataset_raises_error_if_output_already_exists(tmp_path):
+    """Test that export_dataset raises FileExistsError when the output already exists."""
+    import shutil
+
+    class SimpleSample(Sample):
+        label: int = label_field()
+
+    dataset = Dataset(SimpleSample, categories={"label": LABEL_CATEGORIES})
+    dataset.append(SimpleSample(label=1))
+
+    # Directory export: second call should fail
+    output_dir = tmp_path / "export_dir"
+    export_dataset(dataset, output_dir, export_images=ExportMode.SKIP, as_zip=False)
+    with pytest.raises(FileExistsError, match="Output directory already exists"):
+        export_dataset(dataset, output_dir, export_images=ExportMode.SKIP, as_zip=False)
+
+    # After removing the directory, export should succeed again
+    shutil.rmtree(output_dir)
+    export_dataset(dataset, output_dir, export_images=ExportMode.SKIP, as_zip=False)
+    assert (output_dir / METADATA_FILE).exists()
+
+    # Zip export with .zip suffix: second call should fail
+    output_zip = tmp_path / "export.zip"
+    export_dataset(dataset, output_zip, export_images=ExportMode.SKIP, as_zip=True)
+    with pytest.raises(FileExistsError, match="Output file already exists"):
+        export_dataset(dataset, output_zip, export_images=ExportMode.SKIP, as_zip=True)
+
+    # Zip export without .zip suffix (creates dataset.zip inside dir): second call should fail
+    output_dir_zip = tmp_path / "export_zip_dir"
+    export_dataset(dataset, output_dir_zip, export_images=ExportMode.SKIP, as_zip=True)
+    assert (output_dir_zip / "dataset.zip").exists()
+    with pytest.raises(FileExistsError, match="Output file already exists"):
+        export_dataset(dataset, output_dir_zip, export_images=ExportMode.SKIP, as_zip=True)

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -2270,3 +2270,9 @@ def test_export_dataset_raises_error_if_output_already_exists(tmp_path):
     assert (output_dir_zip / "dataset.zip").exists()
     with pytest.raises(FileExistsError, match="Output file already exists"):
         export_dataset(dataset, output_dir_zip, export_images=ExportMode.SKIP, as_zip=True)
+
+    # Zip export without .zip suffix where output_path is an existing file (not a directory)
+    file_path = tmp_path / "existing_file"
+    file_path.touch()
+    with pytest.raises(FileExistsError, match="Output path already exists as a file"):
+        export_dataset(dataset, file_path, export_images=ExportMode.SKIP, as_zip=True)


### PR DESCRIPTION
This pull request adds robust error handling to prevent accidental overwriting of existing export outputs, and introduces comprehensive tests to verify this behavior. The key changes ensure that the export functionality now raises a clear error if the target output directory or zip file already exists, improving safety and user experience.

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
