### PR TITLE
Add KeypointCategories

### DIFF
--- a/src/datumaro/experimental/categories.py
+++ b/src/datumaro/experimental/categories.py
@@ -94,6 +94,7 @@ class Categories:
             "LabelCategories": LabelCategories,
             "HierarchicalLabelCategories": HierarchicalLabelCategories,
             "MaskCategories": MaskCategories,
+            "KeypointCategories": KeypointCategories,
         }
 
         if cat_type in subclass_map:
@@ -664,3 +665,53 @@ class MaskCategories(Categories):
     def __hash__(self):
         colormap_data = self.colormap.data if isinstance(self.colormap, Colormap) else self.colormap
         return hash((tuple(self.labels), frozenset(colormap_data.items())))
+
+
+@dataclass(frozen=True)
+class KeypointCategories(Categories):
+    """
+    Represents the set of keypoint names for a keypoint detection dataset.
+
+    Each entry in ``labels`` corresponds to a single keypoint (e.g.
+    ``("nose", "left_eye", ...)`` for the 17 COCO person keypoints).
+
+    Attributes:
+        labels: Ordered tuple of keypoint names.
+    """
+
+    labels: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self):
+        if isinstance(self.labels, list):
+            object.__setattr__(self, "labels", tuple(self.labels))
+        elif not isinstance(self.labels, tuple):
+            raise TypeError("labels must be a tuple of strings")
+
+    def __getitem__(self, idx: int) -> str:
+        return self.labels[idx]
+
+    def __contains__(self, value: int | str) -> bool:
+        if isinstance(value, str):
+            return value in self.labels
+        return 0 <= value < len(self.labels)
+
+    def __len__(self) -> int:
+        return len(self.labels)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.labels)
+
+    def __hash__(self):
+        return hash(self.labels)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "type": "KeypointCategories",
+            "labels": list(self.labels),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> KeypointCategories:
+        """Deserialize from a JSON dictionary."""
+        return cls(labels=tuple(data["labels"]))

--- a/src/datumaro/experimental/categories.py
+++ b/src/datumaro/experimental/categories.py
@@ -685,8 +685,19 @@ class KeypointCategories(Categories):
         if isinstance(self.labels, list):
             object.__setattr__(self, "labels", tuple(self.labels))
         elif not isinstance(self.labels, tuple):
-            raise TypeError("labels must be a tuple of strings")
+            raise TypeError("labels must be a list or tuple of strings")
 
+        # Ensure that keypoint labels are unique to keep index->name mapping unambiguous
+        seen: set[str] = set()
+        duplicates: set[str] = set()
+        for name in self.labels:
+            if name in seen:
+                duplicates.add(name)
+            else:
+                seen.add(name)
+
+        if duplicates:
+            raise ValueError(f"Duplicate keypoint labels found: {sorted(duplicates)}")
     def __getitem__(self, idx: int) -> str:
         return self.labels[idx]
 

--- a/src/datumaro/experimental/categories.py
+++ b/src/datumaro/experimental/categories.py
@@ -698,6 +698,7 @@ class KeypointCategories(Categories):
 
         if duplicates:
             raise ValueError(f"Duplicate keypoint labels found: {sorted(duplicates)}")
+
     def __getitem__(self, idx: int) -> str:
         return self.labels[idx]
 

--- a/src/datumaro/experimental/data_formats/coco/helpers.py
+++ b/src/datumaro/experimental/data_formats/coco/helpers.py
@@ -13,7 +13,7 @@ from typing import Any
 import numpy as np
 
 from datumaro.experimental import Dataset
-from datumaro.experimental.categories import LabelCategories
+from datumaro.experimental.categories import KeypointCategories, LabelCategories
 from datumaro.experimental.data_formats.coco.sample import CocoCategories, CocoSample
 from datumaro.experimental.fields import ImageInfo, Subset
 
