### PR TITLE
Detect roboflow COCO layout

### DIFF
--- a/src/datumaro/experimental/data_formats/coco/io.py
+++ b/src/datumaro/experimental/data_formats/coco/io.py
@@ -45,6 +45,9 @@ _SUBSET_NAME_TO_ENUM: dict[str, Subset] = {
     _DEFAULT_SUBSET_KEY: Subset.UNASSIGNED,
 }
 
+# Roboflow exports use these subset directory names
+ROBOFLOW_SUBSETS = ("train", "valid", "test")
+
 
 def is_coco_json_file(json_path: Path) -> bool:
     """
@@ -100,12 +103,29 @@ def is_coco_format(input_dir: Path) -> bool:
 
 def _is_roboflow_coco_layout(input_dir: Path) -> bool:
     """Check if directory has Roboflow COCO layout (subset dirs with _annotations.coco.json)."""
-    roboflow_subsets = ["train", "valid", "test"]
-    for subset_name in roboflow_subsets:
+    for subset_name in ROBOFLOW_SUBSETS:
         subset_dir = input_dir / subset_name
         ann_file = subset_dir / "_annotations.coco.json"
-        if ann_file.exists() and is_coco_json_file(ann_file):
+        if ann_file.exists() and _is_roboflow_annotation_file(ann_file):
             return True
+    return False
+
+
+def _is_roboflow_annotation_file(json_path: Path) -> bool:
+    """Check if a JSON file is a valid Roboflow COCO annotation file.
+
+    Stricter than ``is_coco_json_file``: requires both ``images`` and
+    ``annotations`` keys to be present and be lists.
+    """
+    try:
+        with open(json_path) as f:
+            data = json.load(f)
+            if isinstance(data, dict):
+                images = data.get("images")
+                annotations = data.get("annotations")
+                return isinstance(images, list) and isinstance(annotations, list)
+    except (json.JSONDecodeError, OSError):
+        pass
     return False
 
 
@@ -225,24 +245,26 @@ def import_coco_dataset(input_dir: Path) -> Dataset:
     Raises:
         FileNotFoundError: If no COCO annotation files are found
     """
-    # Check for Roboflow-style layout first
+    # Check for standard COCO layout first
+    annotation_files = _find_coco_annotations(input_dir)
+
+    if annotation_files:
+        subset_layout = _detect_subset_image_layout(input_dir, annotation_files)
+        if subset_layout is not None:
+            images_config, annotations_config = subset_layout
+            return load_coco_dataset(images_dir_path=images_config, annotations_path=annotations_config)
+
+        images_dir = _find_coco_images_dir(input_dir)
+        annotations_path = annotation_files if len(annotation_files) > 1 else annotation_files[0]
+        return load_coco_dataset(images_dir_path=images_dir, annotations_path=annotations_path)
+
+    # Fall back to Roboflow-style layout
     roboflow_layout = _detect_roboflow_coco_layout(input_dir)
     if roboflow_layout is not None:
         images_config, annotations_config = roboflow_layout
         return load_coco_dataset(images_dir_path=images_config, annotations_path=annotations_config)
 
