### PR TITLE
Fix converter tracking in pickled dataset and COCO category issues

### DIFF
--- a/src/datumaro/experimental/converters/registry.py
+++ b/src/datumaro/experimental/converters/registry.py
@@ -992,7 +992,7 @@ class ConverterTransform(Transform):
         self._conversion_paths = conversion_paths
         self._df_input_columns = set()
         self._df = pl.DataFrame()
-        self._applied_converters = set()
+        self._applied_converters: set[Converter] = set()
 
         self.apply(batch_outputs)
 
@@ -1031,14 +1031,14 @@ class ConverterTransform(Transform):
 
             if converters is not None:
                 for converter in converters:
-                    if id(converter) not in self._applied_converters:
+                    if converter not in self._applied_converters:
                         if not self._can_apply_converter(converter):
                             # Defer this converter; it will be attempted again on future apply() calls
                             # once the necessary input columns have been materialized.
                             continue
 
                         self._df = converter.convert(self._df)
-                        self._applied_converters.add(id(converter))
+                        self._applied_converters.add(converter)
 
         return self._df
 

--- a/src/datumaro/experimental/data_formats/coco/helpers.py
+++ b/src/datumaro/experimental/data_formats/coco/helpers.py
@@ -98,6 +98,9 @@ def _detect_coco_label_categories_from_paths(
     Returns:
         CocoCategories instance with either discovered labels or defaults.
     """
+    best_label_names: tuple[str, ...] | None = None
+    best_count = 0
+
     for _subset, cfg in subset_config.items():
         annotations_paths = cfg.get("annotations")
         if annotations_paths is None:
@@ -113,13 +116,17 @@ def _detect_coco_label_categories_from_paths(
             annotations_data = _load_json_or_none(annotations_path)
             if annotations_data and isinstance(annotations_data, dict):
                 cats = annotations_data.get("categories") or []
-                if isinstance(cats, list) and len(cats) > 0:
+                if isinstance(cats, list) and len(cats) > best_count:
                     try:
                         cats_sorted = sorted(cats, key=lambda c: c["id"])  # type: ignore[index]
                         label_names = tuple(str(c["name"]) for c in cats_sorted)  # type: ignore[index]
-                        return CocoCategories(labels=label_names)
+                        best_label_names = label_names
+                        best_count = len(cats)
                     except Exception:  # noqa: S110
                         pass
+
+    if best_label_names is not None:
+        return CocoCategories(labels=best_label_names)
 
     logger.warning("Unable to extract labels from COCO annotations, falling back to defaults")
     return CocoCategories()

--- a/src/datumaro/experimental/data_formats/coco/io.py
+++ b/src/datumaro/experimental/data_formats/coco/io.py
@@ -457,10 +457,12 @@ def _find_primary_annotations_data(all_annotations_data: list[dict]) -> dict:
     """Find the annotations dict that contains the most categories.
 
     When multiple annotation files are loaded (e.g., instances, keypoints,
-    captions), the file with the most categories should be used as the
-    primary source for building the category-to-index mapping.  For example,
+    captions), the file with the largest ``categories`` list is used as the
+    primary source for building the category-to-index mapping. For example,
     ``person_keypoints_*.json`` typically contains only one category
     ("person"), while ``instances_*.json`` contains all 80 COCO categories.
