### PR TITLE
Update multi-label conversion to keep last label instead of first

### DIFF
--- a/src/datumaro/experimental/converters/annotation_converters.py
+++ b/src/datumaro/experimental/converters/annotation_converters.py
@@ -340,8 +340,8 @@ class LabelShapeConverter(Converter):
       - ``is_list=True, multi_label=False`` ↔ ``is_list=False, multi_label=True``:
         both map to ``List(dtype)``; the conversion is a no-op on the data.
 
-    Lossy conversions (keep first element, logs a warning):
-      - ``List(dtype) → dtype`` (multi_label or is_list reduction): keeps the first element only
+    Lossy conversions (keep last element, logs a warning):
+      - ``List(dtype) → dtype`` (multi_label or is_list reduction): keeps the last element only
     """
 
     input_label: AttributeSpec[LabelField]
@@ -366,16 +366,16 @@ class LabelShapeConverter(Converter):
     def _convert_multi_label(
         self, df: pl.DataFrame, input_col: str, output_col: str, input_is_list: bool
     ) -> pl.DataFrame:
-        """Reduce multi_label → single-label (inner dimension): keep first label."""
+        """Reduce multi_label → single-label (inner dimension): keep last label."""
         log.warning(
-            "Converting multi-label to single-label for field '%s': keeping the first label only. Data may be lost.",
+            "Converting multi-label to single-label for field '%s': keeping the last label only. Data may be lost.",
             input_col,
         )
         if input_is_list:
-            # List(List(dtype)) → List(dtype): take first element of each inner list
-            return df.with_columns(pl.col(input_col).list.eval(pl.element().list.first()).alias(output_col))
-        # List(dtype) → dtype: take the first element
-        return df.with_columns(pl.col(input_col).list.first().alias(output_col))
+            # List(List(dtype)) → List(dtype): take last element of each inner list
+            return df.with_columns(pl.col(input_col).list.eval(pl.element().list.last()).alias(output_col))
+        # List(dtype) → dtype: take the last element
+        return df.with_columns(pl.col(input_col).list.last().alias(output_col))
 
     def _expand_multi_label(
         self, df: pl.DataFrame, input_col: str, output_col: str, input_is_list: bool
@@ -398,11 +398,11 @@ class LabelShapeConverter(Converter):
         """Handle is_list conversion (outer dimension)."""
         if input_is_list:
             log.warning(
-                "Converting list to non-list for field '%s': keeping the first element only. Data may be lost.",
+                "Converting list to non-list for field '%s': keeping the last element only. Data may be lost.",
                 src_col,
             )
-            # List(X) → X: take the first element
-            return df.with_columns(pl.col(src_col).list.first().alias(output_col))
+            # List(X) → X: take the last element
+            return df.with_columns(pl.col(src_col).list.last().alias(output_col))
         # X → List(X): wrap each sample's value in a 1-element list, preserving nulls
         if not output_multi:
             # Scalar → List(scalar): use native concat_list (fast path)

--- a/tests/unit/experimental/converters/test_annotation_converters.py
+++ b/tests/unit/experimental/converters/test_annotation_converters.py
@@ -825,11 +825,11 @@ def test_label_shape_converter_conversions(
 @pytest.mark.parametrize(
     "input_multi, input_is_list, output_multi, output_is_list, data, schema_type, expected_value, expected_dtype",
     [
-        pytest.param(True,  False, False, False, {"label": [[5, 10, 15]]},            pl.List(pl.UInt32()),          5,          pl.UInt32(),          id="multi_to_single_scalar"),  # noqa: E501
-        pytest.param(True,  True,  False, True,  {"label": [[[5, 10], [15, 20]]]},    pl.List(pl.List(pl.UInt32())), [5, 15],    pl.List(pl.UInt32()), id="multi_to_single_list"),  # noqa: E501
-        pytest.param(False, True,  False, False, {"label": [[10, 20, 30]]},           pl.List(pl.UInt32()),          10,         pl.UInt32(),          id="list_to_scalar"),  # noqa: E501
-        pytest.param(True,  True,  True,  False, {"label": [[[1, 2], [3, 4], [5]]]},  pl.List(pl.List(pl.UInt32())), [1, 2],     pl.List(pl.UInt32()), id="multi_label_list_to_scalar"),  # noqa: E501
-        pytest.param(True,  True,  False, False, {"label": [[[5, 10], [15, 20]]]},    pl.List(pl.List(pl.UInt32())), 5,          pl.UInt32(),          id="both_list_list_to_scalar"),  # noqa: E501
+        pytest.param(True,  False, False, False, {"label": [[5, 10, 15]]},            pl.List(pl.UInt32()),          15,         pl.UInt32(),          id="multi_to_single_scalar"),  # noqa: E501
+        pytest.param(True,  True,  False, True,  {"label": [[[5, 10], [15, 20]]]},    pl.List(pl.List(pl.UInt32())), [10, 20],   pl.List(pl.UInt32()), id="multi_to_single_list"),  # noqa: E501
+        pytest.param(False, True,  False, False, {"label": [[10, 20, 30]]},           pl.List(pl.UInt32()),          30,         pl.UInt32(),          id="list_to_scalar"),  # noqa: E501
+        pytest.param(True,  True,  True,  False, {"label": [[[1, 2], [3, 4], [5]]]},  pl.List(pl.List(pl.UInt32())), [5],        pl.List(pl.UInt32()), id="multi_label_list_to_scalar"),  # noqa: E501
+        pytest.param(True,  True,  False, False, {"label": [[[5, 10], [15, 20]]]},    pl.List(pl.List(pl.UInt32())), 20,         pl.UInt32(),          id="both_list_list_to_scalar"),  # noqa: E501
     ],
 )  # fmt: on  noqa: RUF028
 def test_label_shape_converter_lossy_conversions(
@@ -843,7 +843,7 @@ def test_label_shape_converter_lossy_conversions(
     expected_dtype,
     caplog,
 ):
-    """convert() keeps the first element and logs a warning for lossy multi_label/is_list reductions."""
+    """convert() keeps the last element and logs a warning for lossy multi_label/is_list reductions."""
     from datumaro.experimental.converters import LabelShapeConverter
 
     converter_instance = LabelShapeConverter()
@@ -869,7 +869,7 @@ def test_label_shape_converter_lossy_conversions(
         assert result_val == expected_value
 
     # Verify a warning was logged
-    assert any("keeping the first" in msg for msg in caplog.messages)
+    assert any("keeping the last" in msg for msg in caplog.messages)
 
 
 def test_label_shape_converter_filter_returns_false():


### PR DESCRIPTION
Update the multi/is_list label converter to keep the last label instead of the first label.  This will allow hierarchical tasks to keep their leaf labels if they are sorted in order and converted to multi class classification. 

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
