### PR TITLE
Add support for classification-only VOC datasets

### DIFF
--- a/src/datumaro/experimental/data_formats/voc/helpers.py
+++ b/src/datumaro/experimental/data_formats/voc/helpers.py
@@ -193,8 +193,18 @@ def _detect_classification_label_files(
         label_part, subset_part = stem.rsplit("_", 1)
 
         if label_part not in valid_labels:
+            logger.warning(
+                "Skipping classification file %s: label '%s' not in known categories",
+                txt_file,
+                label_part,
+            )
             continue
         if subset_part not in subset_names:
+            logger.warning(
+                "Skipping classification file %s: subset '%s' not in known subsets",
+                txt_file,
+                subset_part,
+            )
             continue
 
         result.setdefault(subset_part, {})[label_part] = txt_file
@@ -221,6 +231,10 @@ def _parse_classification_labels(
         try:
             label_idx = categories.labels.index(label_name)
         except ValueError:
+            logger.warning(
+                "Skipping classification label '%s': not found in categories",
+                label_name,
+            )
             continue
 
         with open(file_path, encoding="utf-8") as f:
@@ -230,11 +244,21 @@ def _parse_classification_labels(
                     continue
                 parts = line.split()
                 if len(parts) < 2:
+                    logger.warning(
+                        "Skipping malformed line in %s: expected at least 2 fields, got '%s'",
+                        file_path,
+                        line,
+                    )
                     continue
                 image_id = parts[0]
                 try:
                     flag = int(parts[1])
                 except ValueError:
+                    logger.warning(
+                        "Skipping line in %s: cannot parse flag as integer: '%s'",
+                        file_path,
+                        parts[1],
+                    )
                     continue
                 if flag == 1:
                     image_labels[image_id].append(label_idx)

--- a/src/datumaro/experimental/data_formats/voc/helpers.py
+++ b/src/datumaro/experimental/data_formats/voc/helpers.py
@@ -159,6 +159,93 @@ def _detect_voc_subsets(root_path: Path) -> dict[str, Path]:
     return subsets
 
 
+def _detect_classification_label_files(
+    root_path: Path,
+    subset_names: set[str],
+    categories: LabelCategories,
+) -> dict[str, dict[str, Path]]:
+    """Detect label-specific classification files in ImageSets/Main/.
+
+    VOC classification datasets store per-label files with the naming
+    convention ``<label>_<subset>.txt``.  Each line has the format
+    ``image_id  1`` (present) or ``image_id -1`` (absent).
+
+    Only files whose label part matches a known category label (excluding
+    ``background``) are returned so that arbitrary files are not misinterpreted.
+
+    Returns:
+        Nested dict ``{subset_name: {label_name: path}}``.
+    """
+    imagesets_main = root_path / VOC_IMAGESETS_DIR / VOC_MAIN_DIR
+    if not imagesets_main.exists():
+        return {}
+
+    # Build a set of valid foreground label names for fast lookup
+    valid_labels = {lbl for lbl in categories.labels if lbl != "background"}
+
+    result: dict[str, dict[str, Path]] = {}
+    for txt_file in sorted(imagesets_main.glob("*.txt")):
+        stem = txt_file.stem
+        if "_" not in stem:
+            continue  # not a label-specific file
+
+        # Split on the last underscore so labels with underscores work
+        label_part, subset_part = stem.rsplit("_", 1)
+
+        if label_part not in valid_labels:
+            continue
+        if subset_part not in subset_names:
+            continue
+
+        result.setdefault(subset_part, {})[label_part] = txt_file
+
+    return result
+
+
+def _parse_classification_labels(
+    label_files: dict[str, Path],
+    categories: LabelCategories,
+) -> dict[str, list[int]]:
+    """Parse label-specific classification files and return per-image label indices.
+
+    Args:
+        label_files: Mapping ``{label_name: file_path}`` for one subset.
+        categories: The label categories (used to resolve indices).
+
+    Returns:
+        Mapping ``{image_id: sorted list of label indices with positive flag}``.
+    """
+    image_labels: dict[str, list[int]] = defaultdict(list)
+
+    for label_name, file_path in label_files.items():
+        try:
+            label_idx = categories.labels.index(label_name)
+        except ValueError:
+            continue
+
+        with open(file_path, encoding="utf-8") as f:
+            for raw_line in f:
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.split()
+                if len(parts) < 2:
+                    continue
+                image_id = parts[0]
+                try:
+                    flag = int(parts[1])
+                except ValueError:
+                    continue
+                if flag == 1:
+                    image_labels[image_id].append(label_idx)
+
+    # Sort each label list for determinism
+    for image_id, labels in image_labels.items():
+        labels.sort()
+
+    return dict(image_labels)
+
+
 def _parse_subset_list(subset_file: Path) -> list[str]:
     """
     Parse a VOC ImageSets subset file.
@@ -345,8 +432,18 @@ def _create_sample_from_annotation(
     image_id: str,
     ctx: VocLoadContext,
     subset_enum: Subset,
+    classification_labels: list[int] | None = None,
 ) -> VocSample | None:
-    """Create a VocSample from image ID and annotation."""
+    """Create a VocSample from image ID and annotation.
+
+    Args:
+        image_id: Image stem identifier.
+        ctx: Load context with paths and categories.
+        subset_enum: Subset assignment for this sample.
+        classification_labels: Optional list of label indices obtained from
+            ImageSets/Main classification files. When the XML annotation does
+            not contain any objects these are used as image-level labels.
+    """
     # Find image file
     image_path = _find_image_file(ctx.images_dir, image_id)
     if image_path is None:
@@ -363,13 +460,18 @@ def _create_sample_from_annotation(
     if height == 0 or width == 0:
         height, width = _get_image_size(image_path)
 
-    # Create arrays
+    # Create arrays from XML annotations
     bboxes = np.array(annotation["bboxes"], dtype=np.float32) if annotation["bboxes"] else None
     labels = np.array(annotation["labels"], dtype=np.uint32) if annotation["labels"] else None
     difficult = np.array(annotation["difficult"], dtype=bool) if annotation["difficult"] else None
     truncated = np.array(annotation["truncated"], dtype=bool) if annotation["truncated"] else None
     occluded = np.array(annotation["occluded"], dtype=bool) if annotation["occluded"] else None
     pose = np.array(annotation["pose"], dtype=object) if annotation["pose"] else None
+
+    # If no labels from XML annotations, use classification labels from
+    # ImageSets/Main/<label>_<subset>.txt files (image-level classification).
+    if labels is None and classification_labels:
+        labels = np.array(classification_labels, dtype=np.uint32)
 
     # Create lazy mask loaders for segmentation masks
     class_mask_loader = _get_mask_loader(ctx.segmentation_class_dir, image_id, ctx.colormap)
@@ -445,17 +547,39 @@ def _load_samples_from_images(ctx: VocLoadContext) -> list[VocSample]:
 def _load_samples_from_subsets(
     ctx: VocLoadContext,
     subsets: dict[str, Path],
+    classification_label_files: dict[str, dict[str, Path]] | None = None,
 ) -> list[VocSample]:
-    """Load samples from ImageSets subset files."""
+    """Load samples from ImageSets subset files.
+
+    Args:
+        ctx: Load context with paths and categories.
+        subsets: Mapping ``{subset_name: path}`` for each subset txt file.
+        classification_label_files: Optional nested dict
+            ``{subset_name: {label_name: path}}`` from
+            :func:`_detect_classification_label_files`.
+    """
     samples = []
     for subset_name, subset_file in subsets.items():
         subset_enum = VOC_SUBSET_NAME_TO_ENUM.get(subset_name, Subset.UNASSIGNED)
         image_ids = _parse_subset_list(subset_file)
 
+        # Parse classification labels for this subset (if available)
+        cls_labels_map: dict[str, list[int]] = {}
+        if classification_label_files and subset_name in classification_label_files:
+            cls_labels_map = _parse_classification_labels(
+                classification_label_files[subset_name],
+                ctx.categories,
+            )
+
         logger.info("[VOC] Loading subset '%s' with %d images", subset_name, len(image_ids))
 
         for image_id in image_ids:
-            sample = _create_sample_from_annotation(image_id, ctx, subset_enum)
+            sample = _create_sample_from_annotation(
+                image_id,
+                ctx,
+                subset_enum,
+                classification_labels=cls_labels_map.get(image_id),
+            )
             if sample:
                 samples.append(sample)
     return samples
@@ -490,7 +614,9 @@ def _load_voc_from_imagesets(root_path: Path, categories: LabelCategories) -> li
     subsets = _detect_voc_subsets(root_path)
 
     if subsets:
-        return _load_samples_from_subsets(ctx, subsets)
+        # Detect classification label files
+        cls_label_files = _detect_classification_label_files(root_path, set(subsets.keys()), categories)
+        return _load_samples_from_subsets(ctx, subsets, cls_label_files)
     return _load_samples_from_images(ctx)
 
 

--- a/tests/unit/experimental/data_formats/voc/test_voc_helpers.py
+++ b/tests/unit/experimental/data_formats/voc/test_voc_helpers.py
@@ -15,9 +15,11 @@ from datumaro.experimental.data_formats.voc.constants import VOC_LABELS
 from datumaro.experimental.data_formats.voc.helpers import (
     _create_object_element,
     _create_voc_xml_annotation,
+    _detect_classification_label_files,
     _detect_voc_subsets,
     _find_image_file,
     _load_voc_categories,
+    _parse_classification_labels,
     _parse_subset_list,
     _parse_voc_annotation,
     _parse_voc_labelmap,
@@ -559,3 +561,202 @@ def test_create_object_element_without_bbox():
     assert obj_elem.find("pose").text == "Frontal"
     # No bounding box should be present
     assert obj_elem.find("bndbox") is None
+
+
+# ==============================
+# _detect_classification_label_files Tests
+# ==============================
+
+
+def test_detect_classification_label_files_finds_label_files(tmp_path: Path):
+    """Test detecting label-specific classification files in ImageSets/Main."""
+    imagesets_main = tmp_path / "ImageSets" / "Main"
+    imagesets_main.mkdir(parents=True)
+    (imagesets_main / "train.txt").write_text("img1\nimg2\n")
+    (imagesets_main / "dog_train.txt").write_text("img1  1\nimg2 -1\n")
+    (imagesets_main / "cat_train.txt").write_text("img1 -1\nimg2  1\n")
+
+    categories = LabelCategories(labels=("background", "dog", "cat"))
+    result = _detect_classification_label_files(tmp_path, {"train"}, categories)
+
+    assert "train" in result
+    assert "dog" in result["train"]
+    assert "cat" in result["train"]
+    assert result["train"]["dog"] == imagesets_main / "dog_train.txt"
+    assert result["train"]["cat"] == imagesets_main / "cat_train.txt"
+
+
+def test_detect_classification_label_files_skips_unknown_labels(tmp_path: Path):
+    """Test that files with unknown label names are ignored."""
+    imagesets_main = tmp_path / "ImageSets" / "Main"
+    imagesets_main.mkdir(parents=True)
+    (imagesets_main / "train.txt").write_text("img1\n")
+    (imagesets_main / "unknown_train.txt").write_text("img1  1\n")
+
+    categories = LabelCategories(labels=("background", "dog"))
+    result = _detect_classification_label_files(tmp_path, {"train"}, categories)
+
+    assert result == {} or "unknown" not in result.get("train", {})
+
+
+def test_detect_classification_label_files_skips_background(tmp_path: Path):
+    """Test that background label files are excluded."""
+    imagesets_main = tmp_path / "ImageSets" / "Main"
+    imagesets_main.mkdir(parents=True)
+    (imagesets_main / "train.txt").write_text("img1\n")
+    (imagesets_main / "background_train.txt").write_text("img1  1\n")
+
+    categories = LabelCategories(labels=("background", "dog"))
+    result = _detect_classification_label_files(tmp_path, {"train"}, categories)
+
+    assert "background" not in result.get("train", {})
+
+
+def test_detect_classification_label_files_skips_wrong_subset(tmp_path: Path):
+    """Test that files for non-matching subsets are ignored."""
+    imagesets_main = tmp_path / "ImageSets" / "Main"
+    imagesets_main.mkdir(parents=True)
+    (imagesets_main / "train.txt").write_text("img1\n")
+    (imagesets_main / "dog_val.txt").write_text("img1  1\n")
+
+    categories = LabelCategories(labels=("background", "dog"))
+    result = _detect_classification_label_files(tmp_path, {"train"}, categories)
+
+    # dog_val.txt should be ignored because subset_names only contains "train"
+    assert result == {} or "val" not in result
+
+
+def test_detect_classification_label_files_multiple_subsets(tmp_path: Path):
+    """Test detecting label files across multiple subsets."""
+    imagesets_main = tmp_path / "ImageSets" / "Main"
+    imagesets_main.mkdir(parents=True)
+    (imagesets_main / "train.txt").write_text("img1\n")
+    (imagesets_main / "val.txt").write_text("img2\n")
+    (imagesets_main / "dog_train.txt").write_text("img1  1\n")
+    (imagesets_main / "dog_val.txt").write_text("img2  1\n")
+
+    categories = LabelCategories(labels=("background", "dog"))
+    result = _detect_classification_label_files(tmp_path, {"train", "val"}, categories)
+
+    assert "train" in result
+    assert "val" in result
+    assert "dog" in result["train"]
+    assert "dog" in result["val"]
+
+
+def test_detect_classification_label_files_returns_empty_when_no_imagesets(tmp_path: Path):
+    """Test that empty dict is returned when ImageSets/Main doesn't exist."""
+    categories = LabelCategories(labels=("background", "dog"))
+    result = _detect_classification_label_files(tmp_path, {"train"}, categories)
+
+    assert result == {}
+
+
+def test_detect_classification_label_files_handles_label_with_underscore(tmp_path: Path):
+    """Test detecting label files where the label name itself contains an underscore."""
+    imagesets_main = tmp_path / "ImageSets" / "Main"
+    imagesets_main.mkdir(parents=True)
+    (imagesets_main / "train.txt").write_text("img1\n")
+    (imagesets_main / "potted_plant_train.txt").write_text("img1  1\n")
+
+    categories = LabelCategories(labels=("background", "potted_plant"))
+    result = _detect_classification_label_files(tmp_path, {"train"}, categories)
+
+    assert "train" in result
+    assert "potted_plant" in result["train"]
+
+
+# ==============================
+# _parse_classification_labels Tests
+# ==============================
+
+
+def test_parse_classification_labels_returns_positive_labels(tmp_path: Path):
+    """Test parsing classification files returns correct positive label indices."""
+    dog_file = tmp_path / "dog_train.txt"
+    cat_file = tmp_path / "cat_train.txt"
+    dog_file.write_text("img1  1\nimg2 -1\nimg3  1\n")
+    cat_file.write_text("img1 -1\nimg2  1\nimg3  1\n")
+
+    categories = LabelCategories(labels=("background", "dog", "cat"))
+    label_files = {"dog": dog_file, "cat": cat_file}
+
+    result = _parse_classification_labels(label_files, categories)
+
+    assert result["img1"] == [1]  # dog only
+    assert result["img2"] == [2]  # cat only
+    assert result["img3"] == [1, 2]  # both dog and cat
+
+
+def test_parse_classification_labels_excludes_negative_labels(tmp_path: Path):
+    """Test that images with only -1 entries do not appear in results."""
+    dog_file = tmp_path / "dog_train.txt"
+    dog_file.write_text("img1 -1\nimg2 -1\n")
+
+    categories = LabelCategories(labels=("background", "dog"))
+    label_files = {"dog": dog_file}
+
+    result = _parse_classification_labels(label_files, categories)
+
+    assert "img1" not in result
+    assert "img2" not in result
+
+
+def test_parse_classification_labels_handles_empty_file(tmp_path: Path):
+    """Test that an empty label file produces no entries."""
+    empty_file = tmp_path / "dog_train.txt"
+    empty_file.write_text("")
+
+    categories = LabelCategories(labels=("background", "dog"))
+    label_files = {"dog": empty_file}
+
+    result = _parse_classification_labels(label_files, categories)
+
+    assert result == {}
+
+
+def test_parse_classification_labels_skips_unknown_labels(tmp_path: Path):
+    """Test that labels not in categories are ignored."""
+    unknown_file = tmp_path / "unknown_train.txt"
+    unknown_file.write_text("img1  1\n")
+
+    categories = LabelCategories(labels=("background", "dog"))
+    label_files = {"unknown": unknown_file}
+
+    result = _parse_classification_labels(label_files, categories)
+
+    assert result == {}
+
+
+def test_parse_classification_labels_sorts_indices(tmp_path: Path):
+    """Test that label indices are sorted for determinism."""
+    # Create files so that cat (index 2) is parsed before dog (index 1)
+    cat_file = tmp_path / "cat_train.txt"
+    dog_file = tmp_path / "dog_train.txt"
+    cat_file.write_text("img1  1\n")
+    dog_file.write_text("img1  1\n")
+
+    categories = LabelCategories(labels=("background", "dog", "cat"))
+    # Pass cat first to test sorting
+    label_files = {"cat": cat_file, "dog": dog_file}
+
+    result = _parse_classification_labels(label_files, categories)
+
+    # Should be sorted: [1 (dog), 2 (cat)]
+    assert result["img1"] == [1, 2]
+
+
+def test_parse_classification_labels_skips_malformed_lines(tmp_path: Path):
+    """Test that lines without a valid flag are skipped."""
+    label_file = tmp_path / "dog_train.txt"
+    label_file.write_text("img1  1\nimg2\nimg3 abc\nimg4  1\n# comment\n\n")
+
+    categories = LabelCategories(labels=("background", "dog"))
+    label_files = {"dog": label_file}
+
+    result = _parse_classification_labels(label_files, categories)
+
+    assert "img1" in result
+    assert "img2" not in result
+    assert "img3" not in result
+    assert "img4" in result

--- a/tests/unit/experimental/data_formats/voc/test_voc_io.py
+++ b/tests/unit/experimental/data_formats/voc/test_voc_io.py
@@ -379,3 +379,180 @@ def test_roundtrip_preserves_bbox_data(tmp_path: Path):
         if orig.bboxes is not None:
             assert reload.bboxes is not None
             np.testing.assert_array_almost_equal(orig.bboxes, reload.bboxes, decimal=0)
+
+
+# ==============================
+# Classification Label Loading Tests
+# ==============================
+
+
+def _create_classification_voc_structure(root: Path) -> None:
+    """Create a VOC directory structure for a classification-only dataset (no XML annotations)."""
+    (root / "JPEGImages").mkdir(parents=True)
+    (root / "Annotations").mkdir(parents=True)
+    (root / "ImageSets" / "Main").mkdir(parents=True)
+
+    # Create test images
+    _create_test_image(root / "JPEGImages" / "dog01.jpg")
+    _create_test_image(root / "JPEGImages" / "dog02.jpg")
+    _create_test_image(root / "JPEGImages" / "cat01.jpg")
+    _create_test_image(root / "JPEGImages" / "cat02.jpg")
+    _create_test_image(root / "JPEGImages" / "unlabeled01.jpg")
+
+    # Main subset listing
+    (root / "ImageSets" / "Main" / "train.txt").write_text("dog01\ndog02\ncat01\ncat02\nunlabeled01\n")
+
+    # Label-specific classification files
+    (root / "ImageSets" / "Main" / "dog_train.txt").write_text("dog01  1\ndog02  1\ncat01 -1\ncat02 -1\n")
+    (root / "ImageSets" / "Main" / "cat_train.txt").write_text("dog01 -1\ndog02 -1\ncat01  1\ncat02  1\n")
+
+    # Labelmap
+    (root / "labelmap.txt").write_text(
+        "# label:color_rgb:parts:actions\nbackground:0,0,0::\ndog:128,0,0::\ncat:0,128,0::\n"
+    )
+
+
+def test_load_classification_dataset_assigns_labels(tmp_path: Path):
+    """Test that classification labels from ImageSets/Main are loaded when no XML annotations exist."""
+    _create_classification_voc_structure(tmp_path)
+
+    dataset = load_voc_dataset(root_dir=str(tmp_path))
+
+    assert len(dataset) == 5
+
+    labels_by_image = {}
+    for sample in dataset:
+        stem = Path(sample.image.path).stem
+        labels_by_image[stem] = sample.labels
+
+    # dog images should have label index 1 (dog)
+    assert labels_by_image["dog01"] is not None
+    np.testing.assert_array_equal(labels_by_image["dog01"], [1])
+    assert labels_by_image["dog02"] is not None
+    np.testing.assert_array_equal(labels_by_image["dog02"], [1])
+
+    # cat images should have label index 2 (cat)
+    assert labels_by_image["cat01"] is not None
+    np.testing.assert_array_equal(labels_by_image["cat01"], [2])
+    assert labels_by_image["cat02"] is not None
+    np.testing.assert_array_equal(labels_by_image["cat02"], [2])
+
+    # unlabeled image should have no labels
+    assert labels_by_image["unlabeled01"] is None
+
+
+def test_load_classification_dataset_no_bboxes(tmp_path: Path):
+    """Test that classification-only samples have no bounding boxes."""
+    _create_classification_voc_structure(tmp_path)
+
+    dataset = load_voc_dataset(root_dir=str(tmp_path))
+
+    for sample in dataset:
+        assert sample.bboxes is None
+
+
+def test_load_classification_dataset_label_dtype(tmp_path: Path):
+    """Test that classification labels are uint32 arrays."""
+    _create_classification_voc_structure(tmp_path)
+
+    dataset = load_voc_dataset(root_dir=str(tmp_path))
+
+    for sample in dataset:
+        if sample.labels is not None:
+            assert sample.labels.dtype == np.uint32
+
+
+def test_load_classification_dataset_multi_label(tmp_path: Path):
+    """Test that an image can receive multiple classification labels."""
+    root = tmp_path / "multi"
+    (root / "JPEGImages").mkdir(parents=True)
+    (root / "Annotations").mkdir(parents=True)
+    (root / "ImageSets" / "Main").mkdir(parents=True)
+
+    _create_test_image(root / "JPEGImages" / "both.jpg")
+
+    (root / "ImageSets" / "Main" / "train.txt").write_text("both\n")
+    (root / "ImageSets" / "Main" / "dog_train.txt").write_text("both  1\n")
+    (root / "ImageSets" / "Main" / "cat_train.txt").write_text("both  1\n")
+    (root / "labelmap.txt").write_text(
+        "# label:color_rgb:parts:actions\nbackground:0,0,0::\ndog:128,0,0::\ncat:0,128,0::\n"
+    )
+
+    dataset = load_voc_dataset(root_dir=str(root))
+
+    assert len(dataset) == 1
+    sample = dataset[0]
+    assert sample.labels is not None
+    # Both labels present and sorted
+    np.testing.assert_array_equal(sample.labels, [1, 2])
+
+
+def test_xml_annotations_take_precedence_over_classification_labels(tmp_path: Path):
+    """Test that XML annotation labels are used when present, even if classification files exist."""
+    root = tmp_path / "mixed"
+    (root / "JPEGImages").mkdir(parents=True)
+    (root / "Annotations").mkdir(parents=True)
+    (root / "ImageSets" / "Main").mkdir(parents=True)
+
+    _create_test_image(root / "JPEGImages" / "img.jpg", width=640, height=480)
+
+    # XML annotation with a person bbox
+    (root / "Annotations" / "img.xml").write_text("""
+<annotation>
+    <size><width>640</width><height>480</height></size>
+    <object>
+        <name>person</name>
+        <bndbox><xmin>10</xmin><ymin>20</ymin><xmax>100</xmax><ymax>200</ymax></bndbox>
+    </object>
+</annotation>
+    """)
+
+    (root / "ImageSets" / "Main" / "train.txt").write_text("img\n")
+    (root / "ImageSets" / "Main" / "person_train.txt").write_text("img  1\n")
+    (root / "ImageSets" / "Main" / "car_train.txt").write_text("img  1\n")
+    (root / "labelmap.txt").write_text(
+        "# label:color_rgb:parts:actions\nbackground:0,0,0::\nperson:128,0,0::\ncar:0,128,0::\n"
+    )
+
+    dataset = load_voc_dataset(root_dir=str(root))
+
+    sample = dataset[0]
+    # Should have the XML-based label (person=1), not the classification labels
+    assert sample.bboxes is not None
+    assert sample.bboxes.shape == (1, 4)
+    np.testing.assert_array_equal(sample.labels, [1])  # person only from XML
+
+
+def test_load_classification_with_multiple_subsets(tmp_path: Path):
+    """Test classification labels across train and val subsets."""
+    root = tmp_path / "subsets"
+    (root / "JPEGImages").mkdir(parents=True)
+    (root / "Annotations").mkdir(parents=True)
+    (root / "ImageSets" / "Main").mkdir(parents=True)
+
+    _create_test_image(root / "JPEGImages" / "train_img.jpg")
+    _create_test_image(root / "JPEGImages" / "val_img.jpg")
+
+    (root / "ImageSets" / "Main" / "train.txt").write_text("train_img\n")
+    (root / "ImageSets" / "Main" / "val.txt").write_text("val_img\n")
+    (root / "ImageSets" / "Main" / "dog_train.txt").write_text("train_img  1\n")
+    (root / "ImageSets" / "Main" / "cat_val.txt").write_text("val_img  1\n")
+    (root / "labelmap.txt").write_text(
+        "# label:color_rgb:parts:actions\nbackground:0,0,0::\ndog:128,0,0::\ncat:0,128,0::\n"
+    )
+
+    dataset = load_voc_dataset(root_dir=str(root))
+
+    assert len(dataset) == 2
+
+    labels_by_image = {}
+    subset_by_image = {}
+    for sample in dataset:
+        stem = Path(sample.image.path).stem
+        labels_by_image[stem] = sample.labels
+        subset_by_image[stem] = sample.subset
+
+    np.testing.assert_array_equal(labels_by_image["train_img"], [1])  # dog
+    np.testing.assert_array_equal(labels_by_image["val_img"], [2])  # cat
+    assert subset_by_image["train_img"] == Subset.TRAINING
+    assert subset_by_image["val_img"] == Subset.VALIDATION


### PR DESCRIPTION
This pull request enhances support for classification-only datasets in the VOC format by adding logic to detect, parse, and load image-level classification labels from `ImageSets/Main/<label>_<subset>.txt` files. When XML annotations are absent, these per-label files are now used to assign labels to images. 

Resolves https://github.com/open-edge-platform/training_extensions/issues/5831


<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
