### PR TITLE
Tiling patch for instance segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Experimental module
+
+#### Bug fixes
+- Fixed `InstanceMaskTiler` not filtering instance masks during tiling. Instance
+  masks are now pruned to the instances whose bounding box intersects each tile,
+  mirroring `BboxTiler`/`LabelTiler`, so masks stay aligned with boxes and labels
+  (previously `len(masks) != len(bboxes) == len(labels)`, which corrupted
+  instance-segmentation training).
+
 ## Release 1.13.0
 
 This release is centered around the maturation of the experimental dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-### Experimental module
-
-#### Bug fixes
-- Fixed `InstanceMaskTiler` not filtering instance masks during tiling. Instance
-  masks are now pruned to the instances whose bounding box intersects each tile,
-  mirroring `BboxTiler`/`LabelTiler`, so masks stay aligned with boxes and labels
-  (previously `len(masks) != len(bboxes) == len(labels)`, which corrupted
-  instance-segmentation training).
-
 ## Release 1.13.0
 
 This release is centered around the maturation of the experimental dataset

--- a/src/datumaro/experimental/tiling/tilers.py
+++ b/src/datumaro/experimental/tiling/tilers.py
@@ -86,18 +86,57 @@ class MaskTiler(Tiler):
         return pl.DataFrame({column_name: results_data, shape_column: results_shape})
 
 
+def _instance_intersects_tile(instance: np.ndarray, x: int, y: int, width: int, height: int) -> bool:
+    """Return whether an instance mask's bounding box intersects the tile.
+
+    The criterion mirrors :class:`BboxTiler` exactly: using the instance's
+    full-image bounding box ``(x1, y1, x2, y2)`` (derived from its non-zero
+    pixels, with ``x2``/``y2`` exclusive), the instance is kept iff::
+
+        (x2 > tile_x) & (x1 < tile_x2) & (y2 > tile_y) & (y1 < tile_y2)
+
+    An all-zero mask (no pixels) has no bounding box and is dropped.
+
+    Args:
+        instance: Full-image instance mask of shape ``(H, W)``.
+        x: Tile left coordinate.
+        y: Tile top coordinate.
+        width: Tile width.
+        height: Tile height.
+
+    Returns:
+        ``True`` if the instance overlaps the tile rectangle, else ``False``.
+    """
+    rows = np.nonzero(instance.any(axis=1))[0]
+    cols = np.nonzero(instance.any(axis=0))[0]
+    if rows.size == 0 or cols.size == 0:
+        return False
+    y1, y2 = int(rows[0]), int(rows[-1]) + 1
+    x1, x2 = int(cols[0]), int(cols[-1]) + 1
+    return bool((x2 > x) and (x1 < x + width) and (y2 > y) and (y1 < y + height))
+
+
 @TilerRegistry.register(InstanceMaskField)
 class InstanceMaskTiler(Tiler):
     """Tiler for instance segmentation masks.
 
-    Extracts the corresponding region from each instance mask.
-    Adds a keep column to track which instances are present in each tile.
+    Extracts the corresponding region from each instance mask and prunes
+    instances that do not overlap the tile.
+
+    Instance masks are stored as a flattened array plus a separate shape column,
+    a format that the coordinated ``keep``-column filtering mechanism (used by
+    :class:`BboxTiler` and :class:`LabelTiler`) cannot express. To keep masks
+    aligned with the independently filtered bounding boxes and labels, this
+    tiler self-filters instances using the **same tile-intersection criterion**
+    as :class:`BboxTiler` (the instance's full-image mask bounding box must
+    intersect the tile rectangle). Instances are kept in their original order so
+    alignment with boxes/labels is preserved.
     """
 
     field_spec: AttributeSpec[InstanceMaskField]
 
     def tile(self, df: pl.DataFrame, tiles_df: pl.DataFrame, slice_offset: int = 0) -> pl.DataFrame:
-        """Extract instance mask regions for each tile."""
+        """Extract and filter instance mask regions for each tile."""
         column_name = self.field_spec.name
         shape_column = f"{column_name}_shape"
         results_data = []