@@ -123,6 +123,43 @@ def _detect_coco_label_categories_from_paths(
 
     logger.warning("Unable to extract labels from COCO annotations, falling back to defaults")
     return CocoCategories()
+
+
+def _detect_coco_keypoint_categories_from_paths(
+    subset_config: dict[Subset, dict[str, Path | list[Path]]],
+) -> KeypointCategories | None:
+    """
+    Detect COCO keypoint categories by probing available annotation JSON files.
+
+    Looks for ``"keypoints"`` lists inside the ``"categories"`` section of each
+    annotation file (the standard COCO format for person_keypoints files).
+
+    Args:
+        subset_config: Mapping with 'annotations' path(s) for each subset.
+
+    Returns:
+        KeypointCategories with discovered keypoint names, or None if not found.
+    """
+    for _subset, cfg in subset_config.items():
+        annotations_paths = cfg.get("annotations")
+        if annotations_paths is None:
+            continue
+
+        if isinstance(annotations_paths, Path):
+            paths_to_check = [annotations_paths]
+        else:
+            paths_to_check = annotations_paths
+
+        for annotations_path in paths_to_check:
+            annotations_data = _load_json_or_none(annotations_path)
+            if annotations_data and isinstance(annotations_data, dict):
+                for cat in annotations_data.get("categories") or []:
+                    if isinstance(cat, dict):
+                        kp_names = cat.get("keypoints")
+                        if isinstance(kp_names, list) and len(kp_names) > 0:
+                            return KeypointCategories(labels=tuple(str(n) for n in kp_names))
+
+    return None
 
 
 def _cat_id_to_idx_from_primary(primary_data: dict) -> dict[int, int]:

--- a/src/datumaro/experimental/data_formats/coco/io.py
+++ b/src/datumaro/experimental/data_formats/coco/io.py
@@ -18,6 +18,7 @@ from datumaro.experimental import Dataset
 from datumaro.experimental.data_formats.coco.helpers import (
     _assemble_sample_from_image_record,
     _cat_id_to_idx_from_primary,
+    _detect_coco_keypoint_categories_from_paths,
     _detect_coco_label_categories_from_paths,
     _load_json_or_none,
     _prepare_categories,
@@ -133,9 +134,12 @@ def load_coco_dataset(
 
     logger.info("[COCO] Loading dataset with %d subset(s)", len(subset_config))
 
-    # Determine label categories via helper
+    # Determine categories via helpers
     loaded_label_categories = _detect_coco_label_categories_from_paths(subset_config)
-    categories = {"labels": loaded_label_categories}
+    categories: dict = {"labels": loaded_label_categories}
+    loaded_keypoint_categories = _detect_coco_keypoint_categories_from_paths(subset_config)
+    if loaded_keypoint_categories is not None:
+        categories["keypoints"] = loaded_keypoint_categories
     dataset = Dataset(CocoSample, categories=categories)
 
     for subset, config in subset_config.items():

--- a/src/datumaro/experimental/fields/annotations.py
+++ b/src/datumaro/experimental/fields/annotations.py
@@ -326,7 +326,7 @@ class KeypointsField(Field):
         return from_polars_data(polars_data, target_type)
 
     def get_expected_categories_type(self) -> type[Categories] | None:
-        """KeypointsCategories are optional for KeypointsField so we return None here"""
+        """KeypointCategories are optional for KeypointsField so we return None here"""
         return None
 
 

--- a/src/datumaro/experimental/fields/annotations.py
+++ b/src/datumaro/experimental/fields/annotations.py
@@ -325,6 +325,10 @@ class KeypointsField(Field):
         polars_data = df[name][row_index]
         return from_polars_data(polars_data, target_type)
 
+    def get_expected_categories_type(self) -> type[Categories] | None:
+        """KeypointsCategories are optional for KeypointsField so we return None here"""
+        return None
+
 
 def keypoints_field(
     dtype: Any = pl.Float32(),

--- a/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
+++ b/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from datumaro.experimental import Dataset
-from datumaro.experimental.categories import LabelCategories
+from datumaro.experimental.categories import KeypointCategories, LabelCategories
 from datumaro.experimental.data_formats.coco.helpers import (
     InstanceArrays,
     _assemble_sample_from_image_record,
@@ -15,6 +15,7 @@ from datumaro.experimental.data_formats.coco.helpers import (
     _collect_captions_for_image,
     _collect_instances_for_image,
     _collect_keypoints_for_image,
+    _detect_coco_keypoint_categories_from_paths,
     _index_annotations_by_image,
     _load_json_or_none,
     _prepare_categories,
@@ -340,3 +341,157 @@ def test_prepare_categories_and_save_subset(tmp_path: Path):
     assert "instances_train" in written
     content = json.loads(written["instances_train"].read_text())
     assert content["annotations"][0]["bbox"] == pytest.approx([1.0, 2.0, 3.0, 4.0])
+
+
+class DetectCocoKeypointCategoriesTest:
+    """Unit tests for _detect_coco_keypoint_categories_from_paths."""
+
+    def test_returns_none_when_no_keypoints_in_categories(self, tmp_path: Path):
+        ann_file = tmp_path / "instances.json"
+        _write_json(
+            ann_file,
+            {
+                "images": [],
+                "annotations": [],
+                "categories": [{"id": 1, "name": "person"}],
+            },
+        )
+        config = {Subset.TRAINING: {"annotations": [ann_file]}}
+        result = _detect_coco_keypoint_categories_from_paths(config)
+        assert result is None
+
+    def test_returns_none_when_no_categories_section(self, tmp_path: Path):
+        ann_file = tmp_path / "instances.json"
+        _write_json(ann_file, {"images": [], "annotations": []})
+        config = {Subset.TRAINING: {"annotations": [ann_file]}}
+        result = _detect_coco_keypoint_categories_from_paths(config)
+        assert result is None
+
+    def test_returns_none_when_annotations_key_missing(self):
+        config = {Subset.TRAINING: {"images_dir": Path("/tmp")}}
+        result = _detect_coco_keypoint_categories_from_paths(config)
+        assert result is None
+
+    def test_returns_none_when_file_does_not_exist(self, tmp_path: Path):
+        config = {Subset.TRAINING: {"annotations": [tmp_path / "missing.json"]}}
+        result = _detect_coco_keypoint_categories_from_paths(config)
+        assert result is None
+
+    def test_returns_none_for_empty_keypoints_list(self, tmp_path: Path):
+        ann_file = tmp_path / "keypoints.json"
+        _write_json(
+            ann_file,
+            {
+                "images": [],
+                "annotations": [],
+                "categories": [{"id": 1, "name": "person", "keypoints": []}],
+            },
+        )
+        config = {Subset.TRAINING: {"annotations": [ann_file]}}
+        result = _detect_coco_keypoint_categories_from_paths(config)
+        assert result is None
+
+    def test_detects_keypoints_from_single_file(self, tmp_path: Path):
+        ann_file = tmp_path / "person_keypoints.json"
+        _write_json(
+            ann_file,
+            {
+                "images": [],
+                "annotations": [],
+                "categories": [
+                    {
+                        "id": 1,
+                        "name": "person",
+                        "keypoints": ["nose", "left_eye", "right_eye"],
+                    }
+                ],
+            },
+        )
+        config = {Subset.TRAINING: {"annotations": [ann_file]}}
+        result = _detect_coco_keypoint_categories_from_paths(config)
+        assert isinstance(result, KeypointCategories)
+        assert result.labels == ("nose", "left_eye", "right_eye")
+
+    def test_detects_keypoints_from_multiple_files(self, tmp_path: Path):
+        instances_file = tmp_path / "instances.json"
+        _write_json(
+            instances_file,
+            {
+                "images": [],
+                "annotations": [],
+                "categories": [{"id": 1, "name": "person"}],
+            },
+        )
+        kp_file = tmp_path / "person_keypoints.json"
+        _write_json(
+            kp_file,
+            {
+                "images": [],
+                "annotations": [],
+                "categories": [
+                    {
+                        "id": 1,
+                        "name": "person",
+                        "keypoints": ["nose", "left_eye"],
+                    }
+                ],
+            },
+        )
+        config = {Subset.TRAINING: {"annotations": [instances_file, kp_file]}}
+        result = _detect_coco_keypoint_categories_from_paths(config)
+        assert isinstance(result, KeypointCategories)
+        assert result.labels == ("nose", "left_eye")
+
+    def test_detects_keypoints_across_subsets(self, tmp_path: Path):
+        train_file = tmp_path / "train.json"
+        _write_json(
+            train_file,
+            {
+                "images": [],
+                "annotations": [],
+                "categories": [{"id": 1, "name": "person"}],
+            },
+        )
+        val_file = tmp_path / "val_keypoints.json"
+        _write_json(
+            val_file,
+            {
+                "images": [],
+                "annotations": [],
+                "categories": [
+                    {
+                        "id": 1,
+                        "name": "person",
+                        "keypoints": ["ankle", "knee"],
+                    }
+                ],
+            },
+        )
+        config = {
+            Subset.TRAINING: {"annotations": [train_file]},
+            Subset.VALIDATION: {"annotations": [val_file]},
+        }
+        result = _detect_coco_keypoint_categories_from_paths(config)
+        assert isinstance(result, KeypointCategories)
+        assert result.labels == ("ankle", "knee")
+
+    def test_single_path_not_list(self, tmp_path: Path):
+        ann_file = tmp_path / "keypoints.json"
+        _write_json(
+            ann_file,
+            {
+                "images": [],
+                "annotations": [],
+                "categories": [
+                    {
+                        "id": 1,
+                        "name": "person",
+                        "keypoints": ["nose"],
+                    }
+                ],
+            },
+        )
+        config = {Subset.TRAINING: {"annotations": ann_file}}
+        result = _detect_coco_keypoint_categories_from_paths(config)
+        assert isinstance(result, KeypointCategories)
+        assert result.labels == ("nose",)

--- a/tests/unit/experimental/data_formats/coco/test_coco_io_unit.py
+++ b/tests/unit/experimental/data_formats/coco/test_coco_io_unit.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from datumaro.experimental import Dataset
+from datumaro.experimental.categories import KeypointCategories
 from datumaro.experimental.data_formats.coco.io import load_coco_dataset, save_coco_dataset
 from datumaro.experimental.data_formats.coco.sample import CocoCategories, CocoSample
 from datumaro.experimental.fields import ImageInfo, Subset
@@ -272,3 +273,110 @@ def test_load_coco_dataset_mismatched_keys(tmp_path: Path):
             annotations_path={"val": str(tmp_path / "val.json")},
         )
     assert "Subset keys must match" in str(exc_info.value)
+
+
+def test_load_coco_dataset_attaches_keypoint_categories(tmp_path: Path):
+    """When annotation file contains keypoint names, the dataset should have KeypointCategories."""
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    (images_dir / "img.jpg").write_bytes(b"img")
+
+    annotations_file = tmp_path / "person_keypoints.json"
+    _write_json(
+        annotations_file,
+        {
+            "images": [{"id": 1, "file_name": "img.jpg", "height": 10, "width": 8}],
+            "annotations": [
+                {
+                    "id": 1,
+                    "image_id": 1,
+                    "category_id": 1,
+                    "keypoints": [100, 200, 2, 150, 250, 2, 180, 220, 1],
+                    "num_keypoints": 3,
+                }
+            ],
+            "categories": [
+                {
+                    "id": 1,
+                    "name": "person",
+                    "keypoints": ["nose", "left_eye", "right_eye"],
+                    "skeleton": [[0, 1], [0, 2]],
+                }
+            ],
+        },
+    )
+
+    ds = load_coco_dataset(
+        images_dir_path=str(images_dir),
+        annotations_path=str(annotations_file),
+    )
+
+    kp_categories = ds.schema.get_categories_for_field("keypoints")
+    assert isinstance(kp_categories, KeypointCategories)
+    assert kp_categories.labels == ("nose", "left_eye", "right_eye")
+
+
+def test_load_coco_dataset_no_keypoint_categories_when_absent(tmp_path: Path):
+    """When annotation file has no keypoint names, keypoint categories should not be attached."""
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    (images_dir / "img.jpg").write_bytes(b"img")
+
+    annotations_file = tmp_path / "instances.json"
+    _write_json(
+        annotations_file,
+        {
+            "images": [{"id": 1, "file_name": "img.jpg", "height": 10, "width": 8}],
+            "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [0, 0, 2, 2], "area": 4, "iscrowd": 0}],
+            "categories": [{"id": 1, "name": "cat"}],
+        },
+    )
+
+    ds = load_coco_dataset(
+        images_dir_path=str(images_dir),
+        annotations_path=str(annotations_file),
+    )
+
+    kp_categories = ds.schema.get_categories_for_field("keypoints")
+    assert kp_categories is None
+
+
+def test_load_coco_dataset_keypoint_categories_from_second_file(tmp_path: Path):
+    """KeypointCategories should be detected even when only the second annotation file has them."""
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    (images_dir / "img.jpg").write_bytes(b"img")
+
+    instances_file = tmp_path / "instances.json"
+    _write_json(
+        instances_file,
+        {
+            "images": [{"id": 1, "file_name": "img.jpg", "height": 10, "width": 8}],
+            "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [0, 0, 2, 2], "area": 4, "iscrowd": 0}],
+            "categories": [{"id": 1, "name": "person"}],
+        },
+    )
+    keypoints_file = tmp_path / "person_keypoints.json"
+    _write_json(
+        keypoints_file,
+        {
+            "images": [{"id": 1, "file_name": "img.jpg", "height": 10, "width": 8}],
+            "annotations": [],
+            "categories": [
+                {
+                    "id": 1,
+                    "name": "person",
+                    "keypoints": ["left_hip", "right_hip"],
+                }
+            ],
+        },
+    )
+
+    ds = load_coco_dataset(
+        images_dir_path=str(images_dir),
+        annotations_path=[str(instances_file), str(keypoints_file)],
+    )
+
+    kp_categories = ds.schema.get_categories_for_field("keypoints")
+    assert isinstance(kp_categories, KeypointCategories)
+    assert kp_categories.labels == ("left_hip", "right_hip")

--- a/tests/unit/experimental/test_categories.py
+++ b/tests/unit/experimental/test_categories.py
@@ -666,7 +666,7 @@ def test_keypoint_categories_list_coerced_to_tuple():
 
 
 def test_keypoint_categories_invalid_type_raises_error():
-    with pytest.raises(TypeError, match="labels must be a tuple of strings"):
+    with pytest.raises(TypeError, match="labels must be a list or tuple of strings"):
         KeypointCategories(labels="not_a_tuple")
 
 

--- a/tests/unit/experimental/test_categories.py
+++ b/tests/unit/experimental/test_categories.py
@@ -9,6 +9,7 @@ from datumaro.experimental.categories import (
     GroupType,
     HierarchicalLabelCategories,
     HierarchicalLabelCategory,
+    KeypointCategories,
     LabelCategories,
     LabelGroup,
     MaskCategories,
@@ -639,3 +640,104 @@ def test_colormap_serialization_round_trip():
     assert reconstructed_cats.colormap.inverse_colormap[RgbColor(255, 0, 0)] == 0
     assert reconstructed_cats.colormap.inverse_colormap[RgbColor(0, 255, 0)] == 1
     assert reconstructed_cats.colormap.inverse_colormap[RgbColor(0, 0, 255)] == 2
+
+
+# ==================== KeypointCategories Tests ====================
+
+
+def test_keypoint_categories_empty_creation():
+    categories = KeypointCategories()
+    assert len(categories) == 0
+    assert list(categories) == []
+
+
+def test_keypoint_categories_creation_with_labels():
+    categories = KeypointCategories(labels=("nose", "left_eye", "right_eye"))
+    assert len(categories) == 3
+    assert categories[0] == "nose"
+    assert categories[1] == "left_eye"
+    assert categories[2] == "right_eye"
+
+
+def test_keypoint_categories_list_coerced_to_tuple():
+    categories = KeypointCategories(labels=["nose", "left_eye"])
+    assert isinstance(categories.labels, tuple)
+    assert categories.labels == ("nose", "left_eye")
+
+
+def test_keypoint_categories_invalid_type_raises_error():
+    with pytest.raises(TypeError, match="labels must be a tuple of strings"):
+        KeypointCategories(labels="not_a_tuple")
+
+
+def test_keypoint_categories_contains_by_name():
+    categories = KeypointCategories(labels=("nose", "left_eye"))
+    assert "nose" in categories
+    assert "left_eye" in categories
+    assert "right_eye" not in categories
+
+
+def test_keypoint_categories_contains_by_index():
+    categories = KeypointCategories(labels=("nose", "left_eye"))
+    assert 0 in categories
+    assert 1 in categories
+    assert 2 not in categories
+    assert -1 not in categories
+
+
+def test_keypoint_categories_iteration():
+    categories = KeypointCategories(labels=("nose", "left_eye", "right_eye"))
+    names = list(categories)
+    assert names == ["nose", "left_eye", "right_eye"]
+
+
+def test_keypoint_categories_hash():
+    cat1 = KeypointCategories(labels=("nose", "left_eye"))
+    cat2 = KeypointCategories(labels=("nose", "left_eye"))
+    cat3 = KeypointCategories(labels=("nose", "right_eye"))
+
+    assert hash(cat1) == hash(cat2)
+    assert hash(cat1) != hash(cat3)
+
+
+def test_keypoint_categories_serialization():
+    """Test KeypointCategories to_dict/from_dict round-trip."""
+    categories = KeypointCategories(labels=("nose", "left_eye", "right_eye"))
+
+    cat_dict = categories.to_dict()
+    assert cat_dict["type"] == "KeypointCategories"
+    assert cat_dict["labels"] == ["nose", "left_eye", "right_eye"]
+
+    from datumaro.experimental.categories import Categories
+
+    reconstructed = Categories.from_dict(cat_dict)
+    assert isinstance(reconstructed, KeypointCategories)
+    assert reconstructed.labels == categories.labels
+
+
+def test_keypoint_categories_serialization_empty():
+    """Test KeypointCategories serialization with empty labels."""
+    categories = KeypointCategories()
+
+    cat_dict = categories.to_dict()
+    assert cat_dict["type"] == "KeypointCategories"
+    assert cat_dict["labels"] == []
+
+    from datumaro.experimental.categories import Categories
+
+    reconstructed = Categories.from_dict(cat_dict)
+    assert isinstance(reconstructed, KeypointCategories)
+    assert len(reconstructed) == 0
+
+
+def test_keypoint_categories_polymorphic_deserialization():
+    """Test that Categories.from_dict correctly dispatches to KeypointCategories."""
+    from datumaro.experimental.categories import Categories
+
+    kp_dict = {
+        "type": "KeypointCategories",
+        "labels": ["ankle", "knee", "hip"],
+    }
+    result = Categories.from_dict(kp_dict)
+    assert isinstance(result, KeypointCategories)
+    assert result.labels == ("ankle", "knee", "hip")


### PR DESCRIPTION
This pull request adds support for KeypointCategories and integrates them with COCO dataset import. KeypointCategories are used to store individual label names of each keypoint in a keypoint annotation.

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
