### PR TITLE
Refactor ImageField for channels_first conversion and tensor format

### DIFF
--- a/src/datumaro/experimental/converters/media_converters.py
+++ b/src/datumaro/experimental/converters/media_converters.py
@@ -102,18 +102,21 @@ class MediaPathToImageConverter(MediaBridgeConverter):
             try:
                 if frame_idx is not None:
                     # Video frame - use LazyVideoFrame
+                    # Always load as HWC for internal storage; ImageField.from_polars
+                    # handles CHW conversion when channels_first=True.
                     media = LazyVideoFrame(
                         video_path=str(path),
                         frame_index=frame_idx,
                         format=output_format,
-                        channels_first=self.output_image.field.channels_first,
+                        channels_first=False,
                     )
                 else:
                     # Standalone image - use LazyImage
+                    # Always load as HWC for internal storage.
                     media = LazyImage(
                         path=str(path),
                         format=output_format,
-                        channels_first=self.output_image.field.channels_first,
+                        channels_first=False,
                     )
 
                 img_array = media.data

--- a/src/datumaro/experimental/converters/video_converters.py
+++ b/src/datumaro/experimental/converters/video_converters.py
@@ -102,7 +102,6 @@ class VideoFramePathToImageConverter(MediaBridgeConverter):
                 video_path=str(path),
                 frame_index=frame_idx,
                 format=output_format,
-                channels_first=self.output_image.field.channels_first,
             )
 
             try:

--- a/src/datumaro/experimental/fields/images.py
+++ b/src/datumaro/experimental/fields/images.py
@@ -26,12 +26,10 @@ class TensorField(Field):
     Attributes:
         semantic: String tag describing the tensor's purpose
         dtype: Polars data type for tensor elements
-        channels_first: Whether the tensor uses channels-first format (C, H, W) vs channels-last (H, W, C)
     """
 
     semantic: str = "default"
     dtype: pl.DataType = field(default_factory=pl.UInt8)
-    channels_first: bool = False
 
     def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
         """Generate Polars schema with separate columns for data and shape."""
@@ -40,9 +38,6 @@ class TensorField(Field):
     def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
         """Convert tensor to flattened data and shape information."""
         numpy_value = to_numpy(value, self.dtype)
-
-        if self.channels_first and numpy_value is not None:
-            numpy_value = np.transpose(numpy_value, (2, 0, 1))
 
         schema = self.to_polars_schema("tensor")
 
@@ -62,9 +57,6 @@ class TensorField(Field):
         shape = df[name + "_shape"][row_index]
         numpy_data = np.array(flat_data).reshape(shape) if flat_data is not None else None
 
-        if self.channels_first and numpy_data is not None:
-            numpy_data = np.transpose(numpy_data, (2, 0, 1))
-
         return from_polars_data(numpy_data, target_type)  # type: ignore
 
 
@@ -83,18 +75,61 @@ def tensor_field(dtype: Any, semantic: str = "default") -> Any:
 
 
 @dataclass(frozen=True)
-class ImageField(TensorField):
+class ImageField(Field):
     """
     Represents an image tensor field with format information.
 
-    Extends TensorField to include image-specific metadata such as
-    color format (RGB, BGR, etc.).
+    Data is always stored internally in HWC (height, width, channels) format.
+    When channels_first is True, the user provides/receives CHW data, and
+    this field handles the conversion to/from HWC for internal storage.
 
     Attributes:
+        semantic: String tag describing the image's purpose
+        dtype: Polars data type for pixel values
         format: Image color format (e.g., "RGB", "BGR", "RGBA")