@@ -114,9 +153,20 @@ class InstanceMaskTiler(Tiler):
             width = tile_row["width"]
             height = tile_row["height"]
 
-            # Reshape flattened data and extract tile
-            instances = instances_data.reshape(instances_shape).to_numpy()
-            tile_result = instances[:, y : y + height, x : x + width]  # Shape: (num_instances, tile_height, tile_width)
+            # Reshape flattened data
+            instances = instances_data.reshape(instances_shape).to_numpy()  # (N, H, W)
+
+            # Keep only instances whose full-image bounding box intersects the
+            # tile, mirroring BboxTiler so masks stay aligned with boxes/labels.
+            if instances.shape[0] > 0:
+                keep = np.array(
+                    [_instance_intersects_tile(inst, x, y, width, height) for inst in instances],
+                    dtype=bool,
+                )
+                instances = instances[keep]
+
+            # Extract tile region: shape (num_kept_instances, tile_height, tile_width)
+            tile_result = instances[:, y : y + height, x : x + width]
 
             # Flatten result for storage
             results_data.append(tile_result.reshape(-1))

--- a/src/datumaro/experimental/tiling/tilers.py
+++ b/src/datumaro/experimental/tiling/tilers.py
@@ -7,7 +7,8 @@ Implementations of tilers for specific field types.
 """
 
 import operator
-from typing import Any
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar
 
 import numpy as np
 import polars as pl
@@ -28,6 +29,43 @@ from datumaro.experimental.fields import (
 from datumaro.experimental.schema import AttributeSpec
 
 from .tiler_registry import Tiler, TilerRegistry
+
+_T = TypeVar("_T")
+
+
+class _LastImageCache(Generic[_T]):
+    """Single-slot cache keyed on the source image index.
+
+    Tiles are generated grouped by source image: ``_calculate_tiles`` iterates
+    images in order and emits every tile of one image before moving on to the
+    next, so a tiler's :meth:`tile` sees tiles contiguously per image. A cache
+    holding only the **last seen** image therefore captures all the reuse
+    (every run of tiles that share a source image) while keeping memory bounded
+    to a single image's derived data.
+
+    This is preferred over a per-image dictionary, which would grow unbounded
+    across the whole dataset and risk out-of-memory errors on large datasets
+    (many images) or memory-heavy per-image payloads (e.g. reshaped mask
+    stacks).
+    """
+
+    __slots__ = ("_image_id", "_value")
+
+    def __init__(self) -> None:
+        self._image_id: int | None = None
+        self._value: _T | None = None
+
+    def get(self, image_id: int, factory: Callable[[], _T]) -> _T:
+        """Return the cached value for ``image_id``, computing it on a miss.
+
+        On a cache miss (a different image than the previous call) the previous
+        entry is evicted before ``factory`` is invoked, so at most one image's
+        data is retained at any time.
+        """
+        if image_id != self._image_id:
+            self._image_id = image_id
+            self._value = factory()
+        return self._value  # type: ignore[return-value]
 
 
 @TilerRegistry.register(SubsetField)
@@ -64,10 +102,18 @@ class MaskTiler(Tiler):
         results_data = []
         results_shape = []
 
+        # Cache the reshaped mask per source image so the O(H*W) reshape +
+        # to_numpy conversion is paid at most once per image instead of once per
+        # tile. Tiles are processed contiguously per image, so a single-slot
+        # cache is sufficient and keeps memory bounded to one image.
+        mask_cache: _LastImageCache[np.ndarray] = _LastImageCache()
+
         for tile_row in tiles_df["tile"]:
             image_id = tile_row["source_sample_idx"] - slice_offset
-            mask_data = df[column_name][image_id]
-            mask_shape = df[shape_column][image_id]
+            mask = mask_cache.get(
+                image_id,
+                lambda: df[column_name][image_id].reshape(df[shape_column][image_id]).to_numpy(),
+            )
 
             # Get tile coordinates
             x = tile_row["x"]
@@ -75,8 +121,7 @@ class MaskTiler(Tiler):
             width = tile_row["width"]
             height = tile_row["height"]
 
-            # Reshape flattened data and extract tile
-            mask = mask_data.reshape(mask_shape).to_numpy()
+            # Extract tile region from the (cached) reshaped mask
             tile_mask = mask[y : y + height, x : x + width]
 
             # Return flattened tile
@@ -173,21 +218,22 @@ class InstanceMaskTiler(Tiler):
         # derivation) is paid at most once per image instead of once per tile.
         # Many tiles typically share the same source image, so this avoids
         # O(num_tiles * num_instances * H * W) work on large / dense images.
-        instances_cache: dict[int, np.ndarray] = {}
-        boxes_cache: dict[int, np.ndarray] = {}
+        # Tiles are processed contiguously per image (see _calculate_tiles), so a
+        # single-slot cache captures all the reuse while keeping memory bounded
+        # to one image -- avoiding the unbounded growth (and OOM risk on large
+        # datasets) of a per-image dictionary.
+        cache: _LastImageCache[tuple[np.ndarray, np.ndarray]] = _LastImageCache()
+
+        def _load(image_id: int) -> tuple[np.ndarray, np.ndarray]:
+            instances_data = df[column_name][image_id]  # Flattened 3D array
+            instances_shape = df[shape_column][image_id]  # (num_instances, height, width)
+            # Reshape flattened data once per image: (N, H, W)
+            instances = instances_data.reshape(instances_shape).to_numpy()
+            return instances, _instance_bounding_boxes(instances)
 
         for tile_row in tiles_df["tile"]:
             image_id = tile_row["source_sample_idx"] - slice_offset
-
-            instances = instances_cache.get(image_id)
-            if instances is None:
-                instances_data = df[column_name][image_id]  # Flattened 3D array
-                instances_shape = df[shape_column][image_id]  # (num_instances, height, width)
-                # Reshape flattened data once per image: (N, H, W)
-                instances = instances_data.reshape(instances_shape).to_numpy()
-                instances_cache[image_id] = instances
-                boxes_cache[image_id] = _instance_bounding_boxes(instances)
-            boxes = boxes_cache[image_id]
+            instances, boxes = cache.get(image_id, lambda: _load(image_id))
 
             # Get tile coordinates
             x = tile_row["x"]
@@ -243,9 +289,28 @@ class BboxTiler(Tiler):
 
         results = []
 
+        # Cache the per-image exploded/split boxes (the part that only depends on
+        # the source image, not the tile) so it is computed once per image rather
+        # than once per tile. Tiles are processed contiguously per image, so a
+        # single-slot cache is sufficient and keeps memory bounded to one image.
+        # NOTE: bbox payloads are small, so this is a modest speedup rather than
+        # an OOM safeguard (unlike the mask tilers), but it keeps the caching
+        # strategy consistent across tilers.
+        boxes_cache: _LastImageCache[pl.DataFrame] = _LastImageCache()
+
+        def _load_boxes(image_id: int) -> pl.DataFrame:
+            boxes = df[image_id].select(column_name).explode(column_name)
+            return boxes.with_columns(
+                x1=pl.col(column_name).arr.get(0),
+                y1=pl.col(column_name).arr.get(1),
+                x2=pl.col(column_name).arr.get(2),
+                y2=pl.col(column_name).arr.get(3),
+            )
+
         for tile_row in tiles_df["tile"]:
             image_id = tile_row["source_sample_idx"] - slice_offset
-            boxes = df[image_id].select(column_name).explode(column_name)
+            # with_columns below returns new frames, so the cached frame is never mutated.
+            boxes = boxes_cache.get(image_id, lambda: _load_boxes(image_id))
 
             # Get tile coordinates
             tile_x = tile_row["x"]
@@ -254,14 +319,6 @@ class BboxTiler(Tiler):
             tile_height = tile_row["height"]
             tile_x2 = tile_x + tile_width
             tile_y2 = tile_y + tile_height
-
-            # Process each bbox
-            boxes = boxes.with_columns(
-                x1=pl.col(column_name).arr.get(0),
-                y1=pl.col(column_name).arr.get(1),
-                x2=pl.col(column_name).arr.get(2),
-                y2=pl.col(column_name).arr.get(3),
-            )
 
             # Check if box intersects with tile
             boxes = boxes.with_columns(

--- a/src/datumaro/experimental/tiling/tilers.py
+++ b/src/datumaro/experimental/tiling/tilers.py
@@ -86,34 +86,61 @@ class MaskTiler(Tiler):
         return pl.DataFrame({column_name: results_data, shape_column: results_shape})
 
 
-def _instance_intersects_tile(instance: np.ndarray, x: int, y: int, width: int, height: int) -> bool:
-    """Return whether an instance mask's bounding box intersects the tile.
+def _instance_bounding_boxes(instances: np.ndarray) -> np.ndarray:
+    """Compute per-instance full-image bounding boxes from a mask stack.
 
-    The criterion mirrors :class:`BboxTiler` exactly: using the instance's
-    full-image bounding box ``(x1, y1, x2, y2)`` (derived from its non-zero
-    pixels, with ``x2``/``y2`` exclusive), the instance is kept iff::
+    Scans each instance mask **once** to derive its bounding box
+    ``(x1, y1, x2, y2)`` (from non-zero pixels, with ``x2``/``y2`` exclusive).
+    Instances with no pixels (all-zero masks) yield a degenerate ``(0, 0, 0, 0)``
+    box which never intersects any tile (see :func:`_boxes_intersect_tile`), so
+    they are effectively dropped.
+
+    Args:
+        instances: Full-image instance masks of shape ``(N, H, W)``.
+
+    Returns:
+        Integer array of shape ``(N, 4)`` holding ``(x1, y1, x2, y2)`` per
+        instance.
+    """
+    num_instances = instances.shape[0]
+    boxes = np.zeros((num_instances, 4), dtype=np.int64)
+    if num_instances == 0:
+        return boxes
+
+    # Reduce over the full mask once per instance (the only O(H*W) pass).
+    rows_any = instances.any(axis=2)  # (N, H): rows containing any pixel
+    cols_any = instances.any(axis=1)  # (N, W): cols containing any pixel
+    for i in range(num_instances):
+        rows = np.nonzero(rows_any[i])[0]
+        cols = np.nonzero(cols_any[i])[0]
+        if rows.size == 0 or cols.size == 0:
+            continue
+        boxes[i] = (cols[0], rows[0], cols[-1] + 1, rows[-1] + 1)
+    return boxes
+
+
+def _boxes_intersect_tile(boxes: np.ndarray, x: int, y: int, width: int, height: int) -> np.ndarray:
+    """Vectorized bbox-vs-tile intersection test.
+
+    The criterion mirrors :class:`BboxTiler` exactly: an instance whose
+    full-image bounding box is ``(x1, y1, x2, y2)`` is kept iff::
 
         (x2 > tile_x) & (x1 < tile_x2) & (y2 > tile_y) & (y1 < tile_y2)
 
-    An all-zero mask (no pixels) has no bounding box and is dropped.
-
     Args:
-        instance: Full-image instance mask of shape ``(H, W)``.
+        boxes: Integer array of shape ``(N, 4)`` of ``(x1, y1, x2, y2)`` boxes.
         x: Tile left coordinate.
         y: Tile top coordinate.
         width: Tile width.
         height: Tile height.
 
     Returns:
-        ``True`` if the instance overlaps the tile rectangle, else ``False``.
+        Boolean array of shape ``(N,)`` marking intersecting instances.
     """
