### PR TITLE
Enable auto-merging for minor/patch updates for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,7 @@
     schedule: ["* * * * 0"], // weekly
   },
 
-  extends: ["config:base", ":gitSignOff", "helpers:pinGitHubActionDigests"],
+  extends: ["config:recommended", ":gitSignOff", "helpers:pinGitHubActionDigests"],
   // https://docs.renovatebot.com/presets-default/#gitsignoff
   // https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests
 
@@ -73,7 +73,7 @@
       separateMajorMinor: false,
       groupName: "GitHub Actions",
       matchManagers: ["github-actions"],
-      matchPackagePatterns: ["*"],
+      matchPackageNames: ["*"],
       schedule: ["* * 1 * *"], // every month
     },
 
@@ -100,17 +100,26 @@
       matchDepTypes: ["requires-python"],
       matchDepNames: ["python"],
     },
+
+    // Auto-merge non-major updates
+    {
+      automerge: true,
+      automergeType: "pr",
+      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+    },
+
+    // Require manual merge for major updates
+    {
+      automerge: false,
+      matchUpdateTypes: ["major"],
+    },
   ],
 
-  // Auto-merge patch and minor updates
-  automerge: true,
-  automergeType: "pr",
-  matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+  // Use GitHub's native auto-merge feature, which queues the PR to merge
+  // once all branch protection requirements (status checks, reviews, CODEOWNERS)
+  // are satisfied.
+  platformAutomerge: true,
 
-  // Require manual merge for major updates
-  major: {
-    automerge: false,
-  },
 
   // Enable security upgrades
   vulnerabilityAlerts: {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -102,6 +102,16 @@
     },
   ],
 
+  // Auto-merge patch and minor updates
+  automerge: true,
+  automergeType: "pr",
+  matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+
+  // Require manual merge for major updates
+  major: {
+    automerge: false,
+  },
+
   // Enable security upgrades
   vulnerabilityAlerts: {
     enabled: true,


### PR DESCRIPTION
Configure renovate to automatically merge minor/patch updates. Added renovate as an actor that can bypass branch protection rules so code owner review is no longer necessary. This PR also fixes a few migration warnings. 

<img width="758" height="316" alt="image" src="https://github.com/user-attachments/assets/6b1dae2c-3319-4a40-9b19-f2ff71d854db" />


<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
