### PR TITLE
feat(transform): implement picklable transform factories for tiling

### DIFF
--- a/src/datumaro/experimental/filtering/filter_registry.py
+++ b/src/datumaro/experimental/filtering/filter_registry.py
@@ -303,15 +303,30 @@ class FilteringTransform(Transform):
         return self._length
 
 
+class _FilteringTransformFactory:
+    """Module-level callable that builds a :class:`FilteringTransform` from a parent transform.
+
+    Defined at module scope (instead of a local ``factory`` closure) so instances
+    pickle by reference. This allows the returned transform to be safely passed
+    across process boundaries (e.g. multiprocessing, ``cloudpickle``-free paths).
+    """
+
+    __slots__ = ()
+
+    def __call__(self, parent: Transform) -> "FilteringTransform":
+        plan = create_filtering_plan(parent.schema)
+        return FilteringTransform(parent, plan)
+
+
 def create_filtering_transform() -> Callable[[Transform], FilteringTransform]:
     """Create a transform factory for filtering operations.
 
     This is the main entry point for creating a filtering transform. It returns
-    a factory function that will create FilteringTransform instances when needed.
+    a picklable callable that will create FilteringTransform instances when needed.
     This pattern allows the transform to be used in dataset pipelines.
 
     Returns:
-        A factory function that creates FilteringTransform instances.
+        A picklable callable that creates FilteringTransform instances.
 
     Example:
         ```python
@@ -322,9 +337,4 @@ def create_filtering_transform() -> Callable[[Transform], FilteringTransform]:
         dataset = dataset.transform(filtering_transform)
         ```
     """
-
-    def factory(parent: Transform):
-        plan = create_filtering_plan(parent.schema)
-        return FilteringTransform(parent, plan)
-
-    return factory
+    return _FilteringTransformFactory()

--- a/src/datumaro/experimental/tiling/tiler_registry.py
+++ b/src/datumaro/experimental/tiling/tiler_registry.py
@@ -639,13 +639,32 @@ class TilingTransform(Transform):
         return len(self._df)
 
 
+class _TilingTransformFactory:
+    """Module-level callable that builds a :class:`TilingTransform` from a parent transform.
+
+    Defined at module scope (instead of a local ``factory`` closure) so instances
+    pickle by reference. This allows the returned transform to be safely passed
+    across process boundaries (e.g. multiprocessing).
+    """
+
+    __slots__ = ("config", "threshold_drop_ann")
+
+    def __init__(self, config: TilingConfig, threshold_drop_ann: float = 0.8):
+        self.config = config
+        self.threshold_drop_ann = threshold_drop_ann
+
+    def __call__(self, parent: Transform) -> TilingTransform:
+        plan = _create_tiling_plan(parent.schema, self.config, self.threshold_drop_ann)
+        return TilingTransform(parent, plan)
+
+
 def create_tiling_transform(
     config: TilingConfig, threshold_drop_ann: float = 0.8
 ) -> Callable[[Transform], TilingTransform]:
     """Create a transform factory for tiling operations.
 
     This is the main entry point for creating a tiling transform. It returns
-    a factory function that will create TilingTransform instances when needed.
+    a picklable callable that will create TilingTransform instances when needed.
     This pattern allows the transform to be used in dataset pipelines.
 
     Args:
@@ -655,7 +674,7 @@ def create_tiling_transform(
             Defaults to 0.8 (80% of original area must be in tile).
 
     Returns:
-        A factory function that creates TilingTransform instances.
+        A picklable callable that creates TilingTransform instances.
 
     Example:
         ```python
@@ -667,9 +686,4 @@ def create_tiling_transform(
         dataset = dataset.transform(tiling_transform)
         ```
     """
-
-    def factory(parent: Transform) -> TilingTransform:
-        plan = _create_tiling_plan(parent.schema, config, threshold_drop_ann)
-        return TilingTransform(parent, plan)
-
-    return factory
+    return _TilingTransformFactory(config, threshold_drop_ann)

--- a/tests/unit/experimental/filtering/test_filtering.py
+++ b/tests/unit/experimental/filtering/test_filtering.py
@@ -8,8 +8,10 @@ import pytest
 
 from datumaro.experimental.fields import BBoxField, PolygonField, bbox_field, polygon_field
 from datumaro.experimental.filtering.filter_registry import (
+    FilteringTransform,
     FilterRegistry,
     _compute_filter_mask,
+    _FilteringTransformFactory,
     create_filtering_plan,
     create_filtering_transform,
 )
@@ -105,4 +107,45 @@ def test_transform_application():
     filtered_df = transform.apply(["bboxes"])
 
     assert len(filtered_df) == 2  # Should keep only non-empty bboxes
+    assert all(len(bboxes) > 0 for bboxes in filtered_df["bboxes"])
+
+
+def test_create_filtering_transform_returns_module_level_callable():
+    """The returned factory should be an instance of the module-level class,
+    not a local closure, so it can be pickled by reference."""
+    factory = create_filtering_transform()
+
+    assert isinstance(factory, _FilteringTransformFactory)
+    # Module-level qualname (no ``<locals>``) is what enables pickle-by-reference.
+    assert "<locals>" not in type(factory).__qualname__
+    assert type(factory).__module__ == "datumaro.experimental.filtering.filter_registry"
+
+
+def test_create_filtering_transform_factory_is_picklable():
+    """The factory returned by ``create_filtering_transform`` must pickle."""
+    import pickle
+
+    factory = create_filtering_transform()
+    restored = pickle.loads(pickle.dumps(factory))
+
+    assert isinstance(restored, _FilteringTransformFactory)
+
+
+def test_filtering_factory_builds_transform_after_unpickling():
+    """A round-tripped factory should still build a working FilteringTransform."""
+    import pickle
+
+    df = pl.DataFrame({"bboxes": [[], [[0, 0, 10, 10]], [[20, 20, 30, 30]]]})
+    schema = Schema(
+        {
+            "bboxes": AttributeInfo(type=list, field=bbox_field(dtype=pl.Float64())),
+        }
+    )
+
+    factory = pickle.loads(pickle.dumps(create_filtering_transform()))
+    transform = factory(IdentityTransform(df, schema))
+
+    assert isinstance(transform, FilteringTransform)
+    filtered_df = transform.apply(["bboxes"])
+    assert len(filtered_df) == 2
     assert all(len(bboxes) > 0 for bboxes in filtered_df["bboxes"])

