### PR TITLE
feat(image): honor EXIF orientation in image loading and processing

### DIFF
--- a/src/datumaro/experimental/converters/image_converters.py
+++ b/src/datumaro/experimental/converters/image_converters.py
@@ -6,7 +6,7 @@ from typing import Any
 import cv2
 import numpy as np
 import polars as pl
-from PIL import Image
+from PIL import Image, ImageOps
 
 from datumaro.experimental.converters.base import Converter, MediaBridgeConverter, copy_columns_with_shape
 from datumaro.experimental.converters.registry import converter
@@ -27,6 +27,11 @@ _NUMPY_TO_POLARS_DTYPE: dict[np.dtype, pl.DataType] = {
     np.dtype(np.float32): pl.Float32(),
     np.dtype(np.float64): pl.Float64(),
 }
+
+
+# EXIF Orientation tag id. Values 5, 6, 7, 8 imply a 90°/270° rotation
+# (which swaps width and height); 2, 3, 4 are flips / 180° rotations.
+_EXIF_ORIENTATION_TAG = 0x0112
 
 
 @converter
@@ -298,6 +303,8 @@ class ImagePathToImageConverter(MediaBridgeConverter):
         elif output_format == "GRAY" and len(img_array.shape) == 2:
             img_array = img_array[:, :, np.newaxis]
 
+        # Note: cv2.imread auto-applies EXIF orientation for JPEG images
+        # (since OpenCV 3.4), so no additional transform is needed here.
         return img_array
 
     def _load_image_pil(self, path: str, output_format: str) -> np.ndarray:
@@ -313,7 +320,10 @@ class ImagePathToImageConverter(MediaBridgeConverter):
         """
         target_mode = self._PIL_MODES[output_format]
 
-        with Image.open(path) as img:
+        with Image.open(path) as raw_img:
+            # Apply EXIF orientation so the returned array matches the
+            # image's displayed orientation (consistent with LazyImage).
+            img = ImageOps.exif_transpose(raw_img)
             # For 16-bit grayscale images, PIL uses mode 'I;16' or 'I'
             # Convert to target mode if needed, preserving bit depth
             if output_format == "GRAY" and img.mode in ("I;16", "I;16L", "I;16B"):
@@ -490,7 +500,10 @@ class ImageBytesToImageConverter(MediaBridgeConverter):
         """
         from io import BytesIO
 
-        with Image.open(BytesIO(image_bytes)) as img:
+        with Image.open(BytesIO(image_bytes)) as raw_img:
+            # Apply EXIF orientation so decoded bytes match the image's
+            # displayed orientation (consistent with file-based loading).
+            img = ImageOps.exif_transpose(raw_img)
             is_high_depth = img.mode in ("I", "I;16", "I;16B", "I;16L", "I;16N")
 
             if is_high_depth and output_format in ("RGB", "BGR"):
@@ -774,7 +787,12 @@ class ImagePathToImageInfoConverter(MediaBridgeConverter):
                 )
 
             with Image.open(str(path)) as img:
+                # Respect EXIF orientation so reported dimensions match the
+                # image as displayed (and as loaded via LazyImage).
                 w, h = img.size
+                orientation = int(img.getexif().get(_EXIF_ORIENTATION_TAG, 1) or 1)
+                if orientation in (5, 6, 7, 8):
+                    w, h = h, w
                 widths.append(w)
                 heights.append(h)
 

--- a/src/datumaro/experimental/converters/image_converters.py
+++ b/src/datumaro/experimental/converters/image_converters.py
@@ -10,6 +10,7 @@ from PIL import Image, ImageOps
 
 from datumaro.experimental.converters.base import Converter, MediaBridgeConverter, copy_columns_with_shape
 from datumaro.experimental.converters.registry import converter
+from datumaro.experimental.exif_utils import get_exif_orientation, get_oriented_size, has_nontrivial_exif_orientation
 from datumaro.experimental.fields import ImageBytesField
 from datumaro.experimental.fields.images import ImageCallableField, ImageField, ImageInfoField, ImagePathField
 from datumaro.experimental.schema import AttributeSpec
@@ -29,9 +30,8 @@ _NUMPY_TO_POLARS_DTYPE: dict[np.dtype, pl.DataType] = {
 }
 
 