+        channels_first: Whether the user provides/receives CHW format
     """
 
+    semantic: str = "default"
+    dtype: pl.DataType = field(default_factory=pl.UInt8)
     format: str = "RGB"
+    channels_first: bool = False
+
+    def to_polars_schema(self, name: str) -> dict[str, pl.DataType]:
+        """Generate Polars schema with separate columns for data and shape."""
+        return {name: pl.List(self.dtype), name + "_shape": pl.List(pl.Int32())}
+
+    def to_polars(self, name: str, value: Any) -> dict[str, pl.Series]:
+        """Convert image tensor to flattened data."""
+        numpy_value = to_numpy(value, self.dtype)
+
+        if self.channels_first and numpy_value is not None:
+            # User provides CHW; store as HWC internally
+            numpy_value = np.transpose(numpy_value, (1, 2, 0))
+
+        schema = self.to_polars_schema("tensor")
+
+        numpy_value_shape: Any | None = None
+        if numpy_value is not None:
+            numpy_value_shape = numpy_value.shape
+            numpy_value = numpy_value.reshape(-1)
+
+        return {
+            name: pl.Series(name, [numpy_value], dtype=schema["tensor"]),
+            name + "_shape": pl.Series(name + "_shape", [numpy_value_shape], dtype=schema["tensor_shape"]),
+        }
+
+    def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type[T]) -> T:
+        """Reconstruct image tensor, converting from internal HWC to CHW if needed."""
+        flat_data = df[name][row_index]
+        shape = df[name + "_shape"][row_index]
+        numpy_data = np.array(flat_data).reshape(shape) if flat_data is not None else None
+
+        if self.channels_first and numpy_data is not None:
+            # Stored as HWC; user expects CHW
+            numpy_data = np.transpose(numpy_data, (2, 0, 1))
+
+        return from_polars_data(numpy_data, target_type)  # type: ignore
 
 
 def image_field(

--- a/src/datumaro/experimental/fields/images.py
+++ b/src/datumaro/experimental/fields/images.py
@@ -103,7 +103,7 @@ class ImageField(Field):
         """Convert image tensor to flattened data."""
         numpy_value = to_numpy(value, self.dtype)
 
-        if self.channels_first and numpy_value is not None:
+        if self.channels_first and numpy_value is not None and numpy_value.ndim == 3:
             # User provides CHW; store as HWC internally
             numpy_value = np.transpose(numpy_value, (1, 2, 0))
 
@@ -125,7 +125,7 @@ class ImageField(Field):
         shape = df[name + "_shape"][row_index]
         numpy_data = np.array(flat_data).reshape(shape) if flat_data is not None else None
 
-        if self.channels_first and numpy_data is not None:
+        if self.channels_first and numpy_data is not None and numpy_data.ndim == 3:
             # Stored as HWC; user expects CHW
             numpy_data = np.transpose(numpy_data, (2, 0, 1))
 

--- a/src/datumaro/experimental/fields/images.py
+++ b/src/datumaro/experimental/fields/images.py
@@ -79,9 +79,12 @@ class ImageField(Field):
     """
     Represents an image tensor field with format information.
 
-    Data is always stored internally in HWC (height, width, channels) format.
-    When channels_first is True, the user provides/receives CHW data, and
-    this field handles the conversion to/from HWC for internal storage.
+    3D image data is stored internally in HWC (height, width, channels)
+    format. Images without an explicit channel dimension (for example,
+    grayscale images shaped as HW) are stored as-is in HW format.
+    When channels_first is True, the user provides/receives CHW data for
+    3D images, and this field handles the conversion to/from HWC for
+    internal storage. 2D images are not transposed.
 
     Attributes:
         semantic: String tag describing the image's purpose

--- a/tests/unit/experimental/converters/test_video_converters.py
+++ b/tests/unit/experimental/converters/test_video_converters.py
@@ -924,8 +924,8 @@ class ConverterChannelsFirstTest:
         result_df = converter.convert(df)
         image_shape = list(result_df["image_shape"][0])
 
-        # Channels first: (C, H, W)
-        assert image_shape[0] == 3  # RGB channels first
+        # Internally stored as HWC; ImageField.from_polars handles CHW conversion
+        assert image_shape[-1] == 3  # RGB channels last in storage
 
     def test_media_path_converter_channels_first(self, test_video_exists):
         """Test MediaPathToImageConverter with channels_first=True."""
@@ -961,5 +961,5 @@ class ConverterChannelsFirstTest:
         result_df = converter.convert(df)
         image_shape = list(result_df["image_shape"][0])
 
-        # Channels first: (C, H, W)
-        assert image_shape[0] == 3  # RGB channels first
+        # Internally stored as HWC; ImageField.from_polars handles CHW conversion
+        assert image_shape[-1] == 3  # RGB channels last in storage