-    annotation_files = _find_coco_annotations(input_dir)
-    if not annotation_files:
-        raise FileNotFoundError(f"No COCO annotation files found in {input_dir}")
-
-    subset_layout = _detect_subset_image_layout(input_dir, annotation_files)
-    if subset_layout is not None:
-        images_config, annotations_config = subset_layout
-        return load_coco_dataset(images_dir_path=images_config, annotations_path=annotations_config)
-
-    images_dir = _find_coco_images_dir(input_dir)
-    annotations_path = annotation_files if len(annotation_files) > 1 else annotation_files[0]
-    return load_coco_dataset(images_dir_path=images_dir, annotations_path=annotations_path)
+    raise FileNotFoundError(f"No COCO annotation files found in {input_dir}")
 
 
 def _detect_roboflow_coco_layout(
@@ -256,14 +278,14 @@ def _detect_roboflow_coco_layout(
         A tuple of (images_config, annotations_config) dicts if Roboflow layout
         is detected, or None otherwise.
     """
-    roboflow_subsets = ["train", "valid", "test"]
+    roboflow_subsets = ROBOFLOW_SUBSETS
     images_config: dict[str, str] = {}
     annotations_config: dict[str, list[str]] = {}
 
     for subset_name in roboflow_subsets:
         subset_dir = input_dir / subset_name
         ann_file = subset_dir / "_annotations.coco.json"
-        if ann_file.exists() and is_coco_json_file(ann_file):
+        if ann_file.exists() and _is_roboflow_annotation_file(ann_file):
             images_config[subset_name] = str(subset_dir)
             annotations_config[subset_name] = [str(ann_file)]
 

--- a/src/datumaro/experimental/data_formats/coco/io.py
+++ b/src/datumaro/experimental/data_formats/coco/io.py
@@ -38,6 +38,7 @@ _SUBSET_NAME_TO_ENUM: dict[str, Subset] = {
     "train": Subset.TRAINING,
     "training": Subset.TRAINING,
     "val": Subset.VALIDATION,
+    "valid": Subset.VALIDATION,
     "validation": Subset.VALIDATION,
     "test": Subset.TESTING,
     "testing": Subset.TESTING,
@@ -72,6 +73,8 @@ def is_coco_format(input_dir: Path) -> bool:
     COCO format is identified by:
     - An 'annotations' subdirectory containing JSON files with COCO structure
     - OR JSON files in the root containing 'images' and 'annotations' keys
+    - OR Roboflow-style layout with subset folders (train/, valid/, test/)
+      each containing _annotations.coco.json
 
     Args:
         input_dir: Path to the directory to check
@@ -91,6 +94,18 @@ def is_coco_format(input_dir: Path) -> bool:
         if is_coco_json_file(json_file):
             return True
 
+    # Check for Roboflow-style layout: subset folders with _annotations.coco.json
+    return _is_roboflow_coco_layout(input_dir)
+
+
+def _is_roboflow_coco_layout(input_dir: Path) -> bool:
+    """Check if directory has Roboflow COCO layout (subset dirs with _annotations.coco.json)."""
+    roboflow_subsets = ["train", "valid", "test"]
+    for subset_name in roboflow_subsets:
+        subset_dir = input_dir / subset_name
+        ann_file = subset_dir / "_annotations.coco.json"
+        if ann_file.exists() and is_coco_json_file(ann_file):
+            return True
     return False
 
 
@@ -195,9 +210,11 @@ def import_coco_dataset(input_dir: Path) -> Dataset:
     Import a COCO-format dataset from a directory.
 
     Automatically discovers annotation files and image directories.
-    Supports both flat image directories and subset-based layouts
-    (e.g., CVAT exports where images are in ``images/<subset>/`` and
-    annotations are named ``instances_<subset>.json``).
+    Supports:
+    - Flat image directories with annotation files
+    - Subset-based layouts (e.g., CVAT exports with ``images/<subset>/``)
+    - Roboflow-style layouts with subset folders containing
+      ``_annotations.coco.json`` and images in the same directory
 
     Args:
         input_dir: Path to the COCO dataset directory
@@ -208,6 +225,12 @@ def import_coco_dataset(input_dir: Path) -> Dataset:
     Raises:
         FileNotFoundError: If no COCO annotation files are found
     """
+    # Check for Roboflow-style layout first
+    roboflow_layout = _detect_roboflow_coco_layout(input_dir)
+    if roboflow_layout is not None:
+        images_config, annotations_config = roboflow_layout
+        return load_coco_dataset(images_dir_path=images_config, annotations_path=annotations_config)
+
     annotation_files = _find_coco_annotations(input_dir)
     if not annotation_files:
         raise FileNotFoundError(f"No COCO annotation files found in {input_dir}")
@@ -220,6 +243,34 @@ def import_coco_dataset(input_dir: Path) -> Dataset:
     images_dir = _find_coco_images_dir(input_dir)
     annotations_path = annotation_files if len(annotation_files) > 1 else annotation_files[0]
     return load_coco_dataset(images_dir_path=images_dir, annotations_path=annotations_path)
+
+
+def _detect_roboflow_coco_layout(
+    input_dir: Path,
+) -> tuple[dict[str, str], dict[str, list[str]]] | None:
+    """
+    Detect Roboflow COCO layout where each subset folder (train/, valid/, test/)
+    contains _annotations.coco.json and images in the same directory.
+
+    Returns:
+        A tuple of (images_config, annotations_config) dicts if Roboflow layout
+        is detected, or None otherwise.
+    """
+    roboflow_subsets = ["train", "valid", "test"]
+    images_config: dict[str, str] = {}
+    annotations_config: dict[str, list[str]] = {}
+
+    for subset_name in roboflow_subsets:
+        subset_dir = input_dir / subset_name
+        ann_file = subset_dir / "_annotations.coco.json"
+        if ann_file.exists() and is_coco_json_file(ann_file):
+            images_config[subset_name] = str(subset_dir)
+            annotations_config[subset_name] = [str(ann_file)]
+
+    if not images_config:
+        return None
+
+    return images_config, annotations_config
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/experimental/data_formats/coco/test_coco_io_unit.py
+++ b/tests/unit/experimental/data_formats/coco/test_coco_io_unit.py
@@ -400,8 +400,8 @@ def _make_roboflow_coco_annotations(categories=None, num_images=2, num_annotatio
     """Helper to create a minimal Roboflow-style COCO annotation dict."""
     if categories is None:
         categories = [
-            {"id": 0, "name": "cat", "supercategory": "none"},
-            {"id": 1, "name": "dog", "supercategory": "none"},
+            {"id": 1, "name": "cat", "supercategory": "none"},
+            {"id": 2, "name": "dog", "supercategory": "none"},
         ]
     images = [{"id": i, "file_name": f"img_{i}.jpg", "height": 100, "width": 200} for i in range(num_images)]
     annotations = [
@@ -515,4 +515,4 @@ def test_find_dataset_root_roboflow_with_extra_files(tmp_path: Path):
     # Add extra file like Roboflow's README
     (root / "README.roboflow.txt").write_text("metadata")
     # find_dataset_root should return root since format is detectable there
-    assert find_dataset_root(root) == root
+    assert find_dataset_root(root) == root.resolve()

--- a/tests/unit/experimental/data_formats/coco/test_coco_io_unit.py
+++ b/tests/unit/experimental/data_formats/coco/test_coco_io_unit.py
@@ -6,9 +6,18 @@ import pytest
 
 from datumaro.experimental import Dataset
 from datumaro.experimental.categories import KeypointCategories
-from datumaro.experimental.data_formats.coco.io import load_coco_dataset, save_coco_dataset
+from datumaro.experimental.data_formats.base import DataFormat
+from datumaro.experimental.data_formats.coco.io import (
+    _detect_roboflow_coco_layout,
+    _is_roboflow_coco_layout,
+    import_coco_dataset,
+    is_coco_format,
+    load_coco_dataset,
+    save_coco_dataset,
+)
 from datumaro.experimental.data_formats.coco.sample import CocoCategories, CocoSample
 from datumaro.experimental.fields import ImageInfo, Subset
+from datumaro.experimental.format_detection import detect_dataset_format, find_dataset_root
 
 
 def _write_json(path: Path, data: dict) -> None:
@@ -380,3 +389,130 @@ def test_load_coco_dataset_keypoint_categories_from_second_file(tmp_path: Path):
     kp_categories = ds.schema.get_categories_for_field("keypoints")
     assert isinstance(kp_categories, KeypointCategories)
     assert kp_categories.labels == ("left_hip", "right_hip")
+
+
+# ---------------------------------------------------------------------------
+# Roboflow COCO layout tests
+# ---------------------------------------------------------------------------
+
+
+def _make_roboflow_coco_annotations(categories=None, num_images=2, num_annotations=3):
+    """Helper to create a minimal Roboflow-style COCO annotation dict."""
+    if categories is None:
+        categories = [
+            {"id": 0, "name": "cat", "supercategory": "none"},
+            {"id": 1, "name": "dog", "supercategory": "none"},
+        ]
+    images = [{"id": i, "file_name": f"img_{i}.jpg", "height": 100, "width": 200} for i in range(num_images)]
+    annotations = [
+        {
+            "id": a,
+            "image_id": a % num_images,
+            "category_id": categories[0]["id"],
+            "bbox": [10, 20, 30, 40],
+            "area": 1200,
+            "segmentation": [],
+            "iscrowd": 0,
+        }
+        for a in range(num_annotations)
+    ]
+    return {
+        "info": {"description": "Exported from roboflow.com"},
+        "licenses": [{"id": 1, "url": "", "name": "Unknown"}],
+        "categories": categories,
+        "images": images,
+        "annotations": annotations,
+    }
+
+
+def _setup_roboflow_layout(root: Path, subsets=("train",)):
+    """Create a Roboflow-style directory layout under *root*."""
+    for subset_name in subsets:
+        subset_dir = root / subset_name
+        subset_dir.mkdir(parents=True, exist_ok=True)
+        ann_data = _make_roboflow_coco_annotations()
+        _write_json(subset_dir / "_annotations.coco.json", ann_data)
+        for img in ann_data["images"]:
+            (subset_dir / img["file_name"]).write_bytes(b"fake-img")
+
+
+def test_is_roboflow_coco_layout_detected(tmp_path: Path):
+    """_is_roboflow_coco_layout returns True for Roboflow directories."""
+    _setup_roboflow_layout(tmp_path, subsets=("train",))
+    assert _is_roboflow_coco_layout(tmp_path) is True
+
+
+def test_is_roboflow_coco_layout_not_detected(tmp_path: Path):
+    """_is_roboflow_coco_layout returns False for empty or non-Roboflow dirs."""
+    assert _is_roboflow_coco_layout(tmp_path) is False
+
+
+def test_is_coco_format_roboflow(tmp_path: Path):
+    """is_coco_format recognises Roboflow layout."""
+    _setup_roboflow_layout(tmp_path, subsets=("train", "valid"))
+    assert is_coco_format(tmp_path) is True
+
+
+def test_detect_dataset_format_roboflow(tmp_path: Path):
+    """detect_dataset_format returns COCO for Roboflow layout."""
+    _setup_roboflow_layout(tmp_path, subsets=("train",))
+    assert detect_dataset_format(tmp_path) == DataFormat.COCO
+
+
+def test_detect_roboflow_coco_layout_single_subset(tmp_path: Path):
+    """_detect_roboflow_coco_layout returns correct config for train only."""
+    _setup_roboflow_layout(tmp_path, subsets=("train",))
+    result = _detect_roboflow_coco_layout(tmp_path)
+    assert result is not None
+    images_config, annotations_config = result
+    assert set(images_config.keys()) == {"train"}
+    assert str(tmp_path / "train") == images_config["train"]
+    assert len(annotations_config["train"]) == 1
+
+
+def test_detect_roboflow_coco_layout_multiple_subsets(tmp_path: Path):
+    """_detect_roboflow_coco_layout picks up train, valid, and test."""
+    _setup_roboflow_layout(tmp_path, subsets=("train", "valid", "test"))
+    result = _detect_roboflow_coco_layout(tmp_path)
+    assert result is not None
+    images_config, _ = result
+    assert set(images_config.keys()) == {"train", "valid", "test"}
+
+
+def test_import_coco_dataset_roboflow_layout(tmp_path: Path):
+    """import_coco_dataset loads a Roboflow-style dataset correctly."""
+    _setup_roboflow_layout(tmp_path, subsets=("train", "valid"))
+    ds = import_coco_dataset(tmp_path)
+    # 2 images per subset * 2 subsets = 4
+    assert len(ds) == 4
+    subsets = {s.subset for s in ds}
+    assert Subset.TRAINING in subsets
+    assert Subset.VALIDATION in subsets
+
+
+def test_import_coco_dataset_roboflow_train_only(tmp_path: Path):
+    """import_coco_dataset works with a single Roboflow subset."""
+    _setup_roboflow_layout(tmp_path, subsets=("train",))
+    ds = import_coco_dataset(tmp_path)
+    assert len(ds) == 2
+    assert all(s.subset == Subset.TRAINING for s in ds)
+
+
+def test_import_coco_dataset_roboflow_annotations(tmp_path: Path):
+    """Annotations are loaded correctly from Roboflow layout."""
+    _setup_roboflow_layout(tmp_path, subsets=("train",))
+    ds = import_coco_dataset(tmp_path)
+    sample = ds[0]
+    assert sample.bboxes is not None
+    assert sample.labels is not None
+
+
+def test_find_dataset_root_roboflow_with_extra_files(tmp_path: Path):
+    """find_dataset_root detects Roboflow layout even with extra files like README."""
+    root = tmp_path / "dataset"
+    root.mkdir()
+    _setup_roboflow_layout(root, subsets=("train",))
+    # Add extra file like Roboflow's README
+    (root / "README.roboflow.txt").write_text("metadata")
+    # find_dataset_root should return root since format is detectable there
+    assert find_dataset_root(root) == root


### PR DESCRIPTION
This pull request adds support for importing and detecting Roboflow-style COCO dataset layouts in the Datumaro experimental COCO I/O module. It updates the core logic to recognize Roboflow's common directory structure, improves format detection, and introduces comprehensive tests to ensure correct handling of this layout.

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
