### PR TITLE
Fix hierarchical dataset conversion

### DIFF
--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Generic, TypeGuard, Union, cas
 import polars as pl
 from typing_extensions import TypeVar, dataclass_transform
 
-from datumaro.experimental.categories import HierarchicalLabelCategories
+from datumaro.experimental.categories import BaseLabelCategories, HierarchicalLabelCategories
 from datumaro.experimental.converters.registry import ConverterTransform, find_conversion_path
 from datumaro.experimental.fields.annotations import LabelField
 from datumaro.experimental.fields.datasets import Subset, SubsetField
@@ -302,6 +302,24 @@ class Dataset(Generic[DType]):
     def dtype(self) -> type[DType]:
         """Get the sample type of this dataset."""
         return self._dtype
+
+    @property
+    def label_categories(self) -> BaseLabelCategories | None:
+        """Get the label categories from the dataset schema, if any.
+
+        Searches the schema attributes for the first field whose categories
+        are an instance of :class:`BaseLabelCategories` (which covers both
+        :class:`LabelCategories` and :class:`HierarchicalLabelCategories`).
+
+        Returns:
+            The :class:`BaseLabelCategories` instance, or ``None`` if no
+            label categories are defined in the schema.
+        """
+        for attr_name, attr_info in self._schema.attributes.items():
+            categories = self._schema.get_categories_for_field(attr_name)
+            if isinstance(categories, BaseLabelCategories):
+                return categories
+        return None
 
     def _generate_polars_schema(self) -> pl.Schema:
         """Generate a Polars schema from the dataset's field definitions."""