-    rows = np.nonzero(instance.any(axis=1))[0]
-    cols = np.nonzero(instance.any(axis=0))[0]
-    if rows.size == 0 or cols.size == 0:
-        return False
-    y1, y2 = int(rows[0]), int(rows[-1]) + 1
-    x1, x2 = int(cols[0]), int(cols[-1]) + 1
-    return bool((x2 > x) and (x1 < x + width) and (y2 > y) and (y1 < y + height))
+    if boxes.shape[0] == 0:
+        return np.zeros((0,), dtype=bool)
+    x1, y1, x2, y2 = boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3]
+    return (x2 > x) & (x1 < x + width) & (y2 > y) & (y1 < y + height)
 
 
 @TilerRegistry.register(InstanceMaskField)
@@ -142,10 +169,25 @@ class InstanceMaskTiler(Tiler):
         results_data = []
         results_shape = []
 
+        # Cache per source image so the O(H*W) mask scan (reshape + bbox
+        # derivation) is paid at most once per image instead of once per tile.
+        # Many tiles typically share the same source image, so this avoids
+        # O(num_tiles * num_instances * H * W) work on large / dense images.
+        instances_cache: dict[int, np.ndarray] = {}
+        boxes_cache: dict[int, np.ndarray] = {}
+
         for tile_row in tiles_df["tile"]:
             image_id = tile_row["source_sample_idx"] - slice_offset
