### PR TITLE
Add MediaBridgeConverter for handling media field type conversions 

### DIFF
--- a/src/datumaro/experimental/converters/__init__.py
+++ b/src/datumaro/experimental/converters/__init__.py
@@ -28,6 +28,7 @@ from datumaro.experimental.converters.base import (
     AttributeRemapperConverter,
     ConversionError,
     Converter,
+    MediaBridgeConverter,
     copy_columns_with_shape,
     list_eval_ref,
 )
@@ -123,6 +124,7 @@ __all__ = [
     "LabelShapeConverter",
     "MaskCallableToMaskConverter",
     "MaskChannelsFirstConverter",
+    "MediaBridgeConverter",
     "MediaInfoToImageInfoConverter",
     "MediaInfoToVideoInfoConverter",
     "MediaPathToImageCallableConverter",

--- a/src/datumaro/experimental/converters/base.py
+++ b/src/datumaro/experimental/converters/base.py
@@ -212,6 +212,22 @@ class ConversionError(Exception):
     """Exception raised when conversion fails."""
 
 
+class MediaBridgeConverter(Converter, ABC):
+    """Base class for media bridge converters.
+
+    Media bridge converters handle conversions between related media field
+    types (e.g., MediaPathField ↔ ImagePathField, MediaInfoField ↔
+    ImageInfoField, ImageCallableField → ImageField, etc.).
+
+    These converters are always allowed even when ``direct_only=True``
+    because they represent format-level narrowing or widening of media
+    representations rather than semantic cross-field-type transformations.
+
+    Subclass this instead of :class:`Converter` when the converter bridges
+    between different representations of the same media content.
+    """
+
+
 class AttributeRemapperConverter(Converter):
     """
     Special converter for renaming/selecting attributes and dropping others.

--- a/src/datumaro/experimental/converters/image_converters.py
+++ b/src/datumaro/experimental/converters/image_converters.py
@@ -8,7 +8,7 @@ import numpy as np
 import polars as pl
 from PIL import Image
 
-from datumaro.experimental.converters.base import Converter, copy_columns_with_shape
+from datumaro.experimental.converters.base import Converter, MediaBridgeConverter, copy_columns_with_shape
 from datumaro.experimental.converters.registry import converter
 from datumaro.experimental.fields import ImageBytesField
 from datumaro.experimental.fields.images import ImageCallableField, ImageField, ImageInfoField, ImagePathField
@@ -193,7 +193,7 @@ class ImageDtypeConverter(Converter):
 
 
 @converter(lazy=True)
-class ImagePathToImageConverter(Converter):
+class ImagePathToImageConverter(MediaBridgeConverter):
     """
     Lazy converter that loads images from file paths.
 
@@ -397,7 +397,7 @@ class ImagePathToImageConverter(Converter):
 
 
 @converter
-class ImageToImageInfo(Converter):
+class ImageToImageInfo(MediaBridgeConverter):
     """
     Lazy converter that loads images from file paths using Pillow.
 
@@ -443,7 +443,7 @@ class ImageToImageInfo(Converter):
 
 
 @converter(lazy=True)
-class ImageBytesToImageConverter(Converter):
+class ImageBytesToImageConverter(MediaBridgeConverter):
     """
     Lazy converter that decodes images from byte data.
 
@@ -569,7 +569,7 @@ class ImageBytesToImageConverter(Converter):
 
 
 @converter(lazy=True)
-class ImageCallableToImageConverter(Converter):
+class ImageCallableToImageConverter(MediaBridgeConverter):
     """
     Lazy converter that executes callables to generate image data.
 
@@ -724,7 +724,7 @@ class ChannelsFirstConverter(Converter):
 
 
 @converter
-class ImagePathToImageInfoConverter(Converter):
+class ImagePathToImageInfoConverter(MediaBridgeConverter):
     """
     Converter that reads image dimensions from file paths without loading pixel data.
 
@@ -786,7 +786,7 @@ class ImagePathToImageInfoConverter(Converter):
 
 
 @converter
-class ImagePathToImageCallableConverter(Converter):
+class ImagePathToImageCallableConverter(MediaBridgeConverter):
     """
     Converter that wraps ImagePathField as ImageCallableField.
 

--- a/src/datumaro/experimental/converters/media_converters.py
+++ b/src/datumaro/experimental/converters/media_converters.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
-from datumaro.experimental.converters.base import Converter
+from datumaro.experimental.converters.base import MediaBridgeConverter
 from datumaro.experimental.converters.registry import converter
 from datumaro.experimental.fields.images import ImageCallableField, ImageField, ImageInfoField, ImagePathField
 from datumaro.experimental.fields.videos import MediaInfoField, MediaPathField, VideoFramePathField, VideoInfoField
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 
 @converter(lazy=True)
-class MediaPathToImageConverter(Converter):
+class MediaPathToImageConverter(MediaBridgeConverter):
     """
     Lazy converter that loads images/video frames from MediaPathField to ImageField.
 
@@ -130,7 +130,7 @@ class MediaPathToImageConverter(Converter):
 
 
 @converter
-class MediaPathToImageCallableConverter(Converter):
+class MediaPathToImageCallableConverter(MediaBridgeConverter):
     """
     Converter that wraps MediaPathField as ImageCallableField.
 
@@ -193,7 +193,7 @@ class MediaPathToImageCallableConverter(Converter):
 
 
 @converter
-class MediaPathToImagePathConverter(Converter):
+class MediaPathToImagePathConverter(MediaBridgeConverter):
     """
     Converter that converts MediaPathField to ImagePathField.
 
@@ -316,7 +316,7 @@ class MediaPathToImagePathConverter(Converter):
 
 
 @converter
-class MediaInfoToImageInfoConverter(Converter):
+class MediaInfoToImageInfoConverter(MediaBridgeConverter):
     """
     Converter that extracts image info from MediaInfoField to ImageInfoField.
 
@@ -366,7 +366,7 @@ class MediaInfoToImageInfoConverter(Converter):
 
 
 @converter
-class ImagePathToMediaPathConverter(Converter):
+class ImagePathToMediaPathConverter(MediaBridgeConverter):
     """
     Converter that promotes ImagePathField to MediaPathField.
 
@@ -415,7 +415,7 @@ class ImagePathToMediaPathConverter(Converter):
 
 
 @converter
-class VideoFramePathToMediaPathConverter(Converter):
+class VideoFramePathToMediaPathConverter(MediaBridgeConverter):
     """
     Converter that promotes VideoFramePathField to MediaPathField.
 
@@ -466,7 +466,7 @@ class VideoFramePathToMediaPathConverter(Converter):
 
 
 @converter
-class ImageInfoToMediaInfoConverter(Converter):
+class ImageInfoToMediaInfoConverter(MediaBridgeConverter):
     """
     Converter that promotes ImageInfoField to MediaInfoField.
 
@@ -519,7 +519,7 @@ class ImageInfoToMediaInfoConverter(Converter):
 
 
 @converter
-class VideoInfoToMediaInfoConverter(Converter):
+class VideoInfoToMediaInfoConverter(MediaBridgeConverter):
     """
     Converter that promotes VideoInfoField to MediaInfoField.
 
@@ -579,7 +579,7 @@ class VideoInfoToMediaInfoConverter(Converter):
 
 
 @converter
-class MediaInfoToVideoInfoConverter(Converter):
+class MediaInfoToVideoInfoConverter(MediaBridgeConverter):
     """
     Converter that demotes MediaInfoField to VideoInfoField.
 
@@ -639,7 +639,7 @@ class MediaInfoToVideoInfoConverter(Converter):
 
 
 @converter
-class MediaPathToMediaInfoConverter(Converter):
+class MediaPathToMediaInfoConverter(MediaBridgeConverter):
     """
     Converter that extracts media metadata from MediaPathField to MediaInfoField.
 

--- a/src/datumaro/experimental/converters/registry.py
+++ b/src/datumaro/experimental/converters/registry.py
@@ -13,7 +13,12 @@ from typing import TYPE_CHECKING, NamedTuple, get_type_hints, overload
 import polars as pl
 
 from datumaro.experimental.categories import Categories
-from datumaro.experimental.converters.base import AttributeRemapperConverter, ConversionError, Converter
+from datumaro.experimental.converters.base import (
+    AttributeRemapperConverter,
+    ConversionError,
+    Converter,
+    MediaBridgeConverter,
+)
 from datumaro.experimental.fields.base import Field
 from datumaro.experimental.polars_utils import prepare_dataframe_for_pickle, restore_dataframe_from_pickle
 from datumaro.experimental.schema import AttributeSpec, Schema
@@ -262,8 +267,9 @@ def _get_applicable_converters(
         if not available_field_types.issuperset(from_types.values()):
             continue
 
-        # Skip cross-field-type converters when direct_only is True
-        if direct_only:
+        # Skip cross-field-type converters when direct_only is True,
+        # but always allow media bridge converters (e.g. MediaPath→ImagePath).
+        if direct_only and not issubclass(converter_class, MediaBridgeConverter):
             to_types = converter_class.get_to_types()
             input_field_types = set(from_types.values())
             output_field_types = set(to_types.values())
@@ -773,7 +779,7 @@ def converter(
                 return df
 
         @converter(lazy=True)
-        class ImagePathToImageConverter(Converter):
+        class ImagePathToImageConverter(MediaBridgeConverter):
             input_path: AttributeSpec
             output_image: AttributeSpec
 
@@ -843,8 +849,9 @@ def _get_reachable_field_types(
             from_types = converter_class.get_from_types()
             to_types = converter_class.get_to_types()
 
-            # Skip cross-field-type converters when direct_only is True
-            if direct_only:
+            # Skip cross-field-type converters when direct_only is True,
+            # but always allow media bridge converters.
+            if direct_only and not issubclass(converter_class, MediaBridgeConverter):
                 input_field_types = set(from_types.values())
                 output_field_types = set(to_types.values())
                 if not output_field_types.issubset(input_field_types):

--- a/src/datumaro/experimental/converters/registry.py
+++ b/src/datumaro/experimental/converters/registry.py
@@ -253,6 +253,9 @@ def _get_applicable_converters(
         iteration: Current iteration count for uniqueness
         direct_only: If True, only consider converters where all output field types
             are a subset of the input field types (no cross-field-type conversions).
+            :class:`MediaBridgeConverter` subclasses are exempt from this restriction
+            because they represent format-level narrowing/widening of media
+            representations rather than semantic transformations.
     """
     applicable: list[tuple[Converter, _SchemaState]] = []
 
@@ -575,6 +578,7 @@ def _find_conversion_path_for_semantic(
         optional_field_types: Set of optional field types for this semantic
         direct_only: If True, only consider converters where all output field types
             are a subset of the input field types (no cross-field-type conversions).
+            :class:`MediaBridgeConverter` subclasses are exempt from this restriction.
 
     Returns:
         Tuple of (list of converters needed for this semantic group, updated target state)
@@ -831,6 +835,7 @@ def _get_reachable_field_types(
         semantic: The semantic tag to filter by (only fields with matching semantic are considered)
         direct_only: If True, only consider converters where all output field types
             are a subset of the input field types (no cross-field-type conversions).
+            :class:`MediaBridgeConverter` subclasses are exempt from this restriction.
 
     Returns:
         Set of all reachable field types (including those already in start_state)
@@ -920,6 +925,8 @@ def find_conversion_path(
             are a subset of the input field types (no cross-field-type conversions).
             For example, BBoxField→BBoxField format/dtype converters are allowed,
             but BBoxField→PolygonField converters are skipped.
+            :class:`MediaBridgeConverter` subclasses (e.g., MediaPathField→ImagePathField)
+            are always allowed regardless of this flag.
 
     Returns:
         Tuple of (ConversionPaths with separated batch and lazy converter lists,

--- a/src/datumaro/experimental/converters/video_converters.py
+++ b/src/datumaro/experimental/converters/video_converters.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
-from datumaro.experimental.converters.base import Converter
+from datumaro.experimental.converters.base import MediaBridgeConverter
 from datumaro.experimental.converters.registry import converter
 from datumaro.experimental.fields.images import ImageCallableField, ImageField
 from datumaro.experimental.fields.videos import VideoFrameCallableField, VideoFramePathField
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 
 @converter(lazy=True)
-class VideoFramePathToImageConverter(Converter):
+class VideoFramePathToImageConverter(MediaBridgeConverter):
     """
     Lazy converter that loads video frames from VideoFramePathField to ImageField.
 
@@ -120,7 +120,7 @@ class VideoFramePathToImageConverter(Converter):
 
 
 @converter
-class VideoFrameToImageCallableConverter(Converter):
+class VideoFrameToImageCallableConverter(MediaBridgeConverter):
     """
     Converter that wraps VideoFramePathField as ImageCallableField.
 
@@ -184,7 +184,7 @@ class VideoFrameToImageCallableConverter(Converter):
 
 
 @converter
-class VideoFrameCallableToImageCallableConverter(Converter):
+class VideoFrameCallableToImageCallableConverter(MediaBridgeConverter):
     """
     Converter that adapts VideoFrameCallableField to ImageCallableField.
 

--- a/src/datumaro/experimental/dataset.py
+++ b/src/datumaro/experimental/dataset.py
@@ -652,6 +652,9 @@ class Dataset(Generic[DType]):
                 converters (e.g., BBoxField→PolygonField) are skipped. Converters
                 that operate within the same field type (e.g., BBoxField→BBoxField
                 for format or dtype changes) are still allowed.
+                :class:`~datumaro.experimental.converters.base.MediaBridgeConverter`
+                subclasses (e.g., MediaPathField→ImagePathField) are always
+                allowed regardless of this flag.
 
         Returns:
             A new Dataset instance with the converted schema
@@ -858,6 +861,8 @@ class Dataset(Generic[DType]):
             direct_only: If True, only apply converters where all output field types
                 match (are a subset of) the input field types. Cross-field-type
                 converters (e.g., BBoxField→PolygonField) are skipped.
+                :class:`~datumaro.experimental.converters.base.MediaBridgeConverter`
+                subclasses are always allowed regardless of this flag.
         """
         converted_dataset = dataset.convert_to_schema(target_dtype_or_schema=self.schema, direct_only=direct_only)
         self.df = self.df.vstack(converted_dataset.df)
@@ -882,6 +887,8 @@ def convert_sample_to_schema(
         target_dtype_or_schema: The target schema to convert to
         direct_only: If True, only apply converters where all output field types
             match (are a subset of) the input field types.
+            :class:`~datumaro.experimental.converters.base.MediaBridgeConverter`
+            subclasses are always allowed regardless of this flag.
 
     Returns:
         A new Sample instance with the converted schema

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -825,7 +825,10 @@ def export_dataset(
             otherwise, it is ignored.
         direct_only: If True, only apply converters where all output field types
             match (are a subset of) the input field types. Cross-field-type
-            converters (e.g., BBoxField→PolygonField) are skipped. Only has an
+            converters (e.g., BBoxField→PolygonField) are skipped.
+            :class:`~datumaro.experimental.converters.base.MediaBridgeConverter`
+            subclasses (e.g., MediaPathField→ImagePathField) are always
+            allowed regardless of this flag. Only has an
             effect when ``data_format`` is set to a non-Datumaro format that
             requires schema conversion.
         data_format: Target data format for export. When ``None`` (default),

--- a/tests/unit/experimental/converters/test_media_bridge_converters.py
+++ b/tests/unit/experimental/converters/test_media_bridge_converters.py
@@ -1887,3 +1887,149 @@ class MediaPathToMediaInfoConverterTest:
         assert "duration" in field_names
         assert "codec" in field_names
         assert "frame_index" in field_names
+
+
+class DirectOnlyAllowsMediaBridgeConversionsTest:
+    """Tests that direct_only=True allows media bridge converters.
+
+    Media bridge converters (MediaPath→ImagePath, MediaInfo→ImageInfo, etc.)
+    should always be allowed, even with direct_only=True, because they
+    represent format-level narrowing/widening of media representations
+    rather than semantic cross-field-type transformations.
+    """
+
+    def test_direct_only_allows_media_path_to_image_path(self):
+        """Test that MediaPathField→ImagePathField works with direct_only=True."""
+        from datumaro.experimental.converters.registry import find_conversion_path
+        from datumaro.experimental.schema import AttributeInfo, Schema
+
+        source_schema = Schema(
+            attributes={
+                "media": AttributeInfo(
+                    type=str,
+                    field=MediaPathField(),
+                ),
+            }
+        )
+        target_schema = Schema(
+            attributes={
+                "image": AttributeInfo(
+                    type=str,
+                    field=ImagePathField(),
+                ),
+            }
+        )
+
+        # Should succeed with direct_only=True since media→image is a media bridge
+        path, _ = find_conversion_path(source_schema, target_schema, direct_only=True)
+        assert "image" in path.converters
+
+    def test_direct_only_allows_media_info_to_image_info(self):
+        """Test that MediaInfoField→ImageInfoField works with direct_only=True."""
+        from datumaro.experimental.converters.registry import find_conversion_path
+        from datumaro.experimental.schema import AttributeInfo, Schema
+
+        source_schema = Schema(
+            attributes={
+                "info": AttributeInfo(
+                    type=str,
+                    field=MediaInfoField(),
+                ),
+            }
+        )
+        target_schema = Schema(
+            attributes={
+                "info": AttributeInfo(
+                    type=str,
+                    field=ImageInfoField(),
+                ),
+            }
+        )
+
+        path, _ = find_conversion_path(source_schema, target_schema, direct_only=True)
+        assert "info" in path.converters
+
+    def test_direct_only_allows_image_path_to_media_path(self):
+        """Test that ImagePathField→MediaPathField works with direct_only=True."""
+        from datumaro.experimental.converters.registry import find_conversion_path
+        from datumaro.experimental.schema import AttributeInfo, Schema
+
+        source_schema = Schema(
+            attributes={
+                "image": AttributeInfo(
+                    type=str,
+                    field=ImagePathField(),
+                ),
+            }
+        )
+        target_schema = Schema(
+            attributes={
+                "media": AttributeInfo(
+                    type=str,
+                    field=MediaPathField(),
+                ),
+            }
+        )
+
+        path, _ = find_conversion_path(source_schema, target_schema, direct_only=True)
+        assert "media" in path.converters
+
+    def test_direct_only_allows_video_frame_path_to_media_path(self):
+        """Test that VideoFramePathField→MediaPathField works with direct_only=True."""
+        from datumaro.experimental.converters.registry import find_conversion_path
+        from datumaro.experimental.schema import AttributeInfo, Schema
+
+        source_schema = Schema(
+            attributes={
+                "frame": AttributeInfo(
+                    type=str,
+                    field=VideoFramePathField(),
+                ),
+            }
+        )
+        target_schema = Schema(
+            attributes={
+                "media": AttributeInfo(
+                    type=str,
+                    field=MediaPathField(),
+                ),
+            }
+        )
+
+        path, _ = find_conversion_path(source_schema, target_schema, direct_only=True)
+        assert "media" in path.converters
+
+    def test_direct_only_allows_combined_media_to_image_conversion(self):
+        """Test that a schema with both MediaPath and MediaInfo converts to
+        ImagePath and ImageInfo with direct_only=True."""
+        from datumaro.experimental.converters.registry import find_conversion_path
+        from datumaro.experimental.schema import AttributeInfo, Schema
+
+        source_schema = Schema(
+            attributes={
+                "media": AttributeInfo(
+                    type=str,
+                    field=MediaPathField(),
+                ),
+                "info": AttributeInfo(
+                    type=str,
+                    field=MediaInfoField(),
+                ),
+            }
+        )
+        target_schema = Schema(
+            attributes={
+                "image": AttributeInfo(
+                    type=str,
+                    field=ImagePathField(),
+                ),
+                "image_info": AttributeInfo(
+                    type=str,
+                    field=ImageInfoField(),
+                ),
+            }
+        )
+
+        path, _ = find_conversion_path(source_schema, target_schema, direct_only=True)
+        assert "image" in path.converters
+        assert "image_info" in path.converters

--- a/tests/unit/experimental/converters/test_media_bridge_converters.py
+++ b/tests/unit/experimental/converters/test_media_bridge_converters.py
@@ -1927,12 +1927,14 @@ class DirectOnlyAllowsMediaBridgeConversionsTest:
     def test_direct_only_allows_media_info_to_image_info(self):
         """Test that MediaInfoField→ImageInfoField works with direct_only=True."""
         from datumaro.experimental.converters.registry import find_conversion_path
+        from datumaro.experimental.fields.images import ImageInfo
+        from datumaro.experimental.media import MediaInfo
         from datumaro.experimental.schema import AttributeInfo, Schema
 
         source_schema = Schema(
             attributes={
                 "info": AttributeInfo(
-                    type=str,
+                    type=MediaInfo,
                     field=MediaInfoField(),
                 ),
             }
@@ -1940,7 +1942,7 @@ class DirectOnlyAllowsMediaBridgeConversionsTest:
         target_schema = Schema(
             attributes={
                 "info": AttributeInfo(
-                    type=str,
+                    type=ImageInfo,
                     field=ImageInfoField(),
                 ),
             }
@@ -2003,6 +2005,8 @@ class DirectOnlyAllowsMediaBridgeConversionsTest:
         """Test that a schema with both MediaPath and MediaInfo converts to
         ImagePath and ImageInfo with direct_only=True."""
         from datumaro.experimental.converters.registry import find_conversion_path
+        from datumaro.experimental.fields.images import ImageInfo
+        from datumaro.experimental.media import MediaInfo
         from datumaro.experimental.schema import AttributeInfo, Schema
 
         source_schema = Schema(
@@ -2012,7 +2016,7 @@ class DirectOnlyAllowsMediaBridgeConversionsTest:
                     field=MediaPathField(),
                 ),
                 "info": AttributeInfo(
-                    type=str,
+                    type=MediaInfo,
                     field=MediaInfoField(),
                 ),
             }
@@ -2024,7 +2028,7 @@ class DirectOnlyAllowsMediaBridgeConversionsTest:
                     field=ImagePathField(),
                 ),
                 "image_info": AttributeInfo(
-                    type=str,
+                    type=ImageInfo,
                     field=ImageInfoField(),
                 ),
             }


### PR DESCRIPTION
Add shared MediaBridgeConverter interface to enable media conversions when direct_only is true in the `export_dataset` function. 
<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