--- a/src/datumaro/experimental/legacy/dataset_converters.py
+++ b/src/datumaro/experimental/legacy/dataset_converters.py
@@ -116,10 +116,10 @@ def analyze_legacy_dataset(
         if converter is not None:
             ann_converters[ann_type] = converter
             ann_attributes = converter.get_schema_attributes()
-            if is_multi_label or is_hierarchical:
+            if (is_multi_label or is_hierarchical) and AnnotationType.label.name in ann_attributes:
                 ann_attributes[AnnotationType.label.name].field = label_field(multi_label=True)
                 ann_attributes[AnnotationType.label.name].type = np.ndarray
-            if is_hierarchical:
+            if is_hierarchical and AnnotationType.label.name in ann_attributes:
                 categories = legacy_dataset.categories()[AnnotationType.label].items
                 label_categories = tuple(
                     HierarchicalLabelCategory(

--- a/src/datumaro/experimental/legacy/dataset_converters.py
+++ b/src/datumaro/experimental/legacy/dataset_converters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import numpy as np
 import polars as pl
 
 from datumaro import Annotation, AnnotationType, CategoriesInfo, DatasetItem, MediaElement
@@ -115,10 +116,10 @@ def analyze_legacy_dataset(
         if converter is not None:
             ann_converters[ann_type] = converter
             ann_attributes = converter.get_schema_attributes()
-            if is_multi_label:
+            if is_multi_label or is_hierarchical:
                 ann_attributes[AnnotationType.label.name].field = label_field(multi_label=True)
+                ann_attributes[AnnotationType.label.name].type = np.ndarray
             if is_hierarchical:
-                ann_attributes[AnnotationType.label.name].field = label_field(is_list=True)
                 categories = legacy_dataset.categories()[AnnotationType.label].items
                 label_categories = tuple(
                     HierarchicalLabelCategory(

--- a/tests/unit/experimental/legacy/test_legacy_dataset_converters.py
+++ b/tests/unit/experimental/legacy/test_legacy_dataset_converters.py
@@ -693,6 +693,29 @@ class HelperFunctionsTest:
 class HierarchicalLegacyDatasetTest:
     """Tests for hierarchical legacy dataset analysis."""
 
+    def test_convert_hierarchical_dataset_getitem(self):
+        """Test that __getitem__ works on a converted hierarchical dataset.
+
+        Regression test: multi_label label fields were stored with type=int,
+        causing int(Series) to fail when reading back from Polars.
+        """
+        from datumaro.components.annotation import Label
+        from datumaro.components.annotation import LabelCategories as LegacyLabelCategories
+
+        legacy_categories = LegacyLabelCategories()
+        legacy_categories.add("animal")
+        legacy_categories.add("animal__dog")
+        legacy_categories.add("animal__cat")
+
+        item = DatasetItem(id="test", annotations=[Label(label=1)])
+        legacy_dataset = LegacyDataset.from_iterable([item], categories={AnnotationType.label: legacy_categories})
+
+        dataset = convert_from_legacy(legacy_dataset)
+
+        sample = dataset[0]
+        assert isinstance(sample.label, np.ndarray)
+        assert 1 in sample.label
+
     def test_analyze_legacy_dataset_hierarchical(self):
         """Test analyze_legacy_dataset with hierarchical labels."""
         from datumaro.components.annotation import Label
@@ -722,7 +745,7 @@ class HierarchicalLegacyDatasetTest:
         # Check that hierarchical categories were created
         label_attr = analysis_result.schema.attributes[AnnotationType.label.name]
         assert isinstance(label_attr.categories, HierarchicalLabelCategories)
-        assert label_attr.field.is_list is True
+        assert label_attr.field.multi_label is True
 
     def test_analyze_legacy_dataset_non_hierarchical(self):
         """Test analyze_legacy_dataset with non-hierarchical labels."""

--- a/tests/unit/experimental/test_dataset.py
+++ b/tests/unit/experimental/test_dataset.py
@@ -9,7 +9,12 @@ import numpy as np
 import polars as pl
 import pytest
 
-from datumaro.experimental.categories import LabelCategories, MaskCategories
+from datumaro.experimental.categories import (
+    HierarchicalLabelCategories,
+    HierarchicalLabelCategory,
+    LabelCategories,
+    MaskCategories,
+)
 from datumaro.experimental.dataset import AttributeInfo, Dataset, Sample, Schema, convert_sample_to_schema
 from datumaro.experimental.fields import (
     ImageInfo,
@@ -1944,3 +1949,108 @@ def test_filter_by_labels_empty_labels_raises_error():
 
     with pytest.raises(ValueError, match="No labels provided to filter"):
         ds.filter_by_labels([])
+
+
+# ── label_categories property tests ─────────────────────────────────────────
+
+
+def test_label_categories_returns_label_categories():
+    """label_categories returns the LabelCategories from the schema."""
+    categories = LabelCategories(labels=("cat", "dog", "bird"))
+    schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=categories)})
+    ds = Dataset(schema)
+
+    result = ds.label_categories
+    assert result is categories
+    assert isinstance(result, LabelCategories)
+    assert len(result) == 3
+    assert "cat" in result
+
+
+def test_label_categories_returns_none_without_label_categories():
+    """label_categories returns None when no BaseLabelCategories exist in the schema."""
+
+    class SimpleSample(Sample):
+        image: np.ndarray[Any, Any] = image_field(dtype=pl.UInt8(), format="RGB")
+
+    ds = Dataset(SimpleSample)
+    assert ds.label_categories is None
+
+
+def test_label_categories_returns_none_with_only_mask_categories():
+    """label_categories returns None when only non-label categories exist."""
+    mask_cats = MaskCategories(colormap={0: (0, 0, 0), 1: (255, 0, 0)})
+    schema = Schema(
+        attributes={
+            "image": AttributeInfo(
+                type=np.ndarray, field=image_field(dtype=pl.UInt8(), format="RGB"), categories=mask_cats
+            )
+        }
+    )
+    ds = Dataset(schema)
+    assert ds.label_categories is None
+
+
+def test_label_categories_returns_first_label_categories():
+    """When multiple attributes have LabelCategories, the first one is returned."""
+    cats_a = LabelCategories(labels=("a", "b"))
+    cats_b = LabelCategories(labels=("x", "y", "z"))
+    schema = Schema(
+        attributes={
+            "label_a": AttributeInfo(type=int, field=label_field(semantic="a"), categories=cats_a),
+            "label_b": AttributeInfo(type=int, field=label_field(semantic="b"), categories=cats_b),
+        }
+    )
+    ds = Dataset(schema)
+
+    result = ds.label_categories
+    # Should return the first one found (label_a)
+    assert result is cats_a
+
+
+def test_label_categories_with_hierarchical_label_categories():
+    """label_categories returns HierarchicalLabelCategories (subclass of BaseLabelCategories)."""
+    items = (
+        HierarchicalLabelCategory(name="animal"),
+        HierarchicalLabelCategory(name="cat", parent="animal"),
+        HierarchicalLabelCategory(name="dog", parent="animal"),
+    )
+    hier_cats = HierarchicalLabelCategories(items=items)
+    schema = Schema(attributes={"label": AttributeInfo(type=int, field=label_field(), categories=hier_cats)})
+    ds = Dataset(schema)
+
+    result = ds.label_categories
+    assert result is hier_cats
+    assert isinstance(result, HierarchicalLabelCategories)
+
+
+def test_label_categories_with_categories_passed_to_dataset():
+    """label_categories works when categories are passed via Dataset constructor."""
+
+    class TestSample(Sample):
+        label: int = label_field()
+
+    cats = LabelCategories(labels=("person", "car"))
+    ds = Dataset(TestSample, categories={"label": cats})
+
+    result = ds.label_categories
+    assert result is cats
+    assert len(result) == 2
+
+
+def test_label_categories_ignores_non_label_categories():
+    """label_categories skips attributes with non-label categories and finds the right one."""
+    mask_cats = MaskCategories(colormap={0: (0, 0, 0)})
+    label_cats = LabelCategories(labels=("yes", "no"))
+    schema = Schema(
+        attributes={
+            "image": AttributeInfo(
+                type=np.ndarray, field=image_field(dtype=pl.UInt8(), format="RGB"), categories=mask_cats
+            ),
+            "label": AttributeInfo(type=int, field=label_field(), categories=label_cats),
+        }
+    )
+    ds = Dataset(schema)
+
+    result = ds.label_categories
+    assert result is label_cats


### PR DESCRIPTION
Fix an issue with hierarchical classification dataset legacy conversion and add label_categories property to the Dataset class. 

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