--- a/tests/unit/experimental/filtering/test_filtering.py
+++ b/tests/unit/experimental/filtering/test_filtering.py
@@ -118,7 +118,7 @@ def test_create_filtering_transform_returns_module_level_callable():
     assert isinstance(factory, _FilteringTransformFactory)
     # Module-level qualname (no ``<locals>``) is what enables pickle-by-reference.
     assert "<locals>" not in type(factory).__qualname__
-    assert type(factory).__module__ == "datumaro.experimental.filtering.filter_registry"
+    assert type(factory).__module__ == create_filtering_transform.__module__
 
 
 def test_create_filtering_transform_factory_is_picklable():

--- a/tests/unit/experimental/tiling/test_tiling.py
+++ b/tests/unit/experimental/tiling/test_tiling.py
@@ -18,9 +18,12 @@ from datumaro.experimental.schema import Schema
 from datumaro.experimental.tiling.tiler_registry import (
     AttributeSpec,
     TilingConfig,
+    TilingTransform,
     _apply_tiling,
     _calculate_tiles,
     _create_tiling_plan,
+    _TilingTransformFactory,
+    create_tiling_transform,
 )
 
 
@@ -352,3 +355,50 @@ def test_polygon_and_label_tiling():
     assert len(result_df[3, "labels"]) == 2
     assert result_df[3, "labels"][0] == "cat"  # First label kept
     assert result_df[3, "labels"][1] == "dog"  # Second label kept
+
+
+def test_create_tiling_transform_returns_module_level_callable():
+    """The returned factory should be an instance of the module-level class,
+    not a local closure, so it can be pickled by reference."""
+    factory = create_tiling_transform(TilingConfig(tile_width=50, tile_height=50))
+
+    assert isinstance(factory, _TilingTransformFactory)
+    # Module-level qualname (no ``<locals>``) is what enables pickle-by-reference.
+    assert "<locals>" not in type(factory).__qualname__
+    assert type(factory).__module__ == "datumaro.experimental.tiling.tiler_registry"
+
+
+def test_create_tiling_transform_factory_stores_config():
+    """The factory should retain the config and threshold it was created with."""
+    config = TilingConfig(tile_width=64, tile_height=32, overlap_x=0.1, overlap_y=0.2)
+    factory = create_tiling_transform(config, threshold_drop_ann=0.5)
+
+    assert factory.config is config
+    assert factory.threshold_drop_ann == 0.5
+
+
+def test_create_tiling_transform_factory_is_picklable():
+    """The factory returned by ``create_tiling_transform`` must pickle by reference."""
+    import pickle
+
+    config = TilingConfig(tile_width=50, tile_height=50, overlap_x=0.25, overlap_y=0.0)
+    factory = create_tiling_transform(config, threshold_drop_ann=0.3)
+    restored = pickle.loads(pickle.dumps(factory))
+
+    assert isinstance(restored, _TilingTransformFactory)
+    assert restored.config == config
+    assert restored.threshold_drop_ann == 0.3
+
+
+def test_tiling_factory_builds_transform_after_unpickling(sample_df, sample_schema):
+    """A round-tripped factory should still build a working TilingTransform."""
+    import pickle
+
+    from datumaro.experimental.transform import IdentityTransform
+
+    config = TilingConfig(tile_width=50, tile_height=50)
+    factory = pickle.loads(pickle.dumps(create_tiling_transform(config)))
+    transform = factory(IdentityTransform(sample_df, sample_schema))
+
+    assert isinstance(transform, TilingTransform)
+    assert len(transform) == 16  # matches test_apply_tiling

--- a/tests/unit/experimental/tiling/test_tiling.py
+++ b/tests/unit/experimental/tiling/test_tiling.py
@@ -365,7 +365,7 @@ def test_create_tiling_transform_returns_module_level_callable():
     assert isinstance(factory, _TilingTransformFactory)
     # Module-level qualname (no ``<locals>``) is what enables pickle-by-reference.
     assert "<locals>" not in type(factory).__qualname__
-    assert type(factory).__module__ == "datumaro.experimental.tiling.tiler_registry"
+    assert type(factory).__module__ == create_tiling_transform.__module__
 
 
 def test_create_tiling_transform_factory_stores_config():
@@ -373,7 +373,7 @@ def test_create_tiling_transform_factory_stores_config():
     config = TilingConfig(tile_width=64, tile_height=32, overlap_x=0.1, overlap_y=0.2)
     factory = create_tiling_transform(config, threshold_drop_ann=0.5)
 
-    assert factory.config is config
+    assert factory.config == config
     assert factory.threshold_drop_ann == 0.5
 
 


### PR DESCRIPTION
This pull request refactors the creation of filtering and tiling transform factories to ensure they are picklable by reference, which is important for multiprocessing and serialization scenarios. Instead of returning local closures, the factory functions now return instances of module-level callable classes. 

This is needed for example for dataloaders with multiple workers which otherwise raise errors like: 
AttributeError: Can't get local object `create_tiling_transform.<locals>.factory`


<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
