### PR TITLE
Add a temporary fix for coco multi-polygons datasets

### DIFF
--- a/src/datumaro/experimental/data_formats/coco/helpers.py
+++ b/src/datumaro/experimental/data_formats/coco/helpers.py
@@ -447,7 +447,6 @@ def _collect_instances_for_image(
         original_bbox = ann.get("bbox")
         original_area = ann.get("area")
 
-        # Handle multi-part polygons by splitting them into separate annotations
         polygon_parts = _segmentation_to_poly_parts(segmentation)
 
         ic = ann.get("iscrowd", 0)
@@ -456,28 +455,44 @@ def _collect_instances_for_image(
         except Exception:  # pragma: no cover - tolerant casting
             iscrowd_val = False
 
-        for poly_array in polygon_parts:
-            # Compute bbox from polygon points (x, y, w, h format for COCO compatibility)
-            if poly_array.size > 0:
-                x_coords = poly_array[:, 0]
-                y_coords = poly_array[:, 1]
-                x1, y1 = float(x_coords.min()), float(y_coords.min())
-                x2, y2 = float(x_coords.max()), float(y_coords.max())
-                computed_bbox = [x1, y1, x2 - x1, y2 - y1]  # x, y, w, h
-                area = (x2 - x1) * (y2 - y1)
-            elif original_bbox is not None and len(original_bbox) == 4:
-                # Use original bbox from annotation if no polygon
-                computed_bbox = [float(v) for v in original_bbox]
-                area = float(original_area) if original_area is not None else computed_bbox[2] * computed_bbox[3]
-            else:
-                computed_bbox = [0.0, 0.0, 0.0, 0.0]
-                area = 0.0
+        valid_parts = [part for part in polygon_parts if part.size > 0]
+        combined_poly = np.concatenate(valid_parts, axis=0) if valid_parts else np.zeros((0, 2), dtype=np.float32)
 
-            bboxes_list.append(computed_bbox)
-            polygons_list.append(poly_array)
-            labels_list.append(category_idx)
-            areas_list.append(area)
-            iscrowd_list.append(iscrowd_val)
+        if original_bbox is not None and len(original_bbox) == 4:
+            computed_bbox = [float(v) for v in original_bbox]
+            area = float(original_area) if original_area is not None else computed_bbox[2] * computed_bbox[3]
+        elif valid_parts:
+            x1 = float(combined_poly[:, 0].min())
+            y1 = float(combined_poly[:, 1].min())
+            x2 = float(combined_poly[:, 0].max())
+            y2 = float(combined_poly[:, 1].max())
+            computed_bbox: list[float] = [x1, y1, x2 - x1, y2 - y1]
+            area = (x2 - x1) * (y2 - y1)
+        else:
+            computed_bbox = [0.0, 0.0, 0.0, 0.0]
+            area = 0.0
+
+        bboxes_list.append(computed_bbox)
+        polygons_list.append(combined_poly)
+        labels_list.append(category_idx)
+        areas_list.append(area)
+        iscrowd_list.append(iscrowd_val)
+
+    if bboxes_list:
+        seen: set[tuple[int | None, tuple[float, ...]]] = set()
+        dedup_indices: list[int] = []
+        for index, (bbox, label) in enumerate(zip(bboxes_list, labels_list)):
+            key = (label, tuple(round(value, 2) for value in bbox) if bbox else ())
+            if key not in seen:
+                seen.add(key)
+                dedup_indices.append(index)
+
+        if len(dedup_indices) < len(bboxes_list):
+            bboxes_list = [bboxes_list[index] for index in dedup_indices]
+            polygons_list = [polygons_list[index] for index in dedup_indices]
+            labels_list = [labels_list[index] for index in dedup_indices]
+            areas_list = [areas_list[index] for index in dedup_indices]
+            iscrowd_list = [iscrowd_list[index] for index in dedup_indices]
 
     return bboxes_list, polygons_list, labels_list, areas_list, iscrowd_list
 

--- a/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
+++ b/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
@@ -329,7 +329,7 @@ def test_collect_instances_dedup_identical_annotations():
             },
         ]
     }
-    bboxes, polys, labels, areas, iscrowd = _collect_instances_for_image(1, instances_by_image, {1: 0})
+    bboxes, _polys, labels, _areas, _iscrowd = _collect_instances_for_image(1, instances_by_image, {1: 0})
 
     assert len(bboxes) == 1
     assert bboxes[0] == [10.0, 10.0, 20.0, 20.0]

--- a/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
+++ b/tests/unit/experimental/data_formats/coco/test_coco_helpers.py
@@ -247,7 +247,7 @@ def test_collect_helpers_extract_expected_fields():
         ]
     }
     bboxes, polys, labels, areas, iscrowd = _collect_instances_for_image(1, instances_by_image, {2: 0})
-    assert bboxes[0] == [0.0, 0.0, 2.0, 2.0]  # Computed from polygon, not from annotation bbox
+    assert bboxes[0] == [1.0, 1.0, 2.0, 2.0]  # Uses annotation bbox as primary source
     assert polys[0].shape == (4, 2)
     assert labels == [0]
     assert areas[0] == pytest.approx(4.0)
@@ -284,6 +284,56 @@ def test_collect_instances_uses_bbox_when_no_polygon():
     # Should use the original area from annotation
     assert areas[0] == pytest.approx(50000.0)
     assert iscrowd == [False]
+
+
+def test_collect_instances_multi_polygon_union_bbox():
+    """Multi-part polygon annotation yields one bbox covering the union of all parts."""
+    part1 = [0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0]
+    part2 = [20.0, 20.0, 30.0, 20.0, 30.0, 30.0, 20.0, 30.0]
+    instances_by_image = {
+        1: [
+            {
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [0, 0, 30, 30],
+                "segmentation": [part1, part2],
+            },
+        ]
+    }
+    bboxes, polys, labels, areas, iscrowd = _collect_instances_for_image(1, instances_by_image, {1: 0})
+
+    assert len(bboxes) == 1
+    assert bboxes[0] == [0.0, 0.0, 30.0, 30.0]
+    assert len(polys) == 1
+    assert polys[0].shape == (8, 2)
+    assert labels == [0]
+    assert areas[0] == pytest.approx(900.0)
+    assert iscrowd == [False]
+
+
+def test_collect_instances_dedup_identical_annotations():
+    """Exact duplicate (label + bbox) annotations are collapsed to one."""
+    instances_by_image = {
+        1: [
+            {
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [10, 10, 20, 20],
+                "segmentation": [[10, 10, 30, 10, 30, 30, 10, 30]],
+            },
+            {
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [10, 10, 20, 20],
+                "segmentation": [[10, 10, 30, 10, 30, 30, 10, 30]],
+            },
+        ]
+    }
+    bboxes, polys, labels, areas, iscrowd = _collect_instances_for_image(1, instances_by_image, {1: 0})
+
+    assert len(bboxes) == 1
+    assert bboxes[0] == [10.0, 10.0, 20.0, 20.0]
+    assert labels == [0]
 
 
 def test_serialize_instances_requires_labels():


### PR DESCRIPTION

1. Use merged polygons 
2. Use original bbox when available 

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