+    If none of the files define categories, the first loaded annotations
+    dict is kept as a fallback.
     """
     primary_data = all_annotations_data[0]
     max_categories = 0

--- a/src/datumaro/experimental/data_formats/coco/io.py
+++ b/src/datumaro/experimental/data_formats/coco/io.py
@@ -454,11 +454,21 @@ def _load_subset_into_dataset(
 
 
 def _find_primary_annotations_data(all_annotations_data: list[dict]) -> dict:
-    """Find the first annotations dict that contains categories."""
+    """Find the annotations dict that contains the most categories.
+
+    When multiple annotation files are loaded (e.g., instances, keypoints,
+    captions), the file with the most categories should be used as the
+    primary source for building the category-to-index mapping.  For example,
+    ``person_keypoints_*.json`` typically contains only one category
+    ("person"), while ``instances_*.json`` contains all 80 COCO categories.
+    """
     primary_data = all_annotations_data[0]
+    max_categories = 0
     for data in all_annotations_data:
-        if data.get("categories"):
-            return data
+        cats = data.get("categories")
+        if cats and len(cats) > max_categories:
+            max_categories = len(cats)
+            primary_data = data
     return primary_data
 
 

--- a/tests/unit/experimental/converters/test_base_converters.py
+++ b/tests/unit/experimental/converters/test_base_converters.py
@@ -1359,3 +1359,112 @@ def test_find_conversion_path_prefers_direct_over_cross_field_type():
         "KeypointsToBBoxConverter should NOT be used when BBoxField data is already available. "
         "Direct BBoxField→BBoxField conversion should be preferred."
     )
+
+
+class _StubParent:
+    """Minimal parent transform that returns an empty DataFrame for pickle tests.
+
+    Defined at module level so it can be pickled (local classes cannot).
+    """
+
+    def __init__(self, schema: Schema):
+        self._schema = schema
+        self._df = pl.DataFrame()
+
+    def apply(self, fields) -> pl.DataFrame:
+        return self._df
+
+    def get_lazy_attributes(self) -> set[str]:
+        return set()
+
+    def get_batch_attributes(self) -> list[str]:
+        return []
+
+    def slice(self, offset, length=None):
+        return self
+
+    def __len__(self):
+        return 0
+
+
+def test_converter_transform_pickle_roundtrip_preserves_applied_converters():
+    """Test that _applied_converters survives a pickle round-trip.
+
+    When a ConverterTransform is pickled (e.g., for DataLoader workers) and
+    then unpickled, the _applied_converters set must correctly track which
+    converters have already been run so they are not re-executed.
+
+    Regression test for: previously _applied_converters stored id() ints which
+    became stale after unpickling, causing converters (e.g., BBoxFormatConverter
+    XYWH→XYXY) to re-execute and silently corrupt data.  The fix stores
+    Converter object references directly; pickle preserves object identity
+    within a single stream, so the set naturally stays consistent.
+    """
+    import pickle
+
+    from datumaro.experimental.converters.registry import ConverterTransform, find_conversion_path
+
+    # Set up a schema pair that requires BBoxFormatConverter (xywh → x1y1x2y2).
+    source_schema = Schema(
+        attributes={
+            "bboxes": AttributeInfo(
+                type=np.ndarray | None,
+                field=BBoxField(semantic="default", dtype=pl.Float32(), format="xywh"),
+            ),
+        }
+    )
+    target_schema = Schema(
+        attributes={
+            "bboxes": AttributeInfo(
+                type=np.ndarray | None,
+                field=BBoxField(semantic="default", dtype=pl.Float32(), format="x1y1x2y2"),
+            ),
+        }
+    )
+
+    conversion_paths, _ = find_conversion_path(source_schema, target_schema)
+
+    # Collect all unique converter objects that exist in the conversion paths.
+    all_converters: set[Converter] = set()
+    for convs in conversion_paths.converters.values():
+        all_converters.update(convs)
+    assert len(all_converters) > 0, "Expected at least one converter in the conversion path"
+
+    # Build a minimal ConverterTransform with a trivial parent.
+    parent = _StubParent(source_schema)
+    ct = ConverterTransform(parent, target_schema, conversion_paths)
+
+    # Mark all converters as applied to simulate the common post-init state.
+    ct._applied_converters = set(all_converters)
+    applied_before = len(ct._applied_converters)
+
+    # Pickle round-trip — this is what happens when a DataLoader sends the
+    # dataset to a worker process.
+    data = pickle.dumps(ct)
+    ct2 = pickle.loads(data)
+
+    # Collect the converter objects that live in the deserialized _conversion_paths.
+    new_converters: set[Converter] = set()
+    for convs in ct2._conversion_paths.converters.values():
+        new_converters.update(convs)
+
+    # The restored _applied_converters must contain the same (deserialized)
+    # converter objects that appear in _conversion_paths, not stale references.
+    assert len(ct2._applied_converters) == applied_before, (
+        f"Expected {applied_before} applied converters after unpickling, got {len(ct2._applied_converters)}"
+    )
+
+    # Every converter in _applied_converters must be one of the converter
+    # objects living in the deserialized _conversion_paths.
+    for conv in ct2._applied_converters:
+        assert conv in new_converters, (
+            "After unpickling, _applied_converters should reference the same "
+            "converter objects as _conversion_paths. Found a stale reference."
+        )
+
+    # Conversely, every converter in the paths should already be marked applied.
+    for conv in new_converters:
+        assert conv in ct2._applied_converters, (
+            "A converter from _conversion_paths is missing from _applied_converters "
+            "after unpickling — it would be incorrectly re-executed in a worker."
+        )


### PR DESCRIPTION
This PR fixes an issue where a converter could be applied twice if a dataset was pickled. Full details in https://github.com/open-edge-platform/datumaro/issues/2106

Also fixes a bug where imported COCO datasets could pickup only a small set of the available labels incase there are multiple annotation files. 
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves open-edge-platform/training_extensions#111 and open-edge-platform/training_extensions#222.
Depends on open-edge-platform/training_extensions#1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