--- a/tests/unit/experimental/test_schema.py
+++ b/tests/unit/experimental/test_schema.py
@@ -121,6 +121,43 @@ def test_tensor_field_polars_conversion():
     assert np.allclose(reconstructed, test_tensor)
 
 
+def test_tensor_field_channels_first_roundtrip():
+    """Test TensorField is a transparent roundtrip for any shape."""
+    field = TensorField(dtype=pl.UInt8())
+    test_tensor = np.random.randint(0, 255, (3, 720, 1280), dtype=np.uint8)
+
+    polars_data = field.to_polars("img", test_tensor)
+    df = pl.DataFrame(polars_data)
+
+    # Stored shape matches input exactly
+    stored_shape = df["img_shape"][0].to_list()
+    assert stored_shape == [3, 720, 1280]
+
+    # Returned data matches input exactly
+    reconstructed = cast("np.ndarray[Any, Any]", field.from_polars("img", 0, df, np.ndarray))
+    assert reconstructed.shape == (3, 720, 1280)
+    assert np.array_equal(reconstructed, test_tensor)
+
+
+def test_image_field_channels_first_roundtrip():
+    """Test ImageField channels_first: user provides CHW, stored as HWC internally, returned as CHW."""
+    img_field = ImageField(dtype=pl.UInt8(), channels_first=True)
+    # User provides CHW
+    test_image = np.random.randint(0, 255, (3, 720, 1280), dtype=np.uint8)
+
+    polars_data = img_field.to_polars("img", test_image)
+    df = pl.DataFrame(polars_data)
+
+    # Internally stored as HWC
+    stored_shape = df["img_shape"][0].to_list()
+    assert stored_shape == [720, 1280, 3]
+
+    # Returned to user as CHW
+    reconstructed = cast("np.ndarray[Any, Any]", img_field.from_polars("img", 0, df, np.ndarray))
+    assert reconstructed.shape == (3, 720, 1280)
+    assert np.array_equal(reconstructed, test_image)
+
+
 def test_image_field_creation():
     """Test ImageField creation and properties."""
     field = image_field(dtype=pl.UInt8(), format="RGB", semantic="left")
@@ -791,13 +828,12 @@ def test_polygon_field_polars_conversion():
 
 def test_tensor_field_serialization():
     """Test TensorField to_dict/from_dict serialization."""
-    field = TensorField(dtype=pl.Float32(), semantic="bbox", channels_first=True)
+    field = TensorField(dtype=pl.Float32(), semantic="bbox")
 
     # Serialize to dict
     field_dict = field.to_dict()
     assert field_dict["type"] == "TensorField"
     assert field_dict["semantic"] == "bbox"
-    assert field_dict["channels_first"] is True
     assert "Float32" in str(field_dict["dtype"])
 
     # Deserialize from dict
@@ -808,7 +844,6 @@ def test_tensor_field_serialization():
 
     # Compare with original
     assert reconstructed.semantic == field.semantic
-    assert reconstructed.channels_first == field.channels_first
     assert str(reconstructed.dtype) == str(field.dtype)
 
 

--- a/tests/unit/experimental/test_schema.py
+++ b/tests/unit/experimental/test_schema.py
@@ -121,8 +121,8 @@ def test_tensor_field_polars_conversion():
     assert np.allclose(reconstructed, test_tensor)
 
 
-def test_tensor_field_channels_first_roundtrip():
-    """Test TensorField is a transparent roundtrip for any shape."""
+def test_tensor_field_3d_tensor_roundtrip():
+    """Test TensorField preserves a generic 3D tensor through a round-trip."""
     field = TensorField(dtype=pl.UInt8())
     test_tensor = np.random.randint(0, 255, (3, 720, 1280), dtype=np.uint8)
 


### PR DESCRIPTION
Transpose in to/from polars methods of the Tensorfield were incorrectly applied resulting in different outputs when doing a round-trip on a tensor with channels_first=True.

This PR removes the transpose from Tensorfield entirely, it is not needed as no converter needs to know about the stored channel order of a tensor. Instead, ImageField now implements its own to/from_polars methods and gets a fix so the round-trip of an image in polars with channels_first=True gives identical output. 

Resolves #2130 


### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
