### PR TITLE
Enhance cost calculation for direct field-type converters

### DIFF
--- a/src/datumaro/experimental/converters/registry.py
+++ b/src/datumaro/experimental/converters/registry.py
@@ -154,11 +154,11 @@ class _SearchNode:
 
     state: _SchemaState
     path: list[Converter]  # Now stores Converter instances directly
-    g_cost: int  # Actual cost from start
-    h_cost: int  # Heuristic cost to goal
+    g_cost: float  # Actual cost from start
+    h_cost: float  # Heuristic cost to goal
 
     @property
-    def f_cost(self) -> int:
+    def f_cost(self) -> float:
         """Total cost (g + h)."""
         return self.g_cost + self.h_cost
 
@@ -628,7 +628,16 @@ def _find_conversion_path_for_semantic(
                 continue
 
             new_path = [*current_node.path, converter]
-            new_g_cost = current_node.g_cost + 1  # Each converter has cost 1
+            # Base cost of 1 per converter, plus a small penalty for
+            # cross-field-type converters (those that derive an output field
+            # type from a different input field type).  This ensures that
+            # direct in-place transformations (e.g. BBoxField→BBoxField for
+            # format/dtype changes) are preferred over cross-type derivations
+            # (e.g. KeypointsField→BBoxField) when integer costs are equal.
+            input_field_types = {type(s.field) for s in converter.get_input_attr_specs()}
+            output_field_types = {type(s.field) for s in converter.get_output_attr_specs()}
+            is_cross_field_type = not output_field_types.issubset(input_field_types)
+            new_g_cost = current_node.g_cost + 1 + (0.1 if is_cross_field_type else 0)
             new_h_cost = _heuristic_cost(new_state, target_state)
 
             new_node = _SearchNode(state=new_state, path=new_path, g_cost=new_g_cost, h_cost=new_h_cost)

--- a/src/datumaro/experimental/converters/registry.py
+++ b/src/datumaro/experimental/converters/registry.py
@@ -166,7 +166,7 @@ class _SearchNode:
         return self.f_cost < other.f_cost
 
 
-def _heuristic_cost(current_state: _SchemaState, target_state: _SchemaState) -> int:
+def _heuristic_cost(current_state: _SchemaState, target_state: _SchemaState) -> float:
     """
     Heuristic function for A* search.
     Returns the number of missing target fields plus field differences as a heuristic.
@@ -178,7 +178,7 @@ def _heuristic_cost(current_state: _SchemaState, target_state: _SchemaState) -> 
 
     Note: Attribute names are ignored in the heuristic as they can be fixed in post-processing.
     """
-    cost = 0
+    cost = 0.0
 
     current_field_types = set(current_state.field_to_attr_spec.keys())
     target_field_types = set(target_state.field_to_attr_spec.keys())

--- a/tests/unit/experimental/converters/test_base_converters.py
+++ b/tests/unit/experimental/converters/test_base_converters.py
@@ -29,6 +29,7 @@ from datumaro.experimental.fields import (
     Field,
     ImageField,
     ImageInfoField,
+    KeypointsField,
     LabelField,
     MaskField,
     PolygonField,
@@ -1319,3 +1320,63 @@ def test_conversion_error_message_end_to_end():
                 }
             ),
         )
+
+
+def test_find_conversion_path_prefers_direct_over_cross_field_type():
+    """Test that find_conversion_path prefers direct same-field-type converters over cross-field-type converters.
+
+    When the source schema has both BBoxField (xywh) and KeypointsField, and the
+    target needs BBoxField (x1y1x2y2), the A* search should prefer:
+      BBoxFormatConverter (BBoxField → BBoxField, format change)
+    over:
+      KeypointsToBBoxConverter (KeypointsField → BBoxField, cross-field-type)
+
+    Both paths have the same integer step count, but the direct path preserves the
+    original data while the cross-field-type path would derive bboxes from keypoints
+    (which may be null, producing incorrect results).
+    """
+    from datumaro.experimental.converters import BBoxDtypeConverter, BBoxFormatConverter
+
+    source_schema = Schema(
+        attributes={
+            "bboxes": AttributeInfo(
+                type=np.ndarray | None,
+                field=BBoxField(semantic="default", dtype=pl.Float32(), format="xywh"),
+            ),
+            "keypoints": AttributeInfo(
+                type=np.ndarray | None,
+                field=KeypointsField(semantic="default", dtype=pl.Float32()),
+            ),
+        }
+    )
+
+    target_schema = Schema(
+        attributes={
+            "bboxes": AttributeInfo(
+                type=np.ndarray | None,
+                field=BBoxField(semantic="default", dtype=pl.Int32(), format="x1y1x2y2"),
+            ),
+        }
+    )
+
+    conversion_paths, _ = find_conversion_path(source_schema, target_schema)
+
+    # The bboxes conversion chain must use the direct BBoxField→BBoxField path
+    bbox_converters = conversion_paths.converters["bboxes"]
+    bbox_converter_types = [type(c) for c in bbox_converters]
+
+    assert BBoxFormatConverter in bbox_converter_types, (
+        f"Expected BBoxFormatConverter in the conversion chain, got {bbox_converter_types}. "
+        "The A* search should prefer direct same-field-type converters over cross-field-type ones."
+    )
+    assert BBoxDtypeConverter in bbox_converter_types, (
+        f"Expected BBoxDtypeConverter in the conversion chain, got {bbox_converter_types}."
+    )
+
+    # Verify KeypointsToBBoxConverter is NOT in the chain
+    from datumaro.experimental.converters import KeypointsToBBoxConverter
+
+    assert KeypointsToBBoxConverter not in bbox_converter_types, (
+        "KeypointsToBBoxConverter should NOT be used when BBoxField data is already available. "
+        "Direct BBoxField→BBoxField conversion should be preferred."
+    )


### PR DESCRIPTION
This PR updates the search algorithm so that same-field-type conversions are prioritized over cross-field-type conversions by giving cross-field conversions a slightly higher cost in the A* search algorithm. 

Resolves #2080 

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