-            instances_data = df[column_name][image_id]  # Flattened 3D array
-            instances_shape = df[shape_column][image_id]  # (num_instances, height, width)
+
+            instances = instances_cache.get(image_id)
+            if instances is None:
+                instances_data = df[column_name][image_id]  # Flattened 3D array
+                instances_shape = df[shape_column][image_id]  # (num_instances, height, width)
+                # Reshape flattened data once per image: (N, H, W)
+                instances = instances_data.reshape(instances_shape).to_numpy()
+                instances_cache[image_id] = instances
+                boxes_cache[image_id] = _instance_bounding_boxes(instances)
+            boxes = boxes_cache[image_id]
 
             # Get tile coordinates
             x = tile_row["x"]
@@ -153,20 +195,17 @@ class InstanceMaskTiler(Tiler):
             width = tile_row["width"]
             height = tile_row["height"]
 
-            # Reshape flattened data
-            instances = instances_data.reshape(instances_shape).to_numpy()  # (N, H, W)
-
-            # Keep only instances whose full-image bounding box intersects the
-            # tile, mirroring BboxTiler so masks stay aligned with boxes/labels.
+            # Keep only instances whose (cached) full-image bounding box
+            # intersects the tile, mirroring BboxTiler so masks stay aligned
+            # with boxes/labels. This is a cheap vectorized check per tile.
             if instances.shape[0] > 0:
