### PR TITLE
fix(ci): update Renovate config to work with geti-ci tags correctly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -113,7 +113,7 @@
       matchManagers: ["github-actions"],
       matchPackageNames: ["open-edge-platform/geti-ci"],
       schedule: ["* * 1 * *"], // every month
-      versioning: "regex:^(?:[^/]+/)?v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      versioning: "regex:^(?<compatibility>[^/]+)/v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
     },
 
     // uv version used in GitHub Actions is updated manually


### PR DESCRIPTION
This PR updated Renovate config to correctly work with tag form from `geti-ci` repo.
Incorrect behavior
```diff
- uses: open-edge-platform/geti-ci/actions/bandit@940b.....# bandit/v0.1.1
+ uses: open-edge-platform/geti-ci/actions/bandit@0bed7... # zizmor/v0.1.2
```
Correct behavior: 

```diff
- uses: open-edge-platform/geti-ci/actions/bandit@940b.....# bandit/v0.1.1
+ uses: open-edge-platform/geti-ci/actions/bandit@0bed7... # bandit/v0.1.2
```


Was tested in https://github.com/AlexanderBarabanov/datumaro/pull/5

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
