### PR TITLE
Fix from_polars_data to return None for None input

### DIFF
--- a/src/datumaro/experimental/type_registry.py
+++ b/src/datumaro/experimental/type_registry.py
@@ -105,7 +105,7 @@ _to_numpy_converters: dict[type, Callable[[Any], np.ndarray[Any, Any] | None]] =
 }
 
 _from_polars_converters: dict[type, Callable[[Any], Any]] = {
-    np.ndarray: lambda x: None if x is None else np.array(x),
+    np.ndarray: lambda x: np.array(x),
     int: lambda x: int(x),
     float: lambda x: float(x),
     str: lambda x: str(x),
@@ -246,10 +246,11 @@ def from_polars_data(polars_data: Any, target_type: type) -> Any:
         target_type: Target type to convert to
 
     Returns:
-        Value converted to target_type
+        Value converted to target_type, or None if polars_data is None
 
     Raises:
-        TypeError: If target_type is not registered for conversion
+        TypeError: If polars_data is not None and target_type is not registered
+            for conversion
 
     Example:
         >>> import torch
@@ -299,9 +300,6 @@ def from_polars_data(polars_data: Any, target_type: type) -> Any:
 
 
 def _convert_union_types(union_args: tuple[type], polars_data: Any, target_type: type) -> Any:
-    if types.NoneType in union_args and polars_data is None:
-        return None
-
     non_none_args = tuple(arg for arg in union_args if arg is not types.NoneType)
 
     # Try each type in the union until one succeeds

--- a/src/datumaro/experimental/type_registry.py
+++ b/src/datumaro/experimental/type_registry.py
@@ -105,7 +105,7 @@ _to_numpy_converters: dict[type, Callable[[Any], np.ndarray[Any, Any] | None]] =
 }
 
 _from_polars_converters: dict[type, Callable[[Any], Any]] = {
-    np.ndarray: lambda x: np.array(x),
+    np.ndarray: lambda x: None if x is None else np.array(x),
     int: lambda x: int(x),
     float: lambda x: float(x),
     str: lambda x: str(x),
@@ -258,6 +258,10 @@ def from_polars_data(polars_data: Any, target_type: type) -> Any:
         >>> isinstance(tensor, torch.Tensor)
         True
     """
+    # Null polars data should always map to None regardless of target type
+    if polars_data is None:
+        return None
+
     # Handle direct type matches first
     if target_type in _from_polars_converters:
         return _from_polars_converters[target_type](polars_data)

--- a/tests/unit/experimental/test_type_registry.py
+++ b/tests/unit/experimental/test_type_registry.py
@@ -516,7 +516,7 @@ def test_from_polars_data_returns_none_not_array_none():
 
     Regression test: previously, calling from_polars_data(None, np.ndarray) would produce
     np.array(None, dtype=object) instead of None because np.array(None) creates a
-    0-dimensional array wrapping None. This verifies the fix for all registered target types.
+    0-dimensional array wrapping None. This verifies the fix for numpy arrays and basic scalar target types.
     """
     # np.ndarray target must return None, not array(None, dtype=object)
     result = from_polars_data(None, np.ndarray)

--- a/tests/unit/experimental/test_type_registry.py
+++ b/tests/unit/experimental/test_type_registry.py
@@ -509,3 +509,22 @@ def test_typed_numpy_array_multidimensional():
     assert result.dtype == np.int32
     assert result.shape == (4,)
     np.testing.assert_array_equal(result, np.array([10, 15, 30, 35], dtype=np.int32))
+
+
+def test_from_polars_data_returns_none_not_array_none():
+    """Test that from_polars_data returns None (not array(None, dtype=object)) when data is None.
+
+    Regression test: previously, calling from_polars_data(None, np.ndarray) would produce
+    np.array(None, dtype=object) instead of None because np.array(None) creates a
+    0-dimensional array wrapping None. This verifies the fix for all registered target types.
+    """
+    # np.ndarray target must return None, not array(None, dtype=object)
+    result = from_polars_data(None, np.ndarray)
+    assert result is None
+
+    # Scalar target types must also return None
+    assert from_polars_data(None, int) is None
+    assert from_polars_data(None, float) is None
+    assert from_polars_data(None, str) is None
+    assert from_polars_data(None, bool) is None
+    assert from_polars_data(None, bytes) is None


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