-                keep = np.array(
-                    [_instance_intersects_tile(inst, x, y, width, height) for inst in instances],
-                    dtype=bool,
-                )
-                instances = instances[keep]
+                keep = _boxes_intersect_tile(boxes, x, y, width, height)
+                kept_instances = instances[keep]
+            else:
+                kept_instances = instances
 
             # Extract tile region: shape (num_kept_instances, tile_height, tile_width)
-            tile_result = instances[:, y : y + height, x : x + width]
+            tile_result = kept_instances[:, y : y + height, x : x + width]
 
             # Flatten result for storage
             results_data.append(tile_result.reshape(-1))

--- a/tests/unit/experimental/tiling/test_tiling.py
+++ b/tests/unit/experimental/tiling/test_tiling.py
@@ -419,9 +419,13 @@ def _mask_from_box(x1, y1, x2, y2, h=100, w=100):
 
 def test_instance_intersects_tile_drops_empty_mask():
     """An all-zero instance mask has no bounding box and is never kept."""
-    from datumaro.experimental.tiling.tilers import _instance_intersects_tile
+    from datumaro.experimental.tiling.tilers import _boxes_intersect_tile, _instance_bounding_boxes
 
-    assert _instance_intersects_tile(np.zeros((100, 100), dtype=np.uint8), 0, 0, 50, 50) is False
+    instances = np.zeros((1, 100, 100), dtype=np.uint8)
+    boxes = _instance_bounding_boxes(instances)
+    # Empty mask yields a degenerate (0, 0, 0, 0) box.
+    assert boxes.tolist() == [[0, 0, 0, 0]]
+    assert _boxes_intersect_tile(boxes, 0, 0, 50, 50).tolist() == [False]
 
 
 @pytest.mark.parametrize(
@@ -437,14 +441,34 @@ def test_instance_intersects_tile_drops_empty_mask():
 )
 def test_instance_intersects_tile_matches_bbox_tiler(box, tile):
     """The mask-derived keep decision equals the box-based ``BboxTiler`` decision."""