-# EXIF Orientation tag id. Values 5, 6, 7, 8 imply a 90°/270° rotation
-# (which swaps width and height); 2, 3, 4 are flips / 180° rotations.
-_EXIF_ORIENTATION_TAG = 0x0112
+# EXIF Orientation tag id is re-exported from ``datumaro.experimental.exif_utils``
+# (see ``EXIF_ORIENTATION_TAG``). No local constant is needed.
 
 
 @converter
@@ -303,8 +303,10 @@ class ImagePathToImageConverter(MediaBridgeConverter):
         elif output_format == "GRAY" and len(img_array.shape) == 2:
             img_array = img_array[:, :, np.newaxis]
 
-        # Note: cv2.imread auto-applies EXIF orientation for JPEG images
-        # (since OpenCV 3.4), so no additional transform is needed here.
+        # Note: EXIF orientation is handled deterministically by the caller
+        # (``convert``), which routes EXIF-rotated images through the PIL path
+        # (``ImageOps.exif_transpose``) regardless of OpenCV's build-time
+        # auto-orientation behavior.
         return img_array
 
     def _load_image_pil(self, path: str, output_format: str) -> np.ndarray:
@@ -367,12 +369,20 @@ class ImagePathToImageConverter(MediaBridgeConverter):
         for path in df[input_col]:
             path_str = str(path)
 
-            # Try OpenCV first (faster)
-            img_array = self._load_image_opencv(path_str, output_format)
-
-            if img_array is None:
-                # Fallback to PIL for unsupported formats
+            # For deterministic behavior across OpenCV builds (some builds
+            # auto-apply EXIF orientation on JPEG, others don't), skip the
+            # OpenCV fast path when the image has a non-identity EXIF
+            # orientation and defer to the PIL path, which always applies
+            # ``ImageOps.exif_transpose``.
+            if has_nontrivial_exif_orientation(path_str):
                 img_array = self._load_image_pil(path_str, output_format)
+            else:
+                # Try OpenCV first (faster)
+                img_array = self._load_image_opencv(path_str, output_format)
+
+                if img_array is None:
+                    # Fallback to PIL for unsupported formats
+                    img_array = self._load_image_pil(path_str, output_format)
 
             image_data.append(img_array.flatten())
             image_shapes.append(list(img_array.shape))
@@ -790,9 +800,7 @@ class ImagePathToImageInfoConverter(MediaBridgeConverter):
                 # Respect EXIF orientation so reported dimensions match the
                 # image as displayed (and as loaded via LazyImage).
                 w, h = img.size
-                orientation = int(img.getexif().get(_EXIF_ORIENTATION_TAG, 1) or 1)
-                if orientation in (5, 6, 7, 8):
-                    w, h = h, w
+                w, h = get_oriented_size(w, h, get_exif_orientation(img))
                 widths.append(w)
                 heights.append(h)
 

--- a/src/datumaro/experimental/converters/media_converters.py
+++ b/src/datumaro/experimental/converters/media_converters.py
@@ -735,12 +735,12 @@ class MediaPathToMediaInfoConverter(MediaBridgeConverter):
                     continue
 
                 with _PILImage.open(path_str) as img:
+                    from datumaro.experimental.exif_utils import get_exif_orientation, get_oriented_size
+
                     w, h = img.size
                     # Respect EXIF orientation so reported dimensions match
                     # the image as displayed (and as loaded via LazyImage).
