### PR TITLE
Reimplement label shape converter to support multi_label/is_list swaps

### DIFF
--- a/src/datumaro/experimental/converters/annotation_converters.py
+++ b/src/datumaro/experimental/converters/annotation_converters.py
@@ -332,6 +332,10 @@ class LabelShapeConverter(Converter):
     Both change simultaneously:
       - ``dtype → List(List(dtype))``: wrap scalar twice
 
+    Flag swap (no data change - semantic reinterpretation):
+      - ``is_list=True, multi_label=False`` ↔ ``is_list=False, multi_label=True``:
+        both map to ``List(dtype)``; the conversion is a no-op on the data.
+
     Unsupported (lossy) conversions:
       - ``List(dtype) → dtype`` (multi_label or is_list reduction): rejected to prevent silent data loss
     """
@@ -364,6 +368,17 @@ class LabelShapeConverter(Converter):
         output_multi = self.output_label.field.multi_label
         input_is_list = self.input_label.field.is_list
         output_is_list = self.output_label.field.is_list
+
+        # Special case: swapping multi_label and is_list flags.
+        # When one flag goes True→False and the other False→True the underlying
+        # Polars type is identical (both are List(dtype))
+        if input_multi != output_multi and input_is_list != output_is_list:
+            if input_multi and not output_multi and not input_is_list and output_is_list:
+                # List(dtype) [multi_label] → List(dtype) [is_list]: no-op rename
+                return df.with_columns(pl.col(input_col).alias(output_col))
+            if not input_multi and output_multi and input_is_list and not output_is_list:
+                # List(dtype) [is_list] → List(dtype) [multi_label]: no-op rename
+                return df.with_columns(pl.col(input_col).alias(output_col))
 
         # Step 1: handle multi_label conversion (inner dimension)
         if input_multi and not output_multi:

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -148,17 +148,32 @@ def _export_image_path_field(
     idx: int,
     output_dir: Path,
 ) -> str | None:
-    """Export an ImagePathField by copying the file from the filesystem."""
+    """Export an ImagePathField by copying the file from the filesystem.
+
+    The original filename is preserved.  When a name collision occurs
+    (e.g. two source images from different directories share the same
+    filename) a numeric suffix is appended to disambiguate.
+    """
     try:
         source_path = Path(str(value))
         if not source_path.exists():
             log.warning("Image file not found: %s", value)
             return None
 
-        extension = source_path.suffix if source_path.suffix else ".png"
-        rel_path = f"{field_name}_{idx:06d}{extension}"
-        abs_path = output_dir / rel_path
+        # Preserve the original filename; fall back to index-based naming
+        # only when the source has no name at all.
+        dest_name = source_path.name if source_path.name else f"{field_name}_{idx:06d}.png"
+        abs_path = output_dir / dest_name
 
+        # Handle name collisions with a numeric suffix
+        counter = 1
+        while abs_path.exists():
+            stem = source_path.stem if source_path.stem else f"{field_name}_{idx:06d}"
+            suffix = source_path.suffix if source_path.suffix else ".png"
+            abs_path = output_dir / f"{stem}_{counter}{suffix}"
+            counter += 1
+
+        rel_path = abs_path.name
         shutil.copy2(source_path, abs_path)
         return str(rel_path)
     except Exception as e:
@@ -1016,11 +1031,41 @@ def _make_image_loader(path: Path):
     return load_image
 
 
+def _resolve_image_file(
+    field_name: str,
+    idx: int,
+    images_base_dir: Path,
+    df_path: str | None = None,
+) -> Path | None:
+    """Find the exported image file for a given field and row index.
+
+    Resolution order:
+    1. Index-based pattern ``{field_name}_{idx:06d}.*`` (used by callable fields)
+    2. The relative path stored in the parquet DataFrame (used by path fields
+       that preserve the original filename)
+    """
+    # 1. Try index-based naming (callable fields always use this)
+    pattern = f"{field_name}_{idx:06d}.*"
+    matches = sorted(images_base_dir.glob(pattern))
+    if matches:
+        return matches[0]
+
+    # 2. Try the path stored in parquet (original filename preserved by
+    #    _export_image_path_field)
+    if df_path is not None:
+        candidate = images_base_dir / df_path
+        if candidate.exists():
+            return candidate
+
+    return None
+
+
 def _reconstruct_field_values(
     field_name: str,
     field: object,
     images_base_dir: Path,
     num_rows: int,
+    df: pl.DataFrame | None = None,
 ) -> tuple[list[object | None], bool, bool]:
     """
     Reconstruct values for a single image-related field.