-    from datumaro.experimental.tiling.tilers import _instance_intersects_tile
+    from datumaro.experimental.tiling.tilers import _boxes_intersect_tile, _instance_bounding_boxes
 
     x1, y1, x2, y2 = box
     tx, ty, tw, th = tile
-    mask = _mask_from_box(x1, y1, x2, y2)
+    mask = _mask_from_box(x1, y1, x2, y2)[None]  # (1, H, W)
+    boxes = _instance_bounding_boxes(mask)
     # The rasterised mask's exclusive bbox equals (x1, y1, x2, y2) for an axis-aligned rectangle.
+    assert boxes.tolist() == [[x1, y1, x2, y2]]
     expected = _bbox_tiler_keep(x1, y1, x2, y2, tx, ty, tw, th)
-    assert _instance_intersects_tile(mask, tx, ty, tw, th) is expected
+    assert bool(_boxes_intersect_tile(boxes, tx, ty, tw, th)[0]) is expected
+
+
+def test_instance_bounding_boxes_caches_multiple_instances():
+    """Bounding boxes are derived once for a whole instance stack (vectorized)."""
+    from datumaro.experimental.tiling.tilers import _boxes_intersect_tile, _instance_bounding_boxes
+
+    stack = np.stack(
+        [
+            _mask_from_box(10, 10, 40, 40),
+            np.zeros((100, 100), dtype=np.uint8),  # empty -> degenerate box
+            _mask_from_box(60, 60, 90, 90),
+        ]
+    )
+    boxes = _instance_bounding_boxes(stack)
+    assert boxes.tolist() == [[10, 10, 40, 40], [0, 0, 0, 0], [60, 60, 90, 90]]
+    # A single tile check keeps only the first instance for the top-left tile.
+    assert _boxes_intersect_tile(boxes, 0, 0, 50, 50).tolist() == [True, False, False]
+    assert _boxes_intersect_tile(boxes, 50, 50, 50, 50).tolist() == [False, False, True]
 
 
 def test_instance_mask_tiling_stays_aligned_with_bboxes_and_labels():
@@ -484,13 +508,13 @@ def test_instance_mask_tiling_stays_aligned_with_bboxes_and_labels():
             "bboxes": [bboxes],
             "labels": [["a", "b", "c", "a"]],
             "instances": instances.reshape(1, -1),
-            "instances_shape": [instances.shape],
+            "instances_shape": [list(instances.shape)],
         },
         schema={
             **polars_schema,
             "labels": pl.List(pl.Utf8()),
             "instances": pl.List(pl.Boolean()),
-            "instances_shape": pl.List(pl.Int64()),
+            "instances_shape": pl.List(pl.Int32()),
         },
     )
 
@@ -504,4 +528,3 @@ def test_instance_mask_tiling_stays_aligned_with_bboxes_and_labels():
         n_labels = len(result_df[i, "labels"])
         n_masks = result_df[i, "instances_shape"][0]
         assert n_boxes == n_labels == n_masks, f"tile {i}: boxes={n_boxes} labels={n_labels} masks={n_masks}"
-

--- a/tests/unit/experimental/tiling/test_tiling.py
+++ b/tests/unit/experimental/tiling/test_tiling.py
@@ -233,11 +233,12 @@ def test_mask_tiling():
     assert np.any(result_df[0, "segmentation"].to_numpy() == 1)  # Should contain class 1
 
     # Check instance segmentation tile
-    assert result_df[0, "instances"].shape == (2 * 50 * 50,)
-    assert tuple(result_df[0, "instances_shape"]) == (2, 50, 50)
-    instances = result_df[0, "instances"].reshape((2, 50, 50)).to_numpy()
+    # Only instance 0 (bbox 20-70) overlaps the top-left tile; the corner
+    # instance 1 (bbox 80-90) is filtered out to stay aligned with boxes/labels.
+    assert result_df[0, "instances"].shape == (1 * 50 * 50,)
+    assert tuple(result_df[0, "instances_shape"]) == (1, 50, 50)
+    instances = result_df[0, "instances"].reshape((1, 50, 50)).to_numpy()
     assert np.any(instances[0])
