### PR TITLE
fix(dataset): preserve declared label categories for unannotated items

### DIFF
--- a/src/datumaro/experimental/legacy/dataset_converters.py
+++ b/src/datumaro/experimental/legacy/dataset_converters.py
@@ -86,6 +86,7 @@ def analyze_legacy_dataset(
         multi_label_group_names = [name for name in label_group_names if name.startswith("Classification labels__")]
         is_multi_label = (len(multi_label_group_names) > 1 and not is_hierarchical) or multi_label
     else:
+        label_groups = []
         is_hierarchical = False
         is_multi_label = False
 
@@ -116,24 +117,26 @@ def analyze_legacy_dataset(
         if converter is not None:
             ann_converters[ann_type] = converter
             ann_attributes = converter.get_schema_attributes()
-            if (is_multi_label or is_hierarchical) and AnnotationType.label.name in ann_attributes:
-                ann_attributes[AnnotationType.label.name].field = label_field(multi_label=True)
-                ann_attributes[AnnotationType.label.name].type = np.ndarray
-            if is_hierarchical and AnnotationType.label.name in ann_attributes:
-                categories = legacy_dataset.categories()[AnnotationType.label].items
-                label_categories = tuple(
-                    HierarchicalLabelCategory(
-                        name=category.name,
-                        parent=category.parent,
-                        label_semantics=_attributes_to_dict(category.attributes),
-                    )
-                    for category in categories
-                )
-                hierarchical_categories = HierarchicalLabelCategories(
-                    items=label_categories, label_groups=tuple(label_groups)
-                )
-                ann_attributes[AnnotationType.label.name].categories = hierarchical_categories
+            _apply_label_overrides(
+                ann_attributes,
+                legacy_dataset,
+                label_groups=label_groups,
+                is_multi_label=is_multi_label,
+                is_hierarchical=is_hierarchical,
+            )
             attributes.update(ann_attributes)
+
+    # Preserve declared label categories even when no item carries annotations.
+    _ensure_declared_label_categories(
+        legacy_dataset,
+        attributes=attributes,
+        ann_converters=ann_converters,
+        semantic=semantic,
+        label_groups=label_groups,
+        is_multi_label=is_multi_label,
+        is_hierarchical=is_hierarchical,
+    )
+
     schema = Schema(attributes=attributes)
     return AnalysisResult(
         schema=schema,
@@ -143,6 +146,93 @@ def analyze_legacy_dataset(
         is_anomaly=is_anomaly,
         is_hierarchical=is_hierarchical,
     )
+
+
+def _apply_label_overrides(
+    ann_attributes: dict[str, AttributeInfo],
+    legacy_dataset: LegacyDataset,
+    *,
+    label_groups: list[LabelGroup],
+    is_multi_label: bool,
+    is_hierarchical: bool,
+) -> None:
+    """Override label-attribute field/categories for multi-label or hierarchical datasets.
+
+    Mutates ``ann_attributes`` in place.  No-op when the converter produced no
+    label attribute or when neither multi-label nor hierarchical handling is
+    required.
+    """
+    label_key = AnnotationType.label.name
+    if label_key not in ann_attributes:
+        return
+
+    if is_multi_label or is_hierarchical:
+        ann_attributes[label_key].field = label_field(multi_label=True)
+        ann_attributes[label_key].type = np.ndarray
+
+    if is_hierarchical:
+        categories = legacy_dataset.categories()[AnnotationType.label].items
+        hierarchical_items = tuple(
+            HierarchicalLabelCategory(
+                name=category.name,
+                parent=category.parent,
+                label_semantics=_attributes_to_dict(category.attributes),
+            )
+            for category in categories
+        )
+        ann_attributes[label_key].categories = HierarchicalLabelCategories(
+            items=hierarchical_items, label_groups=tuple(label_groups)
+        )
+
+
+def _ensure_declared_label_categories(
+    legacy_dataset: LegacyDataset,
+    *,
+    attributes: dict[str, AttributeInfo],
+    ann_converters: dict[AnnotationType, ForwardAnnotationConverter],
+    semantic: str,
+    label_groups: list[LabelGroup],
+    is_multi_label: bool,
+    is_hierarchical: bool,
+) -> None:
+    """Inject a label converter when categories are declared but no item carries annotations.
+
+    When the legacy dataset declares ``categories[AnnotationType.label]`` with a
+    non-empty label list but every item has empty ``annotations=[]``, the
+    annotation-type loop in :func:`analyze_legacy_dataset` produces no
+    converter because ``legacy_dataset.ann_types()`` is derived purely from
+    observed item annotations.  The result is an experimental schema with no
+    ``label`` attribute, silently dropping the declared LabelCategories on the
+    floor.
+
+    Downstream consumers (e.g. schema-to-target converters, Geti import) rely
+    on declared LabelCategories surviving import even for fully unannotated
+    datasets.  This helper detects that case and registers a synthetic label
+    converter so the categories propagate through the schema and each item
+    receives a ``None`` label value.
+    """
+    if AnnotationType.label in ann_converters:
+        return
+    legacy_label_categories = legacy_dataset.categories().get(AnnotationType.label)
+    if legacy_label_categories is None or len(legacy_label_categories.items) == 0:
+        return
+    if any((attr_name == "label" or attr_name.endswith("labels")) for attr_name in attributes):
+        return
+
+    label_converter = get_forward_annotation_converter(AnnotationType.label, legacy_dataset, semantic, "")
+    if label_converter is None:
+        return
+
+    ann_converters[AnnotationType.label] = label_converter
+    ann_attributes = label_converter.get_schema_attributes()
+    _apply_label_overrides(
+        ann_attributes,
+        legacy_dataset,
+        label_groups=label_groups,
+        is_multi_label=is_multi_label,
+        is_hierarchical=is_hierarchical,
+    )
+    attributes.update(ann_attributes)
 
 
 def _attributes_to_dict(attributes: list[str]) -> dict[str, str]:

--- a/src/datumaro/experimental/legacy/dataset_converters.py
+++ b/src/datumaro/experimental/legacy/dataset_converters.py
@@ -195,22 +195,7 @@ def _ensure_declared_label_categories(
     is_multi_label: bool,
     is_hierarchical: bool,
 ) -> None:
-    """Inject a label converter when categories are declared but no item carries annotations.
-
-    When the legacy dataset declares ``categories[AnnotationType.label]`` with a
-    non-empty label list but every item has empty ``annotations=[]``, the
-    annotation-type loop in :func:`analyze_legacy_dataset` produces no
-    converter because ``legacy_dataset.ann_types()`` is derived purely from
-    observed item annotations.  The result is an experimental schema with no
-    ``label`` attribute, silently dropping the declared LabelCategories on the
-    floor.
-
-    Downstream consumers (e.g. schema-to-target converters, Geti import) rely
-    on declared LabelCategories surviving import even for fully unannotated
-    datasets.  This helper detects that case and registers a synthetic label
-    converter so the categories propagate through the schema and each item
-    receives a ``None`` label value.
-    """
+    """Inject a label converter when categories are declared but no item carries annotations."""
     if AnnotationType.label in ann_converters:
         return
     legacy_label_categories = legacy_dataset.categories().get(AnnotationType.label)

--- a/tests/unit/experimental/legacy/test_legacy_dataset_converters.py
+++ b/tests/unit/experimental/legacy/test_legacy_dataset_converters.py
@@ -295,6 +295,77 @@ class AnalyzeLegacyDatasetTest:
             assert "bboxes" not in analysis_result.schema.attributes
             assert "bbox_labels" not in analysis_result.schema.attributes
 
+    def test_analyze_unannotated_items_preserve_declared_label_categories(self):
+        """Items without annotations must not erase declared LabelCategories.
+
+        Regression test: when a legacy dataset declares
+        ``categories[AnnotationType.label]`` but every item has empty
+        ``annotations=[]``, the inferred experimental schema must still
+        contain a ``label`` attribute whose ``categories`` matches the
+        declared label list. Previously the schema dropped the declared
+        labels because annotation converters were only triggered for
+        annotation types actually present on items.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            image_path = str(temp_path / "image1.jpg")
+            image_media = Image.from_file(image_path, size=(480, 640))
+            item = DatasetItem(id="item1", media=image_media, annotations=[])
+
+            label_categories = LabelCategories()
+            label_categories.add("LED")
+
+            dataset = LegacyDataset.from_iterable(
+                [item],
+                categories={AnnotationType.label: label_categories},
+            )
+
+            analysis_result = analyze_legacy_dataset(dataset)
+
+            assert "label" in analysis_result.schema.attributes
+            preserved = analysis_result.schema.attributes["label"].categories
+            assert preserved is not None
+            assert preserved.labels == ("LED",)
+
+    def test_convert_from_legacy_unannotated_preserves_label_categories(self):
+        """End-to-end: ``convert_from_legacy`` survives all-empty annotations.
+
+        Building the experimental Dataset from a legacy dataset whose items
+        all have ``annotations=[]`` but whose ``categories`` declare labels
+        must succeed and expose those labels via the ``label`` attribute
+        with a populated ``LabelCategories``. Each item's ``label`` value
+        is ``None`` since no Label annotation was present.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            items = []
+            for i in range(3):
+                image_path = str(temp_path / f"image{i}.jpg")
+                image_media = Image.from_file(image_path, size=(480, 640))
+                items.append(DatasetItem(id=f"item{i}", media=image_media, annotations=[]))
+
+            label_categories = LabelCategories()
+            label_categories.add("LED")
+
+            legacy_dataset = LegacyDataset.from_iterable(
+                items,
+                categories={AnnotationType.label: label_categories},
+            )
+
+            experimental_dataset = convert_from_legacy(legacy_dataset)
+
+            assert len(experimental_dataset) == 3
+            assert "label" in experimental_dataset.schema.attributes
+            categories = experimental_dataset.schema.attributes["label"].categories
+            assert categories is not None
+            assert categories.labels == ("LED",)
+            # Every item should carry a null label value (no Label annotation
+            # was present on the source items).
+            for sample in experimental_dataset:
+                assert sample.label is None
+
     def test_analyze_unknown_annotation_type(self):
         """Test analysis with unknown annotation type."""
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/unit/experimental/legacy/test_legacy_dataset_converters.py
+++ b/tests/unit/experimental/legacy/test_legacy_dataset_converters.py
@@ -366,6 +366,36 @@ class AnalyzeLegacyDatasetTest:
             for sample in experimental_dataset:
                 assert sample.label is None
 
+    def test_analyze_bbox_dataset_without_label_categories(self):
+        """Datasets with annotations but no declared label categories must analyze cleanly."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            image_path = str(temp_path / "image1.jpg")
+            image_media = Image.from_file(image_path, size=(480, 640))
+            bbox = Bbox(10, 20, 30, 40)
+            item = DatasetItem(id="item1", media=image_media, annotations=[bbox])
+
+            # Note: no categories[AnnotationType.label] - this is the path
+            # that exercises the `else: label_groups = []` branch.
+            dataset = LegacyDataset.from_iterable(
+                [item],
+                ann_types={AnnotationType.bbox},
+            )
+
+            analysis_result = analyze_legacy_dataset(dataset)
+
+            # Bbox attribute must be present from the bbox converter
+            assert "bboxes" in analysis_result.schema.attributes
+            # No label categories were declared, so no label-bearing
+            # attribute should be synthesised by the fallback
+            assert "label" not in analysis_result.schema.attributes
+            assert "labels" not in analysis_result.schema.attributes
+            # The bbox converter itself reports no label sub-attribute when
+            # no label categories exist
+            assert analysis_result.is_hierarchical is False
+            assert analysis_result.is_anomaly is False
+
     def test_analyze_unknown_annotation_type(self):
         """Test analysis with unknown annotation type."""
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Retain labels in the dataset even if no annotated items exist for this label in the dataset. All new logic is contained in `_ensure_declared_label_categories`


<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
