### PR TITLE
Fix build and deploy to PyPI workflow

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Installing python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: pip
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==3.1.1

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 is used to build x86_64 MacOS binaries while macos-15 is used for arm64
-        os: ["ubuntu-24.04", "windows-2022", "macos-13", "macos-15"]
+        # macos-15-intel is used to build x86_64 MacOS binaries while macos-15 is used for arm64
+        os: ["ubuntu-24.04", "windows-2022", "macos-15-intel", "macos-15"]
     steps:
       - &harden_runner
         name: Harden the runner (audit all outbound calls)


### PR DESCRIPTION
Python got downgraded to 3.10 in the past months for the build and upload workflow. This version is not compatible with cibuildwheel 3.1.1 that the workflow is trying to install. This PR reverts the python version to 3.11.

Additionally, swap out [deprecated macos-13](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) for macos-15-intel to build the x86_64 package.