### PR TITLE
Allow label list conversions

### DIFF
--- a/src/datumaro/experimental/converters/annotation_converters.py
+++ b/src/datumaro/experimental/converters/annotation_converters.py
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
+import logging
+
 import polars as pl
 
 from datumaro.experimental.categories import LabelCategories
-from datumaro.experimental.converters.base import ConversionError, Converter, list_eval_ref
+from datumaro.experimental.converters.base import Converter, list_eval_ref
 from datumaro.experimental.converters.registry import converter
 from datumaro.experimental.fields.annotations import (
     BBoxField,
@@ -17,6 +19,8 @@ from datumaro.experimental.fields.annotations import (
 )
 from datumaro.experimental.fields.images import ImageField
 from datumaro.experimental.schema import AttributeSpec
+
+log = logging.getLogger(__name__)
 
 
 @converter
@@ -336,8 +340,8 @@ class LabelShapeConverter(Converter):
       - ``is_list=True, multi_label=False`` ↔ ``is_list=False, multi_label=True``:
         both map to ``List(dtype)``; the conversion is a no-op on the data.
 
-    Unsupported (lossy) conversions:
-      - ``List(dtype) → dtype`` (multi_label or is_list reduction): rejected to prevent silent data loss
+    Lossy conversions (keep first element, logs a warning):
+      - ``List(dtype) → dtype`` (multi_label or is_list reduction): keeps the first element only
     """
 
     input_label: AttributeSpec[LabelField]
@@ -358,6 +362,63 @@ class LabelShapeConverter(Converter):
         output_field = self.output_label.field
 
         return input_field.multi_label != output_field.multi_label or input_field.is_list != output_field.is_list
+
+    def _convert_multi_label(
+        self, df: pl.DataFrame, input_col: str, output_col: str, input_is_list: bool
+    ) -> pl.DataFrame:
+        """Reduce multi_label → single-label (inner dimension): keep first label."""
+        log.warning(
+            "Converting multi-label to single-label for field '%s': keeping the first label only. Data may be lost.",
+            input_col,
+        )
+        if input_is_list:
+            # List(List(dtype)) → List(dtype): take first element of each inner list
+            return df.with_columns(pl.col(input_col).list.eval(pl.element().list.first()).alias(output_col))
+        # List(dtype) → dtype: take the first element
+        return df.with_columns(pl.col(input_col).list.first().alias(output_col))
+
+    def _expand_multi_label(
+        self, df: pl.DataFrame, input_col: str, output_col: str, input_is_list: bool
+    ) -> pl.DataFrame:
+        """Expand single-label → multi_label (inner dimension): wrap in list."""
+        if input_is_list:
+            # List(dtype) → List(List(dtype)): wrap each element in the list
+            return df.with_columns(pl.col(input_col).list.eval(pl.concat_list(pl.element())).alias(output_col))
+        # dtype → List(dtype): wrap the scalar value in a list, preserving nulls
+        return df.with_columns(
+            pl.when(pl.col(input_col).is_not_null())
+            .then(pl.concat_list(pl.col(input_col)))
+            .otherwise(pl.lit(None, dtype=pl.List(self.input_label.field.dtype)))
+            .alias(output_col)
+        )
+
+    def _convert_is_list(
+        self, df: pl.DataFrame, src_col: str, output_col: str, input_is_list: bool, output_multi: bool
+    ) -> pl.DataFrame:
+        """Handle is_list conversion (outer dimension)."""
+        if input_is_list:
+            log.warning(
+                "Converting list to non-list for field '%s': keeping the first element only. Data may be lost.",
+                self.input_label.name,
+            )
+            # List(X) → X: take the first element
+            return df.with_columns(pl.col(src_col).list.first().alias(output_col))
+        # X → List(X): wrap each sample's value in a 1-element list, preserving nulls
+        if not output_multi:
+            # Scalar → List(scalar): use native concat_list (fast path)
+            return df.with_columns(
+                pl.when(pl.col(src_col).is_not_null())
+                .then(pl.concat_list(pl.col(src_col)))
+                .otherwise(pl.lit(None, dtype=self.output_label.field._pl_type))
+                .alias(output_col)
+            )
+        # List(X) → List(List(X))
+        target_pl_type = self.output_label.field._pl_type
+        return df.with_columns(
+            pl.col(src_col)
+            .map_elements(lambda x: [x] if x is not None else None, return_dtype=target_pl_type)
+            .alias(output_col)
+        )
 
     def convert(self, df: pl.DataFrame) -> pl.DataFrame:
         """Convert label data between different multi_label/is_list configurations."""
@@ -382,55 +443,18 @@ class LabelShapeConverter(Converter):
 
         # Step 1: handle multi_label conversion (inner dimension)
         if input_multi and not output_multi:
-            raise ConversionError(
-                f"Cannot convert multi-label to single-label for field '{input_col}': "
-                "this would discard all labels except the first. "
-                "Please apply an explicit aggregation transform before converting."
-            )
-        if not input_multi and output_multi:
-            if input_is_list:
-                # List(dtype) → List(List(dtype)): wrap each element in the list
-                df = df.with_columns(pl.col(input_col).list.eval(pl.concat_list(pl.element())).alias(output_col))
-            else:
-                # dtype → List(dtype): wrap the scalar value in a list, preserving nulls
-                df = df.with_columns(
-                    pl.when(pl.col(input_col).is_not_null())
-                    .then(pl.concat_list(pl.col(input_col)))
-                    .otherwise(pl.lit(None, dtype=pl.List(self.input_label.field.dtype)))
-                    .alias(output_col)
-                )
+            df = self._convert_multi_label(df, input_col, output_col, input_is_list)
+        elif not input_multi and output_multi:
+            df = self._expand_multi_label(df, input_col, output_col, input_is_list)
 
         # After step 1 the multi_label dimension matches the output.
         # The effective is_list state is still ``input_is_list``.
 
         # Step 2: handle is_list conversion (outer dimension)
-        # Determine the column to read from (may have been updated in step 1)
-        step2_col = output_col if input_multi != output_multi else input_col
-
-        if input_is_list and not output_is_list:
-            raise ConversionError(
-                f"Cannot convert list to non-list for field '{input_col}': "
-                "this would discard all elements except the first. "
-                "Please apply an explicit aggregation transform before converting."
-            )
-        if not input_is_list and output_is_list:
-            # X → List(X): wrap each sample's value in a 1-element list, preserving nulls
-            if not output_multi:
-                # Scalar → List(scalar): use native concat_list (fast path)
-                df = df.with_columns(
-                    pl.when(pl.col(step2_col).is_not_null())
-                    .then(pl.concat_list(pl.col(step2_col)))
-                    .otherwise(pl.lit(None, dtype=self.output_label.field._pl_type))
-                    .alias(output_col)
-                )
-            else:
-                # List(X) → List(List(X))
-                target_pl_type = self.output_label.field._pl_type
-                df = df.with_columns(
-                    pl.col(step2_col)
-                    .map_elements(lambda x: [x] if x is not None else None, return_dtype=target_pl_type)
-                    .alias(output_col)
-                )
+        if input_is_list != output_is_list:
+            # Determine the column to read from (may have been updated in step 1)
+            step2_col = output_col if input_multi != output_multi else input_col
+            df = self._convert_is_list(df, step2_col, output_col, input_is_list, output_multi)
 
         return df
 

--- a/src/datumaro/experimental/converters/annotation_converters.py
+++ b/src/datumaro/experimental/converters/annotation_converters.py
@@ -399,7 +399,7 @@ class LabelShapeConverter(Converter):
         if input_is_list:
             log.warning(
                 "Converting list to non-list for field '%s': keeping the first element only. Data may be lost.",
-                self.input_label.name,
+                src_col,
             )
             # List(X) → X: take the first element
             return df.with_columns(pl.col(src_col).list.first().alias(output_col))

--- a/src/datumaro/experimental/converters/type_converters.py
+++ b/src/datumaro/experimental/converters/type_converters.py
@@ -7,12 +7,16 @@ These converters handle shape (is_list) and dtype conversions for the
 simple value field types defined in :mod:`datumaro.experimental.fields.types`.
 """
 
+import logging
+
 import polars as pl
 
-from datumaro.experimental.converters.base import ConversionError, Converter
+from datumaro.experimental.converters.base import Converter
 from datumaro.experimental.converters.registry import converter
 from datumaro.experimental.fields.types import BoolField, NumericField, StringField
 from datumaro.experimental.schema import AttributeSpec
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # NumericField converters
@@ -28,9 +32,7 @@ class NumericFieldShapeConverter(Converter):
 
     Supported conversions:
       - ``dtype → List(dtype)``: wrap scalar in a one-element list
-
-    Unsupported (lossy) conversions:
-      - ``List(dtype) → dtype``: rejected to prevent silent data loss
+      - ``List(dtype) → dtype``: keep the first element only (lossy, logs a warning)
     """
 
     input_numeric: AttributeSpec[NumericField]
@@ -63,11 +65,11 @@ class NumericFieldShapeConverter(Converter):
         output_is_list = self.output_numeric.field.is_list
 
         if input_is_list and not output_is_list:
-            raise ConversionError(
-                f"Cannot convert list to scalar for numeric field '{input_col}': "
-                "this would discard all elements except the first. "
-                "Please apply an explicit aggregation transform before converting."
+            log.warning(
+                "Converting list to scalar for numeric field '%s': keeping the first element only. Data may be lost.",
+                input_col,
             )
+            df = df.with_columns(pl.col(input_col).list.first().alias(output_col))
         if not input_is_list and output_is_list:
             # dtype → List(dtype): wrap the scalar value in a list, preserving nulls
             df = df.with_columns(
@@ -130,9 +132,7 @@ class BoolFieldShapeConverter(Converter):
 
     Supported conversions:
       - ``Boolean → List(Boolean)``: wrap scalar in a one-element list
-
-    Unsupported (lossy) conversions:
-      - ``List(Boolean) → Boolean``: rejected to prevent silent data loss
+      - ``List(Boolean) → Boolean``: keep the first element only (lossy, logs a warning)
     """
 
     input_bool: AttributeSpec[BoolField]
@@ -164,11 +164,11 @@ class BoolFieldShapeConverter(Converter):
         output_is_list = self.output_bool.field.is_list
 
         if input_is_list and not output_is_list:
-            raise ConversionError(
-                f"Cannot convert list to scalar for boolean field '{input_col}': "
-                "this would discard all elements except the first. "
-                "Please apply an explicit aggregation transform before converting."
+            log.warning(
+                "Converting list to scalar for boolean field '%s': keeping the first element only. Data may be lost.",
+                input_col,
             )
+            df = df.with_columns(pl.col(input_col).list.first().alias(output_col))
         if not input_is_list and output_is_list:
             # Boolean → List(Boolean): wrap the scalar value in a list, preserving nulls
             df = df.with_columns(
@@ -195,9 +195,7 @@ class StringFieldShapeConverter(Converter):
 
     Supported conversions:
       - ``String → List(String)``: wrap scalar in a one-element list
-
-    Unsupported (lossy) conversions:
-      - ``List(String) → String``: rejected to prevent silent data loss
+      - ``List(String) → String``: keep the first element only (lossy, logs a warning)
     """
 
     input_string: AttributeSpec[StringField]
@@ -229,11 +227,11 @@ class StringFieldShapeConverter(Converter):
         output_is_list = self.output_string.field.is_list
 
         if input_is_list and not output_is_list:
-            raise ConversionError(
-                f"Cannot convert list to scalar for string field '{input_col}': "
-                "this would discard all elements except the first. "
-                "Please apply an explicit aggregation transform before converting."
+            log.warning(
+                "Converting list to scalar for string field '%s': keeping the first element only. Data may be lost.",
+                input_col,
             )
+            df = df.with_columns(pl.col(input_col).list.first().alias(output_col))
         if not input_is_list and output_is_list:
             # String → List(String): wrap the scalar value in a list, preserving nulls
             df = df.with_columns(

--- a/tests/unit/experimental/converters/test_annotation_converters.py
+++ b/tests/unit/experimental/converters/test_annotation_converters.py
@@ -823,27 +823,28 @@ def test_label_shape_converter_conversions(
 
 # fmt: off
 @pytest.mark.parametrize(
-    "input_multi, input_is_list, output_multi, output_is_list, data, schema_type, error_match",
+    "input_multi, input_is_list, output_multi, output_is_list, data, schema_type, expected_value, expected_dtype",
     [
-        pytest.param(True,  False, False, False, {"label": [[5, 10, 15]]},            pl.List(pl.UInt32()),          "Cannot convert multi-label to single-label", id="multi_to_single_scalar"),  # noqa: E501
-        pytest.param(True,  True,  False, True,  {"label": [[[5, 10], [15, 20]]]},    pl.List(pl.List(pl.UInt32())), "Cannot convert multi-label to single-label", id="multi_to_single_list"),  # noqa: E501
-        pytest.param(False, True,  False, False, {"label": [[10, 20, 30]]},           pl.List(pl.UInt32()),          "Cannot convert list to non-list",             id="list_to_scalar"),  # noqa: E501
-        pytest.param(True,  True,  True,  False, {"label": [[[1, 2], [3, 4], [5]]]},  pl.List(pl.List(pl.UInt32())), "Cannot convert list to non-list",             id="multi_label_list_to_scalar"),  # noqa: E501
-        pytest.param(True,  True,  False, False, {"label": [[[5, 10], [15, 20]]]},    pl.List(pl.List(pl.UInt32())), "Cannot convert multi-label to single-label", id="both_list_list_to_scalar"),  # noqa: E501
+        pytest.param(True,  False, False, False, {"label": [[5, 10, 15]]},            pl.List(pl.UInt32()),          5,          pl.UInt32(),          id="multi_to_single_scalar"),  # noqa: E501
+        pytest.param(True,  True,  False, True,  {"label": [[[5, 10], [15, 20]]]},    pl.List(pl.List(pl.UInt32())), [5, 15],    pl.List(pl.UInt32()), id="multi_to_single_list"),  # noqa: E501
+        pytest.param(False, True,  False, False, {"label": [[10, 20, 30]]},           pl.List(pl.UInt32()),          10,         pl.UInt32(),          id="list_to_scalar"),  # noqa: E501
+        pytest.param(True,  True,  True,  False, {"label": [[[1, 2], [3, 4], [5]]]},  pl.List(pl.List(pl.UInt32())), [1, 2],     pl.List(pl.UInt32()), id="multi_label_list_to_scalar"),  # noqa: E501
+        pytest.param(True,  True,  False, False, {"label": [[[5, 10], [15, 20]]]},    pl.List(pl.List(pl.UInt32())), 5,          pl.UInt32(),          id="both_list_list_to_scalar"),  # noqa: E501
     ],
 )  # fmt: on  noqa: RUF028
-def test_label_shape_converter_rejects_lossy_conversions(
+def test_label_shape_converter_lossy_conversions(
     input_multi,
     input_is_list,
     output_multi,
     output_is_list,
     data,
     schema_type,
-    error_match,
+    expected_value,
+    expected_dtype,
+    caplog,
 ):
-    """convert() raises ConversionError for lossy multi_label/is_list reductions."""
+    """convert() keeps the first element and logs a warning for lossy multi_label/is_list reductions."""
     from datumaro.experimental.converters import LabelShapeConverter
-    from datumaro.experimental.converters.base import ConversionError
 
     converter_instance = LabelShapeConverter()
 
@@ -857,8 +858,18 @@ def test_label_shape_converter_rejects_lossy_conversions(
     assert converter_instance.filter_output_spec() is True
 
     df = pl.DataFrame(data, schema=pl.Schema({col_name: schema_type}))
-    with pytest.raises(ConversionError, match=error_match):
-        converter_instance.convert(df)
+    with caplog.at_level("WARNING"):
+        result_df = converter_instance.convert(df)
+
+    assert result_df[col_name].dtype == expected_dtype
+    result_val = result_df[col_name][0]
+    if hasattr(result_val, "to_list"):
+        assert result_val.to_list() == expected_value
+    else:
+        assert result_val == expected_value
+
+    # Verify a warning was logged
+    assert any("keeping the first" in msg for msg in caplog.messages)
 
 
 def test_label_shape_converter_filter_returns_false():

--- a/tests/unit/experimental/converters/test_type_converters.py
+++ b/tests/unit/experimental/converters/test_type_converters.py
@@ -62,10 +62,8 @@ def test_numeric_shape_converter_conversions(
         assert result_val == expected_value
 
 
-def test_numeric_shape_converter_rejects_list_to_scalar():
-    """convert() raises ConversionError for lossy list → scalar conversion."""
-    from datumaro.experimental.converters.base import ConversionError
-
+def test_numeric_shape_converter_list_to_scalar(caplog):
+    """convert() keeps the first element and logs a warning for lossy list → scalar conversion."""
     converter_instance = NumericFieldShapeConverter()
 
     input_field = NumericField(semantic="s", dtype=pl.Float32(), is_list=True)
@@ -77,8 +75,12 @@ def test_numeric_shape_converter_rejects_list_to_scalar():
     assert converter_instance.filter_output_spec() is True
 
     df = pl.DataFrame({"score": [[0.5, 0.9]]}, schema=pl.Schema({"score": pl.List(pl.Float32())}))
-    with pytest.raises(ConversionError, match="Cannot convert list to scalar"):
-        converter_instance.convert(df)
+    with caplog.at_level("WARNING"):
+        result_df = converter_instance.convert(df)
+
+    assert result_df["score"].dtype == pl.Float32()
+    assert result_df["score"][0] == pytest.approx(0.5)
+    assert any("keeping the first element only" in msg for msg in caplog.messages)
 
 
 def test_numeric_shape_converter_filter_returns_false():
@@ -258,10 +260,8 @@ def test_bool_shape_converter_conversions(
         assert result_val == expected_value
 
 
-def test_bool_shape_converter_rejects_list_to_scalar():
-    """convert() raises ConversionError for lossy list → scalar conversion."""
-    from datumaro.experimental.converters.base import ConversionError
-
+def test_bool_shape_converter_list_to_scalar(caplog):
+    """convert() keeps the first element and logs a warning for lossy list → scalar conversion."""
     converter_instance = BoolFieldShapeConverter()
 
     input_field = BoolField(semantic="s", is_list=True)
@@ -273,8 +273,12 @@ def test_bool_shape_converter_rejects_list_to_scalar():
     assert converter_instance.filter_output_spec() is True
 
     df = pl.DataFrame({"flag": [[True, False]]}, schema=pl.Schema({"flag": pl.List(pl.Boolean())}))
-    with pytest.raises(ConversionError, match="Cannot convert list to scalar"):
-        converter_instance.convert(df)
+    with caplog.at_level("WARNING"):
+        result_df = converter_instance.convert(df)
+
+    assert result_df["flag"].dtype == pl.Boolean()
+    assert result_df["flag"][0] is True
+    assert any("keeping the first element only" in msg for msg in caplog.messages)
 
 
 def test_bool_shape_converter_filter_returns_false():
@@ -353,10 +357,8 @@ def test_string_shape_converter_conversions(
         assert result_val == expected_value
 
 
-def test_string_shape_converter_rejects_list_to_scalar():
-    """convert() raises ConversionError for lossy list → scalar conversion."""
-    from datumaro.experimental.converters.base import ConversionError
-
+def test_string_shape_converter_list_to_scalar(caplog):
+    """convert() keeps the first element and logs a warning for lossy list → scalar conversion."""
     converter_instance = StringFieldShapeConverter()
 
     input_field = StringField(semantic="s", is_list=True)
@@ -368,8 +370,12 @@ def test_string_shape_converter_rejects_list_to_scalar():
     assert converter_instance.filter_output_spec() is True
 
     df = pl.DataFrame({"tag": [["cat", "dog"]]}, schema=pl.Schema({"tag": pl.List(pl.String())}))
-    with pytest.raises(ConversionError, match="Cannot convert list to scalar"):
-        converter_instance.convert(df)
+    with caplog.at_level("WARNING"):
+        result_df = converter_instance.convert(df)
+
+    assert result_df["tag"].dtype == pl.String()
+    assert result_df["tag"][0] == "cat"
+    assert any("keeping the first element only" in msg for msg in caplog.messages)
 
 
 def test_string_shape_converter_filter_returns_false():


### PR DESCRIPTION
Allow label list conversions once again. This is necessary for when classification datasets are exported in a certain dataset format, for example VOC, which has is_list=True for label field. To be able to reimport this VOC dataset as a classification dataset where the label_field has is_list=False, this conversion must be allowed. 


<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