-    assert not np.any(instances[1])
 
     # Check last tile (bottom-right)
 
@@ -247,6 +248,7 @@ def test_mask_tiling():
     assert np.any(result_df[3, "segmentation"].to_numpy() == 1)  # Should contain class 1
 
     # Check instance segmentation tile
+    # Both instances overlap the bottom-right tile, so both are kept.
     assert result_df[3, "instances"].shape == (2 * 50 * 50,)
     assert tuple(result_df[3, "instances_shape"]) == (2, 50, 50)
     instances = result_df[3, "instances"].reshape((2, 50, 50)).to_numpy()
@@ -402,3 +404,104 @@ def test_tiling_factory_builds_transform_after_unpickling(sample_df, sample_sche
 
     assert isinstance(transform, TilingTransform)
     assert len(transform) == 16  # matches test_apply_tiling
+
+
+def _bbox_tiler_keep(x1, y1, x2, y2, tx, ty, tw, th):
+    """Reference reimplementation of ``BboxTiler``'s keep criterion."""
+    return (x2 > tx) and (x1 < tx + tw) and (y2 > ty) and (y1 < ty + th)
+
+
+def _mask_from_box(x1, y1, x2, y2, h=100, w=100):
+    m = np.zeros((h, w), dtype=np.uint8)
+    m[y1:y2, x1:x2] = 1
+    return m
+
+
+def test_instance_intersects_tile_drops_empty_mask():
+    """An all-zero instance mask has no bounding box and is never kept."""
+    from datumaro.experimental.tiling.tilers import _instance_intersects_tile
+
+    assert _instance_intersects_tile(np.zeros((100, 100), dtype=np.uint8), 0, 0, 50, 50) is False
+
+
+@pytest.mark.parametrize(
+    ("box", "tile"),
+    [
+        ((10, 10, 40, 40), (0, 0, 50, 50)),  # fully inside
+        ((45, 45, 60, 60), (0, 0, 50, 50)),  # straddles bottom-right corner
+        ((49, 49, 55, 55), (0, 0, 50, 50)),  # 1px overlap in the tile
+        ((60, 60, 90, 90), (50, 50, 50, 50)),  # inside the second tile
+        ((50, 10, 70, 30), (0, 0, 50, 50)),  # touches right edge (x1==tile_x2) -> dropped
+        ((10, 10, 40, 40), (50, 0, 50, 50)),  # left of the second tile -> dropped
+    ],
+)
+def test_instance_intersects_tile_matches_bbox_tiler(box, tile):
+    """The mask-derived keep decision equals the box-based ``BboxTiler`` decision."""
+    from datumaro.experimental.tiling.tilers import _instance_intersects_tile
+
+    x1, y1, x2, y2 = box
+    tx, ty, tw, th = tile
+    mask = _mask_from_box(x1, y1, x2, y2)
+    # The rasterised mask's exclusive bbox equals (x1, y1, x2, y2) for an axis-aligned rectangle.
+    expected = _bbox_tiler_keep(x1, y1, x2, y2, tx, ty, tw, th)
+    assert _instance_intersects_tile(mask, tx, ty, tw, th) is expected
+
+
+def test_instance_mask_tiling_stays_aligned_with_bboxes_and_labels():
+    """Instance masks must be filtered in sync with bboxes and labels.
+
+    Regression test: previously ``InstanceMaskTiler`` kept an entry for every
+    source instance in every tile while ``BboxTiler``/``LabelTiler`` pruned
+    non-overlapping instances, leaving ``len(masks) != len(bboxes) == len(labels)``.
+    """
+    schema = Schema(
+        attributes={
+            "image_info": AttributeInfo(type=dict, field=image_info_field()),
+            "bboxes": AttributeInfo(type=list, field=bbox_field(dtype=pl.Float64())),
+            "labels": AttributeInfo(type=list, field=label_field(is_list=True)),
+            "instances": AttributeInfo(type=list, field=instance_mask_field()),
+        }
+    )
+
+    size = 200
+    # Instances placed to fully-contain, straddle, and sit outside tile boundaries at 100.
+    specs = [(10, 10, 40, 40), (90, 90, 110, 110), (150, 20, 180, 60), (95, 150, 140, 190)]
+
+    def inst(x1, y1, x2, y2):
+        m = np.zeros((size, size), dtype=bool)
+        m[y1:y2, x1:x2] = True
+        return m
+
+    instances = np.stack([inst(*s) for s in specs])
+    bboxes = [[float(v) for v in s] for s in specs]
+
+    polars_schema = schema.attributes["image_info"].field.to_polars_schema("image_info")
+    polars_schema.update(schema.attributes["bboxes"].field.to_polars_schema("bboxes"))
+
+    df = pl.DataFrame(
+        {
+            "image_info": [{"width": size, "height": size}],
+            "bboxes": [bboxes],
+            "labels": [["a", "b", "c", "a"]],
+            "instances": instances.reshape(1, -1),
+            "instances_shape": [instances.shape],
+        },
+        schema={
+            **polars_schema,
+            "labels": pl.List(pl.Utf8()),
+            "instances": pl.List(pl.Boolean()),
+            "instances_shape": pl.List(pl.Int64()),
+        },
+    )
+
+    config = TilingConfig(tile_width=100, tile_height=100)
+    plan = _create_tiling_plan(schema, config, threshold_drop_ann=0.0)
+    result_df, _ = _apply_tiling(df, None, plan, ["bboxes", "labels", "instances"])
+
+    assert len(result_df) == 4
+    for i in range(len(result_df)):
+        n_boxes = len(result_df[i, "bboxes"])
+        n_labels = len(result_df[i, "labels"])
+        n_masks = result_df[i, "instances_shape"][0]
+        assert n_boxes == n_labels == n_masks, f"tile {i}: boxes={n_boxes} labels={n_labels} masks={n_masks}"
+

--- a/tests/unit/experimental/tiling/test_tiling.py
+++ b/tests/unit/experimental/tiling/test_tiling.py
@@ -471,6 +471,36 @@ def test_instance_bounding_boxes_caches_multiple_instances():
     assert _boxes_intersect_tile(boxes, 50, 50, 50, 50).tolist() == [False, False, True]
 
 
+def test_last_image_cache_reuses_and_evicts():
+    """The single-slot cache reuses within an image and evicts on image change.
+
+    Tiles are generated grouped by source image, so caching only the last seen
+    image captures all reuse while keeping memory bounded to one image.
+    """
+    from datumaro.experimental.tiling.tilers import _LastImageCache
+
+    cache: _LastImageCache[str] = _LastImageCache()
+    calls = []
+
+    def factory(tag: str):
+        def _make() -> str:
+            calls.append(tag)
+            return tag
+
+        return _make
+
+    # First access for image 0 computes.
+    assert cache.get(0, factory("img0-a")) == "img0-a"
+    # Repeated access for the same image reuses the cached value (no recompute).
+    assert cache.get(0, factory("img0-b")) == "img0-a"
+    # Moving to a new image evicts the previous entry and recomputes.
+    assert cache.get(1, factory("img1")) == "img1"
+    # Returning to image 0 is a miss (single slot only holds the last image).
+    assert cache.get(0, factory("img0-c")) == "img0-c"
+
+    assert calls == ["img0-a", "img1", "img0-c"]
+
+
 def test_instance_mask_tiling_stays_aligned_with_bboxes_and_labels():
     """Instance masks must be filtered in sync with bboxes and labels.
 


### PR DESCRIPTION

<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

Moved tiling patch from Geti Tune to Datumaro
The tiling patch for instance segmentation ensures that the the amount of annotations and labels match for tiled datasets.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added tests to cover my changes or documented any manual tests.
- [x] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
