### PR TITLE
Add cross-platform filename sanitization for dataset imports

### DIFF
--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -1071,7 +1071,7 @@ def _sanitize_extracted_files(directory: Path) -> None:
     # iterating while renaming.
     all_paths = sorted(directory.rglob("*"), key=lambda p: len(p.parts), reverse=True)
     for path in all_paths:
-        sanitized_name = sanitize_filename(path.name, cross_platform=False)
+        sanitized_name = sanitize_filename(path.name)
         if sanitized_name != path.name:
             new_path = path.parent / sanitized_name
             # Handle collisions

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -1313,6 +1313,25 @@ def _match_dtype_from_schema(schema: Schema) -> type[Sample]:
     return Sample
 
 
+def _resolve_reconstructed_video_path(path: str | None, input_dir: Path) -> str | None:
+    """Resolve a reconstructed video path under *input_dir* for copy-mode imports."""
+    if path is None:
+        return None
+    abs_path = input_dir / path
+    if abs_path.exists():
+        return str(abs_path)
+
+    # Fallback for archives where extracted filenames were
+    # sanitized on this OS (e.g. control chars renamed).
+    path_obj = Path(path)
+    sanitized_parts = tuple(sanitize_filename(part, cross_platform=False) for part in path_obj.parts)
+    if sanitized_parts != path_obj.parts:
+        sanitized_abs_path = input_dir.joinpath(*sanitized_parts)
+        if sanitized_abs_path.exists():
+            return str(sanitized_abs_path)
+    return path
+
+
 def _reconstruct_video_fields(
     df: pl.DataFrame,
     metadata: dict,
@@ -1348,17 +1367,8 @@ def _reconstruct_video_fields(
             continue
 
         if export_mode == "copy":
-            # Paths are relative to input_dir, make them absolute
-            def make_absolute(path: str | None) -> str | None:
-                if path is None:
-                    return None
-                abs_path = input_dir / path
-                if abs_path.exists():
-                    return str(abs_path)
-                return path
-
             paths = df[field_name].to_list()
-            updated_paths = [make_absolute(p) for p in paths]
+            updated_paths = [_resolve_reconstructed_video_path(p, input_dir) for p in paths]
             df = df.with_columns(pl.Series(field_name, updated_paths, dtype=pl.String()))
 
     return df

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -1324,6 +1324,7 @@ def _resolve_reconstructed_video_path(path: str | None, input_dir: Path) -> str 
     # Fallback for archives where extracted filenames were
     # sanitized on this OS (e.g. control chars renamed).
     path_obj = Path(path)
+    # Use OS-specific sanitization to mirror _sanitize_extracted_files behavior.
     sanitized_parts = tuple(sanitize_filename(part, cross_platform=False) for part in path_obj.parts)
     if sanitized_parts != path_obj.parts:
         sanitized_abs_path = input_dir.joinpath(*sanitized_parts)

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import json
 import logging
+import platform
+import re
 import shutil
 import tempfile
 from enum import Enum
@@ -106,6 +108,63 @@ class ExportMode(Enum):
     COPY = "copy"
 
 
+# Characters that are illegal in filenames on Windows (and thus unsafe for
+# cross-platform datasets).
+_WINDOWS_ILLEGAL_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+# Reserved device names on Windows (case-insensitive, with or without extension)
+_WINDOWS_RESERVED_NAMES = re.compile(r"^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9])(\..+)?$", re.IGNORECASE)
+
+
+def sanitize_filename(name: str, *, cross_platform: bool = True) -> str:
+    """Sanitize a filename so it is safe for the current (or all) OS(es).
+
+    When *cross_platform* is ``True`` (the default, used during export) the
+    filename is made safe for **all** major operating systems (Windows, macOS,
+    Linux).  When ``False``, only the rules of the **current** OS are applied
+    (useful during import to fix names that are invalid on the importing
+    machine).
+
+    The function replaces illegal characters with underscores, strips trailing
+    dots/spaces (Windows limitation), and prefixes reserved Windows device
+    names with an underscore.
+
+    Args:
+        name: The filename (without directory components) to sanitize.
+        cross_platform: If ``True``, apply rules for all OSes. If ``False``,
+            only apply rules for the current OS.
+
+    Returns:
+        The sanitized filename.
+    """
+    if not name:
+        return name
+
+    current_os = platform.system()  # 'Windows', 'Darwin', 'Linux'
+
+    apply_windows_rules = cross_platform or current_os == "Windows"
+    apply_macos_rules = cross_platform or current_os == "Darwin"
+
+    if apply_windows_rules:
+        name = _WINDOWS_ILLEGAL_CHARS.sub("_", name)
+        name = name.rstrip(". ")
+        if _WINDOWS_RESERVED_NAMES.match(name):
+            name = f"_{name}"
+    else:
+        if apply_macos_rules:
+            # macOS HFS+ / Finder disallows colons (displayed as '/' in
+            # Finder but stored as ':' on disk).
+            name = name.replace(":", "_")
+
+        # On Linux and macOS, replace control characters (0x00-0x1f) that
+        # cause problems with terminals, shells, and many tools.
+        name = re.sub(r"[\x00-\x1f]", "_", name)
+
+    if not name:
+        name = "_"
+
+    return name
+
+
 def _get_image_fields(dataset: Dataset[DType]) -> list[tuple[str, object]]:
     """Extract all image-related fields from the dataset schema.
 
@@ -163,6 +222,7 @@ def _export_image_path_field(
         # Preserve the original filename; fall back to index-based naming
         # only when the source has no name at all.
         dest_name = source_path.name if source_path.name else f"{field_name}_{idx:06d}.png"
+        dest_name = sanitize_filename(dest_name)
         abs_path = output_dir / dest_name
 
         # Handle name collisions with a numeric suffix
@@ -170,7 +230,7 @@ def _export_image_path_field(
         while abs_path.exists():
             stem = source_path.stem if source_path.stem else f"{field_name}_{idx:06d}"
             suffix = source_path.suffix if source_path.suffix else ".png"
-            abs_path = output_dir / f"{stem}_{counter}{suffix}"
+            abs_path = output_dir / sanitize_filename(f"{stem}_{counter}{suffix}")
             counter += 1
 
         rel_path = abs_path.name
@@ -219,7 +279,7 @@ def _export_callable_field(
         if pil_img is None:
             return None
 
-        rel_path = f"{field_name}_{idx:06d}.png"
+        rel_path = sanitize_filename(f"{field_name}_{idx:06d}.png")
         abs_path = output_dir / rel_path
         pil_img.save(abs_path)
         return str(rel_path)
@@ -465,13 +525,13 @@ def _copy_video_files(
                 continue
             raise ValueError(f"Video file not found: {video_path}")
 
-        dest_path = output_dir / source_path.name
+        dest_path = output_dir / sanitize_filename(source_path.name)
         # Handle name collisions
         counter = 1
         while dest_path.exists():
             stem = source_path.stem
             suffix = source_path.suffix
-            dest_path = output_dir / f"{stem}_{counter}{suffix}"
+            dest_path = output_dir / sanitize_filename(f"{stem}_{counter}{suffix}")
             counter += 1
         shutil.copy2(source_path, dest_path)
         rel_path = dest_path.relative_to(output_dir.parent).as_posix()
@@ -992,9 +1052,38 @@ def import_dataset(
                     )
             zipf.extractall(extract_dir)
 
+        _sanitize_extracted_files(extract_dir)
+
         dataset_root = find_dataset_root(extract_dir)
         return _import_dataset_from_dir(dataset_root, dtype)
     return _import_dataset_from_dir(input_path, dtype)
+
+
+def _sanitize_extracted_files(directory: Path) -> None:
+    """Rename files whose names contain characters illegal on the current OS.
+
+    Walks *directory* bottom-up so that files inside subdirectories are
+    renamed before their parent directories.  Only the final path component
+    (the file/directory name) is sanitized; parent components are left as-is
+    because they have already been created by the zip extraction.
+    """
+    # Collect all paths first, then process bottom-up to avoid issues with
+    # iterating while renaming.
+    all_paths = sorted(directory.rglob("*"), key=lambda p: len(p.parts), reverse=True)
+    for path in all_paths:
+        sanitized_name = sanitize_filename(path.name, cross_platform=False)
+        if sanitized_name != path.name:
+            new_path = path.parent / sanitized_name
+            # Handle collisions
+            counter = 1
+            while new_path.exists() and new_path != path:
+                stem, *ext_parts = sanitized_name.rsplit(".", 1)
+                suffix = f".{ext_parts[0]}" if ext_parts else ""
+                new_path = path.parent / f"{stem}_{counter}{suffix}"
+                counter += 1
+            if new_path != path:
+                log.info("Renaming '%s' -> '%s' (filename sanitization)", path.name, new_path.name)
+                path.rename(new_path)
 
 
 def _load_metadata(input_dir: Path) -> dict:
@@ -1062,6 +1151,13 @@ def _resolve_image_file(
         candidate = images_base_dir / df_path
         if candidate.exists():
             return candidate
+        # Try with sanitized filename (handles cross-OS imports, e.g.
+        # colons in filenames from Linux on Windows)
+        sanitized = sanitize_filename(Path(df_path).name, cross_platform=False)
+        if sanitized != Path(df_path).name:
+            candidate = images_base_dir / sanitized
+            if candidate.exists():
+                return candidate
 
     return None
 

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -112,7 +112,7 @@ class ExportMode(Enum):
 # cross-platform datasets).
 _WINDOWS_ILLEGAL_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
 # Reserved device names on Windows (case-insensitive, with or without extension)
-_WINDOWS_RESERVED_NAMES = re.compile(r"^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9])(\..+)?$", re.IGNORECASE)
+_WINDOWS_RESERVED_NAMES = re.compile(r"^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..+)?$", re.IGNORECASE)
 
 
 def sanitize_filename(name: str, *, cross_platform: bool = True) -> str:

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -2705,6 +2705,12 @@ class SanitizeExtractedFilesTest:
 
     def test_control_chars_renamed(self, tmp_path):
         """Files with control characters should be renamed."""
+        import platform
+
+        # Control characters cannot be created in filenames on Windows
+        if platform.system() == "Windows":
+            pytest.skip("Cannot create files with control characters on Windows")
+
         bad_file = tmp_path / "file\x01name.txt"
         bad_file.touch()
         _sanitize_extracted_files(tmp_path)

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -34,9 +34,11 @@ from datumaro.experimental.export_import import (
     _get_video_fields,
     _match_dtype_from_schema,
     _sample_registry,
+    _sanitize_extracted_files,
     export_dataset,
     import_dataset,
     register_sample,
+    sanitize_filename,
 )
 from datumaro.experimental.fields import (
     ImageInfo,
@@ -2520,3 +2522,240 @@ def test_export_import_preserves_filenames_via_zip(tmp_path):
     path = Path(sample.image_path)
     assert path.exists()
     assert path.name == "my_image.png"
+
+
+# ============================================================
+# sanitize_filename unit tests
+# ============================================================
+
+
+class SanitizeFilenameTest:
+    """Unit tests for the sanitize_filename function."""
+
+    def test_empty_string(self):
+        assert sanitize_filename("") == ""
+
+    def test_normal_filename_unchanged(self):
+        assert sanitize_filename("image_001.png") == "image_001.png"
+
+    def test_replaces_colons_cross_platform(self):
+        assert sanitize_filename("2024:01:15_photo.jpg") == "2024_01_15_photo.jpg"
+
+    def test_replaces_angle_brackets(self):
+        assert sanitize_filename("file<1>.txt") == "file_1_.txt"
+
+    def test_replaces_question_mark(self):
+        assert sanitize_filename("what?.png") == "what_.png"
+
+    def test_replaces_asterisk(self):
+        assert sanitize_filename("star*.png") == "star_.png"
+
+    def test_replaces_pipe(self):
+        assert sanitize_filename("a|b.png") == "a_b.png"
+
+    def test_replaces_double_quote(self):
+        assert sanitize_filename('say"hello".png') == "say_hello_.png"
+
+    def test_replaces_backslash(self):
+        assert sanitize_filename("path\\file.png") == "path_file.png"
+
+    def test_strips_trailing_dots(self):
+        assert sanitize_filename("file...") == "file"
+
+    def test_strips_trailing_spaces(self):
+        assert sanitize_filename("file   ") == "file"
+
+    def test_strips_trailing_dots_and_spaces(self):
+        assert sanitize_filename("file. . .") == "file"
+
+    def test_reserved_name_con(self):
+        assert sanitize_filename("CON") == "_CON"
+
+    def test_reserved_name_con_with_extension(self):
+        assert sanitize_filename("CON.txt") == "_CON.txt"
+
+    def test_reserved_name_nul(self):
+        assert sanitize_filename("NUL") == "_NUL"
+
+    def test_reserved_name_com1(self):
+        assert sanitize_filename("COM1") == "_COM1"
+
+    def test_reserved_name_lpt3(self):
+        assert sanitize_filename("LPT3.log") == "_LPT3.log"
+
+    def test_reserved_name_case_insensitive(self):
+        assert sanitize_filename("con") == "_con"
+        assert sanitize_filename("Aux.txt") == "_Aux.txt"
+
+    def test_not_reserved_name(self):
+        # "CONSOLE" is not a reserved name
+        assert sanitize_filename("CONSOLE") == "CONSOLE"
+
+    def test_control_characters_replaced(self):
+        assert sanitize_filename("file\x01name\x1f.png") == "file_name_.png"
+
+    def test_null_byte_replaced(self):
+        assert sanitize_filename("file\x00name.png") == "file_name.png"
+
+    def test_result_not_empty_after_sanitization(self):
+        # All characters are replaced but result is not empty
+        assert sanitize_filename(":::") == "___"
+        # Trailing dots/spaces stripped to empty → falls back to "_"
+        assert sanitize_filename("...") == "_"
+
+    def test_cross_platform_false_on_current_os(self):
+        """cross_platform=False should at least handle control chars."""
+        result = sanitize_filename("file\x00\x01.png", cross_platform=False)
+        assert "\x00" not in result
+        assert "\x01" not in result
+
+    def test_multiple_illegal_chars(self):
+        assert sanitize_filename('a<b>c:d"e|f?g*.png') == "a_b_c_d_e_f_g_.png"
+
+    def test_preserves_unicode(self):
+        assert sanitize_filename("日本語ファイル.png") == "日本語ファイル.png"
+
+    def test_preserves_dashes_and_underscores(self):
+        assert sanitize_filename("my-file_name.png") == "my-file_name.png"
+
+    def test_preserves_dots_in_middle(self):
+        assert sanitize_filename("file.v2.0.png") == "file.v2.0.png"
+
+
+# ============================================================
+# _sanitize_extracted_files tests
+# ============================================================
+
+
+class SanitizeExtractedFilesTest:
+    """Tests for _sanitize_extracted_files which renames files after zip extraction."""
+
+    def test_renames_file_with_colon(self, tmp_path):
+        """Files with colons should be renamed (important for macOS/Windows)."""
+        import platform
+
+        # On macOS/Windows we can't even create files with colons, so skip
+        if platform.system() != "Linux":
+            pytest.skip("Can only create files with colons on Linux")
+
+        bad_file = tmp_path / "image:01.png"
+        bad_file.touch()
+        _sanitize_extracted_files(tmp_path)
+        assert not bad_file.exists()
+        sanitized = tmp_path / "image_01.png"
+        assert sanitized.exists()
+
+    def test_no_rename_needed(self, tmp_path):
+        """Normal files should not be renamed."""
+        good_file = tmp_path / "normal_image.png"
+        good_file.touch()
+        _sanitize_extracted_files(tmp_path)
+        assert good_file.exists()
+
+    def test_handles_collision(self, tmp_path):
+        """When sanitized name already exists, a numeric suffix is added."""
+        import platform
+
+        if platform.system() != "Linux":
+            pytest.skip("Can only create files with colons on Linux")
+
+        # Create the target name first
+        (tmp_path / "image_01.png").touch()
+        # Create the file that needs sanitizing
+        (tmp_path / "image:01.png").touch()
+
+        _sanitize_extracted_files(tmp_path)
+
+        assert (tmp_path / "image_01.png").exists()  # original untouched
+        assert (tmp_path / "image_01_1.png").exists()  # collision resolved
+
+    def test_subdirectories_handled(self, tmp_path):
+        """Files in subdirectories are also sanitized."""
+        import platform
+
+        if platform.system() != "Linux":
+            pytest.skip("Can only create files with colons on Linux")
+
+        sub = tmp_path / "images"
+        sub.mkdir()
+        bad_file = sub / "img:1.png"
+        bad_file.touch()
+
+        _sanitize_extracted_files(tmp_path)
+
+        assert not bad_file.exists()
+        assert (sub / "img_1.png").exists()
+
+    def test_control_chars_renamed(self, tmp_path):
+        """Files with control characters should be renamed."""
+        bad_file = tmp_path / "file\x01name.txt"
+        bad_file.touch()
+        _sanitize_extracted_files(tmp_path)
+        assert not bad_file.exists()
+        assert (tmp_path / "file_name.txt").exists()
+
+
+# ============================================================
+# Export/import roundtrip with sanitized filenames
+# ============================================================
+
+
+def test_export_sanitizes_filenames_cross_platform(tmp_path):
+    """Export with COPY mode should sanitize filenames for cross-platform safety."""
+    import platform
+
+    if platform.system() != "Linux":
+        pytest.skip("Can only create source files with colons on Linux")
+
+    class PathSample(Sample):
+        image_path: str = image_path_field()
+        label: int = label_field()
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    # Create an image with a colon in the name (valid on Linux, invalid on Windows/macOS)
+    img_path = source_dir / "photo:2024:01.png"
+    PILImage.fromarray(np.zeros((10, 10, 3), dtype=np.uint8)).save(img_path)
+
+    dataset = Dataset(PathSample, categories={"label": LABEL_CATEGORIES})
+    dataset.append(PathSample(image_path=str(img_path), label=0))
+
+    output_dir = tmp_path / "export"
+    export_dataset(dataset, output_dir, export_media=ExportMode.COPY)
+
+    # The exported image should have colons replaced
+    images_dir = output_dir / IMAGES_DIR
+    exported_files = list(images_dir.iterdir())
+    assert len(exported_files) == 1
+    assert ":" not in exported_files[0].name
+    assert exported_files[0].name == "photo_2024_01.png"
+
+
+def test_export_import_roundtrip_sanitized_filename(tmp_path):
+    """Full roundtrip: export a dataset with problematic filename, import it back."""
+    import platform
+
+    if platform.system() != "Linux":
+        pytest.skip("Can only create source files with colons on Linux")
+
+    class PathSample(Sample):
+        image_path: str = image_path_field()
+        label: int = label_field()
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    img_path = source_dir / "test:image.png"
+    img_array = np.random.randint(0, 255, (10, 15, 3), dtype=np.uint8)
+    PILImage.fromarray(img_array).save(img_path)
+
+    dataset = Dataset(PathSample, categories={"label": LABEL_CATEGORIES})
+    dataset.append(PathSample(image_path=str(img_path), label=2))
+
+    output_dir = tmp_path / "export"
+    export_dataset(dataset, output_dir, export_media=ExportMode.COPY)
+
+    imported = import_dataset(output_dir, dtype=PathSample)
+    assert len(imported) == 1
+    sample = imported[0]
+    assert Path(sample.image_path).exists()
+    assert sample.label == 2

--- a/tests/integration/experimental/test_export_import.py
+++ b/tests/integration/experimental/test_export_import.py
@@ -33,6 +33,7 @@ from datumaro.experimental.export_import import (
     _get_registered_samples,
     _get_video_fields,
     _match_dtype_from_schema,
+    _reconstruct_video_fields,
     _sample_registry,
     _sanitize_extracted_files,
     export_dataset,
@@ -1731,6 +1732,22 @@ def test_export_videos_copy_mode_creates_correct_paths(tmp_path):
 
     # Path should be relative to export dir and start with videos/
     assert frame_path.startswith(VIDEOS_DIR + "/")
+
+
+def test_reconstruct_video_fields_uses_sanitized_fallback_path(tmp_path):
+    """Video path reconstruction should fall back to sanitized extracted names."""
+    exported_rel_path = f"{VIDEOS_DIR}/clip\x01name.mp4"
+    sanitized_rel_path = f"{VIDEOS_DIR}/clip_name.mp4"
+    sanitized_abs_path = tmp_path / sanitized_rel_path
+    sanitized_abs_path.parent.mkdir(parents=True, exist_ok=True)
+    sanitized_abs_path.touch()
+
+    df = pl.DataFrame({"frame": [exported_rel_path], "frame_frame_index": [0]})
+    metadata = {"videos": {"fields": ["frame"], "export_mode": "copy"}}
+
+    updated_df = _reconstruct_video_fields(df, metadata, tmp_path)
+
+    assert updated_df["frame"][0] == str(sanitized_abs_path)
 
 
 def test_export_video_error_missing_video_file(tmp_path):


### PR DESCRIPTION
This pull request introduces robust cross-platform filename sanitization to the dataset export/import pipeline, ensuring that files with illegal or problematic characters are handled safely across Windows, macOS, and Linux. It adds a new `sanitize_filename` utility, integrates it throughout the export and import code paths, and provides comprehensive unit and integration tests to validate the behavior. These changes prevent export/import failures due to invalid filenames and improve cross-OS compatibility.

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
