### PR TITLE
Update pyo3 to 0.29.0

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 derive_more = "0.99.17"
-pyo3 = "0.27.0"
+pyo3 = "0.29.0"
 serde = { version = "1.0.180", features = ["derive"] }
 serde_json = "1.0.104"
 strum = { version = "0.28", features = ["derive"] }

--- a/rust/src/coco_page_mapper.rs
+++ b/rust/src/coco_page_mapper.rs
@@ -171,24 +171,24 @@ impl CocoPageMapper {
         Ok(CocoPageMapper { reader, mapper })
     }
 
-    fn licenses(self_: PyRef<Self>) -> PyResult<PyObject> {
+    fn licenses(self_: PyRef<Self>) -> PyResult<Py<PyAny>> {
         convert_to_py_object(self_.mapper.licenses(), self_.py())
     }
 
-    fn info(self_: PyRef<Self>) -> PyResult<PyObject> {
+    fn info(self_: PyRef<Self>) -> PyResult<Py<PyAny>> {
         convert_to_py_object(self_.mapper.info(), self_.py())
     }
 
-    fn categories(self_: PyRef<Self>) -> PyResult<PyObject> {
+    fn categories(self_: PyRef<Self>) -> PyResult<Py<PyAny>> {
         convert_to_py_object(self_.mapper.categories(), self_.py())
     }
 
-    fn get_item_dict(&mut self, py: Python<'_>, img_id: i64) -> PyResult<PyObject> {
+    fn get_item_dict(&mut self, py: Python<'_>, img_id: i64) -> PyResult<Py<PyAny>> {
         let item_dict = self.mapper.get_item_dict(&img_id, &mut self.reader)?;
         Ok(convert_to_py_object(&item_dict, py)?)
     }
 
-    fn get_anns_dict(&mut self, py: Python<'_>, img_id: i64) -> PyResult<PyObject> {
+    fn get_anns_dict(&mut self, py: Python<'_>, img_id: i64) -> PyResult<Py<PyAny>> {
         let anns_list = PyList::new(
             py,
             self.mapper

--- a/rust/src/datum_page_mapper.rs
+++ b/rust/src/datum_page_mapper.rs
@@ -180,15 +180,15 @@ impl DatumPageMapper {
         self_.mapper.media_type().clone()
     }
 
-    fn infos(self_: PyRef<Self>) -> PyResult<PyObject> {
+    fn infos(self_: PyRef<Self>) -> PyResult<Py<PyAny>> {
         convert_to_py_object(self_.mapper.infos(), self_.py())
     }
 
-    fn categories(self_: PyRef<Self>) -> PyResult<PyObject> {
+    fn categories(self_: PyRef<Self>) -> PyResult<Py<PyAny>> {
         convert_to_py_object(self_.mapper.categories(), self_.py())
     }
 
-    fn get_item_dict(&mut self, py: Python<'_>, img_id: String) -> PyResult<PyObject> {
+    fn get_item_dict(&mut self, py: Python<'_>, img_id: String) -> PyResult<Py<PyAny>> {
         let item_dict = self.mapper.get_item_dict(&img_id, &mut self.reader)?;
         Ok(convert_to_py_object(&item_dict, py)?)
     }

--- a/rust/src/json_section_page_mapper.rs
+++ b/rust/src/json_section_page_mapper.rs
@@ -181,7 +181,7 @@ impl JsonSectionPageMapper {
         Ok(JsonSectionPageMapper { reader, mapper })
     }
 
-    fn sections(self_: PyRef<Self>) -> PyResult<PyObject> {
+    fn sections(self_: PyRef<Self>) -> PyResult<Py<PyAny>> {
         let dict: HashMap<&str, HashMap<&str, usize>> = self_
             .mapper
             .sections

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -80,7 +80,7 @@ pub fn skip_serde_json_value<R: io::Read>(reader: &mut R) -> Result<(), std::io:
     }
 }
 
-pub fn convert_to_py_object(value: &serde_json::Value, py: Python<'_>) -> PyResult<PyObject> {
+pub fn convert_to_py_object(value: &serde_json::Value, py: Python<'_>) -> PyResult<Py<PyAny>> {
     if value.is_array() {
         let list = PyList::empty(py);
 


### PR DESCRIPTION
Bumped pyo3 from 0.27.0 to 0.29.0 to resolve 2 CVEs:

GHSA-36hh-v3qg-5jq4
GHSA-chgr-c6px-7xpp

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
