### PR TITLE
Fix VOC annotation parsing to support classification-only objects

### DIFF
--- a/src/datumaro/experimental/data_formats/voc/helpers.py
+++ b/src/datumaro/experimental/data_formats/voc/helpers.py
@@ -243,19 +243,18 @@ def _parse_object_element(obj_elem: Element, result: dict, categories: LabelCate
 
     # Parse bounding box
     bndbox = obj_elem.find("bndbox")
-    if bndbox is None:
-        return
+    if bndbox is not None:
+        try:
+            xmin = float(bndbox.find("xmin").text)
+            ymin = float(bndbox.find("ymin").text)
+            xmax = float(bndbox.find("xmax").text)
+            ymax = float(bndbox.find("ymax").text)
+        except (AttributeError, ValueError, TypeError) as e:
+            logger.warning("Invalid bounding box in VOC annotation: %s", e)
+            return
 
-    try:
-        xmin = float(bndbox.find("xmin").text)
-        ymin = float(bndbox.find("ymin").text)
-        xmax = float(bndbox.find("xmax").text)
-        ymax = float(bndbox.find("ymax").text)
-    except (AttributeError, ValueError, TypeError) as e:
-        logger.warning("Invalid bounding box in VOC annotation: %s", e)
-        return
+        result["bboxes"].append([xmin, ymin, xmax, ymax])
 
-    result["bboxes"].append([xmin, ymin, xmax, ymax])
     result["labels"].append(label_idx)
 
     # Parse attributes
@@ -545,6 +544,11 @@ def _create_voc_xml_annotation(
         for i, bbox in enumerate(sample.bboxes):
             obj_elem = _create_object_element(sample, i, bbox, categories)
             root.append(obj_elem)
+    elif sample.labels is not None and len(sample.labels) > 0:
+        # Classification-only: labels without bounding boxes
+        for i in range(len(sample.labels)):
+            obj_elem = _create_object_element(sample, i, None, categories)
+            root.append(obj_elem)
 
     return root
 
@@ -552,7 +556,7 @@ def _create_voc_xml_annotation(
 def _create_object_element(
     sample: VocSample,
     idx: int,
-    bbox: np.ndarray,
+    bbox: np.ndarray | None,
     categories: LabelCategories,
 ) -> Element:
     """Create a single object element for VOC XML."""
@@ -560,14 +564,7 @@ def _create_object_element(
 
     # Name (label)
     name_elem = Element("name")
-    if sample.labels is not None and idx < len(sample.labels):
-        label_idx = int(sample.labels[idx])
-        if label_idx < len(categories.labels):
-            name_elem.text = categories.labels[label_idx]
-        else:
-            name_elem.text = f"unknown_{label_idx}"
-    else:
-        name_elem.text = "unknown"
+    name_elem.text = _get_label_name(sample, idx, categories)
     obj_elem.append(name_elem)
 
     # Pose
@@ -578,47 +575,41 @@ def _create_object_element(
         pose_elem.text = "Unspecified"
     obj_elem.append(pose_elem)
 
-    # Truncated
-    truncated_elem = Element("truncated")
-    if sample.truncated is not None and idx < len(sample.truncated):
-        truncated_elem.text = "1" if sample.truncated[idx] else "0"
-    else:
-        truncated_elem.text = "0"
-    obj_elem.append(truncated_elem)
+    # Boolean attributes
+    for attr_name, attr_array in (
+        ("truncated", sample.truncated),
+        ("difficult", sample.difficult),
+        ("occluded", sample.occluded),
+    ):
+        elem = Element(attr_name)
+        elem.text = "1" if attr_array is not None and idx < len(attr_array) and attr_array[idx] else "0"
+        obj_elem.append(elem)
 
-    # Difficult
-    difficult_elem = Element("difficult")
-    if sample.difficult is not None and idx < len(sample.difficult):
-        difficult_elem.text = "1" if sample.difficult[idx] else "0"
-    else:
-        difficult_elem.text = "0"
-    obj_elem.append(difficult_elem)
-
-    # Occluded
-    occluded_elem = Element("occluded")
-    if sample.occluded is not None and idx < len(sample.occluded):
-        occluded_elem.text = "1" if sample.occluded[idx] else "0"
-    else:
-        occluded_elem.text = "0"
-    obj_elem.append(occluded_elem)
-
-    # Bounding box
-    bndbox_elem = Element("bndbox")
-    xmin_elem = Element("xmin")
-    xmin_elem.text = str(int(bbox[0]))
-    bndbox_elem.append(xmin_elem)
-    ymin_elem = Element("ymin")
-    ymin_elem.text = str(int(bbox[1]))
-    bndbox_elem.append(ymin_elem)
-    xmax_elem = Element("xmax")
-    xmax_elem.text = str(int(bbox[2]))
-    bndbox_elem.append(xmax_elem)
-    ymax_elem = Element("ymax")
-    ymax_elem.text = str(int(bbox[3]))
-    bndbox_elem.append(ymax_elem)
-    obj_elem.append(bndbox_elem)
+    # Bounding box (omitted for classification-only objects)
+    if bbox is not None:
+        obj_elem.append(_create_bndbox_element(bbox))
 
     return obj_elem
+
+
+def _get_label_name(sample: VocSample, idx: int, categories: LabelCategories) -> str:
+    """Get the label name for an object at the given index."""
+    if sample.labels is None or idx >= len(sample.labels):
+        return "unknown"
+    label_idx = int(sample.labels[idx])
+    if label_idx < len(categories.labels):
+        return categories.labels[label_idx]
+    return f"unknown_{label_idx}"
+
+
+def _create_bndbox_element(bbox: np.ndarray) -> Element:
+    """Create a bounding box XML element for VOC annotation."""
+    bndbox_elem = Element("bndbox")
+    for tag, value in zip(("xmin", "ymin", "xmax", "ymax"), bbox):
+        child = Element(tag)
+        child.text = str(int(value))
+        bndbox_elem.append(child)
+    return bndbox_elem
 
 
 def _write_voc_xml(root: Element, output_path: Path) -> None:

--- a/src/datumaro/experimental/data_formats/voc/helpers.py
+++ b/src/datumaro/experimental/data_formats/voc/helpers.py
@@ -216,8 +216,12 @@ def _parse_voc_annotation(anno_path: Path, categories: LabelCategories) -> dict:
                 result["height"] = int(height_elem.text)
 
         # Parse objects
-        for obj_elem in root.findall("object"):
-            _parse_object_element(obj_elem, result, categories)
+        # Pre-check: is this a classification-only annotation (no bndbox anywhere)?
+        obj_elems = root.findall("object")
+        is_classification_only = all(obj.find("bndbox") is None for obj in obj_elems)
+
+        for obj_elem in obj_elems:
+            _parse_object_element(obj_elem, result, categories, is_classification_only)
 
     except ElementTree.ParseError as e:
         logger.warning("Failed to parse VOC annotation %s: %s", anno_path, e)
@@ -225,8 +229,19 @@ def _parse_voc_annotation(anno_path: Path, categories: LabelCategories) -> dict:
     return result
 
 
-def _parse_object_element(obj_elem: Element, result: dict, categories: LabelCategories) -> None:
-    """Parse a single object element from VOC XML."""
+def _parse_object_element(
+    obj_elem: Element,
+    result: dict,
+    categories: LabelCategories,
+    is_classification_only: bool = False,
+) -> None:
+    """Parse a single object element from VOC XML.
+
+    Objects without a bounding box are only included when the entire annotation
+    is classification-only (no objects have bndbox).  In mixed annotations the
+    bbox-less objects are skipped so that bboxes, labels and attribute arrays
+    stay aligned.
+    """
     # Get label name
     name_elem = obj_elem.find("name")
     if name_elem is None or not name_elem.text:
@@ -254,6 +269,11 @@ def _parse_object_element(obj_elem: Element, result: dict, categories: LabelCate
             return
 
         result["bboxes"].append([xmin, ymin, xmax, ymax])
+    elif not is_classification_only:
+        # In mixed annotations, skip objects without bounding boxes
+        # to keep bboxes/labels/attribute arrays aligned
+        logger.debug("Skipping object '%s' without bndbox in detection annotation", label_name)
+        return
 
     result["labels"].append(label_idx)
 

--- a/tests/unit/experimental/data_formats/voc/test_voc_helpers.py
+++ b/tests/unit/experimental/data_formats/voc/test_voc_helpers.py
@@ -13,6 +13,7 @@ import numpy as np
 from datumaro.experimental.categories import LabelCategories
 from datumaro.experimental.data_formats.voc.constants import VOC_LABELS
 from datumaro.experimental.data_formats.voc.helpers import (
+    _create_object_element,
     _create_voc_xml_annotation,
     _detect_voc_subsets,
     _find_image_file,
@@ -393,3 +394,170 @@ def test_write_voc_xml_creates_file(tmp_path: Path):
     content = output_path.read_text()
     assert "<annotation>" in content
     assert "<filename>test.jpg</filename>" in content
+
+
+# ======================================
+# Classification-only (no bbox) Tests
+# ======================================
+
+
+def test_parse_voc_annotation_parses_objects_without_bndbox(tmp_path: Path):
+    """Test that objects without bounding boxes are still parsed for labels and attributes."""
+    anno_path = tmp_path / "test.xml"
+    anno_path.write_text("""
+<annotation>
+    <size>
+        <width>640</width>
+        <height>480</height>
+    </size>
+    <object>
+        <name>person</name>
+        <difficult>1</difficult>
+        <truncated>0</truncated>
+        <occluded>1</occluded>
+        <pose>Frontal</pose>
+    </object>
+</annotation>
+    """)
+
+    categories = LabelCategories(labels=VOC_LABELS)
+    result = _parse_voc_annotation(anno_path, categories)
+
+    assert result["width"] == 640
+    assert result["height"] == 480
+    # Object should be parsed even without bndbox
+    assert len(result["labels"]) == 1
+    assert result["labels"][0] == VOC_LABELS.index("person")
+    # No bounding boxes should be present
+    assert len(result["bboxes"]) == 0
+    # Attributes should still be parsed
+    assert result["difficult"][0] is True
+    assert result["truncated"][0] is False
+    assert result["occluded"][0] is True
+    assert result["pose"][0] == "Frontal"
+
+
+def test_parse_voc_annotation_mixed_objects_with_and_without_bndbox(tmp_path: Path):
+    """Test parsing annotation with both bbox and non-bbox objects."""
+    anno_path = tmp_path / "test.xml"
+    anno_path.write_text("""
+<annotation>
+    <size>
+        <width>640</width>
+        <height>480</height>
+    </size>
+    <object>
+        <name>person</name>
+        <bndbox>
+            <xmin>100</xmin>
+            <ymin>100</ymin>
+            <xmax>200</xmax>
+            <ymax>200</ymax>
+        </bndbox>
+    </object>
+    <object>
+        <name>dog</name>
+        <difficult>1</difficult>
+    </object>
+</annotation>
+    """)
+
+    categories = LabelCategories(labels=VOC_LABELS)
+    result = _parse_voc_annotation(anno_path, categories)
+
+    # Both objects should be parsed
+    assert len(result["labels"]) == 2
+    assert result["labels"][0] == VOC_LABELS.index("person")
+    assert result["labels"][1] == VOC_LABELS.index("dog")
+    # Only the first object has a bounding box
+    assert len(result["bboxes"]) == 1
+    assert result["bboxes"][0] == [100.0, 100.0, 200.0, 200.0]
+
+
+def test_create_voc_xml_annotation_classification_only():
+    """Test creating XML annotation for classification-only samples (labels but no bboxes)."""
+    sample = VocSample(
+        image="/path/to/image.jpg",
+        image_info=ImageInfo(height=480, width=640),
+        bboxes=None,
+        labels=np.array([0, 2], dtype=np.uint32),
+        difficult=np.array([False, True]),
+        truncated=np.array([False, False]),
+        occluded=np.array([False, False]),
+        pose=np.array(["Unspecified", "Unspecified"], dtype=object),
+        subset=Subset.TRAINING,
+    )
+    categories = LabelCategories(labels=VOC_LABELS)
+
+    root = _create_voc_xml_annotation(sample, "image.jpg", categories)
+
+    assert root.tag == "annotation"
+    objects = root.findall("object")
+    assert len(objects) == 2
+
+    # Check label names
+    assert objects[0].find("name").text == VOC_LABELS[0]
+    assert objects[1].find("name").text == VOC_LABELS[2]
+
+    # No bndbox elements should be present
+    assert objects[0].find("bndbox") is None
+    assert objects[1].find("bndbox") is None
+
+    # Attributes should still be set
+    assert objects[1].find("difficult").text == "1"
+
+
+def test_create_object_element_with_bbox():
+    """Test _create_object_element creates bndbox when bbox is provided."""
+    sample = VocSample(
+        image="/path/to/image.jpg",
+        image_info=ImageInfo(height=480, width=640),
+        bboxes=np.array([[10, 20, 30, 40]], dtype=np.float32),
+        labels=np.array([1], dtype=np.uint32),
+        difficult=np.array([True]),
+        truncated=np.array([False]),
+        occluded=np.array([True]),
+        pose=np.array(["Left"], dtype=object),
+        subset=Subset.TRAINING,
+    )
+    categories = LabelCategories(labels=VOC_LABELS)
+    bbox = np.array([10, 20, 30, 40], dtype=np.float32)
+
+    obj_elem = _create_object_element(sample, 0, bbox, categories)
+
+    assert obj_elem.find("name").text == VOC_LABELS[1]
+    assert obj_elem.find("difficult").text == "1"
+    assert obj_elem.find("occluded").text == "1"
+    assert obj_elem.find("pose").text == "Left"
+    # Bounding box should be present
+    bndbox = obj_elem.find("bndbox")
+    assert bndbox is not None
+    assert bndbox.find("xmin").text == "10"
+    assert bndbox.find("ymin").text == "20"
+    assert bndbox.find("xmax").text == "30"
+    assert bndbox.find("ymax").text == "40"
+
+
+def test_create_object_element_without_bbox():
+    """Test _create_object_element omits bndbox when bbox is None."""
+    sample = VocSample(
+        image="/path/to/image.jpg",
+        image_info=ImageInfo(height=480, width=640),
+        bboxes=None,
+        labels=np.array([0], dtype=np.uint32),
+        difficult=np.array([False]),
+        truncated=np.array([True]),
+        occluded=np.array([False]),
+        pose=np.array(["Frontal"], dtype=object),
+        subset=Subset.TRAINING,
+    )
+    categories = LabelCategories(labels=VOC_LABELS)
+
+    obj_elem = _create_object_element(sample, 0, None, categories)
+
+    assert obj_elem.find("name").text == VOC_LABELS[0]
+    assert obj_elem.find("truncated").text == "1"
+    assert obj_elem.find("difficult").text == "0"
+    assert obj_elem.find("pose").text == "Frontal"
+    # No bounding box should be present
+    assert obj_elem.find("bndbox") is None

--- a/tests/unit/experimental/data_formats/voc/test_voc_helpers.py
+++ b/tests/unit/experimental/data_formats/voc/test_voc_helpers.py
@@ -465,11 +465,9 @@ def test_parse_voc_annotation_mixed_objects_with_and_without_bndbox(tmp_path: Pa
     categories = LabelCategories(labels=VOC_LABELS)
     result = _parse_voc_annotation(anno_path, categories)
 
-    # Both objects should be parsed
-    assert len(result["labels"]) == 2
+    # Only objects with a bounding box should be included in object-level data
+    assert len(result["labels"]) == 1
     assert result["labels"][0] == VOC_LABELS.index("person")
-    assert result["labels"][1] == VOC_LABELS.index("dog")
-    # Only the first object has a bounding box
     assert len(result["bboxes"]) == 1
     assert result["bboxes"][0] == [100.0, 100.0, 200.0, 200.0]
 


### PR DESCRIPTION
VOC exported datasets would miss labels if they were coming from samples that have no fields that can be converted to a bounding box. This PR adds a new check for classification like samples (containing only a label) so that VOC exports retain label data. 



<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