-                    orientation = int(img.getexif().get(0x0112, 1) or 1)
-                    if orientation in (5, 6, 7, 8):
-                        w, h = h, w
+                    w, h = get_oriented_size(w, h, get_exif_orientation(img))
 
                 rows.append(
                     {

--- a/src/datumaro/experimental/converters/media_converters.py
+++ b/src/datumaro/experimental/converters/media_converters.py
@@ -736,6 +736,11 @@ class MediaPathToMediaInfoConverter(MediaBridgeConverter):
 
                 with _PILImage.open(path_str) as img:
                     w, h = img.size
+                    # Respect EXIF orientation so reported dimensions match
+                    # the image as displayed (and as loaded via LazyImage).
+                    orientation = int(img.getexif().get(0x0112, 1) or 1)
+                    if orientation in (5, 6, 7, 8):
+                        w, h = h, w
 
                 rows.append(
                     {

--- a/src/datumaro/experimental/data_formats/voc/helpers.py
+++ b/src/datumaro/experimental/data_formats/voc/helpers.py
@@ -39,12 +39,18 @@ logger = logging.getLogger(__name__)
 
 
 def _get_image_size(image_path: Path) -> tuple[int, int]:
-    """Get image dimensions (height, width) using PIL."""
+    """Get image dimensions (height, width) using PIL, honoring EXIF orientation."""
     try:
         from PIL import Image
 
         with Image.open(image_path) as img:
-            return img.size[1], img.size[0]  # height, width
+            w, h = img.size
+            # EXIF Orientation values 5-8 imply a 90/270° rotation, swapping
+            # width and height. Honor it so dimensions match the displayed image.
+            orientation = int(img.getexif().get(0x0112, 1) or 1)
+            if orientation in (5, 6, 7, 8):
+                w, h = h, w
+            return h, w  # height, width
     except Exception as e:
         logger.warning("Failed to read image size from %s: %s", image_path, e)
         return 0, 0

--- a/src/datumaro/experimental/data_formats/voc/helpers.py
+++ b/src/datumaro/experimental/data_formats/voc/helpers.py
@@ -43,13 +43,11 @@ def _get_image_size(image_path: Path) -> tuple[int, int]:
     try:
         from PIL import Image
 
+        from datumaro.experimental.exif_utils import get_exif_orientation, get_oriented_size
+
         with Image.open(image_path) as img:
             w, h = img.size
-            # EXIF Orientation values 5-8 imply a 90/270° rotation, swapping
-            # width and height. Honor it so dimensions match the displayed image.
-            orientation = int(img.getexif().get(0x0112, 1) or 1)
-            if orientation in (5, 6, 7, 8):
-                w, h = h, w
+            w, h = get_oriented_size(w, h, get_exif_orientation(img))
             return h, w  # height, width
     except Exception as e:
         logger.warning("Failed to read image size from %s: %s", image_path, e)

--- a/src/datumaro/experimental/data_formats/yolo/helpers.py
+++ b/src/datumaro/experimental/data_formats/yolo/helpers.py
@@ -49,13 +49,11 @@ def _get_image_size(image_path: Path) -> tuple[int, int]:
     try:
         from PIL import Image
 
+        from datumaro.experimental.exif_utils import get_exif_orientation, get_oriented_size
+
         with Image.open(image_path) as img:
             w, h = img.size
-            # EXIF Orientation values 5-8 imply a 90/270° rotation, swapping
-            # width and height. Honor it so dimensions match the displayed image.
-            orientation = int(img.getexif().get(0x0112, 1) or 1)
-            if orientation in (5, 6, 7, 8):
-                w, h = h, w
+            w, h = get_oriented_size(w, h, get_exif_orientation(img))
             return h, w  # height, width
     except Exception as e:
         logger.warning("Failed to read image size from %s: %s", image_path, e)

--- a/src/datumaro/experimental/data_formats/yolo/helpers.py
+++ b/src/datumaro/experimental/data_formats/yolo/helpers.py
@@ -45,12 +45,18 @@ def _find_image_files(directory: Path) -> list[Path]:
 
 
 def _get_image_size(image_path: Path) -> tuple[int, int]:
-    """Get image dimensions (height, width) using PIL."""
+    """Get image dimensions (height, width) using PIL, honoring EXIF orientation."""
     try:
         from PIL import Image
 
         with Image.open(image_path) as img:
-            return img.size[1], img.size[0]  # height, width
+            w, h = img.size
+            # EXIF Orientation values 5-8 imply a 90/270° rotation, swapping
+            # width and height. Honor it so dimensions match the displayed image.
+            orientation = int(img.getexif().get(0x0112, 1) or 1)
+            if orientation in (5, 6, 7, 8):
+                w, h = h, w
+            return h, w  # height, width
     except Exception as e:
         logger.warning("Failed to read image size from %s: %s", image_path, e)
         return 0, 0

--- a/src/datumaro/experimental/exif_utils.py
+++ b/src/datumaro/experimental/exif_utils.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+"""Shared EXIF orientation helpers.
+
+Centralizes handling of the EXIF ``Orientation`` tag so that dimension/shape
+logic behaves identically across loaders (``LazyImage``, YOLO/VOC helpers,
+and media/image converters).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImageType
+
+# EXIF Orientation tag id.
+EXIF_ORIENTATION_TAG = 0x0112
+
+# Orientations that imply a 90°/270° rotation and therefore swap width/height.
+_DIMENSION_SWAPPING_ORIENTATIONS = frozenset({5, 6, 7, 8})
+
+
+def get_exif_orientation(img: PILImageType) -> int:
+    """Return the EXIF Orientation value for a PIL image, defaulting to 1.
+
+    Safely handles missing/None EXIF tags.
+    """
+    try:
+        value = img.getexif().get(EXIF_ORIENTATION_TAG, 1)
+    except Exception:
+        return 1
+    try:
+        return int(value) if value else 1
+    except (TypeError, ValueError):
+        return 1
+
+
+def needs_dimension_swap(orientation: int) -> bool:
+    """Whether the given EXIF orientation swaps width and height."""
+    return orientation in _DIMENSION_SWAPPING_ORIENTATIONS
+
+
+def get_oriented_size(width: int, height: int, orientation: int) -> tuple[int, int]:
+    """Return ``(width, height)`` after applying EXIF orientation.
+
+    For rotating orientations (5-8), width and height are swapped.
+    """
+    if needs_dimension_swap(orientation):
+        return height, width
+    return width, height
+
+
+def has_nontrivial_exif_orientation(path: str) -> bool:
+    """Return True if the image at ``path`` has a non-identity EXIF orientation.
+
+    Uses a lightweight PIL header read (does not decode pixel data). Returns
+    False if the file can't be opened or has no EXIF data.
+    """
+    try:
+        from PIL import Image
+
+        with Image.open(path) as img:
+            return get_exif_orientation(img) != 1
+    except Exception:
+        return False

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -30,7 +30,7 @@ from zipfile import ZIP_DEFLATED, ZipFile, is_zipfile
 
 import numpy as np
 import polars as pl
-from PIL import Image
+from PIL import Image, ImageOps
 
 from datumaro.experimental.data_formats.base import DataFormat
 from datumaro.experimental.dataset import Dataset, Sample
@@ -1029,7 +1029,10 @@ def _make_image_loader(path: Path):
     """Create a closure that loads an image from a path."""
 
     def load_image():
-        return np.array(Image.open(path))
+        # Apply EXIF orientation so the loaded array matches the image as
+        # displayed (consistent with LazyImage).
+        with Image.open(path) as img:
+            return np.array(ImageOps.exif_transpose(img))
 
     return load_image
 

--- a/src/datumaro/experimental/legacy/media_converters.py
+++ b/src/datumaro/experimental/legacy/media_converters.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import numpy as np
 from PIL import Image as PILImage
+from PIL import ImageOps as PILImageOps
 
 from datumaro import Dataset as LegacyDataset
 from datumaro import DatasetItem, Image, MediaElement
@@ -78,7 +79,10 @@ def _image_callable_impl(bytes_source: Any, is_callable: bool = False):
         raise TypeError(f"Expected bytes data, got {type(bytes_data)}")
     # Convert bytes to image array using PIL
     with PILImage.open(io.BytesIO(bytes_data)) as pil_image:
-        processed_image = pil_image if pil_image.mode == "RGB" else pil_image.convert("RGB")
+        # Apply EXIF orientation so the decoded array matches the image as
+        # displayed (consistent with LazyImage).
+        oriented = PILImageOps.exif_transpose(pil_image)
+        processed_image = oriented if oriented.mode == "RGB" else oriented.convert("RGB")
         return np.array(processed_image, dtype=np.uint8)
 
 

--- a/src/datumaro/experimental/media.py
+++ b/src/datumaro/experimental/media.py
@@ -365,13 +365,10 @@ class LazyImage:
         the image's displayed orientation.
         """
         with Image.open(self.path) as img:
+            from datumaro.experimental.exif_utils import get_exif_orientation, get_oriented_size
+
             w, h = img.size
-            # EXIF Orientation values 5,6,7,8 correspond to a 90/270 degree
-            # rotation, which swaps width and height.
-            orientation = img.getexif().get(0x0112)  # 0x0112 = Orientation tag
-            if orientation in (5, 6, 7, 8):
-                w, h = h, w
-            return w, h
+            return get_oriented_size(w, h, get_exif_orientation(img))
 
     @property
     def shape(self) -> tuple[int, ...]:

--- a/src/datumaro/experimental/media.py
+++ b/src/datumaro/experimental/media.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import numpy as np
 from cachetools import LRUCache, cachedmethod
-from PIL import Image
+from PIL import Image, ImageOps
 
 # Default cache size: 256 MB
 _DEFAULT_CACHE_SIZE_BYTES = 256 * 1024 * 1024
@@ -309,8 +309,11 @@ class LazyImage:
     def _load_data(self) -> np.ndarray:
         """Load the image from disk (cached via @cachedmethod)."""
         with Image.open(self.path) as img:
+            # Apply EXIF orientation so the returned array matches the
+            # image's displayed orientation (and matches ``width``/``height``).
+            oriented_img = ImageOps.exif_transpose(img)
             target_format = self.format.upper()
-            img_array = self._convert_to_format(img, target_format)
+            img_array = self._convert_to_format(oriented_img, target_format)
 
             # Handle channels-first format
             if self.channels_first and img_array.ndim == 3:
@@ -347,20 +350,28 @@ class LazyImage:
     @cached_property
     def width(self) -> int:
         """Get the image width without fully loading the image data."""
-        with Image.open(self.path) as img:
-            return img.width
+        return self.size[0]
 
     @cached_property
     def height(self) -> int:
         """Get the image height without fully loading the image data."""
-        with Image.open(self.path) as img:
-            return img.height
+        return self.size[1]
 
     @cached_property
     def size(self) -> tuple[int, int]:
-        """Get the image size (width, height) without fully loading the image data."""
+        """Get the image size (width, height) without fully loading the image data.
+
+        Accounts for the EXIF orientation so that the reported dimensions match
+        the image's displayed orientation.
+        """
         with Image.open(self.path) as img:
-            return img.size
+            w, h = img.size
+            # EXIF Orientation values 5,6,7,8 correspond to a 90/270 degree
+            # rotation, which swaps width and height.
+            orientation = img.getexif().get(0x0112)  # 0x0112 = Orientation tag
+            if orientation in (5, 6, 7, 8):
+                w, h = h, w
+            return w, h
 
     @property
     def shape(self) -> tuple[int, ...]:

--- a/tests/unit/experimental/converters/test_image_converters.py
+++ b/tests/unit/experimental/converters/test_image_converters.py
@@ -18,6 +18,7 @@ from datumaro.experimental.converters import (
     RedBlueColorConverter,
     find_conversion_path,
 )
+from datumaro.experimental.converters.image_converters import ImagePathToImageInfoConverter
 from datumaro.experimental.fields import ImageBytesField, ImageCallableField, ImageField, ImageInfoField, ImagePathField
 from datumaro.experimental.schema import AttributeInfo, AttributeSpec, Schema
 
@@ -720,3 +721,169 @@ def test_image_dtype_converter_schema_conversion_uint16_to_float32():
     path, _ = find_conversion_path(source_schema, target_schema)
     assert len(path.converters["image"]) == 1
     assert type(path.converters["image"][0]) is ImageDtypeConverter
+
+
+# ============================================================================
+# EXIF orientation handling
+# ============================================================================
+
+
+_EXIF_ORIENTATION_TAG = 0x0112
+
+
+def _save_jpeg_with_orientation(path: str, img_array: np.ndarray, orientation: int) -> None:
+    """Save a JPEG with a given EXIF Orientation tag.
+
+    JPEG is required to round-trip the EXIF orientation tag reliably.
+    """
+    from PIL import Image as PILImage
+
+    img = PILImage.fromarray(img_array)
+    exif = img.getexif()
+    exif[_EXIF_ORIENTATION_TAG] = orientation
+    img.save(path, format="JPEG", exif=exif.tobytes())
+
+
+def _run_image_path_to_image(path: str) -> pl.DataFrame:
+    """Run ImagePathToImageConverter on a single-path DataFrame."""
+    converter_instance = ImagePathToImageConverter()  # type: ignore[call-arg]
+    df = pl.DataFrame({"image_path": [path]})
+
+    setattr(
+        converter_instance,
+        "input_path",
+        AttributeSpec(name="image_path", field=ImagePathField()),
+    )
+    setattr(
+        converter_instance,
+        "output_image",
+        AttributeSpec(name="image", field=ImageField(dtype=pl.UInt8(), format="RGB")),
+    )
+    setattr(
+        converter_instance,
+        "output_info",
+        AttributeSpec(name="image_info", field=ImageInfoField()),
+    )
+    assert converter_instance.filter_output_spec() is True
+    return converter_instance.convert(df)
+
+
+@pytest.mark.parametrize("orientation", [5, 6, 7, 8])
+def test_image_path_to_image_converter_respects_exif_orientation(orientation):
+    """ImagePathToImageConverter must honor EXIF orientation for rotating tags.
+
+    Orientations 5-8 imply a 90°/270° rotation; the loaded pixel data must
+    reflect the oriented dimensions so it stays consistent with LazyImage
+    and with ``image_info`` (which is computed separately by a dedicated
+    converter that also honors EXIF).
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Raw pixels: landscape H=40, W=80.
+        img_array = np.zeros((40, 80, 3), dtype=np.uint8)
+        path = os.path.join(temp_dir, f"orient_{orientation}.jpg")
+        _save_jpeg_with_orientation(path, img_array, orientation)
+
+        result_df = _run_image_path_to_image(path)
+
+        # After orientation, the image is portrait: H=80, W=40.
+        assert list(result_df["image_shape"][0]) == [80, 40, 3]
+
+
+@pytest.mark.parametrize("orientation", [1, 2, 3, 4])
+def test_image_path_to_image_converter_keeps_dimensions_for_non_rotating_orientation(orientation):
+    """Orientations 1-4 do not swap width/height."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        img_array = np.zeros((40, 80, 3), dtype=np.uint8)
+        path = os.path.join(temp_dir, f"orient_{orientation}.jpg")
+        _save_jpeg_with_orientation(path, img_array, orientation)
+
+        result_df = _run_image_path_to_image(path)
+
+        assert list(result_df["image_shape"][0]) == [40, 80, 3]
+
+
+def test_image_bytes_to_image_converter_respects_exif_orientation():
+    """ImageBytesToImageConverter must honor EXIF orientation embedded in bytes."""
+    import io
+
+    from PIL import Image as PILImage
+
+    # Raw pixels: landscape H=40, W=80. Save with orientation=6 (90° CW).
+    img_array = np.zeros((40, 80, 3), dtype=np.uint8)
+    pil_img = PILImage.fromarray(img_array)
+    exif = pil_img.getexif()
+    exif[_EXIF_ORIENTATION_TAG] = 6
+    buf = io.BytesIO()
+    pil_img.save(buf, format="JPEG", exif=exif.tobytes())
+    image_bytes = buf.getvalue()
+
+    converter_instance = ImageBytesToImageConverter()  # type: ignore[call-arg]
+    df = pl.DataFrame({"image_bytes": [image_bytes]})
+
+    setattr(
+        converter_instance,
+        "input_bytes",
+        AttributeSpec(name="image_bytes", field=ImageBytesField()),
+    )
+    setattr(
+        converter_instance,
+        "output_image",
+        AttributeSpec(name="image", field=ImageField(dtype=pl.UInt8(), format="RGB")),
+    )
+    setattr(
+        converter_instance,
+        "output_info",
+        AttributeSpec(name="image_info", field=ImageInfoField()),
+    )
+    assert converter_instance.filter_output_spec() is True
+    result_df = converter_instance.convert(df)
+
+    # After orientation, image is portrait: H=80, W=40.
+    assert list(result_df["image_shape"][0]) == [80, 40, 3]
+
+
+@pytest.mark.parametrize(
+    ("orientation", "expected_width", "expected_height"),
+    [
+        (1, 80, 40),
+        (2, 80, 40),
+        (3, 80, 40),
+        (4, 80, 40),
+        (5, 40, 80),
+        (6, 40, 80),
+        (7, 40, 80),
+        (8, 40, 80),
+    ],
+)
+def test_image_path_to_image_info_converter_respects_exif_orientation(orientation, expected_width, expected_height):
+    """ImagePathToImageInfoConverter must honor EXIF orientation.
+
+    This converter is used when only dimensions are needed (no pixel load),
+    so it's crucial that it reports the oriented dimensions consistently
+    with the full image loader.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Raw pixels: landscape H=40, W=80.
+        img_array = np.zeros((40, 80, 3), dtype=np.uint8)
+        path = os.path.join(temp_dir, f"orient_{orientation}.jpg")
+        _save_jpeg_with_orientation(path, img_array, orientation)
+
+        converter_instance = ImagePathToImageInfoConverter()  # type: ignore[call-arg]
+        df = pl.DataFrame({"image_path": [path]})
+
+        setattr(
+            converter_instance,
+            "input_path",
+            AttributeSpec(name="image_path", field=ImagePathField()),
+        )
+        setattr(
+            converter_instance,
+            "output_info",
+            AttributeSpec(name="image_info", field=ImageInfoField()),
+        )
+        assert converter_instance.filter_output_spec() is True
+        result_df = converter_instance.convert(df)
+
+        info = result_df["image_info"][0]
+        assert info["width"] == expected_width
+        assert info["height"] == expected_height

--- a/tests/unit/experimental/data_formats/voc/test_voc_helpers.py
+++ b/tests/unit/experimental/data_formats/voc/test_voc_helpers.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from xml.etree.ElementTree import Element
 
 import numpy as np
+import pytest
 
 from datumaro.experimental.categories import LabelCategories
 from datumaro.experimental.data_formats.voc.constants import VOC_LABELS
@@ -18,6 +19,7 @@ from datumaro.experimental.data_formats.voc.helpers import (
     _detect_classification_label_files,
     _detect_voc_subsets,
     _find_image_file,
+    _get_image_size,
     _load_voc_categories,
     _parse_classification_labels,
     _parse_subset_list,
@@ -760,3 +762,33 @@ def test_parse_classification_labels_skips_malformed_lines(tmp_path: Path):
     assert "img2" not in result
     assert "img3" not in result
     assert "img4" in result
+
+
+@pytest.mark.parametrize(
+    ("orientation", "expected_height", "expected_width"),
+    [
+        (1, 40, 80),
+        (2, 40, 80),
+        (3, 40, 80),
+        (4, 40, 80),
+        (5, 80, 40),
+        (6, 80, 40),
+        (7, 80, 40),
+        (8, 80, 40),
+    ],
+)
+def test_get_image_size_respects_exif_orientation(tmp_path, orientation, expected_height, expected_width):
+    """VOC _get_image_size must honor EXIF orientation so the dimensions written
+    into VOC XML annotations match the image as displayed and loaded.
+    """
+    from PIL import Image as PILImage
+
+    # Raw pixels: landscape H=40, W=80.
+    img = PILImage.fromarray(np.zeros((40, 80, 3), dtype=np.uint8))
+    exif = img.getexif()
+    exif[0x0112] = orientation
+    path = tmp_path / f"orient_{orientation}.jpg"
+    img.save(path, format="JPEG", exif=exif.tobytes())
+
+    height, width = _get_image_size(path)
+    assert (height, width) == (expected_height, expected_width)

--- a/tests/unit/experimental/data_formats/yolo/test_yolo_helpers.py
+++ b/tests/unit/experimental/data_formats/yolo/test_yolo_helpers.py
@@ -18,6 +18,7 @@ from datumaro.experimental.data_formats.yolo.helpers import (
     _create_sample_from_traditional_image,
     _detect_yolo_format,
     _find_image_file,
+    _get_image_size,
     _get_label_names_from_dataset,
     _group_samples_by_subset,
     _load_categories_from_names,
@@ -505,3 +506,33 @@ def test_get_label_names_from_dataset_returns_empty_when_no_categories():
     result = _get_label_names_from_dataset(dataset)
 
     assert result == []
+
+
+@pytest.mark.parametrize(
+    ("orientation", "expected_height", "expected_width"),
+    [
+        (1, 40, 80),
+        (2, 40, 80),
+        (3, 40, 80),
+        (4, 40, 80),
+        (5, 80, 40),
+        (6, 80, 40),
+        (7, 80, 40),
+        (8, 80, 40),
+    ],
+)
+def test_get_image_size_respects_exif_orientation(tmp_path, orientation, expected_height, expected_width):
+    """YOLO _get_image_size must honor EXIF orientation so image dimensions
+    match the displayed image and the annotations derived from it.
+    """
+    from PIL import Image as PILImage
+
+    # Raw pixels: landscape H=40, W=80.
+    img = PILImage.fromarray(np.zeros((40, 80, 3), dtype=np.uint8))
+    exif = img.getexif()
+    exif[0x0112] = orientation
+    path = tmp_path / f"orient_{orientation}.jpg"
+    img.save(path, format="JPEG", exif=exif.tobytes())
+
+    height, width = _get_image_size(path)
+    assert (height, width) == (expected_height, expected_width)

--- a/tests/unit/experimental/test_media.py
+++ b/tests/unit/experimental/test_media.py
@@ -502,6 +502,112 @@ class LazyImageEdgeCasesTest:
                 assert sample.image.path == expected_path
 
 
+class LazyImageExifOrientationTest:
+    """Tests that LazyImage correctly honors EXIF orientation metadata.
+
+    Some cameras store images in their raw sensor orientation and set an EXIF
+    ``Orientation`` tag indicating that the image should be rotated/flipped for
+    display. PIL's ``Image.open`` does not apply this transform automatically,
+    so ``img.size`` / ``img.width`` / ``img.height`` return the un-oriented
+    dimensions, which don't match what is shown on screen (or what dataset
+    annotations typically reference).
+
+    ``LazyImage`` is expected to apply EXIF orientation so that ``data``,
+    ``width``, ``height``, ``size`` and ``shape`` all correspond to the image
+    as displayed.
+    """
+
+    # EXIF Orientation tag id
+    _ORIENTATION_TAG = 0x0112
+
+    @staticmethod
+    def _save_with_orientation(path: str, img_array: np.ndarray, orientation: int) -> None:
+        """Save a JPEG with a given EXIF Orientation tag."""
+        img = PILImage.fromarray(img_array)
+        exif = img.getexif()
+        exif[LazyImageExifOrientationTest._ORIENTATION_TAG] = orientation
+        # JPEG is required to round-trip the EXIF orientation tag reliably.
+        img.save(path, format="JPEG", exif=exif.tobytes())
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        ImageCache.clear()
+        yield
+        ImageCache.clear()
+
+    @pytest.mark.parametrize("orientation", [1, 2, 3, 4])
+    def test_non_rotating_orientation_preserves_dimensions(self, orientation):
+        """Orientations 1-4 do not swap width/height (identity/flip/180°)."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Raw pixel data is landscape 80 wide x 40 tall (H=40, W=80).
+            img_array = np.zeros((40, 80, 3), dtype=np.uint8)
+            path = os.path.join(temp_dir, f"orient_{orientation}.jpg")
+            self._save_with_orientation(path, img_array, orientation)
+
+            lazy_img = LazyImage(path=path)
+
+            assert lazy_img.width == 80
+            assert lazy_img.height == 40
+            assert lazy_img.size == (80, 40)
+            # data should remain (H, W, C)
+            assert lazy_img.data.shape == (40, 80, 3)
+
+    @pytest.mark.parametrize("orientation", [5, 6, 7, 8])
+    def test_rotating_orientation_swaps_dimensions(self, orientation):
+        """Orientations 5-8 imply a 90/270° rotation, so width/height swap."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Raw pixel data is landscape 80 wide x 40 tall (H=40, W=80).
+            img_array = np.zeros((40, 80, 3), dtype=np.uint8)
+            path = os.path.join(temp_dir, f"orient_{orientation}.jpg")
+            self._save_with_orientation(path, img_array, orientation)
+
+            lazy_img = LazyImage(path=path)
+
+            # After applying EXIF orientation, the image is portrait: 40x80.
+            assert lazy_img.width == 40
+            assert lazy_img.height == 80
+            assert lazy_img.size == (40, 80)
+            # data should match the oriented dimensions: (H=80, W=40, C)
+            assert lazy_img.data.shape == (80, 40, 3)
+
+    def test_orientation_6_data_matches_width_height(self):
+        """Regression: ``data.shape`` must be consistent with width/height.
+
+        Previously ``width``/``height`` returned the raw (un-oriented) size
+        while ``data`` was also un-oriented; since some data sources (e.g.
+        COCO annotations) record oriented dimensions, the mismatch looked
+        like width/height were swapped. After the fix, both report the same
+        (oriented) dimensions and ``data.shape`` matches ``(height, width, C)``.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Use distinct width/height so a swap is detectable.
+            img_array = np.zeros((30, 90, 3), dtype=np.uint8)
+            path = os.path.join(temp_dir, "orient_6.jpg")
+            self._save_with_orientation(path, img_array, 6)
+
+            lazy_img = LazyImage(path=path)
+
+            h, w, _ = lazy_img.data.shape
+            assert (w, h) == lazy_img.size
+            assert w == lazy_img.width
+            assert h == lazy_img.height
+
+    def test_orientation_not_set_uses_raw_dimensions(self):
+        """Images without an EXIF orientation tag should behave as before."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            img_array = np.zeros((40, 80, 3), dtype=np.uint8)
+            path = os.path.join(temp_dir, "no_exif.png")
+            # PNG save without EXIF - no orientation metadata at all.
+            PILImage.fromarray(img_array).save(path)
+
+            lazy_img = LazyImage(path=path)
+
+            assert lazy_img.width == 80
+            assert lazy_img.height == 40
+            assert lazy_img.size == (80, 40)
+            assert lazy_img.data.shape == (40, 80, 3)
+
+
 class LazyImageTypeAliasTest:
     """Tests for the LazyImage type alias to avoid type checker warnings."""
 


### PR DESCRIPTION
This pull request introduces comprehensive, consistent handling of EXIF orientation metadata across all image loading, conversion, and dimension-reporting code in the experimental Datumaro codebase. The changes ensure that images with EXIF rotation tags are loaded and reported with their displayed orientation, preventing mismatches in image shape, width, and height. 