### PR TITLE
Fix YOLO imports for unassigned subsets and label filter fix

### DIFF
--- a/src/datumaro/experimental/data_formats/yolo/constants.py
+++ b/src/datumaro/experimental/data_formats/yolo/constants.py
@@ -42,4 +42,5 @@ TRADITIONAL_DIR_NAME_TO_SUBSET = {
     "val": Subset.VALIDATION,
     "obj_test_data": Subset.TESTING,
     "test": Subset.TESTING,
+    "obj_data": Subset.UNASSIGNED,
 }

--- a/src/datumaro/experimental/filtering/label_filter.py
+++ b/src/datumaro/experimental/filtering/label_filter.py
@@ -181,7 +181,7 @@ def _filter_associated_fields(
         if field_name in df.columns:
 
             def filter_by_mask(s: dict[str, Any], fname: str = field_name) -> list[Any] | None:
-                if s[fname] is None:
+                if s[fname] is None or s["__mask__"] is None:
                     return None
                 return [v for v, m in zip(s[fname], s["__mask__"]) if m]
 

--- a/tests/unit/experimental/data_formats/yolo/test_yolo_io.py
+++ b/tests/unit/experimental/data_formats/yolo/test_yolo_io.py
@@ -193,6 +193,30 @@ def test_load_yolo_dataset_missing_images_dir_raises(tmp_path: Path):
         load_yolo_dataset(str(tmp_path), format="ultralytics")
 
 
+def test_load_yolo_dataset_traditional_obj_data_directory(tmp_path: Path):
+    """Test loading a traditional YOLO dataset that uses the obj_data directory (unassigned subset)."""
+    obj_data_dir = tmp_path / "obj_data"
+    obj_data_dir.mkdir(parents=True)
+
+    # Create images and annotations
+    _create_test_image(obj_data_dir / "img1.jpg", 640, 480)
+    _create_test_image(obj_data_dir / "img2.jpg", 800, 600)
+    (obj_data_dir / "img1.txt").write_text("0 0.5 0.5 0.2 0.3\n")
+    (obj_data_dir / "img2.txt").write_text("0 0.3 0.4 0.15 0.25\n")
+
+    # Create obj.names
+    (tmp_path / "obj.names").write_text("cat\n")
+
+    ds = load_yolo_dataset(str(tmp_path))
+
+    assert len(ds) == 2
+    # All samples should have Subset.UNASSIGNED
+    for sample in ds:
+        assert sample.subset == Subset.UNASSIGNED
+        assert sample.bboxes is not None
+        assert sample.labels is not None
+
+
 # ==========================
 # save_yolo_dataset Tests
 # ==========================

--- a/tests/unit/experimental/filtering/test_label_filter.py
+++ b/tests/unit/experimental/filtering/test_label_filter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2026 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/unit/experimental/filtering/test_label_filter.py
+++ b/tests/unit/experimental/filtering/test_label_filter.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import polars as pl
+
+from datumaro.experimental.filtering.label_filter import _filter_associated_fields
+
+
+def test_filter_associated_fields_null_mask_does_not_raise():
+    """_filter_associated_fields must not crash when the mask is null.
+
+    Regression test: when the labels column is null for a row, the boolean
+    mask expression derived from it also evaluates to null.  Before the fix
+    the inner ``filter_by_mask`` only guarded against a null *field* value
+    but not a null *mask*, causing
+    ``TypeError: 'NoneType' object is not iterable``.
+    """
+    df = pl.DataFrame(
+        {
+            # Row 0: two annotations, labels [0, 1]
+            # Row 1: non-null bboxes but null labels  →  mask will be null
+            # Row 2: one annotation, label [1]
+            "labels": [[0, 1], None, [1]],
+            "bboxes": [
+                [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]],
+                [[9.0, 10.0, 11.0, 12.0]],
+                [[13.0, 14.0, 15.0, 16.0]],
+            ],
+        },
+        schema={
+            "labels": pl.List(pl.UInt32()),
+            "bboxes": pl.List(pl.Array(pl.Float32(), 4)),
+        },
+    )
+
+    # Mask: per-element boolean derived from labels — null when labels is null
+    keep_mask_expr = pl.col("labels").list.eval(pl.element().cast(pl.Int64).is_in([0]))
+
+    exprs = _filter_associated_fields(df, keep_mask_expr, associated_fields=["bboxes"])
+    assert len(exprs) == 1
+
+    # This .with_columns() call is where the original TypeError was raised
+    result = df.with_columns(exprs)
+
+    # Row 0: only label-index 0 matches → keep first bbox only
+    assert result["bboxes"][0].to_list() == [[1.0, 2.0, 3.0, 4.0]]
+    # Row 1: mask is null → returns None
+    assert result["bboxes"][1] is None
+    # Row 2: label-index 1 does not match [0] → empty list
+    assert result["bboxes"][2].to_list() == []


### PR DESCRIPTION
Fix import of YOLO dataset items which are not assigned to any subset

Fix label filter

Resolves https://github.com/open-edge-platform/training_extensions/issues/5911
Resolves https://github.com/open-edge-platform/training_extensions/issues/6003

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