@@ -1040,9 +1085,14 @@ def _reconstruct_field_values(
 
     values: list[object | None] = []
     for idx in range(num_rows):
-        pattern = f"{field_name}_{idx:06d}.*"
-        matches = sorted(images_base_dir.glob(pattern))
-        file_path = matches[0] if matches else None
+        # Get the path stored in parquet (if available) for fallback resolution
+        df_path: str | None = None
+        if df is not None and field_name in df.columns:
+            raw = df[field_name][idx]
+            if raw is not None:
+                df_path = str(raw)
+
+        file_path = _resolve_image_file(field_name, idx, images_base_dir, df_path)
 
         if is_path_field:
             values.append(str(file_path) if file_path is not None else None)
@@ -1097,7 +1147,7 @@ def _reconstruct_image_fields(
             continue
 
         values, is_path_field, is_callable_field = _reconstruct_field_values(
-            field_name, field, images_base_dir, len(df)
+            field_name, field, images_base_dir, len(df), df=df
         )
 
         if is_path_field or is_callable_field:

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -995,7 +995,7 @@ def test_export_import_different_field_types(tmp_path):
     # Verify images were exported
     images_dir = export_dir / IMAGES_DIR
     assert (images_dir / "image_callable_000000.png").exists()
-    assert (images_dir / "image_path_000000.png").exists()
+    assert (images_dir / "source_image.png").exists()  # ImagePathField preserves original filename
     assert (images_dir / "mask_callable_000000.png").exists()
     assert (images_dir / "instance_mask_callable_000000.png").exists()
 
@@ -1092,11 +1092,10 @@ def test_export_dataset_export_media_copy_and_skip(tmp_path):
 
     assert exported_path is not None
     assert exported_path != str(source_img_path)
-    # Verify the exported file exists at the path relative to images/
-    # Note: rel_path in _export_image_path_field is 'img/000000.jpg'
-    assert "000000.jpg" in exported_path
+    # ImagePathField preserves the original filename
+    assert exported_path == "cat1.jpg"
 
-    # Check if the file exists on disk (handling the replacement of / with _ in filename)
+    # Check if the file exists on disk
     exported_file_on_disk = export_dir_true / IMAGES_DIR / exported_path
     assert exported_file_on_disk.exists()
 
@@ -2377,3 +2376,147 @@ def test_export_dataset_raises_error_if_output_already_exists(tmp_path):
     file_path.touch()
     with pytest.raises(FileExistsError, match="Output path already exists as a file"):
         export_dataset(dataset, file_path, export_media=ExportMode.SKIP, as_zip=True)
+
+
+def test_export_import_preserves_original_filenames(tmp_path):
+    """Test that original filenames are preserved through export/import roundtrip.
+
+    When exporting an ImagePathField, the original filename should be kept
+    (not replaced with an index-based name). On import, the path should
+    resolve to the exported file with the original name.
+    """
+
+    class PathSample(Sample):
+        image_path: str = image_path_field()
+        label: int = label_field()
+
+    # Create source images with distinct, meaningful filenames
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+
+    filenames = ["cat_photo.jpg", "dog_running.png", "bird in flight.jpeg"]
+    source_paths = []
+    for fname in filenames:
+        img_path = source_dir / fname
+        img = np.random.randint(0, 255, (20, 30, 3), dtype=np.uint8)
+        pil_img = PILImage.fromarray(img)
+        fmt = "JPEG" if fname.endswith((".jpg", ".jpeg")) else "PNG"
+        pil_img.save(img_path, fmt)
+        source_paths.append(str(img_path))
+
+    dataset = Dataset(PathSample, categories={"label": LABEL_CATEGORIES})
+    for idx, path in enumerate(source_paths):
+        dataset.append(PathSample(image_path=path, label=idx))
+
+    # ---- Export ----
+    export_dir = tmp_path / "export"
+    export_dataset(dataset, export_dir, export_media=ExportMode.COPY, as_zip=False)
+
+    # Verify that the images directory contains files with the original names
+    images_dir = export_dir / IMAGES_DIR
+    for fname in filenames:
+        assert (images_dir / fname).exists(), f"Expected {fname} in images directory"
+
+    # Verify the parquet stores the original filenames (not index-based names)
+    df_exported = pl.read_parquet(export_dir / DATAFRAME_FILE)
+    for idx, fname in enumerate(filenames):
+        assert df_exported["image_path"][idx] == fname
+
+    # ---- Import ----
+    imported_dataset = import_dataset(export_dir, dtype=PathSample)
+
+    assert len(imported_dataset) == len(filenames)
+    for idx, fname in enumerate(filenames):
+        sample = imported_dataset[idx]
+        path = Path(sample.image_path)
+
+        # The path should exist and point to the original-named file
+        assert path.exists(), f"Imported path {path} does not exist"
+        assert path.name == fname, f"Expected filename {fname}, got {path.name}"
+
+        # The image content should be loadable
+        loaded_img = np.array(PILImage.open(path))
+        assert loaded_img.shape[0] == 20
+        assert loaded_img.shape[1] == 30
+
+
+def test_export_import_preserves_filenames_with_collisions(tmp_path):
+    """Test that filename collisions are handled when multiple source files share the same name."""
+
+    class PathSample(Sample):
+        image_path: str = image_path_field()
+
+    # Create two images with the same filename but in different directories
+    dir_a = tmp_path / "source_a"
+    dir_b = tmp_path / "source_b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+
+    img_a = np.full((10, 10, 3), 100, dtype=np.uint8)
+    img_b = np.full((10, 10, 3), 200, dtype=np.uint8)
+    PILImage.fromarray(img_a).save(dir_a / "photo.png")
+    PILImage.fromarray(img_b).save(dir_b / "photo.png")
+
+    dataset = Dataset(PathSample)
+    dataset.append(PathSample(image_path=str(dir_a / "photo.png")))
+    dataset.append(PathSample(image_path=str(dir_b / "photo.png")))
+
+    # ---- Export ----
+    export_dir = tmp_path / "export"
+    export_dataset(dataset, export_dir, export_media=ExportMode.COPY, as_zip=False)
+
+    images_dir = export_dir / IMAGES_DIR
+    # One file keeps the original name, the other gets a numeric suffix
+    assert (images_dir / "photo.png").exists()
+    assert (images_dir / "photo_1.png").exists()
+
+    # ---- Import ----
+    imported_dataset = import_dataset(export_dir, dtype=PathSample)
+    assert len(imported_dataset) == 2
+
+    # Both paths should exist and be distinct
+    path_0 = Path(imported_dataset[0].image_path)
+    path_1 = Path(imported_dataset[1].image_path)
+    assert path_0.exists()
+    assert path_1.exists()
+    assert path_0 != path_1
+
+    # Verify image content is preserved (pixel values distinguish the two)
+    loaded_0 = np.array(PILImage.open(path_0))
+    loaded_1 = np.array(PILImage.open(path_1))
+    assert loaded_0[0, 0, 0] == 100
+    assert loaded_1[0, 0, 0] == 200
+
+
+def test_export_import_preserves_filenames_via_zip(tmp_path):
+    """Test that original filenames survive a ZIP export/import roundtrip."""
+
+    class PathSample(Sample):
+        image_path: str = image_path_field()
+        label: int = label_field()
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    img_path = source_dir / "my_image.png"
+    PILImage.fromarray(np.zeros((15, 20, 3), dtype=np.uint8)).save(img_path)
+
+    dataset = Dataset(PathSample, categories={"label": LABEL_CATEGORIES})
+    dataset.append(PathSample(image_path=str(img_path), label=0))
+
+    # ---- Export as ZIP ----
+    export_zip = tmp_path / "export.zip"
+    export_dataset(dataset, export_zip, export_media=ExportMode.COPY, as_zip=True)
+
+    # Verify the ZIP contains the original filename
+    with zipfile.ZipFile(export_zip) as zf:
+        image_entries = [n for n in zf.namelist() if n.startswith(IMAGES_DIR + "/")]
+        assert any("my_image.png" in entry for entry in image_entries)
+
+    # ---- Import from ZIP ----
+    imported_dataset = import_dataset(export_zip, dtype=PathSample)
+    assert len(imported_dataset) == 1
+
+    sample = imported_dataset[0]
+    path = Path(sample.image_path)
+    assert path.exists()
+    assert path.name == "my_image.png"

--- a/tests/unit/experimental/converters/test_annotation_converters.py
+++ b/tests/unit/experimental/converters/test_annotation_converters.py
@@ -778,6 +778,9 @@ def test_label_dtype_converter_multi_label_and_list():
         pytest.param(True,  False, True,  True,  {"label": [[1, 2, 3]]},              pl.List(pl.UInt32()),         pl.List(pl.List(pl.UInt32)),      [[1, 2, 3]], id="multi_label_scalar_to_list"),  # noqa: E501
         # --- both flags change (non-lossy: both expanding) ---
         pytest.param(False, False, True,  True,  {"label": [5]},                      pl.UInt32(),                  pl.List(pl.List(pl.UInt32)),      [[5]],       id="both_scalar_to_list_list"),  # noqa: E501
+        # --- flag swap (no-op semantic reinterpretation) ---
+        pytest.param(False, True,  True,  False, {"label": [[1, 2, 3]]},              pl.List(pl.UInt32()),         pl.List(pl.UInt32),               [1, 2, 3],   id="swap_is_list_to_multi_label"),  # noqa: E501
+        pytest.param(True,  False, False, True,  {"label": [[1, 2, 3]]},              pl.List(pl.UInt32()),         pl.List(pl.UInt32),               [1, 2, 3],   id="swap_multi_label_to_is_list"),  # noqa: E501
     ],
 )  # fmt: on  noqa: RUF028
 def test_label_shape_converter_conversions(
@@ -827,7 +830,6 @@ def test_label_shape_converter_conversions(
         pytest.param(False, True,  False, False, {"label": [[10, 20, 30]]},           pl.List(pl.UInt32()),          "Cannot convert list to non-list",             id="list_to_scalar"),  # noqa: E501
         pytest.param(True,  True,  True,  False, {"label": [[[1, 2], [3, 4], [5]]]},  pl.List(pl.List(pl.UInt32())), "Cannot convert list to non-list",             id="multi_label_list_to_scalar"),  # noqa: E501
         pytest.param(True,  True,  False, False, {"label": [[[5, 10], [15, 20]]]},    pl.List(pl.List(pl.UInt32())), "Cannot convert multi-label to single-label", id="both_list_list_to_scalar"),  # noqa: E501
-        pytest.param(False, True,  True,  False, {"label": [[1, 2, 3]]},              pl.List(pl.UInt32()),          "Cannot convert list to non-list",             id="both_swap_flags"),  # noqa: E501
     ],
 )  # fmt: on  noqa: RUF028
 def test_label_shape_converter_rejects_lossy_conversions(
@@ -899,6 +901,8 @@ def test_label_shape_converter_preserves_dtype():
         pytest.param(False, True,  True, True, {"labels": [[1, 2], None, [3]]}, pl.List(pl.UInt32()), pl.List(pl.List(pl.UInt32)), {0: [[1], [2]], 2: [[3]]}, 1, id="multi_label_with_nulls"),  # noqa: E501
         pytest.param(False, False, True, False, {"labels": [5, None, 3]},      pl.UInt32(),          pl.List(pl.UInt32),          {0: [5], 2: [3]},          1, id="scalar_to_multi_label_with_nulls"),  # noqa: E501
         pytest.param(False, False, False, True, {"labels": [5, None, 3]},       pl.UInt32(),          pl.List(pl.UInt32),          {0: [5], 2: [3]},          1, id="is_list_with_nulls"),  # noqa: E501
+        pytest.param(False, True,  True, False, {"labels": [[1, 2], None, [3]]}, pl.List(pl.UInt32()), pl.List(pl.UInt32),          {0: [1, 2], 2: [3]},       1, id="swap_is_list_to_multi_label_with_nulls"),  # noqa: E501
+        pytest.param(True,  False, False, True, {"labels": [[1, 2], None, [3]]}, pl.List(pl.UInt32()), pl.List(pl.UInt32),          {0: [1, 2], 2: [3]},       1, id="swap_multi_label_to_is_list_with_nulls"),  # noqa: E501
     ],
 )  # fmt: on noqa: RUF028
 def test_label_shape_converter_with_nulls(


### PR DESCRIPTION
Reimplement swaps from label_field(is_list=True, multi_label=False) to label_field(is_list=False, multi_label=True) and vice-versa

Also keep the original image names when exporting datasets. 

Fix regression from https://github.com/open-edge-platform/datumaro/pull/2083


<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
