### PR TITLE
chore(ci): extend the allowlist in dependency-review config

### DIFF
--- a/.github/dependency_review_config.yml
+++ b/.github/dependency_review_config.yml
@@ -38,5 +38,26 @@ allow-dependencies-licenses:
   - pkg:pypi/nvidia-nccl-cu13
   - pkg:pypi/nvidia-cudnn-cu13
   - pkg:pypi/nvidia-nvshmem-cu13
+
+  # typing-extensions distribution license is PSF-2.0, as declared in the PyPI,
+  # https://pypi.org/pypi/typing-extensions/json
+  - pkg:pypi/typing-extensions
+
+  # lxml distribution license is BSD-3-Clause, as declared in the PyPI,
+  # https://pypi.org/pypi/lxml/json
+  - pkg:pypi/lxml
+
+  # apeye distribution license is LGPL-3.0-or-later, as declared in the PyPI,
+  # https://pypi.org/pypi/apeye/json
+  - pkg:pypi/apeye
+
+  # rfc3987-syntax distribution license is MIT, as declared in the PyPI,
+  # https://pypi.org/pypi/rfc3987-syntax/json
+  - pkg:pypi/rfc3987-syntax
+
+  # Artistic-1.0-Perl license is applied for text-unidecode
+  # as mentioned in https://github.com/kmike/text-unidecode/blob/master/LICENSE
+  - pkg:pypi/text-unidecode
+
 license-check: true
 vulnerability-check: true

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -27,6 +27,8 @@ jobs:
             api.box.com:443
             api.github.com:443
             api.sonarcloud.io:443
+            api.t.ly:443
+            api.unify.id:443
             app.eraser.io:443
             auth.docker.io:443
             ghcr.io:443


### PR DESCRIPTION
- Extended the dependency-review allowlist with several PyPI packages, including inline license/source references.
- Extended the outbound allowlist in the secret scan workflow with two additional API hosts that are required to support detectors https://github.com/trufflesecurity/trufflehog/blob/main/pkg/detectors/tly/tly.go and https://github.com/trufflesecurity/trufflehog/blob/main/pkg/detectors/unifyid/unifyid.go

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
